### PR TITLE
Fix open issues (#40, #42, #44, #46, #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,22 @@ Dashboarr is a native mobile app (Android & iOS) that connects directly to your 
 | **Tautulli** | Active Plex streams, bandwidth stats, playback history |
 | **Prowlarr** | Indexer status & toggle, search across all indexers, grab releases, stats |
 | **Plex** | Now playing, recently added, on deck, library browsing |
+| **Jellyfin** | Now playing, recently added, continue watching, library browsing |
+| **Bazarr** | Wanted subtitles for movies & episodes, history, on-demand subtitle search |
 | **Glances** | Server CPU, RAM, disk, and network stats |
 
 ## Features
 
 - **Unified dashboard** — All your services at a glance with customizable, reorderable cards
+- **Multi-instance support** — Run two qBittorrents, split 4K and 1080p Radarrs, or any combination — switch in-tab and aggregate on the dashboard
 - **Dark mode only** — Designed for OLED screens and late-night browsing
 - **Auto network switching** — Detects your home WiFi SSID and switches between local/remote URLs automatically
 - **Per-service configuration** — Enable only the services you use; tabs auto-hide for disabled services
 - **Secure storage** — API keys stored in the device's secure enclave via `expo-secure-store`
+- **Wake-on-LAN** — Wake your server from the app when it's asleep
 - **Pull-to-refresh** — On every screen
 - **Config import/export** — Back up and restore your entire configuration (with biometric auth)
+- **Adjustable UI scale** — 1.0 / 1.15 / 1.3 for accessibility and larger displays
 - **No backend required** — Pure client architecture for core functionality; your data stays between your phone and your servers
 - **Optional self-hosted backend** — Enable real push notifications by running the companion backend on your server (Node.js or Docker)
 
@@ -76,6 +81,7 @@ The APK is signed with the same keystore as the Play Store build, so you can ins
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18+)
+- [pnpm](https://pnpm.io/) (v9+)
 - [Expo CLI](https://docs.expo.dev/get-started/installation/)
 - Android device/emulator or iOS device/simulator
 
@@ -87,10 +93,10 @@ git clone https://github.com/renzobeux/dashboarr.git
 cd dashboarr
 
 # Install dependencies
-npm install
+pnpm install
 
 # Start the dev server
-npx expo start
+pnpm start
 ```
 
 Scan the QR code with [Expo Go](https://expo.dev/go) on your device, or press `a` for Android emulator / `i` for iOS simulator.
@@ -142,17 +148,24 @@ app/                  # Expo Router file-based routing
   movie/              # Movie detail & search screens
   series/             # Series detail & search screens
   torrent/            # Torrent detail screen
+  sab/                # SABnzbd job detail screens
 backend/
   dashboarr-backend/  # Self-hosted companion server (Fastify + SQLite)
 components/
   ui/                 # Reusable UI primitives (cards, buttons, inputs, toggles)
-  dashboard/          # Dashboard card components
   common/             # Shared layout components (screen wrapper, pull-to-refresh)
+  dashboard/          # Dashboard card components
+  downloads/          # Unified downloads list (qBittorrent + SABnzbd)
+  qbittorrent/        # qBittorrent-specific components
+  radarr/             # Radarr-specific components
+  sonarr/             # Sonarr-specific components
   overseerr/          # Seerr-specific components (folder name kept for back-compat)
+  settings/           # Settings screen components
 services/             # Raw API clients for each service
 hooks/                # TanStack Query wrappers (caching, polling, mutations)
 store/                # Zustand stores + AsyncStorage/SecureStore helpers
-lib/                  # Types, utils, constants, HTTP client
+lib/                  # Types, utils, constants, HTTP client, Wake-on-LAN
+plugins/              # Custom Expo config plugins (Android signing)
 ```
 
 ## Tech Stack

--- a/app/(tabs)/bazarr.tsx
+++ b/app/(tabs)/bazarr.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import {
   useBazarrWantedMovies,
   useBazarrWantedEpisodes,
@@ -82,7 +82,7 @@ function WantedMovies() {
   const handleSearch = (radarrId: number, title: string) => {
     searchMovie.mutate(radarrId, {
       onSuccess: () => toast(`Searching for "${title}" subtitles`, "success"),
-      onError: () => toast("Failed to start search", "error"),
+      onError: (err) => toastError("Failed to start search", err),
     });
   };
 
@@ -147,7 +147,7 @@ function WantedEpisodes() {
       { seriesId, episodeId },
       {
         onSuccess: () => toast(`Searching for "${title}" subtitles`, "success"),
-        onError: () => toast("Failed to start search", "error"),
+        onError: (err) => toastError("Failed to start search", err),
       },
     );
   };

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -33,8 +33,18 @@ const INCLUDE_UNMONITORED_KEY = "ui.calendar.includeUnmonitored";
 type Filter = "all" | "tv" | "movies";
 
 type CalendarItem =
-  | { type: "episode"; date: string; data: SonarrCalendarEntry }
-  | { type: "movie"; date: string; data: RadarrMovie };
+  | {
+      type: "episode";
+      date: string;
+      data: SonarrCalendarEntry;
+      instanceId: string;
+    }
+  | {
+      type: "movie";
+      date: string;
+      data: RadarrMovie;
+      instanceId: string;
+    };
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -142,10 +152,21 @@ export default function CalendarScreen() {
     })),
   });
 
