### PR TITLE
Feat/rtorrent support

### DIFF
--- a/app/(tabs)/downloads.tsx
+++ b/app/(tabs)/downloads.tsx
@@ -28,11 +28,21 @@ import {
   useDeleteTorrent,
   useAddTorrent,
 } from "@/hooks/use-qbittorrent";
+import {
+  useAllRTTorrents,
+  useRTTransferInfo,
+  usePauseRTTorrent,
+  useResumeRTTorrent,
+  useDeleteRTTorrent,
+  useAddRTTorrent,
+} from "@/hooks/use-rtorrent";
 import { useMultiSelect } from "@/hooks/use-multi-select";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { useConfigStore } from "@/store/config-store";
 import { formatSpeed, formatEta, formatBytes, truncateText } from "@/lib/utils";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
-import type { QBTorrent, TorrentState } from "@/lib/types";
+import { rtorrentStateToLabel } from "@/services/rtorrent-api";
+import type { QBTorrent, TorrentState, RTTorrent } from "@/lib/types";
 
 type FilterType = "all" | "downloading" | "seeding" | "completed" | "paused";
 
@@ -51,6 +61,8 @@ const SORT_OPTIONS: { key: DownloadsSortKey; label: string }[] = [
   { key: "size-desc", label: "Size: Large → Small" },
   { key: "added-desc", label: "Added: Newest First" },
 ];
