### PR TITLE
feat: add Jellyfin support with new API integration and UI components

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -34,6 +34,7 @@ export default function TabLayout() {
       <Tabs.Screen name="activity" options={{ href: null }} />
       <Tabs.Screen name="indexers" options={{ href: null }} />
       <Tabs.Screen name="plex" options={{ href: null }} />
+      <Tabs.Screen name="jellyfin" options={{ href: null }} />
       <Tabs.Screen name="glances" options={{ href: null }} />
       <Tabs.Screen name="bazarr" options={{ href: null }} />
       <Tabs.Screen

--- a/app/(tabs)/jellyfin.tsx
+++ b/app/(tabs)/jellyfin.tsx
@@ -1,0 +1,379 @@
+import { useState } from "react";
+import { View, Text, Image, ScrollView } from "react-native";
+import {
+  Play,
+  Pause,
+  Loader,
+  Library,
+  Tv,
+  ArrowUpDown,
+  Check,
+} from "lucide-react-native";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { ServiceHeader } from "@/components/common/service-header";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FilterChip } from "@/components/ui/filter-chip";
+import { ProgressBar } from "@/components/ui/progress-bar";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton, SkeletonCardContent } from "@/components/ui/skeleton";
+import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
+import { SortButton } from "@/components/ui/sort-button";
+import {
+  useSortStore,
+  SORT_DEFAULTS,
+  type JellyfinRecentSortKey,
+} from "@/store/sort-store";
+import {
+  useJellyfinLibraries,
+  useJellyfinRecentlyAdded,
+  useJellyfinResumeItems,
+  useJellyfinSessions,
+} from "@/hooks/use-jellyfin";
+import { getJellyfinImageUrl, isJellyfinTranscoding, ticksToMs } from "@/services/jellyfin-api";
+import { useServiceHealth } from "@/hooks/use-service-health";
+import { usePullToRefresh } from "@/components/common/pull-to-refresh";
+import { truncateText } from "@/lib/utils";
+import type { JellyfinItem, JellyfinLibrary, JellyfinSession } from "@/lib/types";
+
+type Tab = "playing" | "recent" | "resume" | "libraries";
+
+const RECENT_SORT_OPTIONS: { key: JellyfinRecentSortKey; label: string }[] = [
+  { key: "added-desc", label: "Recently Added" },
+  { key: "title-asc", label: "Title: A → Z" },
+  { key: "title-desc", label: "Title: Z → A" },
+  { key: "year-desc", label: "Year: Newest First" },
+  { key: "year-asc", label: "Year: Oldest First" },
+];
+
+function recentTitle(item: JellyfinItem): string {
+  return item.SeriesName || item.Name;
+}
+
+function addedAtMs(item: JellyfinItem): number {
+  if (item.DateCreated) {
+    const t = Date.parse(item.DateCreated);
+    if (!Number.isNaN(t)) return t;
+  }
+  return 0;
+}
+
+function compareRecent(
+  a: JellyfinItem,
+  b: JellyfinItem,
+  sort: JellyfinRecentSortKey,
+): number {
+  switch (sort) {
+    case "added-desc":
+      return addedAtMs(b) - addedAtMs(a);
+    case "title-asc":
+      return recentTitle(a).localeCompare(recentTitle(b));
+    case "title-desc":
+      return recentTitle(b).localeCompare(recentTitle(a));
+    case "year-desc":
+      return (b.ProductionYear ?? 0) - (a.ProductionYear ?? 0);
+    case "year-asc":
+      return (a.ProductionYear ?? 0) - (b.ProductionYear ?? 0);
+  }
+}
+
+export default function JellyfinScreen() {
+  const [tab, setTab] = useState<Tab>("playing");
+  const recentSort = useSortStore((s) => s.jellyfinRecent);
+  const setRecentSort = useSortStore((s) => s.setJellyfinRecent);
+  const [recentSortOpen, setRecentSortOpen] = useState(false);
+  const { data: healthData } = useServiceHealth();
+  const { refreshing, onRefresh } = usePullToRefresh([["jellyfin"]]);
+
+  const jellyfinHealth = healthData?.find((s) => s.id === "jellyfin");
+
+  return (
+    <ScreenWrapper refreshing={refreshing} onRefresh={onRefresh}>
+      <ServiceHeader name="Jellyfin" online={jellyfinHealth?.online} />
+
+      <View className="flex-row items-center gap-2 mb-4">
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerClassName="gap-2"
+          className="flex-1"
+        >
+          {(["playing", "recent", "resume", "libraries"] as Tab[]).map((t) => (
+            <FilterChip
+              key={t}
+              label={
+                t === "playing"
+                  ? "Now Playing"
+                  : t === "resume"
+                    ? "Continue Watching"
+                    : t.charAt(0).toUpperCase() + t.slice(1)
+              }
+              selected={tab === t}
+              onPress={() => setTab(t)}
+            />
+          ))}
+        </ScrollView>
+        {tab === "recent" && (
+          <SortButton
+            onPress={() => setRecentSortOpen(true)}
+            active={recentSort !== SORT_DEFAULTS.jellyfinRecent}
+          />
+        )}
+      </View>
+
+      {tab === "playing" && <NowPlaying />}
+      {tab === "recent" && <RecentlyAdded sort={recentSort} />}
+      {tab === "resume" && <ContinueWatching />}
+      {tab === "libraries" && <Libraries />}
+
+      <ActionSheet
+        visible={recentSortOpen}
+        onClose={() => setRecentSortOpen(false)}
+        title="Sort recently added"
+        actions={RECENT_SORT_OPTIONS.map<ActionSheetAction>((opt) => ({
+          label: opt.label,
+          icon:
+            recentSort === opt.key ? (
+              <Check size={18} color="#3b82f6" />
+            ) : (
+              <ArrowUpDown size={18} color="#71717a" />
+            ),
+          onPress: () => setRecentSort(opt.key),
+        }))}
+      />
+    </ScreenWrapper>
+  );
+}
+
+function NowPlaying() {
+  const { data: sessions, isLoading } = useJellyfinSessions();
+
+  if (isLoading) return <SkeletonCardContent rows={2} />;
+  if (!sessions?.length) {
+    return (
+      <EmptyState
+        icon={<Play size={32} color="#71717a" />}
+        title="Nothing playing"
+        message="No active Jellyfin streams"
+      />
+    );
+  }
+
+  return (
+    <View className="gap-3">
+      {sessions.map((session) => (
+        <SessionCard key={session.Id} session={session} />
+      ))}
+    </View>
+  );
+}
+
+function SessionCard({ session }: { session: JellyfinSession }) {
+  const item = session.NowPlayingItem;
+  const durationMs = ticksToMs(item?.RunTimeTicks);
+  const positionMs = ticksToMs(session.PlayState?.PositionTicks);
+  const progress = durationMs > 0 ? positionMs / durationMs : 0;
+
+  const isPaused = !!session.PlayState?.IsPaused;
+  const transcoding = isJellyfinTranscoding(session);
+  const StateIcon = isPaused ? Pause : transcoding ? Loader : Play;
+  const stateColor = isPaused ? "#f59e0b" : transcoding ? "#f59e0b" : "#22c55e";
+
+  const title =
+    item?.Type === "Episode" && item.SeriesName
+      ? `${item.SeriesName} — ${item.Name}`
+      : (item?.Name ?? "Unknown");
+
+  const thumbUrl = getJellyfinImageUrl(item, "Primary", 80, 120);
+
+  const playMethod = session.PlayState?.PlayMethod ?? "DirectPlay";
+  const transcodeLabel =
+    playMethod === "DirectPlay"
+      ? "Direct Play"
+      : playMethod === "DirectStream"
+        ? "Direct Stream"
+        : "Transcode";
+
+  return (
+    <Card className="flex-row gap-3">
+      {thumbUrl ? (
+        <Image
+          source={{ uri: thumbUrl }}
+          className="w-14 h-20 rounded-lg bg-surface-light"
+          resizeMode="cover"
+        />
+      ) : (
+        <View className="w-14 h-20 rounded-lg bg-surface-light items-center justify-center">
+          <Play size={18} color="#71717a" />
+        </View>
+      )}
+      <View className="flex-1">
+        <View className="flex-row items-center gap-1.5 mb-1">
+          <StateIcon size={14} color={stateColor} />
+          <Text className="text-zinc-200 text-sm flex-1" numberOfLines={1}>
+            {truncateText(title, 30)}
+          </Text>
+        </View>
+        <ProgressBar progress={progress} className="mb-1.5" />
+        <View className="flex-row items-center gap-2">
+          <Badge
+            label={transcodeLabel}
+            variant={transcodeLabel === "Direct Play" ? "success" : "warning"}
+          />
+        </View>
+        <Text className="text-zinc-500 text-xs mt-1">
+          {[session.UserName, session.Client, session.DeviceName]
+            .filter(Boolean)
+            .join(" · ")}
+        </Text>
+      </View>
+    </Card>
+  );
+}
+
+function RecentlyAdded({ sort }: { sort: JellyfinRecentSortKey }) {
+  const { data: items, isLoading } = useJellyfinRecentlyAdded();
+
+  if (isLoading) {
+    return (
+      <View className="flex-row flex-wrap gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <View key={i} className="w-[30%]">
+            <Skeleton width="100%" height={150} borderRadius={12} />
+            <Skeleton width="75%" height={10} borderRadius={4} className="mt-1.5" />
+          </View>
+        ))}
+      </View>
+    );
+  }
+  if (!items?.length) {
+    return <EmptyState title="Nothing recently added" />;
+  }
+
+  const sorted = [...items].sort((a, b) => compareRecent(a, b, sort));
+
+  return (
+    <View className="flex-row flex-wrap gap-3">
+      {sorted.map((item) => (
+        <MediaPoster key={item.Id} item={item} />
+      ))}
+    </View>
+  );
+}
+
+function ContinueWatching() {
+  const { data: items, isLoading } = useJellyfinResumeItems();
+
+  if (isLoading) return <SkeletonCardContent rows={3} />;
+  if (!items?.length) {
+    return <EmptyState title="Nothing to resume" />;
+  }
+
+  return (
+    <View className="gap-2">
+      {items.map((item) => {
+        const thumbUrl = getJellyfinImageUrl(item, "Primary", 80, 120);
+        const title =
+          item.Type === "Episode" && item.SeriesName
+            ? `${item.SeriesName} — ${item.Name}`
+            : item.Name;
+        const durationMs = ticksToMs(item.RunTimeTicks);
+        const positionMs = ticksToMs(item.UserData?.PlaybackPositionTicks);
+        const progress =
+          item.UserData?.PlayedPercentage != null
+            ? item.UserData.PlayedPercentage / 100
+            : durationMs > 0
+              ? positionMs / durationMs
+              : 0;
+
+        return (
+          <Card key={item.Id} className="flex-row gap-3">
+            {thumbUrl ? (
+              <Image
+                source={{ uri: thumbUrl }}
+                className="w-14 h-20 rounded-lg bg-surface-light"
+                resizeMode="cover"
+              />
+            ) : (
+              <View className="w-14 h-20 rounded-lg bg-surface-light items-center justify-center">
+                <Tv size={18} color="#71717a" />
+              </View>
+            )}
+            <View className="flex-1 justify-center">
+              <Text className="text-zinc-200 text-sm" numberOfLines={1}>
+                {title}
+              </Text>
+              {item.Type === "Episode" && item.ParentIndexNumber != null && item.IndexNumber != null && (
+                <Text className="text-zinc-500 text-xs">
+                  S{item.ParentIndexNumber} · E{item.IndexNumber}
+                </Text>
+              )}
+              {item.ProductionYear && (
+                <Text className="text-zinc-600 text-xs">{item.ProductionYear}</Text>
+              )}
+              <ProgressBar progress={progress} className="mt-1.5" />
+            </View>
+          </Card>
+        );
+      })}
+    </View>
+  );
+}
+
+function Libraries() {
+  const { data: libraries, isLoading } = useJellyfinLibraries();
+
+  if (isLoading) return <SkeletonCardContent rows={3} />;
+  if (!libraries?.length) {
+    return <EmptyState title="No libraries found" />;
+  }
+
+  return (
+    <View className="gap-2">
+      {libraries.map((lib) => (
+        <LibraryRow key={lib.Id} lib={lib} />
+      ))}
+    </View>
+  );
+}
+
+function LibraryRow({ lib }: { lib: JellyfinLibrary }) {
+  return (
+    <Card className="flex-row items-center gap-3">
+      <View className="bg-surface-light rounded-xl p-2.5">
+        <Library size={20} color="#a1a1aa" />
+      </View>
+      <View className="flex-1">
+        <Text className="text-zinc-200 text-sm font-medium">{lib.Name}</Text>
+        {lib.CollectionType && (
+          <Text className="text-zinc-500 text-xs capitalize">{lib.CollectionType}</Text>
+        )}
+      </View>
+    </Card>
+  );
+}
+
+function MediaPoster({ item }: { item: JellyfinItem }) {
+  const thumbUrl = getJellyfinImageUrl(item, "Primary", 200, 300);
+  const title =
+    item.Type === "Episode" && item.SeriesName ? item.SeriesName : item.Name;
+
+  return (
+    <View className="w-[30%]">
+      {thumbUrl ? (
+        <Image
+          source={{ uri: thumbUrl }}
+          className="w-full aspect-[2/3] rounded-xl bg-surface-light"
+          resizeMode="cover"
+        />
+      ) : (
+        <View className="w-full aspect-[2/3] rounded-xl bg-surface-light items-center justify-center">
+          <Play size={24} color="#71717a" />
+        </View>
+      )}
+      <Text className="text-zinc-300 text-xs mt-1" numberOfLines={1}>
+        {title}
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -8,6 +8,7 @@ import {
   BarChart3,
   Search,
   PlayCircle,
+  Clapperboard,
   Server,
   Captions,
   Zap,
@@ -26,6 +27,7 @@ const SERVICE_ICONS: Record<ServiceId, React.ElementType> = {
   tautulli: BarChart3,
   prowlarr: Search,
   plex: PlayCircle,
+  jellyfin: Clapperboard,
   glances: Server,
   bazarr: Captions,
 };
@@ -38,6 +40,7 @@ const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   tautulli: "/(tabs)/activity",
   prowlarr: "/(tabs)/indexers",
   plex: "/(tabs)/plex",
+  jellyfin: "/(tabs)/jellyfin",
   glances: "/(tabs)/glances",
   bazarr: "/(tabs)/bazarr",
 };

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -10,6 +10,7 @@ import {
   BarChart3,
   Search,
   PlayCircle,
+  Clapperboard,
   Server,
   Captions,
   ChevronRight,
@@ -52,6 +53,7 @@ const SERVICE_ICONS: Record<ServiceId, React.ElementType> = {
   tautulli: BarChart3,
   prowlarr: Search,
   plex: PlayCircle,
+  jellyfin: Clapperboard,
   glances: Server,
   bazarr: Captions,
 };

--- a/backend/dashboarr-backend/src/index.ts
+++ b/backend/dashboarr-backend/src/index.ts
@@ -48,7 +48,7 @@ async function writeWebhookUrlsFile(publicUrl: string, dataDir: string): Promise
     "# Back-compat — secret in the URL path (works with services that can't send custom headers):",
   ];
   for (const id of SERVICE_IDS) {
-    if (id === "qbittorrent" || id === "prowlarr" || id === "plex" || id === "glances") continue;
+    if (id === "qbittorrent" || id === "prowlarr" || id === "plex" || id === "jellyfin" || id === "glances") continue;
     lines.push(`${id.padEnd(10)} ${webhookBase}/${id}/${webhookSecret}`);
   }
   const content = lines.join("\n") + "\n";

--- a/backend/dashboarr-backend/src/services/http.ts
+++ b/backend/dashboarr-backend/src/services/http.ts
@@ -74,6 +74,12 @@ function applyAuth(headers: Headers, config: StoredServiceConfig): void {
     }
     return;
   }
+  if (id === "jellyfin") {
+    if (config.apiKey) {
+      headers.set("X-Emby-Token", config.apiKey);
+    }
+    return;
+  }
   if (config.apiKey) {
     headers.set("X-Api-Key", config.apiKey);
   }

--- a/backend/dashboarr-backend/src/types.ts
+++ b/backend/dashboarr-backend/src/types.ts
@@ -8,6 +8,7 @@ export const SERVICE_IDS = [
   "tautulli",
   "prowlarr",
   "plex",
+  "jellyfin",
   "glances",
   "bazarr",
 ] as const;
@@ -103,6 +104,7 @@ export const SERVICE_API_BASE: Record<ServiceId, string> = {
   tautulli: "/api/v2",
   prowlarr: "/api/v1",
   plex: "",
+  jellyfin: "",
   glances: "/api/4",
   bazarr: "/api",
 };
@@ -115,6 +117,7 @@ export const SERVICE_PING_PATH: Record<ServiceId, string> = {
   tautulli: "/home",
   prowlarr: "/system/status",
   plex: "/identity",
+  jellyfin: "/System/Info/Public",
   glances: "/cpu",
   bazarr: "/system/status",
 };

--- a/components/dashboard/jellyfin-now-playing-card.tsx
+++ b/components/dashboard/jellyfin-now-playing-card.tsx
@@ -1,0 +1,188 @@
+import { View, Text, Pressable } from "react-native";
+import { useRouter } from "expo-router";
+import { Play, Pause, Loader, PlayCircle, Cog } from "lucide-react-native";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ProgressBar } from "@/components/ui/progress-bar";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SkeletonCardContent } from "@/components/ui/skeleton";
+import { useJellyfinSessions } from "@/hooks/use-jellyfin";
+import { isJellyfinTranscoding, ticksToMs } from "@/services/jellyfin-api";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import {
+  JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS,
+  type JellyfinNowPlayingSettingsValue,
+} from "@/components/dashboard/widget-settings/jellyfin-now-playing-settings";
+import { truncateText } from "@/lib/utils";
+import type { JellyfinSession } from "@/lib/types";
+
+function parseHiddenUsers(value: string): Set<string> {
+  return new Set(
+    value
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+// Jellyfin doesn't tag sessions as local/remote like Plex does, so we sniff
+// the RemoteEndPoint for the standard RFC1918 ranges + IPv6 link-local/ULA.
+// Good enough for "hide my own TV from the dashboard" — not a security boundary.
+function isLocalEndpoint(remote: string | undefined): boolean {
+  if (!remote) return false;
+  const r = remote.toLowerCase().trim();
+  if (!r) return false;
+
+  // Bracketed IPv6 like `[::1]:8443` — pull the address from inside the brackets.
+  // Bare IPv6 (e.g. `fe80::abc`) is left intact since splitting on `:` would
+  // shred it; for IPv4 / hostnames we strip a trailing `:port` if present.
+  let host: string;
+  if (r.startsWith("[")) {
+    const end = r.indexOf("]");
+    host = end > 1 ? r.slice(1, end) : r.slice(1);
+  } else if (r.includes(".") || r.split(":").length === 2) {
+    host = r.split(":")[0]!;
+  } else {
+    host = r;
+  }
+
+  if (!host) return false;
+  if (host === "127.0.0.1" || host === "::1" || host === "localhost") return true;
+  if (host.startsWith("10.")) return true;
+  if (host.startsWith("192.168.")) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  // IPv6 link-local (fe80::/10) and ULA (fc00::/7).
+  if (host.startsWith("fe80:") || host.startsWith("fe80::")) return true;
+  if (host.startsWith("fc") || host.startsWith("fd")) return true;
+  return false;
+}
+
+export function JellyfinNowPlayingCard() {
+  const { settings } = useWidgetSettings<JellyfinNowPlayingSettingsValue>(
+    "jellyfin-now-playing",
+    JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS,
+  );
+  const { data: sessions, isLoading } = useJellyfinSessions();
+  const router = useRouter();
+
+  const hiddenUsers = parseHiddenUsers(settings.hideUsers);
+
+  const filtered = (sessions ?? []).filter((session) => {
+    if (settings.hideLocalPlays && isLocalEndpoint(session.RemoteEndPoint)) return false;
+    const userName = session.UserName?.toLowerCase();
+    if (hiddenUsers.size > 0 && userName && hiddenUsers.has(userName)) {
+      return false;
+    }
+    return true;
+  });
+
+  const display = filtered.slice(0, settings.maxItems);
+  const hasMore = filtered.length > settings.maxItems;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Jellyfin</CardTitle>
+        {filtered.length > 0 && (
+          <Badge
+            label={`${filtered.length} stream${filtered.length !== 1 ? "s" : ""}`}
+            variant="success"
+          />
+        )}
+      </CardHeader>
+
+      {isLoading ? (
+        <SkeletonCardContent rows={2} />
+      ) : display.length === 0 ? (
+        <EmptyState
+          icon={<PlayCircle size={32} color="#71717a" />}
+          title="Nothing playing"
+        />
+      ) : (
+        <View className="gap-3">
+          {display.map((session) => (
+            <JellyfinSessionRow
+              key={session.Id}
+              session={session}
+              settings={settings}
+            />
+          ))}
+          {hasMore && (
+            <Pressable
+              onPress={() => router.push("/(tabs)/jellyfin")}
+              className="active:opacity-70"
+            >
+              <Text className="text-primary text-sm text-center font-medium">
+                View All →
+              </Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </Card>
+  );
+}
+
+function JellyfinSessionRow({
+  session,
+  settings,
+}: {
+  session: JellyfinSession;
+  settings: JellyfinNowPlayingSettingsValue;
+}) {
+  const item = session.NowPlayingItem;
+  const durationMs = ticksToMs(item?.RunTimeTicks);
+  const positionMs = ticksToMs(session.PlayState?.PositionTicks);
+  const progress = durationMs > 0 ? positionMs / durationMs : 0;
+
+  const isPaused = !!session.PlayState?.IsPaused;
+  const transcoding = isJellyfinTranscoding(session);
+  // Jellyfin reports playback "buffering" via TranscodingInfo.CompletionPercentage
+  // rather than a discrete state — we just collapse it into the transcoding case.
+  const StateIcon = isPaused ? Pause : transcoding ? Loader : Play;
+  const stateColor = isPaused ? "#f59e0b" : transcoding ? "#f59e0b" : "#22c55e";
+
+  const title =
+    item?.Type === "Episode" && item.SeriesName
+      ? `${item.SeriesName} — ${item.Name}`
+      : (item?.Name ?? "Unknown");
+
+  const bitrateKbps = session.TranscodingInfo?.Bitrate
+    ? Math.round(session.TranscodingInfo.Bitrate / 1000)
+    : 0;
+
+  const subtitleParts: string[] = [];
+  if (settings.showUserAndDevice && (session.UserName || session.Client)) {
+    subtitleParts.push(
+      [session.UserName, session.Client].filter(Boolean).join(" · "),
+    );
+  }
+  if (settings.showBitrate && bitrateKbps > 0) {
+    subtitleParts.push(`${(bitrateKbps / 1000).toFixed(1)} Mbps`);
+  }
+
+  return (
+    <View>
+      <View className="flex-row items-center gap-2 mb-1">
+        <StateIcon size={14} color={stateColor} />
+        <Text className="text-zinc-200 text-sm flex-1" numberOfLines={1}>
+          {truncateText(title, 30)}
+        </Text>
+        {settings.showTranscoding && transcoding && (
+          <View className="flex-row items-center gap-1">
+            <Cog size={12} color="#f59e0b" />
+            <Text className="text-amber-500 text-[10px] font-semibold uppercase">
+              Transcode
+            </Text>
+          </View>
+        )}
+      </View>
+      <ProgressBar progress={progress} className="mb-1" />
+      {subtitleParts.length > 0 && (
+        <Text className="text-zinc-500 text-xs" numberOfLines={1}>
+          {subtitleParts.join(" · ")}
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -8,6 +8,7 @@ import {
   BarChart3,
   Search,
   PlayCircle,
+  Clapperboard,
   Captions,
 } from "lucide-react-native";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,6 +23,7 @@ const SERVICE_ICONS: Partial<Record<ServiceId, React.ElementType>> = {
   tautulli: BarChart3,
   prowlarr: Search,
   plex: PlayCircle,
+  jellyfin: Clapperboard,
   bazarr: Captions,
 };
 

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   CalendarDays,
   Captions,
+  Clapperboard,
   Cpu,
   Download,
   Film,
@@ -22,6 +23,7 @@ import { CalendarCard } from "@/components/dashboard/calendar-card";
 import { TautulliActivityCard } from "@/components/dashboard/tautulli-activity-card";
 import { OverseerrRequestsCard } from "@/components/dashboard/overseerr-requests-card";
 import { PlexNowPlayingCard } from "@/components/dashboard/plex-now-playing-card";
+import { JellyfinNowPlayingCard } from "@/components/dashboard/jellyfin-now-playing-card";
 import { ProwlarrStatsCard } from "@/components/dashboard/prowlarr-stats-card";
 import { BazarrWantedCard } from "@/components/dashboard/bazarr-wanted-card";
 import { WolDevicesCard } from "@/components/dashboard/wol-devices-card";
@@ -45,6 +47,11 @@ import {
   PLEX_NOW_PLAYING_DEFAULT_SETTINGS,
   type PlexNowPlayingSettingsValue,
 } from "@/components/dashboard/widget-settings/plex-now-playing-settings";
+import {
+  JellyfinNowPlayingSettings,
+  JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS,
+  type JellyfinNowPlayingSettingsValue,
+} from "@/components/dashboard/widget-settings/jellyfin-now-playing-settings";
 import {
   TautulliActivitySettings,
   TAUTULLI_ACTIVITY_DEFAULT_SETTINGS,
@@ -165,6 +172,16 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     settingsComponent: PlexNowPlayingSettings,
     defaultSettings: PLEX_NOW_PLAYING_DEFAULT_SETTINGS,
   },
+  "jellyfin-now-playing": {
+    id: "jellyfin-now-playing",
+    label: "Jellyfin Now Playing",
+    description: "Live playback sessions on your Jellyfin server",
+    icon: Clapperboard,
+    service: "jellyfin",
+    component: JellyfinNowPlayingCard,
+    settingsComponent: JellyfinNowPlayingSettings,
+    defaultSettings: JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS,
+  },
   "prowlarr-stats": {
     id: "prowlarr-stats",
     label: "Prowlarr Stats",
@@ -203,6 +220,7 @@ export type {
   CalendarSettingsValue,
   DownloadsSettingsValue,
   PlexNowPlayingSettingsValue,
+  JellyfinNowPlayingSettingsValue,
   TautulliActivitySettingsValue,
   OverseerrRequestsSettingsValue,
 };

--- a/components/dashboard/widget-settings/jellyfin-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/jellyfin-now-playing-settings.tsx
@@ -1,0 +1,103 @@
+import { View, Text } from "react-native";
+import { Toggle } from "@/components/ui/toggle";
+import { TextInput } from "@/components/ui/text-input";
+import { FilterChip } from "@/components/ui/filter-chip";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+
+export interface JellyfinNowPlayingSettingsValue extends Record<string, unknown> {
+  maxItems: number;
+  hideLocalPlays: boolean;
+  hideUsers: string;
+  showBitrate: boolean;
+  showTranscoding: boolean;
+  showUserAndDevice: boolean;
+}
+
+export const JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS: JellyfinNowPlayingSettingsValue = {
+  maxItems: 3,
+  hideLocalPlays: false,
+  hideUsers: "",
+  showBitrate: false,
+  showTranscoding: true,
+  showUserAndDevice: true,
+};
+
+const MAX_OPTIONS: { value: number; label: string }[] = [
+  { value: 3, label: "3" },
+  { value: 5, label: "5" },
+  { value: 10, label: "10" },
+];
+
+export function JellyfinNowPlayingSettings(_props: WidgetSettingsComponentProps) {
+  const { settings, update } = useWidgetSettings<JellyfinNowPlayingSettingsValue>(
+    "jellyfin-now-playing",
+    JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS,
+  );
+
+  return (
+    <View className="px-4 py-2 gap-5">
+      <View>
+        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
+          Filters
+        </Text>
+        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+          <Toggle
+            label="Hide local plays"
+            description="Skip sessions whose remote endpoint is on a private network"
+            value={settings.hideLocalPlays}
+            onValueChange={(hideLocalPlays) => update({ hideLocalPlays })}
+          />
+        </View>
+        <View className="mt-3">
+          <TextInput
+            label="Hide users"
+            placeholder="comma-separated usernames"
+            value={settings.hideUsers}
+            onChangeText={(hideUsers) => update({ hideUsers })}
+          />
+        </View>
+      </View>
+
+      <View>
+        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
+          Show
+        </Text>
+        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+          <Toggle
+            label="User and device"
+            value={settings.showUserAndDevice}
+            onValueChange={(showUserAndDevice) => update({ showUserAndDevice })}
+          />
+          <Toggle
+            label="Transcoding indicator"
+            value={settings.showTranscoding}
+            onValueChange={(showTranscoding) => update({ showTranscoding })}
+          />
+          <Toggle
+            label="Bitrate"
+            description="Transcoding stream bitrate in Mbps"
+            value={settings.showBitrate}
+            onValueChange={(showBitrate) => update({ showBitrate })}
+          />
+        </View>
+      </View>
+
+      <View>
+        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
+          Max items
+        </Text>
+        <View className="flex-row flex-wrap gap-2">
+          {MAX_OPTIONS.map((option) => (
+            <FilterChip
+              key={option.value}
+              label={option.label}
+              selected={settings.maxItems === option.value}
+              onPress={() => update({ maxItems: option.value })}
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -263,6 +263,10 @@
         <p>Now playing, recently added, on deck</p>
       </div>
       <div class="service-card">
+        <h3>Jellyfin</h3>
+        <p>Now playing, recently added, continue watching</p>
+      </div>
+      <div class="service-card">
         <h3>Glances</h3>
         <p>Server CPU, RAM, disk, network stats</p>
       </div>

--- a/hooks/use-jellyfin.ts
+++ b/hooks/use-jellyfin.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getLibraries,
+  getRecentlyAdded,
+  getResumeItems,
+  getSessions,
+  resolveUserId,
+} from "@/services/jellyfin-api";
+import { useConfigStore } from "@/store/config-store";
+import { POLLING_INTERVALS } from "@/lib/constants";
+
+export function useJellyfinEnabled() {
+  return useConfigStore((s) => s.services.jellyfin.enabled);
+}
+
+// Resolves the userId tied to the configured API key. User-scoped queries
+// gate on this so they don't fire with an undefined user. Cached for 5min —
+// the binding rarely changes within a session.
+export function useJellyfinUserId() {
+  const enabled = useJellyfinEnabled();
+  return useQuery({
+    queryKey: ["jellyfin", "userId"],
+    queryFn: resolveUserId,
+    enabled,
+    staleTime: 300000,
+    gcTime: 600000,
+  });
+}
+
+export function useJellyfinLibraries() {
+  const enabled = useJellyfinEnabled();
+  const { data: userId } = useJellyfinUserId();
+  return useQuery({
+    queryKey: ["jellyfin", "libraries", userId],
+    queryFn: () => getLibraries(userId!),
+    enabled: enabled && !!userId,
+    staleTime: 300000,
+  });
+}
+
+export function useJellyfinRecentlyAdded(parentId?: string, count = 20) {
+  const enabled = useJellyfinEnabled();
+  const { data: userId } = useJellyfinUserId();
+  return useQuery({
+    queryKey: ["jellyfin", "recentlyAdded", userId, parentId ?? null],
+    queryFn: () => getRecentlyAdded(userId!, parentId, count),
+    refetchInterval: POLLING_INTERVALS.calendar,
+    enabled: enabled && !!userId,
+  });
+}
+
+export function useJellyfinResumeItems(count = 20) {
+  const enabled = useJellyfinEnabled();
+  const { data: userId } = useJellyfinUserId();
+  return useQuery({
+    queryKey: ["jellyfin", "resume", userId],
+    queryFn: () => getResumeItems(userId!, count),
+    refetchInterval: POLLING_INTERVALS.calendar,
+    enabled: enabled && !!userId,
+  });
+}
+
+export function useJellyfinSessions() {
+  const enabled = useJellyfinEnabled();
+  return useQuery({
+    queryKey: ["jellyfin", "sessions"],
+    queryFn: getSessions,
+    refetchInterval: POLLING_INTERVALS.activeTorrents, // 5s — same cadence as Plex now-playing
+    enabled,
+  });
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -6,6 +6,7 @@ export const SERVICE_IDS = [
   "tautulli",
   "prowlarr",
   "plex",
+  "jellyfin",
   "glances",
   "bazarr",
 ] as const;
@@ -28,6 +29,7 @@ export const SERVICE_DEFAULTS: Record<
   tautulli: { name: "Tautulli", defaultPort: 8181, apiBasePath: "/api/v2", pingPath: "/home" },
   prowlarr: { name: "Prowlarr", defaultPort: 9696, apiBasePath: "/api/v1", pingPath: "/system/status" },
   plex: { name: "Plex", defaultPort: 32400, apiBasePath: "", pingPath: "/identity" },
+  jellyfin: { name: "Jellyfin", defaultPort: 8096, apiBasePath: "", pingPath: "/System/Info/Public" },
   glances: { name: "Glances", defaultPort: 61208, apiBasePath: "/api/4", pingPath: "/cpu" },
   bazarr: { name: "Bazarr", defaultPort: 6767, apiBasePath: "/api", pingPath: "/system/status" },
 };
@@ -50,6 +52,7 @@ export const DASHBOARD_WIDGET_IDS = [
   "tautulli-activity",
   "overseerr-requests",
   "plex-now-playing",
+  "jellyfin-now-playing",
   "prowlarr-stats",
   "bazarr-wanted",
   "wol-devices",

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -567,6 +567,65 @@ const DEMO_PLEX_MEDIA_CONTAINER = {
   },
 };
 
+// --- Jellyfin ---
+
+const DEMO_JELLYFIN_USER_ID = "demo-user-id-0001";
+
+const DEMO_JELLYFIN_ME = {
+  Id: DEMO_JELLYFIN_USER_ID,
+  Name: "demo",
+  Policy: { IsAdministrator: true, IsDisabled: false },
+};
+
+const DEMO_JELLYFIN_USERS = [DEMO_JELLYFIN_ME];
+
+const DEMO_JELLYFIN_VIEWS = {
+  Items: [
+    { Id: "lib-movies", Name: "Movies", CollectionType: "movies", ImageTags: { Primary: "tag-movies" } },
+    { Id: "lib-tv", Name: "TV Shows", CollectionType: "tvshows", ImageTags: { Primary: "tag-tv" } },
+    { Id: "lib-music", Name: "Music", CollectionType: "music", ImageTags: { Primary: "tag-music" } },
+  ],
+  TotalRecordCount: 3,
+};
+
+const DEMO_JELLYFIN_LATEST: unknown[] = [
+  { Id: "jf-1", Name: "Dune: Part Two", Type: "Movie", ProductionYear: 2024, RunTimeTicks: 9960000 * 10000, DateCreated: new Date(NOW_TS * 1000 - 3600 * 1000).toISOString(), ImageTags: { Primary: "tag-1" } },
+  { Id: "jf-2", Name: "Oppenheimer", Type: "Movie", ProductionYear: 2023, RunTimeTicks: 11040000 * 10000, DateCreated: new Date(NOW_TS * 1000 - 86400 * 1000).toISOString(), ImageTags: { Primary: "tag-2" } },
+  { Id: "jf-3", Name: "The End", Type: "Episode", SeriesName: "Fallout", SeriesId: "jf-series-fallout", SeasonName: "Season 1", ParentIndexNumber: 1, IndexNumber: 8, RunTimeTicks: 4200000 * 10000, DateCreated: new Date(NOW_TS * 1000 - 7200 * 1000).toISOString(), ImageTags: { Primary: "tag-3" }, SeriesPrimaryImageTag: "tag-series-fallout" },
+  { Id: "jf-4", Name: "The Big Door Prize", Type: "Episode", SeriesName: "Fallout", SeriesId: "jf-series-fallout", SeasonName: "Season 1", ParentIndexNumber: 1, IndexNumber: 5, RunTimeTicks: 3720000 * 10000, DateCreated: new Date(NOW_TS * 1000 - 3600 * 1000).toISOString(), ImageTags: { Primary: "tag-4" }, SeriesPrimaryImageTag: "tag-series-fallout" },
+];
+
+const DEMO_JELLYFIN_RESUME = {
+  Items: [
+    { Id: "jf-r1", Name: "Dune: Part Two", Type: "Movie", ProductionYear: 2024, RunTimeTicks: 9960000 * 10000, UserData: { PlaybackPositionTicks: 4681200 * 10000, PlayedPercentage: 47 }, ImageTags: { Primary: "tag-1" } },
+    { Id: "jf-r2", Name: "The Radio", Type: "Episode", SeriesName: "Fallout", SeriesId: "jf-series-fallout", ParentIndexNumber: 1, IndexNumber: 6, RunTimeTicks: 3780000 * 10000, UserData: { PlaybackPositionTicks: 1500000 * 10000, PlayedPercentage: 39 }, ImageTags: { Primary: "tag-r2" }, SeriesPrimaryImageTag: "tag-series-fallout" },
+  ],
+  TotalRecordCount: 2,
+};
+
+const DEMO_JELLYFIN_SESSIONS = [
+  {
+    Id: "session-demo-1",
+    UserId: DEMO_JELLYFIN_USER_ID,
+    UserName: "demo",
+    Client: "Jellyfin Web",
+    DeviceName: "Living Room TV",
+    DeviceId: "device-1",
+    ApplicationVersion: "10.8.13",
+    RemoteEndPoint: "192.168.1.45",
+    IsActive: true,
+    NowPlayingItem: {
+      Id: "jf-1",
+      Name: "Dune: Part Two",
+      Type: "Movie",
+      ProductionYear: 2024,
+      RunTimeTicks: 9960000 * 10000,
+      ImageTags: { Primary: "tag-1" },
+    },
+    PlayState: { PositionTicks: 4681200 * 10000, IsPaused: false, PlayMethod: "DirectPlay" },
+  },
+];
+
 // --- Glances ---
 
 const DEMO_GLANCES_CPU = { total: 43.2, user: 29.8, system: 11.4, idle: 56.8, iowait: 1.8, cpucore: 8 };
@@ -699,6 +758,16 @@ export function getDemoResponse(serviceId: ServiceId, path: string): unknown {
       if (normalized.startsWith("/torrents/files")) return [];
       if (normalized.startsWith("/torrents/trackers")) return [];
       if (normalized.startsWith("/app/version")) return "5.0.0";
+      return undefined;
+    }
+    case "jellyfin": {
+      if (basePath === "/System/Info/Public") return { Version: "10.8.13", ServerName: "Demo Jellyfin" };
+      if (basePath === "/Users/Me") return DEMO_JELLYFIN_ME;
+      if (basePath === "/Users") return DEMO_JELLYFIN_USERS;
+      if (basePath === "/Sessions") return DEMO_JELLYFIN_SESSIONS;
+      if (basePath.endsWith("/Views")) return DEMO_JELLYFIN_VIEWS;
+      if (basePath.endsWith("/Items/Latest")) return DEMO_JELLYFIN_LATEST;
+      if (basePath.endsWith("/Items/Resume")) return DEMO_JELLYFIN_RESUME;
       return undefined;
     }
     default:

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -86,6 +86,10 @@ export async function serviceRequest<T>(
       headers.set("X-Plex-Token", secrets.apiKey);
       headers.set("Accept", "application/json");
     }
+  } else if (serviceId === "jellyfin") {
+    if (secrets.apiKey) {
+      headers.set("X-Emby-Token", secrets.apiKey);
+    }
   } else {
     // Radarr, Sonarr, Overseerr, Tautulli, Prowlarr use X-Api-Key
     if (secrets.apiKey) {
@@ -141,6 +145,8 @@ export async function pingService(serviceId: ServiceId, urlOverride?: string): P
   if (serviceId === "plex") {
     if (secrets.apiKey) headers.set("X-Plex-Token", secrets.apiKey);
     headers.set("Accept", "application/json");
+  } else if (serviceId === "jellyfin") {
+    if (secrets.apiKey) headers.set("X-Emby-Token", secrets.apiKey);
   } else if (serviceId === "glances") {
     if (secrets.username && secrets.password) {
       const encoded = btoa(`${secrets.username}:${secrets.password}`);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -647,6 +647,133 @@ export interface PlexSessionsResponse {
   };
 }
 
+// --- Jellyfin Types ---
+
+export interface JellyfinUser {
+  Id: string;
+  Name: string;
+  Policy?: {
+    IsAdministrator?: boolean;
+    IsDisabled?: boolean;
+  };
+}
+
+export type JellyfinCollectionType =
+  | "movies"
+  | "tvshows"
+  | "music"
+  | "musicvideos"
+  | "homevideos"
+  | "boxsets"
+  | "books"
+  | "playlists"
+  | "livetv"
+  | "mixed"
+  | string;
+
+export interface JellyfinLibrary {
+  Id: string;
+  Name: string;
+  CollectionType?: JellyfinCollectionType;
+  ImageTags?: { Primary?: string };
+}
+
+export interface JellyfinUserData {
+  PlayedPercentage?: number;
+  PlaybackPositionTicks?: number;
+  PlayCount?: number;
+  IsFavorite?: boolean;
+  Played?: boolean;
+  LastPlayedDate?: string;
+}
+
+export type JellyfinItemType =
+  | "Movie"
+  | "Series"
+  | "Season"
+  | "Episode"
+  | "Audio"
+  | "MusicAlbum"
+  | "MusicArtist"
+  | "BoxSet"
+  | "CollectionFolder"
+  | "Folder"
+  | string;
+
+export interface JellyfinItem {
+  Id: string;
+  Name: string;
+  Type: JellyfinItemType;
+  SeriesId?: string;
+  SeriesName?: string;
+  SeasonId?: string;
+  SeasonName?: string;
+  ParentIndexNumber?: number;
+  IndexNumber?: number;
+  ProductionYear?: number;
+  PremiereDate?: string;
+  DateCreated?: string;
+  RunTimeTicks?: number;
+  Overview?: string;
+  CommunityRating?: number;
+  ImageTags?: {
+    Primary?: string;
+    Backdrop?: string;
+    Thumb?: string;
+    Logo?: string;
+  };
+  BackdropImageTags?: string[];
+  ParentBackdropImageTags?: string[];
+  ParentBackdropItemId?: string;
+  SeriesPrimaryImageTag?: string;
+  ParentThumbImageTag?: string;
+  ParentThumbItemId?: string;
+  UserData?: JellyfinUserData;
+}
+
+export interface JellyfinItemsResponse {
+  Items: JellyfinItem[];
+  TotalRecordCount: number;
+}
+
+export interface JellyfinTranscodingInfo {
+  AudioCodec?: string;
+  VideoCodec?: string;
+  Container?: string;
+  IsVideoDirect?: boolean;
+  IsAudioDirect?: boolean;
+  Bitrate?: number;
+  Framerate?: number;
+  CompletionPercentage?: number;
+  Width?: number;
+  Height?: number;
+  TranscodeReasons?: string[];
+}
+
+export interface JellyfinPlayState {
+  PositionTicks?: number;
+  CanSeek?: boolean;
+  IsPaused?: boolean;
+  IsMuted?: boolean;
+  PlayMethod?: "Transcode" | "DirectStream" | "DirectPlay";
+  RepeatMode?: string;
+}
+
+export interface JellyfinSession {
+  Id: string;
+  UserId?: string;
+  UserName?: string;
+  Client: string;
+  DeviceName: string;
+  DeviceId?: string;
+  ApplicationVersion?: string;
+  RemoteEndPoint?: string;
+  IsActive?: boolean;
+  NowPlayingItem?: JellyfinItem;
+  PlayState?: JellyfinPlayState;
+  TranscodingInfo?: JellyfinTranscodingInfo;
+}
+
 // --- Glances Types ---
 
 export interface GlancesCpu {

--- a/services/jellyfin-api.ts
+++ b/services/jellyfin-api.ts
@@ -1,0 +1,175 @@
+import { useConfigStore } from "@/store/config-store";
+import { serviceRequest } from "@/lib/http-client";
+import type {
+  JellyfinItem,
+  JellyfinItemsResponse,
+  JellyfinLibrary,
+  JellyfinSession,
+  JellyfinUser,
+} from "@/lib/types";
+
+// Single source of truth for "is this session being transcoded". `PlayMethod`
+// is the authoritative signal; `TranscodingInfo` can also be present for
+// direct-stream-with-audio-remux cases, so we cross-check the IsXDirect flags
+// before treating it as a transcode.
+export function isJellyfinTranscoding(session: JellyfinSession): boolean {
+  if (session.PlayState?.PlayMethod === "Transcode") return true;
+  const info = session.TranscodingInfo;
+  if (!info) return false;
+  return info.IsVideoDirect === false || info.IsAudioDirect === false;
+}
+
+// --- Users ---
+
+export async function getCurrentUser(): Promise<JellyfinUser> {
+  return serviceRequest<JellyfinUser>("jellyfin", "/Users/Me");
+}
+
+export async function getUsers(): Promise<JellyfinUser[]> {
+  return serviceRequest<JellyfinUser[]>("jellyfin", "/Users");
+}
+
+// Resolve the userId associated with the configured API key. Tries the cheap
+// `/Users/Me` endpoint first (works with user-scoped keys); falls back to
+// scanning `/Users` and picking the first non-disabled administrator. Used by
+// the hook layer so user-scoped queries can run without making the user paste
+// a userId into the config form.
+export async function resolveUserId(): Promise<string | null> {
+  try {
+    const me = await getCurrentUser();
+    if (me?.Id) return me.Id;
+  } catch {
+    // ignore — fall through to /Users
+  }
+  try {
+    const users = await getUsers();
+    const admin = users.find((u) => u.Policy?.IsAdministrator && !u.Policy?.IsDisabled);
+    if (admin) return admin.Id;
+    const enabled = users.find((u) => !u.Policy?.IsDisabled);
+    return enabled?.Id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// --- Libraries ---
+
+export async function getLibraries(userId: string): Promise<JellyfinLibrary[]> {
+  const data = await serviceRequest<JellyfinItemsResponse>(
+    "jellyfin",
+    `/Users/${encodeURIComponent(userId)}/Views`,
+  );
+  return (data.Items ?? []) as unknown as JellyfinLibrary[];
+}
+
+// --- Recently Added ---
+
+export async function getRecentlyAdded(
+  userId: string,
+  parentId?: string,
+  count = 20,
+): Promise<JellyfinItem[]> {
+  const params: Record<string, string | number | boolean> = {
+    Limit: count,
+    Fields: "PrimaryImageAspectRatio,ProductionYear,DateCreated",
+  };
+  if (parentId) params.ParentId = parentId;
+  return serviceRequest<JellyfinItem[]>(
+    "jellyfin",
+    `/Users/${encodeURIComponent(userId)}/Items/Latest`,
+    { params },
+  );
+}
+
+// --- Resume / Continue Watching ---
+
+export async function getResumeItems(
+  userId: string,
+  count = 20,
+): Promise<JellyfinItem[]> {
+  const data = await serviceRequest<JellyfinItemsResponse>(
+    "jellyfin",
+    `/Users/${encodeURIComponent(userId)}/Items/Resume`,
+    {
+      params: {
+        Limit: count,
+        MediaTypes: "Video",
+        Fields: "PrimaryImageAspectRatio,ProductionYear",
+      },
+    },
+  );
+  return data.Items ?? [];
+}
+
+// --- Now Playing (Sessions) ---
+
+export async function getSessions(): Promise<JellyfinSession[]> {
+  // Server-wide endpoint — returns every connected session, not just the
+  // current user's. Filter on the client if/when needed.
+  const data = await serviceRequest<JellyfinSession[]>("jellyfin", "/Sessions", {
+    params: { ActiveWithinSeconds: 960 },
+  });
+  // Only keep sessions that are actually playing something; idle clients also
+  // show up in /Sessions.
+  return (data ?? []).filter((s) => s.NowPlayingItem);
+}
+
+// --- Image URL helpers ---
+
+// Build a primary-image URL for a Jellyfin item. Mirrors getPlexImageUrl in
+// services/plex-api.ts — token in the query string so plain <Image> tags can
+// load the asset without setting custom headers.
+export function getJellyfinImageUrl(
+  item: Pick<
+    JellyfinItem,
+    "Id" | "ImageTags" | "SeriesId" | "SeriesPrimaryImageTag" | "ParentBackdropItemId" | "ParentBackdropImageTags" | "ParentThumbItemId" | "ParentThumbImageTag"
+  > | null | undefined,
+  type: "Primary" | "Backdrop" | "Thumb" = "Primary",
+  width = 300,
+  height = 450,
+): string | null {
+  if (!item) return null;
+  const store = useConfigStore.getState();
+  const baseUrl = store.getActiveUrl("jellyfin");
+  const secrets = store.secrets.jellyfin;
+  if (!baseUrl) return null;
+  const trimmed = baseUrl.replace(/\/+$/, "");
+
+  // Pick the best available image source for the requested type. For episodes
+  // we fall back to the parent series' primary art so the row doesn't render
+  // a black tile when an episode lacks its own thumbnail.
+  let itemId = item.Id;
+  let tag = item.ImageTags?.[type];
+
+  if (!tag) {
+    if (type === "Primary" && item.SeriesId && item.SeriesPrimaryImageTag) {
+      itemId = item.SeriesId;
+      tag = item.SeriesPrimaryImageTag;
+    } else if (type === "Backdrop" && item.ParentBackdropItemId && item.ParentBackdropImageTags?.[0]) {
+      itemId = item.ParentBackdropItemId;
+      tag = item.ParentBackdropImageTags[0];
+    } else if (type === "Thumb" && item.ParentThumbItemId && item.ParentThumbImageTag) {
+      itemId = item.ParentThumbItemId;
+      tag = item.ParentThumbImageTag;
+    } else if (type === "Backdrop" && item.ImageTags?.Backdrop) {
+      tag = item.ImageTags.Backdrop;
+    }
+  }
+
+  if (!tag) return null;
+
+  const params = new URLSearchParams({
+    fillWidth: String(width),
+    fillHeight: String(height),
+    quality: "90",
+    tag,
+  });
+  if (secrets?.apiKey) params.set("api_key", secrets.apiKey);
+  return `${trimmed}/Items/${encodeURIComponent(itemId)}/Images/${type}?${params.toString()}`;
+}
+
+// Convert Jellyfin's "ticks" (100-nanosecond units) to milliseconds.
+export function ticksToMs(ticks: number | undefined | null): number {
+  if (!ticks || ticks <= 0) return 0;
+  return Math.floor(ticks / 10000);
+}

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -15,8 +15,10 @@ import type { ExportPayload } from "@/store/config-store";
  *   v6  — added optional homeBSSID for rogue-AP-resistant auto-switch
  *   v7  — added per-widget settings; renamed sonarr-calendar → calendar
  *   v8  — added hapticsEnabled global preference
+ *   v9  — added jellyfin service entry (no schema change; defaultServices()
+ *         backfills the new id, so this is a version stamp only)
  */
-export const CURRENT_CONFIG_VERSION = 8;
+export const CURRENT_CONFIG_VERSION = 9;
 
 /**
  * Each key N is a function that transforms a version-N payload into version N+1.
@@ -117,6 +119,11 @@ const migrations: Record<number, (payload: any) => any> = {
     version: 8,
     hapticsEnabled: typeof payload.hapticsEnabled === "boolean" ? payload.hapticsEnabled : true,
   }),
+
+  // v8 → v9: jellyfin added to SERVICE_IDS. importConfig merges over
+  // defaultServices() afterward, so older payloads that lack a jellyfin entry
+  // get the disabled default automatically — nothing to transform here.
+  8: (payload) => ({ ...payload, version: 9 }),
 };
 
 /**

--- a/store/sort-store.ts
+++ b/store/sort-store.ts
@@ -20,6 +20,10 @@ export type PlexRecentSortKey =
   | "year-desc"
   | "year-asc";
 
+// Jellyfin's "Recently Added" tab sorts on the same axes as Plex's, so reuse
+// the type instead of forking a parallel one.
+export type JellyfinRecentSortKey = PlexRecentSortKey;
+
 export type RequestsSortKey =
   | "created-desc"
   | "created-asc"
@@ -37,6 +41,7 @@ interface SortPreferences {
   movies: MoviesSortKey;
   series: SeriesSortKey;
   plexRecent: PlexRecentSortKey;
+  jellyfinRecent: JellyfinRecentSortKey;
   requests: RequestsSortKey;
   downloads: DownloadsSortKey;
 }
@@ -45,6 +50,7 @@ export const SORT_DEFAULTS: SortPreferences = {
   movies: "added-desc",
   series: "added-desc",
   plexRecent: "added-desc",
+  jellyfinRecent: "added-desc",
   requests: "created-desc",
   downloads: "progress-desc",
 };
@@ -54,6 +60,7 @@ interface SortStore extends SortPreferences {
   setMovies: (v: MoviesSortKey) => void;
   setSeries: (v: SeriesSortKey) => void;
   setPlexRecent: (v: PlexRecentSortKey) => void;
+  setJellyfinRecent: (v: JellyfinRecentSortKey) => void;
   setRequests: (v: RequestsSortKey) => void;
   setDownloads: (v: DownloadsSortKey) => void;
 }
@@ -63,6 +70,7 @@ function snapshot(state: SortPreferences): SortPreferences {
     movies: state.movies,
     series: state.series,
     plexRecent: state.plexRecent,
+    jellyfinRecent: state.jellyfinRecent,
     requests: state.requests,
     downloads: state.downloads,
   };
@@ -90,6 +98,10 @@ export const useSortStore = create<SortStore>((set, get) => ({
   setPlexRecent: (plexRecent) => {
     set({ plexRecent });
     setJSON(STORAGE_KEY, snapshot({ ...get(), plexRecent }));
+  },
+  setJellyfinRecent: (jellyfinRecent) => {
+    set({ jellyfinRecent });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), jellyfinRecent }));
   },
   setRequests: (requests) => {
     set({ requests });


### PR DESCRIPTION
- Implemented Jellyfin service request handling in http-client.ts
- Added Jellyfin types in types.ts for user, library, item, and session data
- Updated config-migrations.ts to include Jellyfin service entry
- Enhanced sort-store.ts to support Jellyfin recent sort keys
- Created Jellyfin screen with tabs for playing, recently added, resume, and libraries
- Developed Jellyfin now playing card component for dashboard
- Added settings for Jellyfin now playing widget
- Introduced hooks for fetching Jellyfin data (libraries, recently added, resume items, sessions)
- Implemented Jellyfin API service functions for user, library, and session management