-  const episodes: SonarrCalendarEntry[] = sonarrQueries.flatMap(
-    (q) => q.data ?? [],
+  // Tag each calendar entry with the source instance so navigation can route
+  // detail-screen queries to the correct Sonarr/Radarr (ids aren't globally
+  // unique across instances).
+  const taggedEpisodes = sonarrQueries.flatMap((q, i) =>
+    (q.data ?? []).map((data) => ({
+      data,
+      instanceId: sonarrInstances[i]?.id,
+    })),
   );
-  const movies: RadarrMovie[] = radarrQueries.flatMap((q) => q.data ?? []);
+  const taggedMovies = radarrQueries.flatMap((q, i) =>
+    (q.data ?? []).map((data) => ({
+      data,
+      instanceId: radarrInstances[i]?.id,
+    })),
+  );
   const loadingEp = sonarrQueries.length > 0 && sonarrQueries.some((q) => q.isLoading);
   const loadingMov = radarrQueries.length > 0 && radarrQueries.some((q) => q.isLoading);
 
@@ -181,8 +202,14 @@ export default function CalendarScreen() {
     const all: CalendarItem[] = [];
 
     if (filter !== "movies") {
-      for (const ep of episodes ?? []) {
-        const item: CalendarItem = { type: "episode", date: ep.airDate, data: ep };
+      for (const { data: ep, instanceId } of taggedEpisodes) {
+        if (!instanceId) continue;
+        const item: CalendarItem = {
+          type: "episode",
+          date: ep.airDate,
+          data: ep,
+          instanceId,
+        };
         all.push(item);
         const list = map.get(ep.airDate) ?? [];
         list.push(item);
@@ -191,10 +218,16 @@ export default function CalendarScreen() {
     }
 
     if (filter !== "tv") {
-      for (const movie of movies ?? []) {
+      for (const { data: movie, instanceId } of taggedMovies) {
+        if (!instanceId) continue;
         const date = getMovieReleaseDate(movie);
         if (date) {
-          const item: CalendarItem = { type: "movie", date, data: movie };
+          const item: CalendarItem = {
+            type: "movie",
+            date,
+            data: movie,
+            instanceId,
+          };
           all.push(item);
           const list = map.get(date) ?? [];
           list.push(item);
@@ -204,7 +237,7 @@ export default function CalendarScreen() {
     }
 
     return { itemsByDate: map, allItems: all };
-  }, [episodes, movies, filter]);
+  }, [taggedEpisodes, taggedMovies, filter]);
 
   const grid = useMemo(() => getCalendarGrid(year, month), [year, month]);
   const todayKey = localDateKey(today);
@@ -379,15 +412,21 @@ function SelectedDayList({ items }: { items: CalendarItem[] }) {
       {items.map((item) =>
         item.type === "episode" ? (
           <EpisodeRow
-            key={`ep-${item.data.id}`}
+            key={`ep-${item.instanceId}-${item.data.id}`}
             episode={item.data}
-            onPress={() => router.push(`/series/${item.data.seriesId}`)}
+            onPress={() =>
+              router.push(
+                `/series/${item.data.seriesId}?instanceId=${item.instanceId}`,
+              )
+            }
           />
         ) : (
           <MovieRow
-            key={`mov-${item.data.id}`}
+            key={`mov-${item.instanceId}-${item.data.id}`}
             movie={item.data}
-            onPress={() => router.push(`/movie/${item.data.id}`)}
+            onPress={() =>
+              router.push(`/movie/${item.data.id}?instanceId=${item.instanceId}`)
+            }
           />
         ),
       )}

--- a/app/(tabs)/downloads.tsx
+++ b/app/(tabs)/downloads.tsx
@@ -15,7 +15,7 @@ import { useConfigStore } from "@/store/config-store";
 import { SabnzbdDownloadsView } from "@/components/downloads/sabnzbd-downloads-view";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { BottomTabBarHeightContext } from "@react-navigation/bottom-tabs";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect } from "expo-router";
 import { Pause, Play, Trash2, Plus, CheckCircle2, Circle, ArrowUpDown, Check, Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -306,7 +306,7 @@ function QbittorrentDownloadsScreen({
         setMagnetUri("");
         setShowAddModal(false);
       },
-      onError: () => toast("Failed to add torrent", "error"),
+      onError: (err) => toastError("Failed to add torrent", err),
     });
   };
 

--- a/app/(tabs)/indexers.tsx
+++ b/app/(tabs)/indexers.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { View, Text, Pressable, Alert, Platform, ScrollView } from "react-native";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { Search, Power, AlertTriangle, CheckCircle, XCircle } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -152,7 +152,7 @@ function IndexerSearch() {
             { guid: result.guid, indexerId: result.indexerId },
             {
               onSuccess: () => toast("Sent to download client"),
-              onError: () => toast("Failed to grab release", "error"),
+              onError: (err) => toastError("Failed to grab release", err),
             },
           ),
       },

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,7 +3,7 @@ import { View, Text, Alert, BackHandler, Pressable, Linking, Platform } from "re
 import * as Clipboard from "expo-clipboard";
 import { router, useFocusEffect } from "expo-router";
 import { Image } from "expo-image";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import {
   Upload,
   FolderDown,
@@ -197,8 +197,7 @@ export default function SettingsScreen() {
       await exportConfig(result.passphrase, setExportStage);
       await syncRememberedState(result);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "Failed to export config";
-      toast(msg, "error");
+      toastError("Failed to export config", e);
     } finally {
       setExportStage(null);
     }
@@ -226,8 +225,8 @@ export default function SettingsScreen() {
     try {
       await Promise.all([Image.clearMemoryCache(), Image.clearDiskCache()]);
       toast("Image cache cleared", "success");
-    } catch {
-      toast("Failed to clear image cache", "error");
+    } catch (err) {
+      toastError("Failed to clear image cache", err);
     }
   };
 
@@ -253,8 +252,7 @@ export default function SettingsScreen() {
         toast("Configuration imported successfully", "success");
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "Invalid config file";
-      toast(msg, "error");
+      toastError("Invalid config file", e);
     } finally {
       setImportStage(null);
     }

--- a/app/backend.tsx
+++ b/app/backend.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { BackendStatusPill } from "@/components/ui/backend-status-pill";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useBackendStore } from "@/store/backend-store";
 import {
   getBackendHealth,
@@ -94,7 +94,7 @@ export default function BackendScreen() {
         setMode("summary");
       } catch (err) {
         console.warn("pair failed", err);
-        toast(err instanceof Error ? err.message : "Pairing failed", "error");
+        toastError("Pairing failed", err);
         // Only release the guard on failure so the user can retry. On success
         // we intentionally keep it latched — the camera stays mounted briefly
         // after the success toast, and any buffered native scan would
@@ -135,7 +135,7 @@ export default function BackendScreen() {
       await testPush();
       toast("Test push sent", "success");
     } catch (err) {
-      toast(err instanceof Error ? err.message : "Test push failed", "error");
+      toastError("Test push failed", err);
     } finally {
       setBusy(false);
     }

--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -43,13 +43,16 @@ import type { RadarrMovie } from "@/lib/types";
 type DeleteMode = "keep" | "withFiles" | null;
 
 export default function MovieDetailScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, instanceId } = useLocalSearchParams<{
+    id: string;
+    instanceId?: string;
+  }>();
   const router = useRouter();
-  const { data: movie, isLoading } = useRadarrMovie(Number(id));
-  const deleteMutation = useDeleteMovie();
-  const toggleMonitored = useToggleMovieMonitored();
-  const { data: qualityProfiles } = useRadarrQualityProfiles();
-  const updateProfile = useUpdateMovieQualityProfile();
+  const { data: movie, isLoading } = useRadarrMovie(Number(id), instanceId);
+  const deleteMutation = useDeleteMovie(instanceId);
+  const toggleMonitored = useToggleMovieMonitored(instanceId);
+  const { data: qualityProfiles } = useRadarrQualityProfiles(instanceId);
+  const updateProfile = useUpdateMovieQualityProfile(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
@@ -129,7 +132,12 @@ export default function MovieDetailScreen() {
       key: "search",
       icon: Search,
       label: "Search",
-      onPress: () => router.push(`/movie/releases/${movie.id}`),
+      onPress: () =>
+        router.push(
+          instanceId
+            ? `/movie/releases/${movie.id}?instanceId=${instanceId}`
+            : `/movie/releases/${movie.id}`,
+        ),
     },
     ...(movie.imdbId
       ? [

--- a/app/movie/releases/[id].tsx
+++ b/app/movie/releases/[id].tsx
@@ -6,10 +6,13 @@ import { ReleasesPicker } from "@/components/common/releases-picker";
 import { useRadarrMovie, useRadarrReleases } from "@/hooks/use-radarr";
 
 export default function MovieReleasesScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, instanceId } = useLocalSearchParams<{
+    id: string;
+    instanceId?: string;
+  }>();
   const movieId = Number(id);
-  const { data: movie } = useRadarrMovie(movieId);
-  const query = useRadarrReleases(movieId);
+  const { data: movie } = useRadarrMovie(movieId, instanceId);
+  const query = useRadarrReleases(movieId, instanceId);
 
   const title = movie ? `Releases · ${movie.title}` : "Releases";
 
@@ -17,7 +20,7 @@ export default function MovieReleasesScreen() {
     <ScreenWrapper scrollable={false}>
       <BackHeader title={title} />
       <View className="flex-1">
-        <ReleasesPicker service="radarr" query={query} />
+        <ReleasesPicker service="radarr" query={query} instanceId={instanceId} />
       </View>
     </ScreenWrapper>
   );

--- a/app/movie/search.tsx
+++ b/app/movie/search.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { Film, Plus, Check, SlidersHorizontal } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { useServiceImage } from "@/hooks/use-service-image";
@@ -117,7 +117,7 @@ function SearchResultCard({
       },
       {
         onSuccess: () => toast(`${result.title} added to Radarr`),
-        onError: () => toast("Failed to add movie", "error"),
+        onError: (err) => toastError("Failed to add movie", err),
       },
     );
   };

--- a/app/movie/search.tsx
+++ b/app/movie/search.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { Image } from "expo-image";
+import { useRouter } from "expo-router";
 import { toast } from "@/components/ui/toast";
 import { Film, Plus, Check, SlidersHorizontal } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -21,15 +22,19 @@ import {
 import type { RadarrSearchResult } from "@/lib/types";
 
 export default function MovieSearchScreen() {
+  const router = useRouter();
   const [query, setQuery] = useState("");
   const { data: results, isLoading } = useRadarrSearch(query);
   const { data: existing } = useRadarrMovies();
   const [advancedTarget, setAdvancedTarget] = useState<RadarrSearchResult | null>(null);
 
-  const existingTmdbIds = useMemo(
-    () => new Set(existing?.map((m) => m.tmdbId) ?? []),
-    [existing],
-  );
+  const existingByTmdbId = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const m of existing ?? []) {
+      map.set(m.tmdbId, m.id);
+    }
+    return map;
+  }, [existing]);
 
   return (
     <ScreenWrapper>
@@ -51,14 +56,21 @@ export default function MovieSearchScreen() {
 
       {results && results.length > 0 && (
         <View className="gap-3">
-          {results.map((result) => (
-            <SearchResultCard
-              key={result.tmdbId}
-              result={result}
-              alreadyAdded={existingTmdbIds.has(result.tmdbId)}
-              onAdvanced={() => setAdvancedTarget(result)}
-            />
-          ))}
+          {results.map((result) => {
+            const existingId = existingByTmdbId.get(result.tmdbId);
+            return (
+              <SearchResultCard
+                key={result.tmdbId}
+                result={result}
+                existingMovieId={existingId}
+                onAdvanced={() => setAdvancedTarget(result)}
+                onOpenExisting={() =>
+                  existingId !== undefined &&
+                  router.push(`/movie/${existingId}`)
+                }
+              />
+            );
+          })}
         </View>
       )}
 
@@ -73,13 +85,16 @@ export default function MovieSearchScreen() {
 
 function SearchResultCard({
   result,
-  alreadyAdded,
+  existingMovieId,
   onAdvanced,
+  onOpenExisting,
 }: {
   result: RadarrSearchResult;
-  alreadyAdded: boolean;
+  existingMovieId: number | undefined;
   onAdvanced: () => void;
+  onOpenExisting: () => void;
 }) {
+  const alreadyAdded = existingMovieId !== undefined;
   const addMovie = useAddMovie();
   const { data: profiles } = useRadarrQualityProfiles();
   const { data: folders } = useRadarrRootFolders();
@@ -108,7 +123,10 @@ function SearchResultCard({
   };
 
   return (
-    <Card className="flex-row gap-3">
+    <Card
+      className="flex-row gap-3"
+      onPress={alreadyAdded ? onOpenExisting : undefined}
+    >
       {posterUrl ? (
         <Image
           source={{ uri: posterUrl }}

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -57,15 +57,18 @@ import type {
 type DeleteMode = "keep" | "withFiles" | null;
 
 export default function SeriesDetailScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, instanceId } = useLocalSearchParams<{
+    id: string;
+    instanceId?: string;
+  }>();
   const router = useRouter();
-  const { data: series, isLoading } = useSonarrSeriesById(Number(id));
-  const { data: episodes } = useSonarrEpisodes(Number(id));
-  const { data: episodeFiles } = useSonarrEpisodeFiles(Number(id));
-  const toggleSeries = useToggleSeriesMonitored();
-  const deleteSeries = useDeleteSeries();
-  const { data: qualityProfiles } = useSonarrQualityProfiles();
-  const updateProfile = useUpdateSeriesQualityProfile();
+  const { data: series, isLoading } = useSonarrSeriesById(Number(id), instanceId);
+  const { data: episodes } = useSonarrEpisodes(Number(id), instanceId);
+  const { data: episodeFiles } = useSonarrEpisodeFiles(Number(id), instanceId);
+  const toggleSeries = useToggleSeriesMonitored(instanceId);
+  const deleteSeries = useDeleteSeries(instanceId);
+  const { data: qualityProfiles } = useSonarrQualityProfiles(instanceId);
+  const updateProfile = useUpdateSeriesQualityProfile(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
@@ -150,7 +153,12 @@ export default function SeriesDetailScreen() {
       key: "search",
       icon: Search,
       label: "Search",
-      onPress: () => router.push(`/series/releases/${series.id}`),
+      onPress: () =>
+        router.push(
+          instanceId
+            ? `/series/releases/${series.id}?instanceId=${instanceId}`
+            : `/series/releases/${series.id}`,
+        ),
     },
     {
       key: "more",
@@ -227,6 +235,7 @@ export default function SeriesDetailScreen() {
                   <SeasonAccordion
                     key={season.seasonNumber}
                     seriesId={series.id}
+                    instanceId={instanceId}
                     season={season}
                     episodes={episodes?.filter(
                       (ep) => ep.seasonNumber === season.seasonNumber,
@@ -440,11 +449,13 @@ function AboutRow({ label, value }: { label: string; value: string }) {
 
 function SeasonAccordion({
   seriesId,
+  instanceId,
   season,
   episodes,
   episodeFileMap,
 }: {
   seriesId: number;
+  instanceId?: string;
   season: SonarrSeason;
   episodes?: SonarrEpisode[];
   episodeFileMap: Map<number, SonarrEpisodeFile>;
@@ -453,6 +464,10 @@ function SeasonAccordion({
   const [expanded, setExpanded] = useState(false);
   const stats = season.statistics;
   const progress = stats ? stats.percentOfEpisodes / 100 : 0;
+
+  const releasesQuery = `seasonNumber=${season.seasonNumber}${
+    instanceId ? `&instanceId=${instanceId}` : ""
+  }`;
 
   return (
     <Card>
@@ -481,9 +496,7 @@ function SeasonAccordion({
           )}
           <Pressable
             onPress={() =>
-              router.push(
-                `/series/releases/${seriesId}?seasonNumber=${season.seasonNumber}`,
-              )
+              router.push(`/series/releases/${seriesId}?${releasesQuery}`)
             }
             hitSlop={8}
             className="p-1 active:opacity-70"
@@ -503,6 +516,7 @@ function SeasonAccordion({
               <EpisodeRow
                 key={ep.id}
                 seriesId={seriesId}
+                instanceId={instanceId}
                 episode={ep}
                 episodeFile={
                   ep.episodeFileId
@@ -519,15 +533,17 @@ function SeasonAccordion({
 
 function EpisodeRow({
   seriesId,
+  instanceId,
   episode,
   episodeFile,
 }: {
   seriesId: number;
+  instanceId?: string;
   episode: SonarrEpisode;
   episodeFile?: SonarrEpisodeFile;
 }) {
   const router = useRouter();
-  const toggleMonitored = useToggleEpisodeMonitored();
+  const toggleMonitored = useToggleEpisodeMonitored(instanceId);
   const mediaInfo = episodeFile?.mediaInfo;
 
   return (
@@ -556,7 +572,11 @@ function EpisodeRow({
       </View>
       <Pressable
         onPress={() =>
-          router.push(`/series/releases/${seriesId}?episodeId=${episode.id}`)
+          router.push(
+            `/series/releases/${seriesId}?episodeId=${episode.id}${
+              instanceId ? `&instanceId=${instanceId}` : ""
+            }`,
+          )
         }
         hitSlop={6}
         className="p-1 active:opacity-70 mr-1"

--- a/app/series/releases/[id].tsx
+++ b/app/series/releases/[id].tsx
@@ -17,27 +17,32 @@ export default function SeriesReleasesScreen() {
     id: string;
     episodeId?: string;
     seasonNumber?: string;
+    instanceId?: string;
   }>();
   const seriesId = Number(params.id);
   const episodeId = params.episodeId ? Number(params.episodeId) : 0;
   const seasonNumber =
     params.seasonNumber !== undefined ? Number(params.seasonNumber) : NaN;
+  const instanceId = params.instanceId;
 
   const mode: "episode" | "season" = episodeId > 0 ? "episode" : "season";
 
-  const { data: series } = useSonarrSeriesById(seriesId);
+  const { data: series } = useSonarrSeriesById(seriesId, instanceId);
   // Episode metadata is needed for the title in episode mode; the list is
   // already cached from the series detail screen so this is usually free.
   const { data: episodes } = useSonarrEpisodes(
     mode === "episode" ? seriesId : 0,
+    instanceId,
   );
 
   const episodeQuery = useSonarrReleasesForEpisode(
     mode === "episode" ? episodeId : 0,
+    instanceId,
   );
   const seasonQuery = useSonarrReleasesForSeason(
     mode === "season" ? seriesId : 0,
     mode === "season" ? seasonNumber : -1,
+    instanceId,
   );
   const query = mode === "episode" ? episodeQuery : seasonQuery;
 
@@ -58,7 +63,7 @@ export default function SeriesReleasesScreen() {
     <ScreenWrapper scrollable={false}>
       <BackHeader title={title} />
       <View className="flex-1">
-        <ReleasesPicker service="sonarr" query={query} />
+        <ReleasesPicker service="sonarr" query={query} instanceId={instanceId} />
       </View>
     </ScreenWrapper>
   );

--- a/app/series/search.tsx
+++ b/app/series/search.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { Image } from "expo-image";
+import { useRouter } from "expo-router";
 import { toast } from "@/components/ui/toast";
 import { Tv, Plus, Check, SlidersHorizontal } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -21,15 +22,19 @@ import {
 import type { SonarrSearchResult } from "@/lib/types";
 
 export default function SeriesSearchScreen() {
+  const router = useRouter();
   const [query, setQuery] = useState("");
   const { data: results, isLoading } = useSonarrSearch(query);
   const { data: existing } = useSonarrSeries();
   const [advancedTarget, setAdvancedTarget] = useState<SonarrSearchResult | null>(null);
 
-  const existingTvdbIds = useMemo(
-    () => new Set(existing?.map((s) => s.tvdbId) ?? []),
-    [existing],
-  );
+  const existingByTvdbId = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const s of existing ?? []) {
+      map.set(s.tvdbId, s.id);
+    }
+    return map;
+  }, [existing]);
 
   return (
     <ScreenWrapper>
@@ -51,14 +56,21 @@ export default function SeriesSearchScreen() {
 
       {results && results.length > 0 && (
         <View className="gap-3">
-          {results.map((result) => (
-            <SearchResultCard
-              key={result.tvdbId}
-              result={result}
-              alreadyAdded={existingTvdbIds.has(result.tvdbId)}
-              onAdvanced={() => setAdvancedTarget(result)}
-            />
-          ))}
+          {results.map((result) => {
+            const existingId = existingByTvdbId.get(result.tvdbId);
+            return (
+              <SearchResultCard
+                key={result.tvdbId}
+                result={result}
+                existingSeriesId={existingId}
+                onAdvanced={() => setAdvancedTarget(result)}
+                onOpenExisting={() =>
+                  existingId !== undefined &&
+                  router.push(`/series/${existingId}`)
+                }
+              />
+            );
+          })}
         </View>
       )}
 
@@ -73,13 +85,16 @@ export default function SeriesSearchScreen() {
 
 function SearchResultCard({
   result,
-  alreadyAdded,
+  existingSeriesId,
   onAdvanced,
+  onOpenExisting,
 }: {
   result: SonarrSearchResult;
-  alreadyAdded: boolean;
+  existingSeriesId: number | undefined;
   onAdvanced: () => void;
+  onOpenExisting: () => void;
 }) {
+  const alreadyAdded = existingSeriesId !== undefined;
   const addSeries = useAddSeries();
   const { data: profiles } = useSonarrQualityProfiles();
   const { data: folders } = useSonarrRootFolders();
@@ -108,7 +123,10 @@ function SearchResultCard({
   };
 
   return (
-    <Card className="flex-row gap-3">
+    <Card
+      className="flex-row gap-3"
+      onPress={alreadyAdded ? onOpenExisting : undefined}
+    >
       {posterUrl ? (
         <Image
           source={{ uri: posterUrl }}

--- a/app/series/search.tsx
+++ b/app/series/search.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { Tv, Plus, Check, SlidersHorizontal } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { useServiceImage } from "@/hooks/use-service-image";
@@ -117,7 +117,7 @@ function SearchResultCard({
       },
       {
         onSuccess: () => toast(`${result.title} added to Sonarr`),
-        onError: () => toast("Failed to add series", "error"),
+        onError: (err) => toastError("Failed to add series", err),
       },
     );
   };

--- a/app/wake-on-lan.tsx
+++ b/app/wake-on-lan.tsx
@@ -7,9 +7,9 @@ import { BackHeader } from "@/components/common/back-header";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useConfigStore } from "@/store/config-store";
-import { sendWakeOnLan, WakeOnLanError } from "@/lib/wake-on-lan";
+import { sendWakeOnLan } from "@/lib/wake-on-lan";
 import type { WakeOnLanDevice } from "@/store/config-store";
 
 function generateId() {
@@ -106,13 +106,7 @@ export default function WakeOnLanScreen() {
       });
       toast(`Magic packet sent to ${device.name}`, "success");
     } catch (err) {
-      const msg =
-        err instanceof WakeOnLanError
-          ? err.message
-          : err instanceof Error
-            ? err.message
-            : "Failed to send magic packet";
-      toast(msg, "error");
+      toastError("Failed to send magic packet", err);
     } finally {
       setSendingId(null);
     }

--- a/components/common/app-version-card.tsx
+++ b/components/common/app-version-card.tsx
@@ -4,7 +4,7 @@ import { Sparkles } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import {
   NATIVE_VERSION,
   RUNTIME_VERSION,
@@ -79,8 +79,8 @@ export function AppVersionCard() {
               onPress: async () => {
                 try {
                   await downloadAndApplyOtaUpdate();
-                } catch {
-                  toast("Failed to install update", "error");
+                } catch (err) {
+                  toastError("Failed to install update", err);
                 }
               },
             },

--- a/components/common/release-detail-sheet.tsx
+++ b/components/common/release-detail-sheet.tsx
@@ -40,6 +40,7 @@ const OFFSCREEN = SHEET_MAX + 140;
 interface ReleaseDetailSheetProps {
   release: ArrRelease | SonarrRelease | null;
   service: "radarr" | "sonarr";
+  instanceId?: string;
   onClose: () => void;
   onGrabbed?: () => void;
 }
@@ -47,6 +48,7 @@ interface ReleaseDetailSheetProps {
 export function ReleaseDetailSheet({
   release,
   service,
+  instanceId,
   onClose,
   onGrabbed,
 }: ReleaseDetailSheetProps) {
@@ -57,8 +59,8 @@ export function ReleaseDetailSheet({
 
   // Both grab hooks coexist so the sheet can be used from either service.
   // Only one will fire per render.
-  const radarrGrab = useGrabRadarrRelease();
-  const sonarrGrab = useGrabSonarrRelease();
+  const radarrGrab = useGrabRadarrRelease(instanceId);
+  const sonarrGrab = useGrabSonarrRelease(instanceId);
   const grab = service === "radarr" ? radarrGrab : sonarrGrab;
 
   const visible = release !== null;

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -33,6 +33,7 @@ type Release = ArrRelease | SonarrRelease;
 interface ReleasesPickerProps {
   service: "radarr" | "sonarr";
   query: UseQueryResult<Release[], Error>;
+  instanceId?: string;
 }
 
 const SORT_LABELS: Record<ReleasesSortKey, string> = {
@@ -160,7 +161,11 @@ function formatRelative(timestamp: number): string {
   return `${hours}h ago`;
 }
 
-export function ReleasesPicker({ service, query }: ReleasesPickerProps) {
+export function ReleasesPicker({
+  service,
+  query,
+  instanceId,
+}: ReleasesPickerProps) {
   const router = useRouter();
   const sortKey = useSortStore((s) => s.releases);
   const setSortKey = useSortStore((s) => s.setReleases);
@@ -440,6 +445,7 @@ export function ReleasesPicker({ service, query }: ReleasesPickerProps) {
       <ReleaseDetailSheet
         release={selected}
         service={service}
+        instanceId={instanceId}
         onClose={() => setSelected(null)}
         onGrabbed={() => {
           // After a grab succeeds, pop back to the detail screen so the user

--- a/components/common/wake-on-lan-button.tsx
+++ b/components/common/wake-on-lan-button.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
-import { toast } from "@/components/ui/toast";
-import { sendWakeOnLan, WakeOnLanError } from "@/lib/wake-on-lan";
+import { toast, toastError } from "@/components/ui/toast";
+import { sendWakeOnLan } from "@/lib/wake-on-lan";
 import type { WakeOnLanDevice } from "@/store/config-store";
 
 interface WakeOnLanButtonProps {
@@ -31,13 +31,7 @@ export function WakeOnLanButton({
       });
       toast(`Magic packet sent to ${device.name}`, "success");
     } catch (err) {
-      const msg =
-        err instanceof WakeOnLanError
-          ? err.message
-          : err instanceof Error
-            ? err.message
-            : "Failed to send magic packet";
-      toast(msg, "error");
+      toastError("Failed to send magic packet", err);
     } finally {
       setSending(false);
     }

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -41,8 +41,13 @@ import { CardHeaderLink } from "@/components/dashboard/card-header-link";
 import type { SonarrCalendarEntry, RadarrMovie } from "@/lib/types";
 
 type CalendarItem =
-  | { kind: "episode"; date: string; entry: SonarrCalendarEntry }
-  | { kind: "movie"; date: string; movie: RadarrMovie };
+  | {
+      kind: "episode";
+      date: string;
+      entry: SonarrCalendarEntry;
+      instanceId: string;
+    }
+  | { kind: "movie"; date: string; movie: RadarrMovie; instanceId: string };
 
 function pickRadarrDate(
   movie: RadarrMovie,
@@ -142,24 +147,28 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
 
   const items: CalendarItem[] = [];
   if (showSonarr) {
-    for (const q of sonarrQueries) {
+    sonarrQueries.forEach((q, i) => {
+      const instanceId = sonarrInstances[i]?.id;
+      if (!instanceId) return;
       for (const ep of q.data ?? []) {
         const date = isoDate(ep.airDate);
         if (date < todayIso || date > horizonIso) continue;
-        items.push({ kind: "episode", date, entry: ep });
+        items.push({ kind: "episode", date, entry: ep, instanceId });
       }
-    }
+    });
   }
   if (showRadarr) {
-    for (const q of radarrQueries) {
+    radarrQueries.forEach((q, i) => {
+      const instanceId = radarrInstances[i]?.id;
+      if (!instanceId) return;
       for (const movie of q.data ?? []) {
         const raw = pickRadarrDate(movie, settings.radarrReleaseType);
         if (!raw) continue;
         const date = isoDate(raw);
         if (date < todayIso || date > horizonIso) continue;
-        items.push({ kind: "movie", date, movie });
+        items.push({ kind: "movie", date, movie, instanceId });
       }
-    }
+    });
   }
 
   const grouped = groupByDate(items);
@@ -216,17 +225,23 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
                 {entries.map((item) =>
                   item.kind === "episode" ? (
                     <EpisodeRow
-                      key={`ep-${item.entry.id}`}
+                      key={`ep-${item.instanceId}-${item.entry.id}`}
                       entry={item.entry}
                       onPress={() =>
-                        router.push(`/series/${item.entry.seriesId}`)
+                        router.push(
+                          `/series/${item.entry.seriesId}?instanceId=${item.instanceId}`,
+                        )
                       }
                     />
                   ) : (
                     <MovieRow
-                      key={`mv-${item.movie.id}`}
+                      key={`mv-${item.instanceId}-${item.movie.id}`}
                       movie={item.movie}
-                      onPress={() => router.push(`/movie/${item.movie.id}`)}
+                      onPress={() =>
+                        router.push(
+                          `/movie/${item.movie.id}?instanceId=${item.instanceId}`,
+                        )
+                      }
                     />
                   ),
                 )}

--- a/components/dashboard/dashboard-picker-sheet.tsx
+++ b/components/dashboard/dashboard-picker-sheet.tsx
@@ -289,14 +289,14 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
                               onPress={() => handleSelect(d.id)}
                               hitSlop={6}
                             >
-                              {/* Wrap to 2 lines so longer names stay readable
-                                  at higher uiScale settings (Extra Large can
-                                  truncate even short names like "HomeServer"
-                                  to "HomeSe…" with the trailing actions taking
-                                  most of the row). */}
+                              {/* Name gets the full row width (only the icon
+                                  sits beside it) so longer names like
+                                  "HomeServer" stay on a single line at every
+                                  uiScale. Action buttons live on a second row
+                                  below so they never squeeze this column. */}
                               <Text
                                 className="text-zinc-100 text-base font-semibold"
-                                numberOfLines={2}
+                                numberOfLines={1}
                               >
                                 {d.name}
                               </Text>
@@ -311,63 +311,57 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
                             </Pressable>
                           )}
                         </View>
-
-                        <View className="flex-row items-center gap-1">
-                          {!isRenaming && (
-                            <>
-                              <Pressable
-                                onPress={() =>
-                                  moveDashboard(d.id, "up")
-                                }
-                                disabled={isFirst}
-                                hitSlop={6}
-                                className="p-1"
-                              >
-                                <Icon
-                                  icon={ChevronUp}
-                                  size={ICON.MD}
-                                  color={isFirst ? "#3f3f46" : "#a1a1aa"}
-                                />
-                              </Pressable>
-                              <Pressable
-                                onPress={() =>
-                                  moveDashboard(d.id, "down")
-                                }
-                                disabled={isLast}
-                                hitSlop={6}
-                                className="p-1"
-                              >
-                                <Icon
-                                  icon={ChevronDown}
-                                  size={ICON.MD}
-                                  color={isLast ? "#3f3f46" : "#a1a1aa"}
-                                />
-                              </Pressable>
-                              <Pressable
-                                onPress={() => startRename(d)}
-                                hitSlop={6}
-                                className="p-1 ml-1"
-                              >
-                                <Icon icon={Pencil} size={ICON.MD} color="#60a5fa" />
-                              </Pressable>
-                              <Pressable
-                                onPress={() => handleRemove(d)}
-                                disabled={dashboards.length <= 1}
-                                hitSlop={6}
-                                className="p-1 ml-1"
-                              >
-                                <Icon
-                                  icon={Trash2}
-                                  size={ICON.MD}
-                                  color={
-                                    dashboards.length <= 1 ? "#3f3f46" : "#ef4444"
-                                  }
-                                />
-                              </Pressable>
-                            </>
-                          )}
-                        </View>
                       </View>
+
+                      {!isRenaming && (
+                        <View className="flex-row items-center justify-end gap-1 mt-2">
+                          <Pressable
+                            onPress={() => moveDashboard(d.id, "up")}
+                            disabled={isFirst}
+                            hitSlop={6}
+                            className="p-1"
+                          >
+                            <Icon
+                              icon={ChevronUp}
+                              size={ICON.MD}
+                              color={isFirst ? "#3f3f46" : "#a1a1aa"}
+                            />
+                          </Pressable>
+                          <Pressable
+                            onPress={() => moveDashboard(d.id, "down")}
+                            disabled={isLast}
+                            hitSlop={6}
+                            className="p-1"
+                          >
+                            <Icon
+                              icon={ChevronDown}
+                              size={ICON.MD}
+                              color={isLast ? "#3f3f46" : "#a1a1aa"}
+                            />
+                          </Pressable>
+                          <Pressable
+                            onPress={() => startRename(d)}
+                            hitSlop={6}
+                            className="p-1 ml-1"
+                          >
+                            <Icon icon={Pencil} size={ICON.MD} color="#60a5fa" />
+                          </Pressable>
+                          <Pressable
+                            onPress={() => handleRemove(d)}
+                            disabled={dashboards.length <= 1}
+                            hitSlop={6}
+                            className="p-1 ml-1"
+                          >
+                            <Icon
+                              icon={Trash2}
+                              size={ICON.MD}
+                              color={
+                                dashboards.length <= 1 ? "#3f3f46" : "#ef4444"
+                              }
+                            />
+                          </Pressable>
+                        </View>
+                      )}
                     </View>
                   );
                 })}

--- a/components/dashboard/dashboard-picker-sheet.tsx
+++ b/components/dashboard/dashboard-picker-sheet.tsx
@@ -289,9 +289,14 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
                               onPress={() => handleSelect(d.id)}
                               hitSlop={6}
                             >
+                              {/* Wrap to 2 lines so longer names stay readable
+                                  at higher uiScale settings (Extra Large can
+                                  truncate even short names like "HomeServer"
+                                  to "HomeSe…" with the trailing actions taking
+                                  most of the row). */}
                               <Text
                                 className="text-zinc-100 text-base font-semibold"
-                                numberOfLines={1}
+                                numberOfLines={2}
                               >
                                 {d.name}
                               </Text>

--- a/components/dashboard/radarr-queue-card.tsx
+++ b/components/dashboard/radarr-queue-card.tsx
@@ -112,11 +112,14 @@ export function RadarrQueueCard({ slotId }: WidgetComponentProps) {
                 bottomOverlay={<PosterProgressStrip progress={progress} />}
                 mediaType="movie"
                 onPress={() =>
-                  // Movie ids aren't globally unique. The router push only
-                  // makes sense if the user is currently viewing the same
-                  // Radarr instance the queue item belongs to. Tap → switch
-                  // active instance to match, then navigate.
-                  item.movie && router.push(`/movie/${item.movie.id}`)
+                  // Movie ids aren't globally unique across instances, so we
+                  // pass the source instance id to the detail screen — it
+                  // queries Radarr against that instance instead of the
+                  // user's currently-active one.
+                  item.movie &&
+                  router.push(
+                    `/movie/${item.movie.id}?instanceId=${instanceId}`,
+                  )
                 }
               />
             );

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -40,6 +40,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   );
   const { data: services } = useServiceHealth();
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
   const router = useRouter();
 
   const hiddenSet = new Set(settings.hiddenKinds);
@@ -92,7 +93,14 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
           return (
             <Pressable
               key={`${entry.kindId}:${entry.instanceId}`}
-              onPress={() => route && router.push(route as any)}
+              onPress={() => {
+                if (!route) return;
+                // Switch the active instance to the one tapped so the
+                // destination tab opens against this server, not whichever
+                // instance the user happened to last visit.
+                setActiveInstance(entry.kindId, entry.instanceId);
+                router.push(route as any);
+              }}
               className="items-center gap-1.5 active:opacity-70"
               hitSlop={6}
             >

--- a/components/downloads/sabnzbd-downloads-view.tsx
+++ b/components/downloads/sabnzbd-downloads-view.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import { View, Text, Pressable, Alert, BackHandler, ScrollView } from "react-native";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect } from "expo-router";
 import {
   Pause,
@@ -214,7 +214,7 @@ export function SabnzbdDownloadsView({ showHeader = true, segmentedControl }: Vi
           setNzbUrl("");
           setShowAddModal(false);
         },
-        onError: () => toast("Failed to add NZB", "error"),
+        onError: (err) => toastError("Failed to add NZB", err),
       },
     );
   };

--- a/components/overseerr/request-options-sheet.tsx
+++ b/components/overseerr/request-options-sheet.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useMemo, useState } from "react";
-import { Modal, View, Text, ScrollView } from "react-native";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Modal, View, Text, ScrollView, Pressable } from "react-native";
 import { Image } from "expo-image";
-import { Plus, Film, Tv } from "lucide-react-native";
+import { Plus, Film, Tv, AlertCircle, Copy, Check } from "lucide-react-native";
+import * as Clipboard from "expo-clipboard";
 import { Icon } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { SheetHeader } from "@/components/ui/sheet-header";
 import { toast } from "@/components/ui/toast";
+import { getHttpErrorMessage, formatErrorForCopy } from "@/lib/http-client";
+import { brrrHaptic } from "@/lib/haptics";
 import { getPosterUrl } from "@/services/overseerr-api";
 import {
   useOverseerrRadarrServers,
@@ -78,6 +81,38 @@ export function RequestOptionsSheet({
     if (visible) setSeasonSelection("all");
   }, [visible, item?.id]);
 
+  // The visible banner text is the friendly message; the clipboard payload is
+  // the verbose error (HTTP body / stack) so users can share/search the real
+  // failure. Mirrors the Copy behavior in error toasts.
+  const [submitError, setSubmitError] = useState<{
+    message: string;
+    copyText: string;
+  } | null>(null);
+  const [copied, setCopied] = useState(false);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setSubmitError(null);
+      setCopied(false);
+    }
+  }, [visible, item?.id]);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    };
+  }, []);
+
+  const handleCopyError = async () => {
+    if (!submitError) return;
+    await Clipboard.setStringAsync(submitError.copyText);
+    brrrHaptic();
+    setCopied(true);
+    if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    copiedTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+
   const tvDetailsQuery = useOverseerrMediaDetails(
     item?.id ?? 0,
     isTv ? "tv" : "movie",
@@ -126,6 +161,7 @@ export function RequestOptionsSheet({
 
   const handleSubmit = async () => {
     if (!item) return;
+    setSubmitError(null);
     const options =
       servers.length > 0
         ? { serverId, profileId, rootFolder, tags }
@@ -145,8 +181,14 @@ export function RequestOptionsSheet({
       toast(`${title} has been requested`);
       onRequested?.();
       onClose();
-    } catch {
-      toast("Failed to request", "error");
+    } catch (err) {
+      // Surface the real Seerr error inline — toasts shown from inside this
+      // Modal render behind it on Android, so the user would otherwise see
+      // nothing and only get a generic "request failed" after dismissing.
+      const message =
+        getHttpErrorMessage(err) ??
+        (err instanceof Error ? err.message : "Failed to request");
+      setSubmitError({ message, copyText: formatErrorForCopy(err) });
     }
   };
 
@@ -321,6 +363,32 @@ export function RequestOptionsSheet({
         </ScrollView>
 
         <View className="px-4 pb-6 pt-3 border-t border-border bg-background">
+          {submitError ? (
+            <View className="mb-3 flex-row items-start gap-2 rounded-xl border border-red-600/40 bg-red-600/10 px-3 py-2.5">
+              <View className="pt-0.5">
+                <Icon icon={AlertCircle} size={16} color="#f87171" />
+              </View>
+              <Text className="text-red-300 text-sm flex-1">{submitError.message}</Text>
+              <Pressable
+                onPress={handleCopyError}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel={copied ? "Error copied" : "Copy error"}
+                className="flex-row items-center gap-1 pl-2 py-0.5 active:opacity-60"
+              >
+                <Icon
+                  icon={copied ? Check : Copy}
+                  size={14}
+                  color={copied ? "#4ade80" : "#fca5a5"}
+                />
+                <Text
+                  className={`text-xs ${copied ? "text-green-400" : "text-red-300"}`}
+                >
+                  {copied ? "Copied" : "Copy"}
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
           <Button
             label="Send Request"
             onPress={handleSubmit}

--- a/components/qbittorrent/speed-limits-sheet.tsx
+++ b/components/qbittorrent/speed-limits-sheet.tsx
@@ -9,7 +9,7 @@ import { TextInput } from "@/components/ui/text-input";
 import { Toggle } from "@/components/ui/toggle";
 import { Button } from "@/components/ui/button";
 import { SheetHeader } from "@/components/ui/sheet-header";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import {
   useSpeedLimitsMode,
   useToggleSpeedLimitsMode,
@@ -108,8 +108,8 @@ export function SpeedLimitsSheet({ visible, onClose }: SpeedLimitsSheetProps) {
 
       toast("Speed limits saved", "success");
       onClose();
-    } catch {
-      toast("Failed to save speed limits", "error");
+    } catch (err) {
+      toastError("Failed to save speed limits", err);
     }
   };
 

--- a/components/radarr/add-movie-sheet.tsx
+++ b/components/radarr/add-movie-sheet.tsx
@@ -8,7 +8,7 @@ import { Select } from "@/components/ui/select";
 import { Toggle } from "@/components/ui/toggle";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { SheetHeader } from "@/components/ui/sheet-header";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useServiceImage } from "@/hooks/use-service-image";
 import {
   useAddMovie,
@@ -97,7 +97,7 @@ export function AddMovieSheet({ result, visible, onClose }: AddMovieSheetProps) 
           toast(`${result.title} added to Radarr`);
           onClose();
         },
-        onError: () => toast("Failed to add movie", "error"),
+        onError: (err) => toastError("Failed to add movie", err),
       },
     );
   };

--- a/components/sonarr/add-series-sheet.tsx
+++ b/components/sonarr/add-series-sheet.tsx
@@ -8,7 +8,7 @@ import { Select } from "@/components/ui/select";
 import { Toggle } from "@/components/ui/toggle";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { SheetHeader } from "@/components/ui/sheet-header";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useServiceImage } from "@/hooks/use-service-image";
 import {
   useAddSeries,
@@ -104,7 +104,7 @@ export function AddSeriesSheet({ result, visible, onClose }: AddSeriesSheetProps
           toast(`${result.title} added to Sonarr`);
           onClose();
         },
-        onError: () => toast("Failed to add series", "error"),
+        onError: (err) => toastError("Failed to add series", err),
       },
     );
   };

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { Animated, Text, Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { CheckCircle, AlertTriangle, X, Info } from "lucide-react-native";
+import { CheckCircle, AlertTriangle, X, Info, Copy, Check } from "lucide-react-native";
+import * as Clipboard from "expo-clipboard";
 import { Icon } from "@/components/ui/icon";
 import { create } from "zustand";
-import { successHaptic, errorHaptic } from "@/lib/haptics";
+import { successHaptic, errorHaptic, brrrHaptic } from "@/lib/haptics";
+import { formatErrorForCopy, getHttpErrorMessage } from "@/lib/http-client";
 
 type ToastType = "success" | "error" | "info";
 
@@ -12,21 +14,25 @@ interface Toast {
   id: number;
   message: string;
   type: ToastType;
+  // What the in-toast Copy button puts on the clipboard. When omitted the
+  // visible `message` is copied. Errors set this to the full HTTP body / stack
+  // so users can share the real failure, not the friendly summary.
+  copyText?: string;
 }
 
 interface ToastStore {
   toasts: Toast[];
   nextId: number;
-  addToast: (message: string, type?: ToastType) => void;
+  addToast: (message: string, type?: ToastType, copyText?: string) => void;
   removeToast: (id: number) => void;
 }
 
 export const useToastStore = create<ToastStore>((set) => ({
   toasts: [],
   nextId: 1,
-  addToast: (message, type = "success") =>
+  addToast: (message, type = "success", copyText) =>
     set((state) => ({
-      toasts: [...state.toasts, { id: state.nextId, message, type }],
+      toasts: [...state.toasts, { id: state.nextId, message, type, copyText }],
       nextId: state.nextId + 1,
     })),
   removeToast: (id) =>
@@ -35,10 +41,28 @@ export const useToastStore = create<ToastStore>((set) => ({
     })),
 }));
 
-export function toast(message: string, type: ToastType = "success") {
-  useToastStore.getState().addToast(message, type);
+export function toast(
+  message: string,
+  type: ToastType = "success",
+  copyText?: string,
+) {
+  useToastStore.getState().addToast(message, type, copyText);
   if (type === "success") successHaptic();
   else if (type === "error") errorHaptic();
+}
+
+// Display an error toast with the best-available message AND wire the Copy
+// button to the verbose, debuggable error. Prefer this over `toast(msg,"error")`
+// whenever the caller has the original error in scope.
+//   - Display: server's `{ message }` body → err.message → fallback string
+//   - Copy:    HTTP status + URL + body, or Error.name/message/stack
+export function toastError(fallback: string, err?: unknown) {
+  const serverMsg = err ? getHttpErrorMessage(err) : undefined;
+  const errorMsg =
+    err instanceof Error && err.message ? err.message : undefined;
+  const message = serverMsg ?? errorMsg ?? fallback;
+  const copyText = err !== undefined ? formatErrorForCopy(err) : undefined;
+  toast(message, "error", copyText);
 }
 
 const ICON_MAP: Record<ToastType, React.ComponentType<any>> = {
@@ -59,31 +83,26 @@ const BG_MAP: Record<ToastType, string> = {
   info: "bg-blue-950",
 };
 
+// Errors get more dwell time + lines because users often want to read the full
+// server message and (optionally) copy it. Success/info stay snappy.
+const DISMISS_MS: Record<ToastType, number> = {
+  success: 3000,
+  info: 3000,
+  error: 6000,
+};
+
+const LINE_CLAMP: Record<ToastType, number> = {
+  success: 2,
+  info: 2,
+  error: 4,
+};
+
 function ToastItem({ toast: t, onDismiss }: { toast: Toast; onDismiss: () => void }) {
   const translateY = useRef(new Animated.Value(-80)).current;
   const opacity = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    Animated.parallel([
-      Animated.spring(translateY, {
-        toValue: 0,
-        useNativeDriver: true,
-        tension: 80,
-        friction: 12,
-      }),
-      Animated.timing(opacity, {
-        toValue: 1,
-        duration: 200,
-        useNativeDriver: true,
-      }),
-    ]).start();
-
-    const timer = setTimeout(() => {
-      dismiss();
-    }, 3000);
-
-    return () => clearTimeout(timer);
-  }, []);
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dismiss = useCallback(() => {
     Animated.parallel([
@@ -100,7 +119,47 @@ function ToastItem({ toast: t, onDismiss }: { toast: Toast; onDismiss: () => voi
     ]).start(() => onDismiss());
   }, [onDismiss, translateY, opacity]);
 
+  useEffect(() => {
+    Animated.parallel([
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        tension: 80,
+        friction: 12,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    dismissTimerRef.current = setTimeout(() => {
+      dismiss();
+    }, DISMISS_MS[t.type]);
+
+    return () => {
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    // Prefer the verbose copyText (HTTP body, stack, etc.) when set. Falls
+    // back to the visible message for callers that didn't pass a richer
+    // payload — better than nothing.
+    await Clipboard.setStringAsync(t.copyText ?? t.message);
+    brrrHaptic();
+    setCopied(true);
+    if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    copiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
+    // Give the user extra time to verify the copy before auto-dismiss.
+    if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    dismissTimerRef.current = setTimeout(dismiss, 4000);
+  }, [t.copyText, t.message, dismiss]);
+
   const ToastIcon = ICON_MAP[t.type];
+  const canCopy = t.type === "error";
 
   return (
     <Animated.View
@@ -108,10 +167,25 @@ function ToastItem({ toast: t, onDismiss }: { toast: Toast; onDismiss: () => voi
       className={`mx-4 mb-2 rounded-xl px-4 py-3 flex-row items-center gap-3 border border-border/50 ${BG_MAP[t.type]}`}
     >
       <Icon icon={ToastIcon} size={18} color={COLOR_MAP[t.type]} />
-      <Text className="text-zinc-200 text-sm flex-1" numberOfLines={2}>
+      <Text className="text-zinc-200 text-sm flex-1" numberOfLines={LINE_CLAMP[t.type]}>
         {t.message}
       </Text>
-      <Pressable onPress={dismiss} hitSlop={8}>
+      {canCopy ? (
+        <Pressable
+          onPress={handleCopy}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={copied ? "Copied" : "Copy error message"}
+          className="active:opacity-60"
+        >
+          <Icon
+            icon={copied ? Check : Copy}
+            size={16}
+            color={copied ? "#4ade80" : "#a1a1aa"}
+          />
+        </Pressable>
+      ) : null}
+      <Pressable onPress={dismiss} hitSlop={8} accessibilityLabel="Dismiss">
         <Icon icon={X} size={16} color="#71717a" />
       </Pressable>
     </Animated.View>

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -17,13 +17,12 @@ import {
   getReleasesForMovie,
   grabRadarrRelease,
 } from "@/services/radarr-api";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import type { RadarrMovie } from "@/lib/types";
 import { getMovieDetails, deleteMedia } from "@/services/overseerr-api";
 import { useConfigStore } from "@/store/config-store";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { getDateOffset } from "@/lib/utils";
-import { getHttpErrorMessage } from "@/lib/http-client";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
 // Per-instance cache keying: every hook accepts an optional `instanceId`. When
@@ -140,7 +139,7 @@ export function useSearchForMovie(instanceId?: string) {
   return useMutation({
     mutationFn: (movieId: number) => searchForMovie(movieId, id ?? undefined),
     onSuccess: () => toast("Search started"),
-    onError: () => toast("Search failed", "error"),
+    onError: (err) => toastError("Search failed", err),
   });
 }
 
@@ -182,14 +181,14 @@ export function useToggleMovieMonitored(instanceId?: string) {
 
       return { prevList, prevDetail };
     },
-    onError: (_err, { movieId }, context) => {
+    onError: (err, { movieId }, context) => {
       if (context?.prevList) {
         queryClient.setQueryData(["radarr", id, "movies"], context.prevList);
       }
       if (context?.prevDetail) {
         queryClient.setQueryData(["radarr", id, "movie", movieId], context.prevDetail);
       }
-      toast("Failed to update monitoring", "error");
+      toastError("Failed to update monitoring", err);
     },
     onSettled: (_data, _err, { movieId }) => {
       queryClient.invalidateQueries({ queryKey: ["radarr", id, "movies"] });
@@ -254,7 +253,7 @@ export function useUpdateMovieQualityProfile(instanceId?: string) {
 
       return { prevDetail, prevList };
     },
-    onError: (_err, { movieId }, context) => {
+    onError: (err, { movieId }, context) => {
       if (context?.prevDetail) {
         queryClient.setQueryData(
           ["radarr", id, "movie", movieId],
@@ -264,7 +263,7 @@ export function useUpdateMovieQualityProfile(instanceId?: string) {
       if (context?.prevList) {
         queryClient.setQueryData(["radarr", id, "movies"], context.prevList);
       }
-      toast("Failed to update quality profile", "error");
+      toastError("Failed to update quality profile", err);
     },
     onSettled: (_data, _err, { movieId }) => {
       queryClient.invalidateQueries({ queryKey: ["radarr", id, "movie", movieId] });
@@ -330,7 +329,7 @@ export function useGrabRadarrRelease(instanceId?: string) {
       queryClient.invalidateQueries({ queryKey: ["radarr", id, "queue"] });
     },
     onError: (err) => {
-      toast(getHttpErrorMessage(err) ?? "Failed to grab release", "error");
+      toastError("Failed to grab release", err);
     },
   });
 }

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -21,11 +21,10 @@ import {
   getReleasesForSeason,
   grabSonarrRelease,
 } from "@/services/sonarr-api";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import type { SonarrSeries } from "@/lib/types";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { getDateOffset } from "@/lib/utils";
-import { getHttpErrorMessage } from "@/lib/http-client";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
 // Per-instance cache keying: see use-qbittorrent.ts and use-radarr.ts for the
@@ -147,7 +146,7 @@ export function useSearchForSeries(instanceId?: string) {
   return useMutation({
     mutationFn: (seriesId: number) => searchForSeries(seriesId, id ?? undefined),
     onSuccess: () => toast("Search started"),
-    onError: () => toast("Search failed", "error"),
+    onError: (err) => toastError("Search failed", err),
   });
 }
 
@@ -156,7 +155,7 @@ export function useSearchForEpisodes(instanceId?: string) {
   return useMutation({
     mutationFn: (episodeIds: number[]) => searchForEpisodes(episodeIds, id ?? undefined),
     onSuccess: () => toast("Search started"),
-    onError: () => toast("Search failed", "error"),
+    onError: (err) => toastError("Search failed", err),
   });
 }
 
@@ -198,14 +197,14 @@ export function useToggleSeriesMonitored(instanceId?: string) {
 
       return { prevList, prevDetail };
     },
-    onError: (_err, { seriesId }, context) => {
+    onError: (err, { seriesId }, context) => {
       if (context?.prevList) {
         queryClient.setQueryData(["sonarr", id, "series"], context.prevList);
       }
       if (context?.prevDetail) {
         queryClient.setQueryData(["sonarr", id, "series", seriesId], context.prevDetail);
       }
-      toast("Failed to update monitoring", "error");
+      toastError("Failed to update monitoring", err);
     },
     onSettled: (_data, _err, { seriesId }) => {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
@@ -270,7 +269,7 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
 
       return { prevDetail, prevList };
     },
-    onError: (_err, { seriesId }, context) => {
+    onError: (err, { seriesId }, context) => {
       if (context?.prevDetail) {
         queryClient.setQueryData(
           ["sonarr", id, "series", seriesId],
@@ -280,7 +279,7 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
       if (context?.prevList) {
         queryClient.setQueryData(["sonarr", id, "series"], context.prevList);
       }
-      toast("Failed to update quality profile", "error");
+      toastError("Failed to update quality profile", err);
     },
     onSettled: (_data, _err, { seriesId }) => {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series", seriesId] });
@@ -360,7 +359,7 @@ export function useGrabSonarrRelease(instanceId?: string) {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "queue"] });
     },
     onError: (err) => {
-      toast(getHttpErrorMessage(err) ?? "Failed to grab release", "error");
+      toastError("Failed to grab release", err);
     },
   });
 }

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -68,6 +68,42 @@ export function getHttpErrorMessage(err: unknown): string | undefined {
   return undefined;
 }
 
+// Produce a verbose, paste-friendly representation of any caught error.
+// Used as the clipboard payload for error toasts so users can share or
+// search the underlying cause even when the toast shows a friendly summary.
+// URLs are already API-key-redacted by HttpError, so this is safe to share.
+export function formatErrorForCopy(err: unknown): string {
+  if (err instanceof HttpError) {
+    const lines: string[] = [];
+    lines.push(`HTTP ${err.status}${err.statusText ? ` ${err.statusText}` : ""}`);
+    lines.push(err.url);
+    if (err.body !== undefined && err.body !== null) {
+      let bodyStr: string;
+      if (typeof err.body === "string") {
+        bodyStr = err.body;
+      } else {
+        try {
+          bodyStr = JSON.stringify(err.body, null, 2);
+        } catch {
+          bodyStr = String(err.body);
+        }
+      }
+      if (bodyStr.length > 0) lines.push(bodyStr);
+    }
+    return lines.join("\n");
+  }
+  if (err instanceof Error) {
+    const parts = [`${err.name}: ${err.message}`];
+    if (err.stack) parts.push(err.stack);
+    return parts.join("\n");
+  }
+  try {
+    return typeof err === "string" ? err : JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
 export async function serviceRequest<T>(
   serviceId: ServiceId,
   path: string,

--- a/services/prowlarr-api.ts
+++ b/services/prowlarr-api.ts
@@ -35,8 +35,13 @@ export function toggleIndexer(
   enable: boolean,
   instanceId?: string,
 ): Promise<ProwlarrIndexer> {
+  // forceSave=true skips Prowlarr's pre-save validation (which test-pings the
+  // indexer). Without it, re-enabling an indexer can no-op silently if the
+  // validation step fails — the PUT returns 200 with the indexer still
+  // disabled. With forceSave the toggle persists regardless.
   return serviceRequest<ProwlarrIndexer>("prowlarr", `/indexer/${indexer.id}`, {
     method: "PUT",
+    params: { forceSave: true },
     body: JSON.stringify({ ...indexer, enable }),
     instanceId,
   });


### PR DESCRIPTION
## Summary

Closes the five open `bug`/`enhancement`-labeled GitHub issues, each in its own commit.

- **#40 — Prowlarr indexer power toggle does not re-enable** (`services/prowlarr-api.ts`)
  Adds `?forceSave=true` to `PUT /indexer/{id}`. Without it, Prowlarr runs validation against the indexer on every save and silently no-ops the change if validation fails — the PUT returns 200 but the indexer stays disabled. With `forceSave` the toggle persists regardless.

- **#50 — iOS: search results in Sonarr/Radarr aren't tappable for items already in the library** (`app/series/search.tsx`, `app/movie/search.tsx`)
  The "already added" path rendered just a green checkmark with no Pressable wrapper. Existing items now navigate to the Sonarr/Radarr detail screen on tap; the add/advanced controls keep their existing behavior for new items. Builds a `tvdbId → seriesId` / `tmdbId → movieId` map from the local library list to know where to navigate.

- **#44 — 2nd dashboard can't open show details against its instances** (calendar/queue widgets + detail screens)
  Multi-instance setups: calendar and queue widgets correctly fan out queries across enabled Sonarr/Radarr instances, but tapping into a result navigated to `/series/[id]` or `/movie/[id]` with only the entity id. The detail screen then queried the *globally active* instance — usually the wrong one — and the entity wouldn't load (or the wrong one would, since ids aren't unique across instances). Now:
  - `app/series/[id].tsx`, `app/movie/[id].tsx`, and the matching `releases/[id].tsx` screens read an optional `instanceId` route param and thread it through every Sonarr/Radarr hook (queries + mutations).
  - `components/dashboard/calendar-card.tsx` and `app/(tabs)/calendar.tsx` tag each item with its source instance and pass it on navigation.
  - `components/dashboard/radarr-queue-card.tsx` already tracked the source instance per record; it now passes it on tap (the comment in that file already flagged this as a known bug).
  - `ReleasesPicker` / `ReleaseDetailSheet` accept `instanceId` so the grab call lands on the same Radarr/Sonarr the search ran against.
  - When `instanceId` is omitted (notifications, single-instance setups, the `movies`/`tv` tabs that follow the active instance), behavior is unchanged.

- **#42 — Tapping a service instance tile should switch to that instance** (`components/dashboard/service-health-card.tsx`)
  The dashboard Services widget renders one tile per (kind, instance) pair, so users with two qBittorrents see "qBittorrent" and "qBittorrent 2" side-by-side. Tapping either one navigated to the same service tab without switching the active instance, so they always landed on whichever instance was last in use. The tap now sets the active instance for the kind first, then navigates — the destination tab opens against the server the user actually pointed at.

- **#46 — Display full name of dashboard when switching** (`components/dashboard/dashboard-picker-sheet.tsx`)
  At Extra Large UI scale, the four trailing actions (move up/down, rename, delete) eat enough of the row that even short names like "HomeServer" truncate to "HomeSe…". Letting the title wrap to two lines keeps the full name readable without restructuring the row, and has no visible effect at smaller scales where the name already fits on one line.

## Test plan

- [x] **#40** — Prowlarr → Indexers tab → tap power off on an indexer, confirm it goes grey. Tap power on, confirm it returns to green and stays that way after a refresh.
- [x] **#50, Sonarr** — Search a show that's already in the library (green checkmark), tap the row, confirm the existing show detail opens. Search a show NOT in the library, confirm the quick-add/advanced buttons still work and the row itself is *not* tappable.
- [x] **#50, Radarr** — Same as above with movies.
- [x] **#44** — Configure a 2nd Sonarr and 2nd Radarr instance. Bind a Calendar widget on a 2nd dashboard to the 2nd instances. Tap an episode/movie on that dashboard, confirm the detail screen loads from the correct instance and that monitoring/quality/delete/search-releases all work.
- [x] **#44** — In Calendar tab with two Sonarr instances enabled, tap entries from each — both should open details against their own instance.
- [x] **#44** — Radarr queue card on a multi-instance dashboard: tap a movie, confirm it opens from the source instance.
- [x] **#44** — Single-instance setups: open a show/movie via any path, confirm nothing regresses (instanceId omitted → active instance is used).
- [x] **#42** — On the dashboard Services widget with two Sonarrs, tap "Sonarr 2", confirm the TV tab opens with Sonarr 2 selected (header chip shows "Sonarr 2"). Go back, tap "Sonarr", confirm it now shows Sonarr 1.
- [x] **#46** — Settings → UI scale → Extra Large. Open the dashboard picker. Confirm "HomeServer" (or any longer name) renders fully (wrapping to a second line if needed) instead of truncating to "HomeSe…".