+
+// --- qBittorrent helpers ---
 
 function compareTorrents(a: QBTorrent, b: QBTorrent, sort: DownloadsSortKey): number {
   switch (sort) {
@@ -75,30 +87,88 @@ function getTorrentBadgeVariant(state: TorrentState): "downloading" | "seeding" 
   return "default";
 }
 
+// --- rTorrent helpers ---
+
+function compareRTTorrents(a: RTTorrent, b: RTTorrent, sort: DownloadsSortKey): number {
+  const aProgress = a.size > 0 ? a.bytes_done / a.size : 0;
+  const bProgress = b.size > 0 ? b.bytes_done / b.size : 0;
+  switch (sort) {
+    case "progress-desc":
+      return bProgress - aProgress;
+    case "progress-asc":
+      return aProgress - bProgress;
+    case "name-asc":
+      return a.name.localeCompare(b.name);
+    case "size-desc":
+      return b.size - a.size;
+    case "added-desc":
+      return b.timestamp_started - a.timestamp_started;
+  }
+}
+
+function getRTBadgeVariant(t: RTTorrent): "downloading" | "seeding" | "paused" | "error" | "default" {
+  const state = rtorrentStateToLabel(t);
+  if (state === "downloading") return "downloading";
+  if (state === "seeding") return "seeding";
+  if (state === "paused" || state === "stopped") return "paused";
+  return "default";
+}
+
+// --- Main screen ---
+
 export default function DownloadsScreen() {
+  const qbEnabled = useConfigStore((s) => s.services.qbittorrent.enabled);
+  const rtEnabled = useConfigStore((s) => s.services.rtorrent.enabled);
+  // qBittorrent takes priority when both are enabled
+  const activeClient = qbEnabled ? "qbittorrent" : rtEnabled ? "rtorrent" : null;
+  const qbActive = activeClient === "qbittorrent";
+  const rtActive = activeClient === "rtorrent";
+
   const [filter, setFilter] = useState<FilterType>("all");
   const sort = useSortStore((s) => s.downloads);
   const setSort = useSortStore((s) => s.setDownloads);
   const [sortSheetOpen, setSortSheetOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
-  const { data: torrents } = useAllTorrents(filter === "all" ? undefined : filter);
-  const sortedTorrents = useMemo(
-    () => (torrents ? [...torrents].sort((a, b) => compareTorrents(a, b, sort)) : torrents),
-    [torrents, sort],
+
+  // qBittorrent hooks (internally gated by qbEnabled)
+  const { data: qbTorrents } = useAllTorrents(filter === "all" ? undefined : filter, qbActive);
+  const { data: qbTransfer } = useTransferInfo(qbActive);
+  const qbAddTorrent = useAddTorrent();
+  const qbPause = usePauseTorrent();
+  const qbResume = useResumeTorrent();
+  const qbDelete = useDeleteTorrent();
+
+  // rTorrent hooks (internally gated by rtEnabled)
+  const { data: rtTorrents, error: rtError } = useAllRTTorrents(
+    filter === "all" ? undefined : filter,
+    rtActive,
   );
-  const { data: transfer } = useTransferInfo();
+  const { data: rtTransfer } = useRTTransferInfo(rtActive);
+  const rtAddTorrent = useAddRTTorrent();
+  const rtPause = usePauseRTTorrent();
+  const rtResume = useResumeRTTorrent();
+  const rtDelete = useDeleteRTTorrent();
+
   const { data: healthData } = useServiceHealth();
-  const addTorrent = useAddTorrent();
-  const pauseMutation = usePauseTorrent();
-  const resumeMutation = useResumeTorrent();
-  const deleteMutation = useDeleteTorrent();
   const router = useRouter();
-  const { refreshing, onRefresh } = usePullToRefresh([["qbittorrent"]]);
+  const { refreshing, onRefresh } = usePullToRefresh([[activeClient ?? "qbittorrent"]]);
 
-  const multiSelect = useMultiSelect<QBTorrent>((t) => t.hash);
+  const clientHealth = healthData?.find((s) => s.id === (activeClient ?? "qbittorrent"));
 
-  const qbHealth = healthData?.find((s) => s.id === "qbittorrent");
+  // Sorted torrent lists
+  const sortedQBTorrents = useMemo(
+    () => (qbTorrents ? [...qbTorrents].sort((a, b) => compareTorrents(a, b, sort)) : qbTorrents),
+    [qbTorrents, sort],
+  );
+  const sortedRTTorrents = useMemo(
+    () => (rtTorrents ? [...rtTorrents].sort((a, b) => compareRTTorrents(a, b, sort)) : rtTorrents),
+    [rtTorrents, sort],
+  );
+
+  const qbMultiSelect = useMultiSelect<QBTorrent>((t) => t.hash);
+  const rtMultiSelect = useMultiSelect<RTTorrent>((t) => t.hash);
+  const multiSelect = activeClient === "rtorrent" ? rtMultiSelect : qbMultiSelect;
 
   useFocusEffect(
     useCallback(() => {
@@ -111,9 +181,18 @@ export default function DownloadsScreen() {
     }, [multiSelect.isActive, multiSelect.clear]),
   );
 
+  const pauseMutation = activeClient === "rtorrent" ? rtPause : qbPause;
+  const resumeMutation = activeClient === "rtorrent" ? rtResume : qbResume;
+
+  const dlSpeed =
+    activeClient === "rtorrent" ? rtTransfer?.dl_rate : qbTransfer?.dl_info_speed;
+  const upSpeed =
+    activeClient === "rtorrent" ? rtTransfer?.up_rate : qbTransfer?.up_info_speed;
+
   const handleAdd = () => {
     if (!magnetUri.trim()) return;
-    addTorrent.mutate(magnetUri.trim(), {
+    const addMutate = activeClient === "rtorrent" ? rtAddTorrent : qbAddTorrent;
+    addMutate.mutate(magnetUri.trim(), {
       onSuccess: () => {
         setMagnetUri("");
         setShowAddModal(false);
@@ -122,77 +201,118 @@ export default function DownloadsScreen() {
     });
   };
 
-  const selectedHashes = () =>
-    torrents ? multiSelect.selectedItems(torrents).map((t) => t.hash) : [];
-
   const handleBulkPause = () => {
-    const hashes = selectedHashes();
-    if (hashes.length === 0) return;
-    pauseMutation.mutate(hashes);
-  };
-
-  const handleBulkResume = () => {
-    const hashes = selectedHashes();
-    if (hashes.length === 0) return;
-    resumeMutation.mutate(hashes);
-  };
-
-  const handleBulkDelete = () => {
-    const hashes = selectedHashes();
-    if (hashes.length === 0) return;
-    Alert.alert("Delete Torrents", `Delete ${hashes.length} torrent(s)?`, [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          deleteMutation.mutate({ hashes });
-          multiSelect.clear();
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          deleteMutation.mutate({ hashes, deleteFiles: true });
-          multiSelect.clear();
-        },
-      },
-    ]);
-  };
-
-  const handleTorrentPress = (torrent: QBTorrent) => {
-    if (multiSelect.isActive) {
-      multiSelect.toggle(torrent);
+    if (activeClient === "rtorrent") {
+      const hashes = sortedRTTorrents
+        ? rtMultiSelect.selectedItems(sortedRTTorrents).map((t) => t.hash)
+        : [];
+      if (hashes.length) rtPause.mutate(hashes);
     } else {
-      router.push(`/torrent/${torrent.hash}`);
+      const hashes = sortedQBTorrents
+        ? qbMultiSelect.selectedItems(sortedQBTorrents).map((t) => t.hash)
+        : [];
+      if (hashes.length) qbPause.mutate(hashes);
     }
   };
 
-  const handleTorrentLongPress = (torrent: QBTorrent) => {
-    if (multiSelect.isActive) return;
-    mediumHaptic();
-    multiSelect.enter(torrent);
+  const handleBulkResume = () => {
+    if (activeClient === "rtorrent") {
+      const hashes = sortedRTTorrents
+        ? rtMultiSelect.selectedItems(sortedRTTorrents).map((t) => t.hash)
+        : [];
+      if (hashes.length) rtResume.mutate(hashes);
+    } else {
+      const hashes = sortedQBTorrents
+        ? qbMultiSelect.selectedItems(sortedQBTorrents).map((t) => t.hash)
+        : [];
+      if (hashes.length) qbResume.mutate(hashes);
+    }
+  };
+
+  const handleBulkDelete = () => {
+    if (activeClient === "rtorrent") {
+      const selected = sortedRTTorrents
+        ? rtMultiSelect.selectedItems(sortedRTTorrents)
+        : [];
+      if (!selected.length) return;
+      Alert.alert("Delete Torrents", `Delete ${selected.length} torrent(s)?`, [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            errorHaptic();
+            rtDelete.mutate({ hashes: selected.map((t) => t.hash) });
+            rtMultiSelect.clear();
+          },
+        },
+        {
+          text: "Delete + Files",
+          style: "destructive",
+          onPress: () => {
+            errorHaptic();
+            rtDelete.mutate({
+              hashes: selected.map((t) => t.hash),
+              deleteFiles: true,
+              basePaths: selected.map((t) => t.base_path),
+            });
+            rtMultiSelect.clear();
+          },
+        },
+      ]);
+    } else {
+      const hashes = sortedQBTorrents
+        ? qbMultiSelect.selectedItems(sortedQBTorrents).map((t) => t.hash)
+        : [];
+      if (!hashes.length) return;
+      Alert.alert("Delete Torrents", `Delete ${hashes.length} torrent(s)?`, [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            errorHaptic();
+            qbDelete.mutate({ hashes });
+            qbMultiSelect.clear();
+          },
+        },
+        {
+          text: "Delete + Files",
+          style: "destructive",
+          onPress: () => {
+            errorHaptic();
+            qbDelete.mutate({ hashes, deleteFiles: true });
+            qbMultiSelect.clear();
+          },
+        },
+      ]);
+    }
   };
 
   const bulkBusy =
-    pauseMutation.isPending ||
-    resumeMutation.isPending ||
-    deleteMutation.isPending;
+    pauseMutation.isPending || resumeMutation.isPending ||
+    qbDelete.isPending || rtDelete.isPending;
+
+  const addPending =
+    activeClient === "rtorrent" ? rtAddTorrent.isPending : qbAddTorrent.isPending;
+
+  const sortedTorrents =
+    activeClient === "rtorrent" ? sortedRTTorrents : sortedQBTorrents;
 
   return (
     <ScreenWrapper refreshing={refreshing} onRefresh={onRefresh}>
       {multiSelect.isActive ? (
         <SelectionBar
           count={multiSelect.count}
-          total={torrents?.length ?? 0}
+          total={sortedTorrents?.length ?? 0}
           onCancel={multiSelect.clear}
           onSelectAll={() => {
-            if (!torrents) return;
-            if (multiSelect.count === torrents.length) multiSelect.clear();
-            else multiSelect.selectAll(torrents);
+            if (!sortedTorrents) return;
+            if (multiSelect.count === sortedTorrents.length) multiSelect.clear();
+            else {
+              if (activeClient === "rtorrent") rtMultiSelect.selectAll(sortedRTTorrents ?? []);
+              else qbMultiSelect.selectAll(sortedQBTorrents ?? []);
+            }
           }}
           onPause={handleBulkPause}
           onResume={handleBulkResume}
@@ -201,19 +321,19 @@ export default function DownloadsScreen() {
         />
       ) : (
         <>
-          <ServiceHeader name="Downloads" online={qbHealth?.online} />
+          <ServiceHeader name="Downloads" online={clientHealth?.online} />
 
           {/* Speed Summary */}
-          {transfer && (
+          {(dlSpeed !== undefined || upSpeed !== undefined) && (
             <View className="flex-row gap-3 mb-4">
               <View className="flex-1 bg-blue-600/10 rounded-xl p-3">
                 <Text className="text-download text-lg font-bold">
-                  ↓ {formatSpeed(transfer.dl_info_speed)}
+                  ↓ {formatSpeed(dlSpeed ?? 0)}
                 </Text>
               </View>
               <View className="flex-1 bg-green-600/10 rounded-xl p-3">
                 <Text className="text-upload text-lg font-bold">
-                  ↑ {formatSpeed(transfer.up_info_speed)}
+                  ↑ {formatSpeed(upSpeed ?? 0)}
                 </Text>
               </View>
             </View>
@@ -243,7 +363,7 @@ export default function DownloadsScreen() {
                   label="Add"
                   size="sm"
                   onPress={handleAdd}
-                  loading={addTorrent.isPending}
+                  loading={addPending}
                   className="flex-1"
                 />
               </View>
@@ -284,18 +404,47 @@ export default function DownloadsScreen() {
       )}
 
       {/* Torrent List */}
-      {!sortedTorrents || sortedTorrents.length === 0 ? (
+      {activeClient === "rtorrent" && rtError ? (
+        <EmptyState title="rTorrent error" message={(rtError as Error).message ?? "Failed to fetch torrents"} />
+      ) : !sortedTorrents || sortedTorrents.length === 0 ? (
         <EmptyState title="No torrents" message={`No ${filter} torrents found`} />
+      ) : activeClient === "rtorrent" ? (
+        <View className="gap-2">
+          {(sortedRTTorrents ?? []).map((torrent) => (
+            <RTorrentListItem
+              key={torrent.hash}
+              torrent={torrent}
+              selectionMode={rtMultiSelect.isActive}
+              isSelected={rtMultiSelect.isSelected(torrent)}
+              onPress={() => {
+                if (rtMultiSelect.isActive) rtMultiSelect.toggle(torrent);
+                else router.push(`/torrent/${torrent.hash}`);
+              }}
+              onLongPress={() => {
+                if (rtMultiSelect.isActive) return;
+                mediumHaptic();
+                rtMultiSelect.enter(torrent);
+              }}
+            />
+          ))}
+        </View>
       ) : (
         <View className="gap-2">
-          {sortedTorrents.map((torrent) => (
+          {(sortedQBTorrents ?? []).map((torrent) => (
             <TorrentListItem
               key={torrent.hash}
               torrent={torrent}
-              selectionMode={multiSelect.isActive}
-              isSelected={multiSelect.isSelected(torrent)}
-              onPress={() => handleTorrentPress(torrent)}
-              onLongPress={() => handleTorrentLongPress(torrent)}
+              selectionMode={qbMultiSelect.isActive}
+              isSelected={qbMultiSelect.isSelected(torrent)}
+              onPress={() => {
+                if (qbMultiSelect.isActive) qbMultiSelect.toggle(torrent);
+                else router.push(`/torrent/${torrent.hash}`);
+              }}
+              onLongPress={() => {
+                if (qbMultiSelect.isActive) return;
+                mediumHaptic();
+                qbMultiSelect.enter(torrent);
+              }}
             />
           ))}
         </View>
@@ -467,6 +616,123 @@ function TorrentListItem({
           {torrent.eta > 0 && torrent.eta < 8640000 && (
             <Text className="text-zinc-500 text-xs">
               ETA {formatEta(torrent.eta)}
+            </Text>
+          )}
+        </View>
+
+        {!selectionMode && (
+          <View className="flex-row gap-1">
+            <Pressable
+              onPress={() =>
+                isPaused
+                  ? resumeMutation.mutate([torrent.hash])
+                  : pauseMutation.mutate([torrent.hash])
+              }
+              disabled={pauseMutation.isPending || resumeMutation.isPending}
+              className={`p-1.5 active:opacity-70 ${pauseMutation.isPending || resumeMutation.isPending ? "opacity-50" : ""}`}
+              hitSlop={6}
+            >
+              {isPaused ? (
+                <Play size={16} color="#3b82f6" />
+              ) : (
+                <Pause size={16} color="#f59e0b" />
+              )}
+            </Pressable>
+            <Pressable
+              onPress={handleDelete}
+              disabled={deleteMutation.isPending}
+              className={`p-1.5 active:opacity-70 ${deleteMutation.isPending ? "opacity-50" : ""}`}
+              hitSlop={6}
+            >
+              <Trash2 size={16} color="#ef4444" />
+            </Pressable>
+          </View>
+        )}
+      </View>
+    </Card>
+  );
+}
+
+function RTorrentListItem({
+  torrent,
+  onPress,
+  onLongPress,
+  selectionMode,
+  isSelected,
+}: {
+  torrent: RTTorrent;
+  onPress: () => void;
+  onLongPress: () => void;
+  selectionMode: boolean;
+  isSelected: boolean;
+}) {
+  const pauseMutation = usePauseRTTorrent();
+  const resumeMutation = useResumeRTTorrent();
+  const deleteMutation = useDeleteRTTorrent();
+
+  const state = rtorrentStateToLabel(torrent);
+  const isPaused = state === "paused" || state === "stopped";
+  const badgeVariant = getRTBadgeVariant(torrent);
+  const progress = torrent.size > 0 ? torrent.bytes_done / torrent.size : 0;
+
+  const handleDelete = () => {
+    Alert.alert("Delete Torrent", `Delete "${truncateText(torrent.name, 30)}"?`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: () => {
+          errorHaptic();
+          deleteMutation.mutate({ hashes: [torrent.hash] });
+        },
+      },
+      {
+        text: "Delete + Files",
+        style: "destructive",
+        onPress: () => {
+          errorHaptic();
+          deleteMutation.mutate({
+            hashes: [torrent.hash],
+            deleteFiles: true,
+            basePaths: [torrent.base_path],
+          });
+        },
+      },
+    ]);
+  };
+
+  return (
+    <Card
+      onPress={onPress}
+      onLongPress={onLongPress}
+      className={isSelected ? "border-primary" : ""}
+    >
+      <View className="flex-row items-start justify-between mb-1">
+        {selectionMode && (
+          <View className="mr-2 mt-0.5">
+            {isSelected ? (
+              <CheckCircle2 size={18} color="#3b82f6" />
+            ) : (
+              <Circle size={18} color="#71717a" />
+            )}
+          </View>
+        )}
+        <Text className="text-zinc-200 text-sm flex-1 mr-2" numberOfLines={2}>
+          {torrent.name}
+        </Text>
+        <Badge label={state} variant={badgeVariant} />
+      </View>
+
+      <ProgressBar progress={progress} showLabel className="my-2" />
+
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row gap-3">
+          <Text className="text-zinc-500 text-xs">
+            {formatBytes(torrent.size)}
+          </Text>
+          {torrent.dl_rate > 0 && (
+            <Text className="text-zinc-500 text-xs">
+              ↓ {formatSpeed(torrent.dl_rate)}
             </Text>
           )}
         </View>

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -20,6 +20,7 @@ import type { ServiceId } from "@/lib/constants";
 
 const SERVICE_ICONS: Record<ServiceId, React.ElementType> = {
   qbittorrent: Download,
+  rtorrent: Download,
   radarr: Film,
   sonarr: Tv,
   overseerr: Inbox,
@@ -32,6 +33,7 @@ const SERVICE_ICONS: Record<ServiceId, React.ElementType> = {
 
 const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   qbittorrent: "/(tabs)/downloads",
+  rtorrent: "/(tabs)/downloads",
   radarr: "/(tabs)/movies",
   sonarr: "/(tabs)/tv",
   overseerr: "/(tabs)/requests",

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -57,6 +57,13 @@ const SERVICE_ICONS: Record<ServiceId, React.ElementType> = {
   bazarr: Captions,
 };
 
+const URL_PLACEHOLDERS: Partial<Record<ServiceId, { local: string; remote: string }>> = {
+  rtorrent: {
+    local: "http://192.168.1.100:8080/RPC2",
+    remote: "https://service.mydomain.com/RPC2",
+  },
+};
+
 export default function SettingsScreen() {
   const [editingService, setEditingService] = useState<ServiceId | null>(null);
   const [exportStage, setExportStage] = useState<ExportStage | null>(null);
@@ -444,6 +451,10 @@ function ServiceEditor({
   const [testing, setTesting] = useState(false);
 
   const isQB = serviceId === "qbittorrent" || serviceId === "glances" || serviceId === "rtorrent";
+  const placeholders = URL_PLACEHOLDERS[serviceId] ?? {
+    local: "http://192.168.1.100:8080",
+    remote: "https://service.mydomain.com",
+  };
 
   const isDirty =
     localUrl !== config.localUrl ||
@@ -552,14 +563,14 @@ function ServiceEditor({
       <Card className="gap-4 mb-4">
         <TextInput
           label="Local URL"
-          placeholder="http://192.168.1.100:8080"
+          placeholder={placeholders.local}
           value={localUrl}
           onChangeText={setLocalUrl}
           keyboardType="url"
         />
         <TextInput
           label="Remote URL"
-          placeholder="https://service.mydomain.com"
+          placeholder={placeholders.remote}
           value={remoteUrl}
           onChangeText={setRemoteUrl}
           keyboardType="url"

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -46,6 +46,7 @@ import {
 
 const SERVICE_ICONS: Record<ServiceId, React.ElementType> = {
   qbittorrent: Download,
+  rtorrent: Download,
   radarr: Film,
   sonarr: Tv,
   overseerr: Inbox,
@@ -432,6 +433,8 @@ function ServiceEditor({
   const updateService = useConfigStore((s) => s.updateService);
   const updateSecrets = useConfigStore((s) => s.updateSecrets);
   const toggleService = useConfigStore((s) => s.toggleService);
+  const qbEnabled = useConfigStore((s) => s.services.qbittorrent.enabled);
+  const rtEnabled = useConfigStore((s) => s.services.rtorrent.enabled);
 
   const [localUrl, setLocalUrl] = useState(config.localUrl);
   const [remoteUrl, setRemoteUrl] = useState(config.remoteUrl);
@@ -440,7 +443,7 @@ function ServiceEditor({
   const [password, setPassword] = useState(secrets.password ?? "");
   const [testing, setTesting] = useState(false);
 
-  const isQB = serviceId === "qbittorrent" || serviceId === "glances";
+  const isQB = serviceId === "qbittorrent" || serviceId === "glances" || serviceId === "rtorrent";
 
   const isDirty =
     localUrl !== config.localUrl ||
@@ -527,7 +530,22 @@ function ServiceEditor({
         <Toggle
           label="Enabled"
           value={config.enabled}
-          onValueChange={() => toggleService(serviceId)}
+          onValueChange={() => {
+            if (serviceId === "rtorrent" && !config.enabled && qbEnabled) {
+              Alert.alert(
+                "qBittorrent already enabled",
+                "Using both torrent clients at once is not recommended. The Downloads screen uses qBittorrent when both are enabled. Consider disabling qBittorrent.",
+                [{ text: "OK" }],
+              );
+            } else if (serviceId === "qbittorrent" && !config.enabled && rtEnabled) {
+              Alert.alert(
+                "rTorrent already enabled",
+                "Using both torrent clients at once is not recommended. The Downloads screen uses qBittorrent when both are enabled. Consider disabling rTorrent.",
+                [{ text: "OK" }],
+              );
+            }
+            toggleService(serviceId);
+          }}
         />
       </Card>
 

--- a/app/torrent/[hash].tsx
+++ b/app/torrent/[hash].tsx
@@ -14,21 +14,185 @@ import {
   useResumeTorrent,
   useDeleteTorrent,
 } from "@/hooks/use-qbittorrent";
+import {
+  useAllRTTorrents,
+  useRTTorrentFiles,
+  usePauseRTTorrent,
+  useResumeRTTorrent,
+  useDeleteRTTorrent,
+} from "@/hooks/use-rtorrent";
+import { useConfigStore } from "@/store/config-store";
+import { rtorrentStateToLabel } from "@/services/rtorrent-api";
 import { formatBytes, formatSpeed, formatEta } from "@/lib/utils";
 
 export default function TorrentDetailScreen() {
   const { hash } = useLocalSearchParams<{ hash: string }>();
   const router = useRouter();
-  const { data: torrents } = useAllTorrents();
-  const { data: files } = useTorrentFiles(hash);
-  const { data: trackers } = useTorrentTrackers(hash);
-  const pauseMutation = usePauseTorrent();
-  const resumeMutation = useResumeTorrent();
-  const deleteMutation = useDeleteTorrent();
 
-  const torrent = torrents?.find((t) => t.hash === hash);
+  const qbEnabled = useConfigStore((s) => s.services.qbittorrent.enabled);
+  const rtEnabled = useConfigStore((s) => s.services.rtorrent.enabled);
+  const activeClient = qbEnabled ? "qbittorrent" : rtEnabled ? "rtorrent" : null;
+  const qbActive = activeClient === "qbittorrent";
+  const rtActive = activeClient === "rtorrent";
 
-  if (!torrent) {
+  // qBittorrent hooks
+  const { data: qbTorrents } = useAllTorrents(undefined, qbActive);
+  const { data: qbFiles } = useTorrentFiles(hash, qbActive);
+  useTorrentTrackers(hash, qbActive); // keep subscribed for cache warmth
+  const qbPause = usePauseTorrent();
+  const qbResume = useResumeTorrent();
+  const qbDelete = useDeleteTorrent();
+
+  // rTorrent hooks
+  const { data: rtTorrents } = useAllRTTorrents(undefined, rtActive);
+  const { data: rtFiles } = useRTTorrentFiles(hash, rtActive);
+  const rtPause = usePauseRTTorrent();
+  const rtResume = useResumeRTTorrent();
+  const rtDelete = useDeleteRTTorrent();
+
+  const qbTorrent = qbTorrents?.find((t) => t.hash === hash);
+  const rtTorrent = rtTorrents?.find((t) => t.hash === hash);
+
+  // --- rTorrent detail ---
+  if (activeClient === "rtorrent") {
+    if (!rtTorrent) {
+      return (
+        <ScreenWrapper>
+          <Text className="text-zinc-400 text-center mt-10">Torrent not found</Text>
+        </ScreenWrapper>
+      );
+    }
+
+    const state = rtorrentStateToLabel(rtTorrent);
+    const isPaused = state === "paused" || state === "stopped";
+    const progress = rtTorrent.size > 0 ? rtTorrent.bytes_done / rtTorrent.size : 0;
+
+    const handleDelete = () => {
+      Alert.alert("Delete Torrent", "Are you sure?", [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            rtDelete.mutate({ hashes: [hash] });
+            router.back();
+          },
+        },
+        {
+          text: "Delete + Files",
+          style: "destructive",
+          onPress: () => {
+            rtDelete.mutate({
+              hashes: [hash],
+              deleteFiles: true,
+              basePaths: [rtTorrent.base_path],
+            });
+            router.back();
+          },
+        },
+      ]);
+    };
+
+    return (
+      <ScreenWrapper>
+        <Text className="text-zinc-100 text-lg font-bold mt-2 mb-1">
+          {rtTorrent.name}
+        </Text>
+        <Badge
+          label={state}
+          variant={isPaused ? "paused" : state === "seeding" ? "seeding" : "downloading"}
+          className="self-start mb-4"
+        />
+
+        <Card className="mb-4">
+          <ProgressBar progress={progress} showLabel className="mb-3" />
+          <View className="flex-row justify-between">
+            <View className="flex-row items-center gap-1">
+              <ArrowDown size={14} color="#3b82f6" />
+              <Text className="text-zinc-300 text-sm">
+                {formatSpeed(rtTorrent.dl_rate)}
+              </Text>
+            </View>
+            <View className="flex-row items-center gap-1">
+              <ArrowUp size={14} color="#22c55e" />
+              <Text className="text-zinc-300 text-sm">
+                {formatSpeed(rtTorrent.up_rate)}
+              </Text>
+            </View>
+          </View>
+        </Card>
+
+        <Card className="mb-4 gap-2">
+          <InfoRow label="Size" value={formatBytes(rtTorrent.size)} />
+          <InfoRow label="Downloaded" value={formatBytes(rtTorrent.bytes_done)} />
+          <InfoRow label="Ratio" value={(rtTorrent.ratio / 1000).toFixed(2)} />
+          <InfoRow label="Peers" value={String(rtTorrent.peers_connected)} />
+          <InfoRow label="Save Path" value={rtTorrent.base_path} />
+        </Card>
+
+        {rtFiles && rtFiles.length > 0 && (
+          <Card className="mb-4">
+            <Text className="text-zinc-400 text-xs font-semibold uppercase mb-2">
+              Files ({rtFiles.length})
+            </Text>
+            {rtFiles.slice(0, 10).map((file, i) => {
+              const fileProgress =
+                file.size_chunks > 0
+                  ? Math.round((file.completed_chunks / file.size_chunks) * 100)
+                  : 0;
+              return (
+                <View key={i} className="py-1.5 border-b border-border/50">
+                  <Text className="text-zinc-300 text-xs" numberOfLines={1}>
+                    {file.path}
+                  </Text>
+                  <Text className="text-zinc-500 text-[10px]">
+                    {formatBytes(file.size_bytes)} — {fileProgress}%
+                  </Text>
+                </View>
+              );
+            })}
+            {rtFiles.length > 10 && (
+              <Text className="text-zinc-500 text-xs mt-2">
+                +{rtFiles.length - 10} more files
+              </Text>
+            )}
+          </Card>
+        )}
+
+        <View className="flex-row gap-3">
+          <Button
+            label={isPaused ? "Resume" : "Pause"}
+            variant="outline"
+            onPress={() =>
+              isPaused
+                ? rtResume.mutate([hash])
+                : rtPause.mutate([hash])
+            }
+            loading={rtPause.isPending || rtResume.isPending}
+            icon={
+              isPaused ? (
+                <Play size={16} color="#3b82f6" />
+              ) : (
+                <Pause size={16} color="#f59e0b" />
+              )
+            }
+            className="flex-1"
+          />
+          <Button
+            label="Delete"
+            variant="danger"
+            onPress={handleDelete}
+            loading={rtDelete.isPending}
+            icon={<Trash2 size={16} color="white" />}
+            className="flex-1"
+          />
+        </View>
+      </ScreenWrapper>
+    );
+  }
+
+  // --- qBittorrent detail (default) ---
+  if (!qbTorrent) {
     return (
       <ScreenWrapper>
         <Text className="text-zinc-400 text-center mt-10">Torrent not found</Text>
@@ -36,7 +200,7 @@ export default function TorrentDetailScreen() {
     );
   }
 
-  const isPaused = torrent.state.includes("paused");
+  const isPaused = qbTorrent.state.includes("paused");
 
   const handleDelete = () => {
     Alert.alert("Delete Torrent", "Are you sure?", [
@@ -45,7 +209,7 @@ export default function TorrentDetailScreen() {
         text: "Delete",
         style: "destructive",
         onPress: () => {
-          deleteMutation.mutate({ hashes: [hash] });
+          qbDelete.mutate({ hashes: [hash] });
           router.back();
         },
       },
@@ -53,7 +217,7 @@ export default function TorrentDetailScreen() {
         text: "Delete + Files",
         style: "destructive",
         onPress: () => {
-          deleteMutation.mutate({ hashes: [hash], deleteFiles: true });
+          qbDelete.mutate({ hashes: [hash], deleteFiles: true });
           router.back();
         },
       },
@@ -62,56 +226,52 @@ export default function TorrentDetailScreen() {
 
   return (
     <ScreenWrapper>
-      {/* Header */}
       <Text className="text-zinc-100 text-lg font-bold mt-2 mb-1">
-        {torrent.name}
+        {qbTorrent.name}
       </Text>
       <Badge
-        label={torrent.state}
+        label={qbTorrent.state}
         variant={isPaused ? "paused" : "downloading"}
         className="self-start mb-4"
       />
 
-      {/* Progress */}
       <Card className="mb-4">
-        <ProgressBar progress={torrent.progress} showLabel className="mb-3" />
+        <ProgressBar progress={qbTorrent.progress} showLabel className="mb-3" />
         <View className="flex-row justify-between">
           <View className="flex-row items-center gap-1">
             <ArrowDown size={14} color="#3b82f6" />
             <Text className="text-zinc-300 text-sm">
-              {formatSpeed(torrent.dlspeed)}
+              {formatSpeed(qbTorrent.dlspeed)}
             </Text>
           </View>
           <View className="flex-row items-center gap-1">
             <ArrowUp size={14} color="#22c55e" />
             <Text className="text-zinc-300 text-sm">
-              {formatSpeed(torrent.upspeed)}
+              {formatSpeed(qbTorrent.upspeed)}
             </Text>
           </View>
-          {torrent.eta > 0 && torrent.eta < 8640000 && (
-            <Text className="text-zinc-400 text-sm">ETA {formatEta(torrent.eta)}</Text>
+          {qbTorrent.eta > 0 && qbTorrent.eta < 8640000 && (
+            <Text className="text-zinc-400 text-sm">ETA {formatEta(qbTorrent.eta)}</Text>
           )}
         </View>
       </Card>
 
-      {/* Info */}
       <Card className="mb-4 gap-2">
-        <InfoRow label="Size" value={formatBytes(torrent.size)} />
-        <InfoRow label="Downloaded" value={formatBytes(torrent.downloaded)} />
-        <InfoRow label="Uploaded" value={formatBytes(torrent.uploaded)} />
-        <InfoRow label="Ratio" value={torrent.ratio.toFixed(2)} />
-        <InfoRow label="Seeds" value={String(torrent.num_seeds)} />
-        <InfoRow label="Peers" value={String(torrent.num_leechs)} />
-        <InfoRow label="Save Path" value={torrent.save_path} />
+        <InfoRow label="Size" value={formatBytes(qbTorrent.size)} />
+        <InfoRow label="Downloaded" value={formatBytes(qbTorrent.downloaded)} />
+        <InfoRow label="Uploaded" value={formatBytes(qbTorrent.uploaded)} />
+        <InfoRow label="Ratio" value={qbTorrent.ratio.toFixed(2)} />
+        <InfoRow label="Seeds" value={String(qbTorrent.num_seeds)} />
+        <InfoRow label="Peers" value={String(qbTorrent.num_leechs)} />
+        <InfoRow label="Save Path" value={qbTorrent.save_path} />
       </Card>
 
-      {/* Files */}
-      {files && files.length > 0 && (
+      {qbFiles && qbFiles.length > 0 && (
         <Card className="mb-4">
           <Text className="text-zinc-400 text-xs font-semibold uppercase mb-2">
-            Files ({files.length})
+            Files ({qbFiles.length})
           </Text>
-          {files.slice(0, 10).map((file) => (
+          {qbFiles.slice(0, 10).map((file) => (
             <View key={file.index} className="py-1.5 border-b border-border/50">
               <Text className="text-zinc-300 text-xs" numberOfLines={1}>
                 {file.name}
@@ -121,25 +281,24 @@ export default function TorrentDetailScreen() {
               </Text>
             </View>
           ))}
-          {files.length > 10 && (
+          {qbFiles.length > 10 && (
             <Text className="text-zinc-500 text-xs mt-2">
-              +{files.length - 10} more files
+              +{qbFiles.length - 10} more files
             </Text>
           )}
         </Card>
       )}
 
-      {/* Actions */}
       <View className="flex-row gap-3">
         <Button
           label={isPaused ? "Resume" : "Pause"}
           variant="outline"
           onPress={() =>
             isPaused
-              ? resumeMutation.mutate([hash])
-              : pauseMutation.mutate([hash])
+              ? qbResume.mutate([hash])
+              : qbPause.mutate([hash])
           }
-          loading={pauseMutation.isPending || resumeMutation.isPending}
+          loading={qbPause.isPending || qbResume.isPending}
           icon={
             isPaused ? (
               <Play size={16} color="#3b82f6" />
@@ -153,7 +312,7 @@ export default function TorrentDetailScreen() {
           label="Delete"
           variant="danger"
           onPress={handleDelete}
-          loading={deleteMutation.isPending}
+          loading={qbDelete.isPending}
           icon={<Trash2 size={16} color="white" />}
           className="flex-1"
         />

--- a/components/dashboard/download-card.tsx
+++ b/components/dashboard/download-card.tsx
@@ -5,6 +5,8 @@ import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useAllTorrents, usePauseTorrent, useResumeTorrent } from "@/hooks/use-qbittorrent";
+import { useAllRTTorrents, usePauseRTTorrent, useResumeRTTorrent } from "@/hooks/use-rtorrent";
+import { useConfigStore } from "@/store/config-store";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { lightHaptic } from "@/lib/haptics";
 import { formatSpeed, formatEta, truncateText } from "@/lib/utils";
@@ -14,15 +16,16 @@ import {
   type DownloadsSettingsValue,
   type DownloadsSortBy,
 } from "@/components/dashboard/widget-settings/downloads-settings";
-import type { QBTorrent, TorrentState } from "@/lib/types";
+import { rtorrentStateToLabel } from "@/services/rtorrent-api";
+import type { QBTorrent, TorrentState, RTTorrent } from "@/lib/types";
 
 type StateGroup = "downloading" | "seeding" | "paused" | "errored" | "other";
 
-// qBittorrent uses 8640000 (100 days) as a sentinel for "unknown ETA". Treat
-// that and anything larger as missing so it sorts to the end.
 const ETA_UNKNOWN = 8640000;
 
-function classifyState(state: TorrentState): StateGroup {
+// --- qBittorrent helpers ---
+
+function classifyQBState(state: TorrentState): StateGroup {
   if (state === "error" || state === "missingFiles") return "errored";
   if (state === "pausedDL" || state === "pausedUP") return "paused";
   if (
@@ -48,10 +51,9 @@ function classifyState(state: TorrentState): StateGroup {
   return "other";
 }
 
-function compareTorrents(a: QBTorrent, b: QBTorrent, sortBy: DownloadsSortBy): number {
+function compareQBTorrents(a: QBTorrent, b: QBTorrent, sortBy: DownloadsSortBy): number {
   switch (sortBy) {
     case "speed": {
-      // Combined throughput so a busy seeder ranks alongside a fast downloader.
       const aSpeed = a.dlspeed + a.upspeed;
       const bSpeed = b.dlspeed + b.upspeed;
       return bSpeed - aSpeed;
@@ -68,12 +70,48 @@ function compareTorrents(a: QBTorrent, b: QBTorrent, sortBy: DownloadsSortBy): n
   }
 }
 
+// --- rTorrent helpers ---
+
+function classifyRTState(t: RTTorrent): StateGroup {
+  const state = rtorrentStateToLabel(t);
+  if (state === "downloading") return "downloading";
+  if (state === "seeding") return "seeding";
+  if (state === "paused" || state === "stopped") return "paused";
+  return "other";
+}
+
+function compareRTTorrents(a: RTTorrent, b: RTTorrent, sortBy: DownloadsSortBy): number {
+  const aProgress = a.size > 0 ? a.bytes_done / a.size : 0;
+  const bProgress = b.size > 0 ? b.bytes_done / b.size : 0;
+  switch (sortBy) {
+    case "speed":
+      return (b.dl_rate + b.up_rate) - (a.dl_rate + a.up_rate);
+    case "progress":
+      return bProgress - aProgress;
+    case "eta":
+      return aProgress - bProgress; // higher progress = closer to done
+    case "added":
+      return b.timestamp_started - a.timestamp_started;
+  }
+}
+
+// --- Widget ---
+
 export function DownloadCard() {
   const { settings } = useWidgetSettings<DownloadsSettingsValue>(
     "downloads",
     DOWNLOADS_DEFAULT_SETTINGS,
   );
-  const { data: torrents, isLoading } = useAllTorrents();
+
+  const qbEnabled = useConfigStore((s) => s.services.qbittorrent.enabled);
+  const rtEnabled = useConfigStore((s) => s.services.rtorrent.enabled);
+  const activeClient = qbEnabled ? "qbittorrent" : rtEnabled ? "rtorrent" : null;
+  const qbActive = activeClient === "qbittorrent";
+  const rtActive = activeClient === "rtorrent";
+
+  const { data: qbTorrents, isLoading: qbLoading } = useAllTorrents(undefined, qbActive);
+  const { data: rtTorrents, isLoading: rtLoading } = useAllRTTorrents(undefined, rtActive);
+
   const router = useRouter();
 
   const allowedGroups = new Set<StateGroup>();
@@ -82,13 +120,67 @@ export function DownloadCard() {
   if (settings.showPaused) allowedGroups.add("paused");
   if (settings.showErrored) allowedGroups.add("errored");
 
-  const filtered = (torrents ?? [])
-    .filter((t) => allowedGroups.has(classifyState(t.state)))
-    .sort((a, b) => compareTorrents(a, b, settings.sortBy));
+  const allHidden = allowedGroups.size === 0;
+  const isLoading = activeClient === "rtorrent" ? rtLoading : qbLoading;
 
+  if (activeClient === "rtorrent") {
+    const filtered = (rtTorrents ?? [])
+      .filter((t) => allowedGroups.has(classifyRTState(t)))
+      .sort((a, b) => compareRTTorrents(a, b, settings.sortBy));
+    const displayTorrents = filtered.slice(0, settings.maxItems);
+    const hasMore = filtered.length > settings.maxItems;
+
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Downloads</CardTitle>
+          {filtered.length > 0 && (
+            <Text className="text-zinc-500 text-sm">{filtered.length}</Text>
+          )}
+        </CardHeader>
+
+        {allHidden ? (
+          <Text className="text-zinc-500 text-sm py-1">
+            All states hidden — enable one in the widget settings.
+          </Text>
+        ) : isLoading ? (
+          <SkeletonCardContent rows={3} />
+        ) : displayTorrents.length === 0 ? (
+          <EmptyState
+            icon={<CheckCircle size={32} color="#71717a" />}
+            title="Nothing to show"
+          />
+        ) : (
+          <View className="gap-3">
+            {displayTorrents.map((torrent) => (
+              <RTorrentRow
+                key={torrent.hash}
+                torrent={torrent}
+                onPress={() => router.push(`/torrent/${torrent.hash}`)}
+              />
+            ))}
+            {hasMore && (
+              <Pressable
+                onPress={() => router.push("/(tabs)/downloads")}
+                className="active:opacity-70"
+              >
+                <Text className="text-primary text-sm text-center font-medium">
+                  View All →
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        )}
+      </Card>
+    );
+  }
+
+  // qBittorrent (default)
+  const filtered = (qbTorrents ?? [])
+    .filter((t) => allowedGroups.has(classifyQBState(t.state)))
+    .sort((a, b) => compareQBTorrents(a, b, settings.sortBy));
   const displayTorrents = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;
-  const allHidden = allowedGroups.size === 0;
 
   return (
     <Card>
@@ -179,6 +271,67 @@ function TorrentRow({
             {torrent.eta > 0 && torrent.eta < ETA_UNKNOWN && (
               <Text className="text-zinc-500 text-xs">
                 ETA {formatEta(torrent.eta)}
+              </Text>
+            )}
+          </View>
+        </View>
+        <Pressable
+          onPress={handleToggle}
+          className="p-2 active:opacity-70"
+          hitSlop={8}
+        >
+          {isPaused ? (
+            <Play size={20} color="#3b82f6" />
+          ) : (
+            <Pause size={20} color="#f59e0b" />
+          )}
+        </Pressable>
+      </View>
+    </Pressable>
+  );
+}
+
+function RTorrentRow({
+  torrent,
+  onPress,
+}: {
+  torrent: RTTorrent;
+  onPress: () => void;
+}) {
+  const pauseMutation = usePauseRTTorrent();
+  const resumeMutation = useResumeRTTorrent();
+
+  const state = rtorrentStateToLabel(torrent);
+  const isPaused = state === "paused" || state === "stopped";
+  const isDownloading = state === "downloading";
+  const progress = torrent.size > 0 ? torrent.bytes_done / torrent.size : 0;
+
+  const handleToggle = () => {
+    lightHaptic();
+    if (isPaused) {
+      resumeMutation.mutate([torrent.hash]);
+    } else {
+      pauseMutation.mutate([torrent.hash]);
+    }
+  };
+
+  return (
+    <Pressable onPress={onPress} className="active:opacity-80">
+      <View className="flex-row items-center gap-3">
+        <View className="flex-1">
+          <Text className="text-zinc-200 text-sm" numberOfLines={1}>
+            {truncateText(torrent.name, 40)}
+          </Text>
+          <ProgressBar progress={progress} showLabel className="mt-1.5" />
+          <View className="flex-row gap-3 mt-1">
+            {isDownloading && torrent.dl_rate > 0 && (
+              <Text className="text-zinc-500 text-xs">
+                ↓ {formatSpeed(torrent.dl_rate)}
+              </Text>
+            )}
+            {torrent.up_rate > 0 && (
+              <Text className="text-zinc-500 text-xs">
+                ↑ {formatSpeed(torrent.up_rate)}
               </Text>
             )}
           </View>

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -16,6 +16,7 @@ import { ICON, type ServiceId } from "@/lib/constants";
 
 const SERVICE_ICONS: Partial<Record<ServiceId, React.ElementType>> = {
   qbittorrent: Download,
+  rtorrent: Download,
   radarr: Film,
   sonarr: Tv,
   overseerr: Inbox,
@@ -27,6 +28,7 @@ const SERVICE_ICONS: Partial<Record<ServiceId, React.ElementType>> = {
 
 const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   qbittorrent: "/(tabs)/downloads",
+  rtorrent: "/(tabs)/downloads",
   radarr: "/(tabs)/movies",
   sonarr: "/(tabs)/tv",
 };

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -3,12 +3,31 @@ import { ArrowDown, ArrowUp } from "lucide-react-native";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useTransferInfo } from "@/hooks/use-qbittorrent";
+import { useRTTransferInfo } from "@/hooks/use-rtorrent";
+import { useConfigStore } from "@/store/config-store";
 import { formatSpeed, formatBytes } from "@/lib/utils";
 
 export function SpeedStatsCard() {
-  const { data, isLoading } = useTransferInfo();
+  const qbEnabled = useConfigStore((s) => s.services.qbittorrent.enabled);
+  const rtEnabled = useConfigStore((s) => s.services.rtorrent.enabled);
+  const activeClient = qbEnabled ? "qbittorrent" : rtEnabled ? "rtorrent" : null;
+  const qbActive = activeClient === "qbittorrent";
+  const rtActive = activeClient === "rtorrent";
 
-  if (isLoading || !data) {
+  const { data: qbData, isLoading: qbLoading } = useTransferInfo(qbActive);
+  const { data: rtData, isLoading: rtLoading } = useRTTransferInfo(rtActive);
+
+  const isLoading = activeClient === "rtorrent" ? rtLoading : qbLoading;
+  const dlSpeed =
+    activeClient === "rtorrent" ? rtData?.dl_rate : qbData?.dl_info_speed;
+  const upSpeed =
+    activeClient === "rtorrent" ? rtData?.up_rate : qbData?.up_info_speed;
+  const dlTotal =
+    activeClient === "rtorrent" ? rtData?.dl_total : qbData?.dl_info_data;
+  const upTotal =
+    activeClient === "rtorrent" ? rtData?.up_total : qbData?.up_info_data;
+
+  if (isLoading || (dlSpeed === undefined && upSpeed === undefined)) {
     return (
       <Card className="flex-row gap-3">
         <View className="flex-1 flex-row items-center gap-3 rounded-xl p-3 bg-blue-600/10">
@@ -33,13 +52,13 @@ export function SpeedStatsCard() {
     <Card className="flex-row gap-3">
       <SpeedPill
         direction="down"
-        speed={formatSpeed(data.dl_info_speed)}
-        total={formatBytes(data.dl_info_data)}
+        speed={formatSpeed(dlSpeed ?? 0)}
+        total={formatBytes(dlTotal ?? 0)}
       />
       <SpeedPill
         direction="up"
-        speed={formatSpeed(data.up_info_speed)}
-        total={formatBytes(data.up_info_data)}
+        speed={formatSpeed(upSpeed ?? 0)}
+        total={formatBytes(upTotal ?? 0)}
       />
     </Card>
   );

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -104,7 +104,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     label: "Speed Stats",
     description: "Live download and upload speeds",
     icon: Gauge,
-    service: "qbittorrent",
+    service: null,
     component: SpeedStatsCard,
   },
   "downloads": {
@@ -112,7 +112,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     label: "Downloads",
     description: "Top active torrents with pause and resume",
     icon: Download,
-    service: "qbittorrent",
+    service: null,
     component: DownloadCard,
     settingsComponent: DownloadsSettings,
     defaultSettings: DOWNLOADS_DEFAULT_SETTINGS,

--- a/hooks/use-notification-watchers.ts
+++ b/hooks/use-notification-watchers.ts
@@ -1,14 +1,17 @@
 import { useEffect, useRef } from "react";
 import { useAllTorrents } from "@/hooks/use-qbittorrent";
+import { useAllRTTorrents } from "@/hooks/use-rtorrent";
 import { useRadarrQueue } from "@/hooks/use-radarr";
 import { useSonarrQueue } from "@/hooks/use-sonarr";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useOverseerrRequests } from "@/hooks/use-overseerr";
 import { useNotificationStore } from "@/store/notifications-store";
 import { useBackendStore } from "@/store/backend-store";
+import { useConfigStore } from "@/store/config-store";
 import { sendLocalNotification } from "@/lib/notifications";
 import { toast } from "@/components/ui/toast";
-import type { QBTorrent, TorrentState } from "@/lib/types";
+import { rtorrentStateToLabel } from "@/services/rtorrent-api";
+import type { QBTorrent, TorrentState, RTTorrent } from "@/lib/types";
 
 const DOWNLOADING_STATES: TorrentState[] = [
   "downloading",
@@ -45,6 +48,8 @@ export function useNotificationWatchers() {
     (s) => s.hydrated && !!s.sharedSecret && !!s.url && s.isHealthy,
   );
 
+  const rtEnabled = useConfigStore((s) => s.services.rtorrent.enabled);
+
   // --- qBittorrent: torrent downloading → completed ---
   const { data: torrents } = useAllTorrents();
   const prevTorrents = useRef<Map<string, QBTorrent> | null>(null);
@@ -68,6 +73,34 @@ export function useNotificationWatchers() {
     }
     prevTorrents.current = new Map(torrents.map((t) => [t.hash, t]));
   }, [torrents, hydrated, enabled, torrentCompleted, backendActive]);
+
+  // --- rTorrent: torrent downloading → completed ---
+  const { data: rtTorrents } = useAllRTTorrents();
+  const prevRTTorrents = useRef<Map<string, RTTorrent> | null>(null);
+
+  useEffect(() => {
+    if (backendActive) return;
+    if (!hydrated || !enabled || !torrentCompleted) return;
+    if (!rtEnabled || !Array.isArray(rtTorrents)) return;
+    const prev = prevRTTorrents.current;
+    if (prev !== null) {
+      for (const t of rtTorrents) {
+        const prevT = prev.get(t.hash);
+        if (prevT) {
+          const wasDownloading = rtorrentStateToLabel(prevT) === "downloading";
+          const isNowComplete = t.complete === 1 && prevT.complete === 0;
+          if (wasDownloading && isNowComplete) {
+            sendLocalNotification({
+              title: "Download complete",
+              body: t.name,
+              data: { type: "torrent", hash: t.hash },
+            });
+          }
+        }
+      }
+    }
+    prevRTTorrents.current = new Map(rtTorrents.map((t) => [t.hash, t]));
+  }, [rtTorrents, hydrated, enabled, torrentCompleted, backendActive, rtEnabled]);
 
   // --- Radarr: queue item disappears (success only) ---
   const { data: radarrQueue } = useRadarrQueue();

--- a/hooks/use-qbittorrent.ts
+++ b/hooks/use-qbittorrent.ts
@@ -16,41 +16,44 @@ function useQBEnabled() {
   return useConfigStore((s) => s.services.qbittorrent.enabled);
 }
 
-export function useTransferInfo() {
-  const enabled = useQBEnabled();
+export function useTransferInfo(enabled = true) {
+  const serviceEnabled = useQBEnabled();
   return useQuery({
     queryKey: ["qbittorrent", "transfer"],
     queryFn: getTransferInfo,
     refetchInterval: POLLING_INTERVALS.transferSpeed,
-    enabled,
+    enabled: serviceEnabled && enabled,
   });
 }
 
 export function useAllTorrents(
   filter?: "all" | "downloading" | "seeding" | "completed" | "paused" | "active" | "inactive" | "stalled",
+  enabled = true,
 ) {
-  const enabled = useQBEnabled();
+  const serviceEnabled = useQBEnabled();
   return useQuery({
     queryKey: ["qbittorrent", "torrents", filter ?? "all"],
     queryFn: () => getTorrents(filter),
     refetchInterval: POLLING_INTERVALS.activeTorrents,
-    enabled,
+    enabled: serviceEnabled && enabled,
   });
 }
 
-export function useTorrentFiles(hash: string) {
+export function useTorrentFiles(hash: string, enabled = true) {
+  const serviceEnabled = useQBEnabled();
   return useQuery({
     queryKey: ["qbittorrent", "files", hash],
     queryFn: () => getTorrentFiles(hash),
-    enabled: !!hash,
+    enabled: serviceEnabled && enabled && !!hash,
   });
 }
 
-export function useTorrentTrackers(hash: string) {
+export function useTorrentTrackers(hash: string, enabled = true) {
+  const serviceEnabled = useQBEnabled();
   return useQuery({
     queryKey: ["qbittorrent", "trackers", hash],
     queryFn: () => getTorrentTrackers(hash),
-    enabled: !!hash,
+    enabled: serviceEnabled && enabled && !!hash,
   });
 }
 

--- a/hooks/use-rtorrent.ts
+++ b/hooks/use-rtorrent.ts
@@ -1,0 +1,106 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getRtTransferInfo,
+  getRtTorrents,
+  getRtTorrentFiles,
+  getRtTorrentTrackers,
+  pauseRtTorrents,
+  resumeRtTorrents,
+  deleteRtTorrents,
+  addRtTorrentMagnet,
+} from "@/services/rtorrent-api";
+import { useConfigStore } from "@/store/config-store";
+import { POLLING_INTERVALS } from "@/lib/constants";
+
+function useRTEnabled() {
+  return useConfigStore((s) => s.services.rtorrent.enabled);
+}
+
+export function useRTTransferInfo(enabled = true) {
+  const serviceEnabled = useRTEnabled();
+  return useQuery({
+    queryKey: ["rtorrent", "transfer"],
+    queryFn: getRtTransferInfo,
+    refetchInterval: POLLING_INTERVALS.transferSpeed,
+    enabled: serviceEnabled && enabled,
+  });
+}
+
+export function useAllRTTorrents(
+  filter?: "all" | "downloading" | "seeding" | "completed" | "paused",
+  enabled = true,
+) {
+  const serviceEnabled = useRTEnabled();
+  return useQuery({
+    queryKey: ["rtorrent", "torrents", filter ?? "all"],
+    queryFn: () => getRtTorrents(filter),
+    refetchInterval: POLLING_INTERVALS.activeTorrents,
+    enabled: serviceEnabled && enabled,
+  });
+}
+
+export function useRTTorrentFiles(hash: string, enabled = true) {
+  const serviceEnabled = useRTEnabled();
+  return useQuery({
+    queryKey: ["rtorrent", "files", hash],
+    queryFn: () => getRtTorrentFiles(hash),
+    enabled: serviceEnabled && enabled && !!hash,
+  });
+}
+
+export function useRTTorrentTrackers(hash: string, enabled = true) {
+  const serviceEnabled = useRTEnabled();
+  return useQuery({
+    queryKey: ["rtorrent", "trackers", hash],
+    queryFn: () => getRtTorrentTrackers(hash),
+    enabled: serviceEnabled && enabled && !!hash,
+  });
+}
+
+export function usePauseRTTorrent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (hashes: string[]) => pauseRtTorrents(hashes),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["rtorrent", "torrents"] });
+    },
+  });
+}
+
+export function useResumeRTTorrent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (hashes: string[]) => resumeRtTorrents(hashes),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["rtorrent", "torrents"] });
+    },
+  });
+}
+
+export function useDeleteRTTorrent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      hashes,
+      deleteFiles = false,
+      basePaths,
+    }: {
+      hashes: string[];
+      deleteFiles?: boolean;
+      basePaths?: string[];
+    }) => deleteRtTorrents(hashes, deleteFiles, basePaths),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["rtorrent", "torrents"] });
+    },
+  });
+}
+
+export function useAddRTTorrent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (magnetUri: string) => addRtTorrentMagnet(magnetUri),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["rtorrent", "torrents"] });
+    },
+  });
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,5 +1,6 @@
 export const SERVICE_IDS = [
   "qbittorrent",
+  "rtorrent",
   "radarr",
   "sonarr",
   "overseerr",
@@ -21,6 +22,12 @@ export const SERVICE_DEFAULTS: Record<
     defaultPort: 8080,
     apiBasePath: "/api/v2",
     pingPath: "/app/version",
+  },
+  rtorrent: {
+    name: "rTorrent",
+    defaultPort: 8080,
+    apiBasePath: "",
+    pingPath: "",
   },
   radarr: { name: "Radarr", defaultPort: 7878, apiBasePath: "/api/v3", pingPath: "/system/status" },
   sonarr: { name: "Sonarr", defaultPort: 8989, apiBasePath: "/api/v3", pingPath: "/system/status" },

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -126,6 +126,90 @@ const DEMO_QB_TORRENTS = [
   },
 ];
 
+// --- rTorrent ---
+
+const DEMO_RT_TRANSFER_INFO = {
+  dl_rate: 5242880,
+  up_rate: 1048576,
+  dl_total: 107374182400,
+  up_total: 21474836480,
+};
+
+const DEMO_RT_TORRENTS = [
+  {
+    name: "The.Dark.Knight.2008.2160p.UHD.BluRay.x265-TERMINAL",
+    hash: "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2",
+    size: 48318382080,
+    bytes_done: 30441095168,
+    dl_rate: 4194304,
+    up_rate: 524288,
+    state: 1,
+    is_active: 1,
+    is_open: 1,
+    complete: 0,
+    ratio: 180,
+    peers_connected: 7,
+    timestamp_started: NOW_TS - 7200,
+    timestamp_finished: 0,
+    label: "movies",
+    base_path: "/downloads/movies/The.Dark.Knight.2008.2160p.UHD.BluRay.x265-TERMINAL",
+  },
+  {
+    name: "Fallout.S01E01-E08.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb",
+    hash: "B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3",
+    size: 22548578304,
+    bytes_done: 9244916736,
+    dl_rate: 1048576,
+    up_rate: 204800,
+    state: 1,
+    is_active: 1,
+    is_open: 1,
+    complete: 0,
+    ratio: 90,
+    peers_connected: 3,
+    timestamp_started: NOW_TS - 3600,
+    timestamp_finished: 0,
+    label: "tv",
+    base_path: "/downloads/tv/Fallout.S01E01-E08",
+  },
+  {
+    name: "Dune.Part.Two.2024.1080p.BluRay.x264-SPARKS",
+    hash: "C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4",
+    size: 14495514624,
+    bytes_done: 14495514624,
+    dl_rate: 0,
+    up_rate: 786432,
+    state: 1,
+    is_active: 1,
+    is_open: 1,
+    complete: 1,
+    ratio: 2140,
+    peers_connected: 22,
+    timestamp_started: NOW_TS - 86400,
+    timestamp_finished: NOW_TS - 72000,
+    label: "movies",
+    base_path: "/downloads/movies/Dune.Part.Two.2024.1080p.BluRay.x264-SPARKS",
+  },
+  {
+    name: "House.of.the.Dragon.S02E08.1080p.MAX.WEB-DL.DDP5.1.H.264-FLUX",
+    hash: "D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5",
+    size: 4831838208,
+    bytes_done: 4831838208,
+    dl_rate: 0,
+    up_rate: 0,
+    state: 1,
+    is_active: 0,
+    is_open: 1,
+    complete: 1,
+    ratio: 870,
+    peers_connected: 0,
+    timestamp_started: NOW_TS - 172800,
+    timestamp_finished: NOW_TS - 169200,
+    label: "tv",
+    base_path: "/downloads/tv/House.of.the.Dragon.S02E08",
+  },
+];
+
 // --- Radarr ---
 
 function makeMovie(id: number, title: string, year: number, tmdbId: number, hasFile: boolean) {
@@ -699,6 +783,11 @@ export function getDemoResponse(serviceId: ServiceId, path: string): unknown {
       if (normalized.startsWith("/torrents/files")) return [];
       if (normalized.startsWith("/torrents/trackers")) return [];
       if (normalized.startsWith("/app/version")) return "5.0.0";
+      return undefined;
+    }
+    case "rtorrent": {
+      if (path === "transfer") return DEMO_RT_TRANSFER_INFO;
+      if (path === "torrents") return DEMO_RT_TORRENTS;
       return undefined;
     }
     default:

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -135,6 +135,32 @@ export async function pingService(serviceId: ServiceId, urlOverride?: string): P
   const baseUrl = urlOverride ?? store.getActiveUrl(serviceId);
   if (!baseUrl) return null;
 
+  // rTorrent is pinged via XML-RPC POST, not a REST GET
+  if (serviceId === "rtorrent") {
+    if (useConfigStore.getState().demoMode) return 45;
+    const body =
+      '<?xml version="1.0"?><methodCall><methodName>system.client_version</methodName><params/></methodCall>';
+    const pingHeaders = new Headers({ "Content-Type": "application/xml" });
+    if (secrets.username && secrets.password) {
+      pingHeaders.set("Authorization", `Basic ${btoa(`${secrets.username}:${secrets.password}`)}`);
+    }
+    const start = Date.now();
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+      const response = await fetch(baseUrl, {
+        method: "POST",
+        headers: pingHeaders,
+        body,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      return response.status < 500 ? Date.now() - start : null;
+    } catch {
+      return null;
+    }
+  }
+
   const url = buildUrl(baseUrl, defaults.apiBasePath, defaults.pingPath);
 
   const headers = new Headers();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -768,6 +768,51 @@ export interface BazarrProvider {
   retry?: string;
 }
 
+// --- rTorrent Types ---
+
+export type RTorrentState = "downloading" | "seeding" | "paused" | "stopped" | "error";
+
+export interface RTTransferInfo {
+  dl_rate: number;
+  up_rate: number;
+  dl_total: number;
+  up_total: number;
+}
+
+export interface RTTorrent {
+  hash: string;
+  name: string;
+  size: number;
+  bytes_done: number;
+  dl_rate: number;
+  up_rate: number;
+  state: number;
+  is_active: number;
+  is_open: number;
+  complete: number;
+  ratio: number; // x1000 — divide by 1000 for display
+  peers_connected: number;
+  timestamp_started: number;
+  timestamp_finished: number;
+  label: string;
+  base_path: string;
+}
+
+export interface RTTorrentFile {
+  path: string;
+  size_bytes: number;
+  completed_chunks: number;
+  size_chunks: number;
+  priority: number;
+}
+
+export interface RTTorrentTracker {
+  url: string;
+  activity_time_last: number;
+  scrape_complete: number;
+  scrape_incomplete: number;
+}
+
 // --- Shared Types ---
 
 export interface ServiceHealthStatus {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-updates": "~29.0.16",
+    "fast-xml-parser": "^5.7.2",
     "lucide-react-native": "^1.7.0",
     "nativewind": "^4.1.0",
     "react": "19.1.0",

--- a/services/rtorrent-api.ts
+++ b/services/rtorrent-api.ts
@@ -1,0 +1,344 @@
+import { XMLParser } from "fast-xml-parser";
+import { useConfigStore } from "@/store/config-store";
+import { getDemoResponse } from "@/lib/demo-data";
+import type { RTTorrent, RTTorrentFile, RTTorrentTracker, RTTransferInfo } from "@/lib/types";
+
+// --- XML-RPC builder ---
+
+type XmlRpcParam = string | number;
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function xmlRpcString(v: string): string {
+  return `<value><string>${escapeXml(v)}</string></value>`;
+}
+
+function xmlRpcParam(v: XmlRpcParam): string {
+  if (typeof v === "number") return `<value><i8>${Math.trunc(v)}</i8></value>`;
+  return xmlRpcString(v);
+}
+
+function buildXmlRpcCall(methodName: string, params: XmlRpcParam[]): string {
+  const paramsXml = params.map((p) => `<param>${xmlRpcParam(p)}</param>`).join("");
+  return `<?xml version="1.0"?><methodCall><methodName>${escapeXml(methodName)}</methodName><params>${paramsXml}</params></methodCall>`;
+}
+
+function buildSystemMulticall(calls: Array<{ method: string; params: XmlRpcParam[] }>): string {
+  const items = calls
+    .map((c) => {
+      const paramsXml = c.params.map(xmlRpcParam).join("");
+      return `<value><struct>
+<member><name>methodName</name>${xmlRpcString(c.method)}</member>
+<member><name>params</name><value><array><data>${paramsXml}</data></array></value></member>
+</struct></value>`;
+    })
+    .join("");
+  return `<?xml version="1.0"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data>${items}</data></array></value></param></params></methodCall>`;
+}
+
+// --- XML-RPC response parser ---
+
+const XMLRPC_PARSER = new XMLParser({
+  ignoreAttributes: true,
+  parseTagValue: true,
+  isArray: (name) => name === "value" || name === "member",
+  numberParseOptions: { leadingZeros: false, hex: false },
+  removeNSPrefix: true,
+});
+
+function parseXmlRpcValueNode(node: unknown): unknown {
+  if (node === undefined || node === null) return null;
+  if (typeof node === "string" || typeof node === "number" || typeof node === "boolean") return node;
+  const n = node as Record<string, unknown>;
+  if ("string" in n) return String(n.string ?? "");
+  if ("i8" in n) return Number(n.i8);
+  if ("i4" in n) return Number(n.i4);
+  if ("int" in n) return Number(n.int);
+  if ("double" in n) return Number(n.double);
+  if ("boolean" in n) return n.boolean === 1 || n.boolean === "1" || n.boolean === true;
+  if ("array" in n) {
+    const data = (n.array as Record<string, unknown> | null)?.data as Record<string, unknown> | null;
+    if (!data || !("value" in data)) return [];
+    const values = Array.isArray(data.value) ? data.value : [data.value];
+    return values.map(parseXmlRpcValueNode);
+  }
+  if ("struct" in n) {
+    const result: Record<string, unknown> = {};
+    const members = (n.struct as Record<string, unknown>)?.member;
+    if (!members) return result;
+    const memberList = Array.isArray(members) ? members : [members];
+    for (const m of memberList) {
+      if (!m) continue;
+      const mb = m as Record<string, unknown>;
+      const valueArr = mb.value;
+      const vNode = Array.isArray(valueArr) ? valueArr[0] : valueArr;
+      result[String(mb.name)] = parseXmlRpcValueNode(vNode);
+    }
+    return result;
+  }
+  return node;
+}
+
+function parseXmlRpcResponse(xml: string): unknown {
+  const doc = XMLRPC_PARSER.parse(xml) as Record<string, unknown>;
+  const mr = doc.methodResponse as Record<string, unknown>;
+  if (mr.fault) {
+    const faultVal = ((mr.fault as Record<string, unknown>).value as unknown[]) ?? [];
+    const fault = parseXmlRpcValueNode(faultVal[0]) as Record<string, unknown>;
+    const message = fault?.faultString ?? JSON.stringify(fault);
+    throw new Error(`rTorrent error: ${message}`);
+  }
+  const params = mr.params as Record<string, unknown>;
+  const param = params.param;
+  const paramItem = Array.isArray(param) ? param[0] : param;
+  const valueArr = (paramItem as Record<string, unknown>).value;
+  const valueNode = Array.isArray(valueArr) ? valueArr[0] : valueArr;
+  return parseXmlRpcValueNode(valueNode);
+}
+
+// --- HTTP transport ---
+
+const DEFAULT_TIMEOUT = 15000;
+
+async function rtRequest(body: string): Promise<unknown> {
+  const store = useConfigStore.getState();
+
+  if (store.demoMode) {
+    await new Promise((r) => setTimeout(r, 80 + Math.random() * 120));
+    return null; // caller uses demo data via getDemoResponse
+  }
+
+  const baseUrl = store.getActiveUrl("rtorrent");
+  if (!baseUrl) throw new Error("No URL configured for rTorrent");
+
+  const secrets = store.secrets.rtorrent;
+  const headers = new Headers({ "Content-Type": "application/xml" });
+  if (secrets.username && secrets.password) {
+    headers.set("Authorization", `Basic ${btoa(`${secrets.username}:${secrets.password}`)}`);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+  try {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers,
+      body,
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`rTorrent request failed: ${response.status}`);
+    const text = await response.text();
+    return parseXmlRpcResponse(text);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// --- State helper ---
+
+export function rtorrentStateToLabel(t: RTTorrent): import("@/lib/types").RTorrentState {
+  if (t.is_open === 0) return "stopped";
+  if (t.is_active === 0) return "paused";
+  if (t.complete === 1) return "seeding";
+  return "downloading";
+}
+
+// --- Field definitions (positional — order must match d.multicall2 call) ---
+
+const TORRENT_FIELDS = [
+  "d.name=",
+  "d.hash=",
+  "d.size_bytes=",
+  "d.bytes_done=",
+  "d.down.rate=",
+  "d.up.rate=",
+  "d.state=",
+  "d.is_active=",
+  "d.is_open=",
+  "d.complete=",
+  "d.ratio=",
+  "d.peers_connected=",
+  "d.timestamp.started=",
+  "d.timestamp.finished=",
+  "d.custom1=",
+  "d.base_path=",
+];
+
+function mapTorrentFields(fields: unknown[]): RTTorrent {
+  return {
+    name: String(fields[0] ?? ""),
+    hash: String(fields[1] ?? ""),
+    size: Number(fields[2] ?? 0),
+    bytes_done: Number(fields[3] ?? 0),
+    dl_rate: Number(fields[4] ?? 0),
+    up_rate: Number(fields[5] ?? 0),
+    state: Number(fields[6] ?? 0),
+    is_active: Number(fields[7] ?? 0),
+    is_open: Number(fields[8] ?? 0),
+    complete: Number(fields[9] ?? 0),
+    ratio: Number(fields[10] ?? 0),
+    peers_connected: Number(fields[11] ?? 0),
+    timestamp_started: Number(fields[12] ?? 0),
+    timestamp_finished: Number(fields[13] ?? 0),
+    label: String(fields[14] ?? ""),
+    base_path: String(fields[15] ?? ""),
+  };
+}
+
+type RTorrentFilter = "all" | "downloading" | "seeding" | "completed" | "paused";
+
+const FILTER_VIEW: Record<RTorrentFilter, string> = {
+  all: "main",
+  downloading: "leeching",
+  seeding: "seeding",
+  completed: "complete",
+  paused: "stopped",
+};
+
+// --- API functions ---
+
+export async function getRtTransferInfo(): Promise<RTTransferInfo> {
+  const store = useConfigStore.getState();
+  if (store.demoMode) {
+    await new Promise((r) => setTimeout(r, 80 + Math.random() * 120));
+    return getDemoResponse("rtorrent", "transfer") as RTTransferInfo;
+  }
+
+  const body = buildSystemMulticall([
+    { method: "throttle.global_down.rate", params: [] },
+    { method: "throttle.global_up.rate", params: [] },
+    { method: "throttle.global_down.total", params: [] },
+    { method: "throttle.global_up.total", params: [] },
+  ]);
+  const results = (await rtRequest(body)) as unknown[][];
+  return {
+    dl_rate: Number((results[0] as unknown[])[0] ?? 0),
+    up_rate: Number((results[1] as unknown[])[0] ?? 0),
+    dl_total: Number((results[2] as unknown[])[0] ?? 0),
+    up_total: Number((results[3] as unknown[])[0] ?? 0),
+  };
+}
+
+export async function getRtTorrents(filter?: RTorrentFilter): Promise<RTTorrent[]> {
+  const store = useConfigStore.getState();
+  if (store.demoMode) {
+    await new Promise((r) => setTimeout(r, 80 + Math.random() * 120));
+    return getDemoResponse("rtorrent", "torrents") as RTTorrent[];
+  }
+
+  const view = FILTER_VIEW[filter ?? "all"];
+  const body = buildXmlRpcCall("d.multicall2", ["", view, ...TORRENT_FIELDS]);
+  const results = (await rtRequest(body)) as unknown[][];
+  if (!Array.isArray(results)) {
+    return [];
+  }
+  return results.map((fields) => mapTorrentFields(fields as unknown[]));
+}
+
+export async function getRtTorrentFiles(hash: string): Promise<RTTorrentFile[]> {
+  const store = useConfigStore.getState();
+  if (store.demoMode) {
+    await new Promise((r) => setTimeout(r, 80 + Math.random() * 120));
+    return [];
+  }
+
+  const body = buildXmlRpcCall("f.multicall", [
+    hash,
+    "",
+    "f.path=",
+    "f.size_bytes=",
+    "f.completed_chunks=",
+    "f.size_chunks=",
+    "f.priority=",
+  ]);
+  const results = (await rtRequest(body)) as unknown[][];
+  if (!Array.isArray(results)) return [];
+  return results.map((fields) => ({
+    path: String((fields as unknown[])[0] ?? ""),
+    size_bytes: Number((fields as unknown[])[1] ?? 0),
+    completed_chunks: Number((fields as unknown[])[2] ?? 0),
+    size_chunks: Number((fields as unknown[])[3] ?? 1),
+    priority: Number((fields as unknown[])[4] ?? 0),
+  }));
+}
+
+export async function getRtTorrentTrackers(hash: string): Promise<RTTorrentTracker[]> {
+  const store = useConfigStore.getState();
+  if (store.demoMode) {
+    await new Promise((r) => setTimeout(r, 80 + Math.random() * 120));
+    return [];
+  }
+
+  const body = buildXmlRpcCall("t.multicall", [
+    hash,
+    "",
+    "t.url=",
+    "t.scrape_time_last=",
+    "t.scrape_complete=",
+    "t.scrape_incomplete=",
+  ]);
+  const results = (await rtRequest(body)) as unknown[][];
+  if (!Array.isArray(results)) return [];
+  return results.map((fields) => ({
+    url: String((fields as unknown[])[0] ?? ""),
+    activity_time_last: Number((fields as unknown[])[1] ?? 0),
+    scrape_complete: Number((fields as unknown[])[2] ?? 0),
+    scrape_incomplete: Number((fields as unknown[])[3] ?? 0),
+  }));
+}
+
+export async function pauseRtTorrents(hashes: string[]): Promise<void> {
+  if (!hashes.length) return;
+  const body = buildSystemMulticall(hashes.map((h) => ({ method: "d.stop", params: [h] })));
+  await rtRequest(body);
+}
+
+export async function resumeRtTorrents(hashes: string[]): Promise<void> {
+  if (!hashes.length) return;
+  const body = buildSystemMulticall(hashes.map((h) => ({ method: "d.start", params: [h] })));
+  await rtRequest(body);
+}
+
+export async function deleteRtTorrents(
+  hashes: string[],
+  deleteFiles = false,
+  basePaths?: string[],
+): Promise<void> {
+  if (!hashes.length) return;
+
+  if (deleteFiles && basePaths && basePaths.length === hashes.length) {
+    const calls: Array<{ method: string; params: XmlRpcParam[] }> = [];
+    for (let i = 0; i < hashes.length; i++) {
+      const bp = basePaths[i];
+      if (bp) {
+        calls.push({ method: "execute.throw", params: ["rm", "-rf", bp] });
+      }
+      calls.push({ method: "d.erase", params: [hashes[i]!] });
+    }
+    const body = buildSystemMulticall(calls);
+    await rtRequest(body);
+  } else {
+    const body = buildSystemMulticall(hashes.map((h) => ({ method: "d.erase", params: [h] })));
+    await rtRequest(body);
+  }
+}
+
+export async function addRtTorrentMagnet(magnetUri: string): Promise<void> {
+  const body = buildXmlRpcCall("load.start", ["", magnetUri]);
+  await rtRequest(body);
+}
+
+export async function setRtDownloadLimit(limit: number): Promise<void> {
+  const body = buildXmlRpcCall("throttle.global_down.max_rate.set_kb", [Math.floor(limit / 1024)]);
+  await rtRequest(body);
+}
+
+export async function setRtUploadLimit(limit: number): Promise<void> {
+  const body = buildXmlRpcCall("throttle.global_up.max_rate.set_kb", [Math.floor(limit / 1024)]);
+  await rtRequest(body);
+}


### PR DESCRIPTION
This pull request adds full support for rTorrent as a downloads client alongside qBittorrent in the app. The downloads screen, multi-select actions, and torrent list rendering have been refactored to support switching between qBittorrent and rTorrent, with appropriate hooks, UI, and bulk actions for both clients. Additionally, rTorrent is now integrated into the services and settings screens, including iconography and URL placeholders.

**rTorrent client integration:**

* The downloads screen (`downloads.tsx`) now supports both qBittorrent and rTorrent, with logic to select the active client based on configuration. All torrent actions (list, add, pause/resume, delete, multi-select) are implemented for rTorrent using new hooks and helpers. The UI adapts to the active client, including error handling and list rendering. [[1]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eR31-R45) [[2]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eR90-R171) [[3]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eR184-R195) [[4]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eL125-R315) [[5]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eL204-R336) [[6]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eL246-R366) [[7]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eL287-R447) [[8]](diffhunk://#diff-1c25fb2059e466e28ab102d13374d236bd17c044181a65a53b08f1a45425d69eR655-R771)

* A new `RTorrentListItem` component is added for displaying rTorrent torrents, supporting pause/resume, delete (with/without files), and selection UI.

**Service and settings screen updates:**

* rTorrent is now recognized as a first-class service in the services and settings screens, with appropriate icons and navigation routes. [[1]](diffhunk://#diff-6c5df3c0fdbd22caa0c791ddc1e1a5c0fb3d2f20abeacbf8a6ece7f09d9280f5R23) [[2]](diffhunk://#diff-6c5df3c0fdbd22caa0c791ddc1e1a5c0fb3d2f20abeacbf8a6ece7f09d9280f5R36) [[3]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938R49)

* Added URL placeholders for rTorrent in the settings screen to guide users during configuration.

* The service editor logic is updated to treat rTorrent similarly to qBittorrent for relevant UI and configuration behaviors. [[1]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938R443-R444) [[2]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L443-R457)