### PR TITLE
feat: enhancements batch — sorts, reordering, GPU stats, root folders

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -71,7 +71,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       foregroundImage: "./assets/adaptive-icon.png",
       backgroundColor: "#09090b",
     },
-    package: BUNDLE_ID,
+    // Always the base id at prebuild time. The dev variant suffix (".dev") is
+    // applied at Gradle build time by plugins/withDevVariant — that lets one
+    // prebuilt android/ project produce both variants by toggling APP_VARIANT
+    // when invoking gradlew, without a second prebuild.
+    package: "com.dashboarr.app",
     versionCode: nativeBuildNumber,
     googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
   },
@@ -91,6 +95,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "expo-secure-store",
     "./plugins/withAndroidSigning",
     "./plugins/withCleartextTraffic",
+    "./plugins/withDevVariant",
     [
       "expo-location",
       {

--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -1,5 +1,5 @@
 import { View, Text } from "react-native";
-import { Cpu, MemoryStick, HardDrive, Activity } from "lucide-react-native";
+import { Cpu, MemoryStick, HardDrive, Activity, Gpu } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -14,11 +14,12 @@ import {
   useGlancesMem,
   useGlancesFs,
   useGlancesDiskIO,
+  useGlancesGpu,
 } from "@/hooks/use-glances";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { formatBytes, formatSpeed } from "@/lib/utils";
-import type { GlancesFsItem, GlancesDiskIOItem } from "@/lib/types";
+import type { GlancesFsItem, GlancesDiskIOItem, GlancesGpuItem } from "@/lib/types";
 
 function usageBarColor(percent: number): string {
   if (percent >= 85) return "bg-red-500";
@@ -43,6 +44,7 @@ export default function GlancesScreen() {
       <View className="gap-4">
         <CpuCard />
         <MemoryCard />
+        <GpuCard />
         <DisksCard />
         <DiskIOCard />
       </View>
@@ -163,6 +165,84 @@ function MemoryCard() {
         </View>
       )}
     </Card>
+  );
+}
+
+function GpuCard() {
+  const { data: gpus, isLoading } = useGlancesGpu();
+
+  // Hide entirely on hosts with no GPU — the endpoint returns [] when the
+  // plugin is enabled but no card is detected (and getGpu swallows 404 when
+  // the plugin is disabled), so an empty list isn't an error condition.
+  if (!isLoading && (!gpus || gpus.length === 0)) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>GPU</CardTitle>
+      </CardHeader>
+
+      {isLoading ? (
+        <SkeletonCardContent rows={2} />
+      ) : (
+        <View className="gap-4">
+          {gpus!.map((gpu, idx) => (
+            <GpuDetail key={gpu.gpu_id ?? idx} gpu={gpu} />
+          ))}
+        </View>
+      )}
+    </Card>
+  );
+}
+
+function GpuDetail({ gpu }: { gpu: GlancesGpuItem }) {
+  const proc = typeof gpu.proc === "number" ? gpu.proc : null;
+  const mem = typeof gpu.mem === "number" ? gpu.mem : null;
+
+  return (
+    <View>
+      <View className="flex-row items-center gap-2 mb-2">
+        <Icon icon={Gpu} size={14} color="#a1a1aa" />
+        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
+          {gpu.name || gpu.gpu_id}
+        </Text>
+      </View>
+
+      {proc !== null && (
+        <View className="mb-2">
+          <View className="flex-row justify-between mb-1">
+            <Text className="text-zinc-500 text-xs">Compute</Text>
+            <Text className={`text-xs font-medium ${usageTextColor(proc)}`}>
+              {proc.toFixed(1)}%
+            </Text>
+          </View>
+          <ProgressBar progress={proc / 100} color={usageBarColor(proc)} />
+        </View>
+      )}
+
+      {mem !== null && (
+        <View className="mb-2">
+          <View className="flex-row justify-between mb-1">
+            <Text className="text-zinc-500 text-xs">VRAM</Text>
+            <Text className={`text-xs font-medium ${usageTextColor(mem)}`}>
+              {mem.toFixed(1)}%
+            </Text>
+          </View>
+          <ProgressBar progress={mem / 100} color={usageBarColor(mem)} />
+        </View>
+      )}
+
+      {(typeof gpu.temperature === "number" || typeof gpu.fan_speed === "number") && (
+        <View className="flex-row gap-3 flex-wrap mt-1">
+          {typeof gpu.temperature === "number" && (
+            <StatPill label="Temp" value={`${gpu.temperature.toFixed(0)}°C`} />
+          )}
+          {typeof gpu.fan_speed === "number" && (
+            <StatPill label="Fan" value={`${gpu.fan_speed.toFixed(0)} RPM`} />
+          )}
+        </View>
+      )}
+    </View>
   );
 }
 

--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -58,12 +58,25 @@ const MONITOR_FILTERS: { value: MonitorFilter; label: string }[] = [
 
 const SORT_OPTIONS: { key: MoviesSortKey; label: string }[] = [
   { key: "added-desc", label: "Recently Added" },
+  { key: "next-airing-asc", label: "Next Airing" },
   { key: "title-asc", label: "Title: A → Z" },
   { key: "title-desc", label: "Title: Z → A" },
   { key: "year-desc", label: "Year: Newest First" },
   { key: "year-asc", label: "Year: Oldest First" },
   { key: "size-desc", label: "Size: Largest First" },
 ];
+
+function nextReleaseTime(m: RadarrMovie): number | null {
+  const times = [m.inCinemas, m.digitalRelease, m.physicalRelease]
+    .filter((d): d is string => Boolean(d))
+    .map((d) => new Date(d).getTime())
+    .filter((t) => Number.isFinite(t));
+  if (!times.length) return null;
+  const now = Date.now();
+  const future = times.filter((t) => t >= now);
+  if (future.length) return Math.min(...future);
+  return Math.max(...times);
+}
 
 function compareMovies(a: RadarrMovie, b: RadarrMovie, sort: MoviesSortKey): number {
   switch (sort) {
@@ -79,6 +92,20 @@ function compareMovies(a: RadarrMovie, b: RadarrMovie, sort: MoviesSortKey): num
       return a.year - b.year;
     case "size-desc":
       return (b.sizeOnDisk ?? 0) - (a.sizeOnDisk ?? 0);
+    case "next-airing-asc": {
+      const aT = nextReleaseTime(a);
+      const bT = nextReleaseTime(b);
+      if (aT === null && bT === null)
+        return (a.sortTitle || a.title).localeCompare(b.sortTitle || b.title);
+      if (aT === null) return 1;
+      if (bT === null) return -1;
+      const now = Date.now();
+      const aFuture = aT >= now;
+      const bFuture = bT >= now;
+      if (aFuture && !bFuture) return -1;
+      if (!aFuture && bFuture) return 1;
+      return aFuture ? aT - bT : bT - aT;
+    }
   }
 }
 

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -1,6 +1,7 @@
+import { useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
-import { Zap } from "lucide-react-native";
+import { ArrowLeft, ArrowRight, Check, Pencil, Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -25,13 +26,59 @@ const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   bazarr: "/(tabs)/bazarr",
 };
 
+// Materialize the user's display order: known entries from servicesOrder in
+// the order they chose, then any SERVICE_IDS missing from that list appended
+// in canonical order. A user who only ever moved one tile still gets every
+// service rendered.
+function applyServicesOrder(order: ServiceId[]): ServiceId[] {
+  const seen = new Set<ServiceId>();
+  const out: ServiceId[] = [];
+  for (const id of order) {
+    if (seen.has(id)) continue;
+    if (!SERVICE_IDS.includes(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  for (const id of SERVICE_IDS) {
+    if (seen.has(id)) continue;
+    out.push(id);
+  }
+  return out;
+}
+
 export default function ServicesScreen() {
   const router = useRouter();
   const services = useConfigStore((s) => s.services);
   const wolDevices = useConfigStore((s) => s.wolDevices);
+  const servicesOrder = useConfigStore((s) => s.servicesOrder);
+  const setServicesOrder = useConfigStore((s) => s.setServicesOrder);
   const { data: health } = useServiceHealth();
+  const [editing, setEditing] = useState(false);
 
-  const enabledServices = SERVICE_IDS.filter((id) => services[id].enabled && SERVICE_ROUTES[id]);
+  const fullOrder = useMemo(() => applyServicesOrder(servicesOrder), [servicesOrder]);
+  const enabledServices = useMemo(
+    () => fullOrder.filter((id) => services[id].enabled && SERVICE_ROUTES[id]),
+    [fullOrder, services],
+  );
+
+  // Reorder in the visible-list space: swap `id` with its previous/next
+  // visible neighbor. The store keeps the full ordering (including disabled
+  // services), so we look up both ids in the full list and swap there — that
+  // way disabled rows interleaved between two visible ones don't sabotage the
+  // user's tap. Anything outside the swap pair stays put.
+  const moveInVisible = (id: ServiceId, direction: "up" | "down") => {
+    const visibleIdx = enabledServices.indexOf(id);
+    if (visibleIdx === -1) return;
+    const target = direction === "up" ? visibleIdx - 1 : visibleIdx + 1;
+    if (target < 0 || target >= enabledServices.length) return;
+    const otherId = enabledServices[target];
+    const a = fullOrder.indexOf(id);
+    const b = fullOrder.indexOf(otherId);
+    if (a === -1 || b === -1) return;
+    const next = [...fullOrder];
+    [next[a], next[b]] = [next[b], next[a]];
+    setServicesOrder(next);
+  };
 
   if (!enabledServices.length) {
     return (
@@ -46,31 +93,65 @@ export default function ServicesScreen() {
     );
   }
 
+  // Only show the reorder affordance once there's more than one tile to
+  // reorder — a single-service install can't be rearranged.
+  const canReorder = enabledServices.length > 1;
+
   return (
     <ScreenWrapper>
       <View className="flex-row items-center justify-between mb-4">
         <Text className="text-zinc-100 text-2xl font-bold">Services</Text>
-        {wolDevices.length > 0 && (
-          <Pressable
-            onPress={() => router.push("/wake-on-lan")}
-            className="flex-row items-center gap-1.5 bg-surface border border-border rounded-xl px-3 py-2 active:opacity-70"
-          >
-            <Icon icon={Zap} size={14} color="#a1a1aa" />
-            <Text className="text-zinc-300 text-sm">Wake</Text>
-          </Pressable>
-        )}
+        <View className="flex-row items-center gap-2">
+          {canReorder && (
+            <Pressable
+              onPress={() => setEditing((v) => !v)}
+              className={`flex-row items-center gap-1.5 border rounded-xl px-3 py-2 active:opacity-70 ${
+                editing
+                  ? "bg-primary/15 border-primary"
+                  : "bg-surface border-border"
+              }`}
+            >
+              <Icon
+                icon={editing ? Check : Pencil}
+                size={14}
+                color={editing ? "#60a5fa" : "#a1a1aa"}
+              />
+              <Text className={`text-sm ${editing ? "text-primary" : "text-zinc-300"}`}>
+                {editing ? "Done" : "Reorder"}
+              </Text>
+            </Pressable>
+          )}
+          {!editing && wolDevices.length > 0 && (
+            <Pressable
+              onPress={() => router.push("/wake-on-lan")}
+              className="flex-row items-center gap-1.5 bg-surface border border-border rounded-xl px-3 py-2 active:opacity-70"
+            >
+              <Icon icon={Zap} size={14} color="#a1a1aa" />
+              <Text className="text-zinc-300 text-sm">Wake</Text>
+            </Pressable>
+          )}
+        </View>
       </View>
       <View className="flex-row flex-wrap gap-3">
-        {enabledServices.map((id) => {
+        {enabledServices.map((id, idx) => {
           const service = services[id];
           const status = health?.find((h) => h.id === id);
           const online = status?.online ?? false;
+          const isFirst = idx === 0;
+          const isLast = idx === enabledServices.length - 1;
 
+          // While reordering, suppress the tile's onPress so a tap can't
+          // accidentally drop into a service mid-rearrange. The arrows are the
+          // only interactive elements on the tile in this mode.
           return (
             <Pressable
               key={id}
-              onPress={() => router.push(SERVICE_ROUTES[id]! as any)}
-              className="w-[47%] bg-surface border border-border rounded-2xl p-4 items-center gap-3 active:opacity-70"
+              onPress={
+                editing ? undefined : () => router.push(SERVICE_ROUTES[id]! as any)
+              }
+              className={`w-[47%] bg-surface border rounded-2xl p-4 items-center gap-3 ${
+                editing ? "border-primary/40" : "border-border active:opacity-70"
+              }`}
             >
               <View className="relative">
                 <View className="bg-surface-light rounded-xl p-3">
@@ -83,6 +164,28 @@ export default function ServicesScreen() {
                 />
               </View>
               <Text className="text-zinc-100 text-sm font-medium">{service.name}</Text>
+              {editing && (
+                <View className="flex-row items-center justify-between w-full mt-1">
+                  <Pressable
+                    onPress={() => moveInVisible(id, "up")}
+                    disabled={isFirst}
+                    hitSlop={6}
+                    className="p-2 active:opacity-60"
+                    style={{ opacity: isFirst ? 0.3 : 1 }}
+                  >
+                    <Icon icon={ArrowLeft} size={18} color="#a1a1aa" />
+                  </Pressable>
+                  <Pressable
+                    onPress={() => moveInVisible(id, "down")}
+                    disabled={isLast}
+                    hitSlop={6}
+                    className="p-2 active:opacity-60"
+                    style={{ opacity: isLast ? 0.3 : 1 }}
+                  >
+                    <Icon icon={ArrowRight} size={18} color="#a1a1aa" />
+                  </Pressable>
+                </View>
+              )}
             </Pressable>
           );
         })}

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -7,8 +7,8 @@ import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
-import { SERVICE_IDS } from "@/lib/constants";
 import type { ServiceId } from "@/lib/constants";
+import { applyServicesOrder } from "@/lib/services-order";
 
 const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   qbittorrent: "/(tabs)/downloads",
@@ -25,26 +25,6 @@ const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   glances: "/(tabs)/glances",
   bazarr: "/(tabs)/bazarr",
 };
-
-// Materialize the user's display order: known entries from servicesOrder in
-// the order they chose, then any SERVICE_IDS missing from that list appended
-// in canonical order. A user who only ever moved one tile still gets every
-// service rendered.
-function applyServicesOrder(order: ServiceId[]): ServiceId[] {
-  const seen = new Set<ServiceId>();
-  const out: ServiceId[] = [];
-  for (const id of order) {
-    if (seen.has(id)) continue;
-    if (!SERVICE_IDS.includes(id)) continue;
-    seen.add(id);
-    out.push(id);
-  }
-  for (const id of SERVICE_IDS) {
-    if (seen.has(id)) continue;
-    out.push(id);
-  }
-  return out;
-}
 
 export default function ServicesScreen() {
   const router = useRouter();

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
+import Animated, { LinearTransition } from "react-native-reanimated";
 import { useRouter } from "expo-router";
 import { ArrowLeft, ArrowRight, Check, Pencil, Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -7,8 +8,14 @@ import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { lightHaptic } from "@/lib/haptics";
 import type { ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
+
+// Spring tuned to feel snappy but visible — too fast and the user can't tell a
+// tile moved; too slow and successive taps queue up before the previous one
+// settles. ~300ms total motion is the sweet spot.
+const REORDER_LAYOUT = LinearTransition.springify().damping(18).stiffness(180).mass(0.7);
 
 const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   qbittorrent: "/(tabs)/downloads",
@@ -57,6 +64,7 @@ export default function ServicesScreen() {
     if (a === -1 || b === -1) return;
     const next = [...fullOrder];
     [next[a], next[b]] = [next[b], next[a]];
+    lightHaptic();
     setServicesOrder(next);
   };
 
@@ -123,13 +131,23 @@ export default function ServicesScreen() {
           // While reordering, suppress the tile's onPress so a tap can't
           // accidentally drop into a service mid-rearrange. The arrows are the
           // only interactive elements on the tile in this mode.
+          //
+          // The Animated.View wrapper carries the layout transition so when
+          // servicesOrder mutates and React re-renders the children in a new
+          // order, each tile springs to its new flex position instead of
+          // jump-cutting. The width lives on the wrapper (the actual flex
+          // child); the Pressable inside fills it.
           return (
-            <Pressable
+            <Animated.View
               key={id}
+              layout={REORDER_LAYOUT}
+              className="w-[47%]"
+            >
+            <Pressable
               onPress={
                 editing ? undefined : () => router.push(SERVICE_ROUTES[id]! as any)
               }
-              className={`w-[47%] bg-surface border rounded-2xl p-4 items-center gap-3 ${
+              className={`bg-surface border rounded-2xl p-4 items-center gap-3 ${
                 editing ? "border-primary/40" : "border-border active:opacity-70"
               }`}
             >
@@ -167,6 +185,7 @@ export default function ServicesScreen() {
                 </View>
               )}
             </Pressable>
+            </Animated.View>
           );
         })}
       </View>

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -56,6 +56,7 @@ const MONITOR_FILTERS: { value: MonitorFilter; label: string }[] = [
 
 const SORT_OPTIONS: { key: SeriesSortKey; label: string }[] = [
   { key: "added-desc", label: "Recently Added" },
+  { key: "next-airing-asc", label: "Next Airing" },
   { key: "title-asc", label: "Title: A → Z" },
   { key: "title-desc", label: "Title: Z → A" },
   { key: "year-desc", label: "Year: Newest First" },
@@ -77,6 +78,15 @@ function compareSeries(a: SonarrSeries, b: SonarrSeries, sort: SeriesSortKey): n
       return a.year - b.year;
     case "size-desc":
       return (b.sizeOnDisk ?? 0) - (a.sizeOnDisk ?? 0);
+    case "next-airing-asc": {
+      const aT = a.nextAiring ? new Date(a.nextAiring).getTime() : null;
+      const bT = b.nextAiring ? new Date(b.nextAiring).getTime() : null;
+      if (aT === null && bT === null)
+        return (a.sortTitle || a.title).localeCompare(b.sortTitle || b.title);
+      if (aT === null) return 1;
+      if (bT === null) return -1;
+      return aT - bT;
+    }
   }
 }
 

--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { View, Text, ScrollView, Linking } from "react-native";
+import { View, Text, ScrollView, Linking, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   Trash2,
@@ -10,6 +10,8 @@ import {
   Film,
   Circle,
   Check,
+  ChevronRight,
+  FolderTree,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -32,6 +34,8 @@ import {
   useToggleMovieMonitored,
   useRadarrQualityProfiles,
   useUpdateMovieQualityProfile,
+  useRadarrRootFolders,
+  useUpdateMovieRootFolder,
 } from "@/hooks/use-radarr";
 import { useServiceImage } from "@/hooks/use-service-image";
 import {
@@ -54,9 +58,13 @@ export default function MovieDetailScreen() {
   const toggleMonitored = useToggleMovieMonitored(instanceId);
   const { data: qualityProfiles } = useRadarrQualityProfiles(instanceId);
   const updateProfile = useUpdateMovieQualityProfile(instanceId);
+  const { data: rootFolders } = useRadarrRootFolders(instanceId);
+  const updateRootFolder = useUpdateMovieRootFolder(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
+  const [rootFolderVisible, setRootFolderVisible] = useState(false);
+  const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<DeleteMode>(null);
 
   const poster = movie?.images.find((i) => i.coverType === "poster");
@@ -224,7 +232,14 @@ export default function MovieDetailScreen() {
 
           <ReleaseDatesBlock movie={movie} />
 
-          <AboutBlock movie={movie} />
+          <AboutBlock
+            movie={movie}
+            onPressRoot={
+              rootFolders && rootFolders.length > 0
+                ? () => setRootFolderVisible(true)
+                : undefined
+            }
+          />
         </View>
       </ScreenWrapper>
 
@@ -270,6 +285,63 @@ export default function MovieDetailScreen() {
             });
           },
         }))}
+      />
+
+      <ActionSheet
+        visible={rootFolderVisible}
+        onClose={() => setRootFolderVisible(false)}
+        title="Root Folder"
+        subtitle={movie.title}
+        actions={(rootFolders ?? []).map((f) => ({
+          label: `${f.path}  ·  ${formatBytes(f.freeSpace)} free`,
+          icon: (
+            <Icon
+              icon={f.path === movie.rootFolderPath ? Check : Circle}
+              size={18}
+              color={f.path === movie.rootFolderPath ? "#60a5fa" : "#71717a"}
+            />
+          ),
+          onPress: () => {
+            if (f.path === movie.rootFolderPath) return;
+            setRootFolderVisible(false);
+            setPendingRootFolder(f.path);
+          },
+        }))}
+      />
+
+      <ActionSheet
+        visible={pendingRootFolder !== null}
+        onClose={() => setPendingRootFolder(null)}
+        title="Move existing files?"
+        subtitle={pendingRootFolder ?? ""}
+        actions={[
+          {
+            label: "Move existing files",
+            icon: <Icon icon={FolderTree} size={18} color="#60a5fa" />,
+            onPress: () => {
+              if (!pendingRootFolder) return;
+              updateRootFolder.mutate({
+                movieId: movie.id,
+                rootFolderPath: pendingRootFolder,
+                moveFiles: true,
+              });
+              setPendingRootFolder(null);
+            },
+          },
+          {
+            label: "Keep files in place",
+            icon: <Icon icon={Circle} size={18} color="#71717a" />,
+            onPress: () => {
+              if (!pendingRootFolder) return;
+              updateRootFolder.mutate({
+                movieId: movie.id,
+                rootFolderPath: pendingRootFolder,
+                moveFiles: false,
+              });
+              setPendingRootFolder(null);
+            },
+          },
+        ]}
       />
 
       <ConfirmModal
@@ -436,21 +508,39 @@ function ReleaseDatesBlock({ movie }: { movie: RadarrMovie }) {
   );
 }
 
-function AboutBlock({ movie }: { movie: RadarrMovie }) {
+function AboutBlock({
+  movie,
+  onPressRoot,
+}: {
+  movie: RadarrMovie;
+  onPressRoot?: () => void;
+}) {
   return (
     <View className="mb-5">
       <SectionLabel>About</SectionLabel>
       <View className="rounded-2xl bg-surface border border-border p-4 gap-2.5">
-        <AboutRow label="Root" value={movie.rootFolderPath} />
+        <AboutRow
+          label="Root"
+          value={movie.rootFolderPath}
+          onPress={onPressRoot}
+        />
         <AboutRow label="Added" value={formatReleaseDate(movie.added)} />
       </View>
     </View>
   );
 }
 
-function AboutRow({ label, value }: { label: string; value: string }) {
-  return (
-    <View className="flex-row items-center">
+function AboutRow({
+  label,
+  value,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  onPress?: () => void;
+}) {
+  const content = (
+    <>
       <Text className="text-zinc-500 text-[0.65rem] uppercase font-semibold tracking-wider w-14">
         {label}
       </Text>
@@ -461,6 +551,23 @@ function AboutRow({ label, value }: { label: string; value: string }) {
       >
         {value}
       </Text>
-    </View>
+      {onPress ? (
+        <Icon icon={ChevronRight} size={14} color="#71717a" />
+      ) : null}
+    </>
   );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        className="flex-row items-center active:opacity-60"
+        hitSlop={6}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return <View className="flex-row items-center">{content}</View>;
 }

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -13,6 +13,7 @@ import {
   Award,
   Tv,
   Circle,
+  FolderTree,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -40,6 +41,8 @@ import {
   useDeleteSeries,
   useSonarrQualityProfiles,
   useUpdateSeriesQualityProfile,
+  useSonarrRootFolders,
+  useUpdateSeriesRootFolder,
 } from "@/hooks/use-sonarr";
 import {
   formatEpisodeCode,
@@ -70,9 +73,13 @@ export default function SeriesDetailScreen() {
   const deleteSeries = useDeleteSeries(instanceId);
   const { data: qualityProfiles } = useSonarrQualityProfiles(instanceId);
   const updateProfile = useUpdateSeriesQualityProfile(instanceId);
+  const { data: rootFolders } = useSonarrRootFolders(instanceId);
+  const updateRootFolder = useUpdateSeriesRootFolder(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
+  const [rootFolderVisible, setRootFolderVisible] = useState(false);
+  const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<DeleteMode>(null);
 
   const episodeFileMap = useMemo(() => {
@@ -233,7 +240,14 @@ export default function SeriesDetailScreen() {
             </View>
           ) : null}
 
-          <AboutBlock series={series} />
+          <AboutBlock
+            series={series}
+            onPressRoot={
+              rootFolders && rootFolders.length > 0
+                ? () => setRootFolderVisible(true)
+                : undefined
+            }
+          />
 
           <View className="mb-2">
             <SectionLabel>Seasons</SectionLabel>
@@ -299,6 +313,63 @@ export default function SeriesDetailScreen() {
             });
           },
         }))}
+      />
+
+      <ActionSheet
+        visible={rootFolderVisible}
+        onClose={() => setRootFolderVisible(false)}
+        title="Root Folder"
+        subtitle={series.title}
+        actions={(rootFolders ?? []).map((f) => ({
+          label: `${f.path}  ·  ${formatBytes(f.freeSpace)} free`,
+          icon: (
+            <Icon
+              icon={f.path === series.rootFolderPath ? Check : Circle}
+              size={18}
+              color={f.path === series.rootFolderPath ? "#60a5fa" : "#71717a"}
+            />
+          ),
+          onPress: () => {
+            if (f.path === series.rootFolderPath) return;
+            setRootFolderVisible(false);
+            setPendingRootFolder(f.path);
+          },
+        }))}
+      />
+
+      <ActionSheet
+        visible={pendingRootFolder !== null}
+        onClose={() => setPendingRootFolder(null)}
+        title="Move existing files?"
+        subtitle={pendingRootFolder ?? ""}
+        actions={[
+          {
+            label: "Move existing files",
+            icon: <Icon icon={FolderTree} size={18} color="#60a5fa" />,
+            onPress: () => {
+              if (!pendingRootFolder) return;
+              updateRootFolder.mutate({
+                seriesId: series.id,
+                rootFolderPath: pendingRootFolder,
+                moveFiles: true,
+              });
+              setPendingRootFolder(null);
+            },
+          },
+          {
+            label: "Keep files in place",
+            icon: <Icon icon={Circle} size={18} color="#71717a" />,
+            onPress: () => {
+              if (!pendingRootFolder) return;
+              updateRootFolder.mutate({
+                seriesId: series.id,
+                rootFolderPath: pendingRootFolder,
+                moveFiles: false,
+              });
+              setPendingRootFolder(null);
+            },
+          },
+        ]}
       />
 
       <ConfirmModal
@@ -421,7 +492,13 @@ function EpisodeProgressBlock({ series }: { series: SonarrSeries }) {
   );
 }
 
-function AboutBlock({ series }: { series: SonarrSeries }) {
+function AboutBlock({
+  series,
+  onPressRoot,
+}: {
+  series: SonarrSeries;
+  onPressRoot?: () => void;
+}) {
   return (
     <View className="mb-5">
       <SectionLabel>About</SectionLabel>
@@ -432,16 +509,28 @@ function AboutBlock({ series }: { series: SonarrSeries }) {
             value={formatReleaseDate(series.firstAired)}
           />
         ) : null}
-        <AboutRow label="Root" value={series.rootFolderPath} />
+        <AboutRow
+          label="Root"
+          value={series.rootFolderPath}
+          onPress={onPressRoot}
+        />
         <AboutRow label="Added" value={formatReleaseDate(series.added)} />
       </View>
     </View>
   );
 }
 
-function AboutRow({ label, value }: { label: string; value: string }) {
-  return (
-    <View className="flex-row items-center">
+function AboutRow({
+  label,
+  value,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  onPress?: () => void;
+}) {
+  const content = (
+    <>
       <Text className="text-zinc-500 text-[0.65rem] uppercase font-semibold tracking-wider w-14">
         {label}
       </Text>
@@ -452,8 +541,25 @@ function AboutRow({ label, value }: { label: string; value: string }) {
       >
         {value}
       </Text>
-    </View>
+      {onPress ? (
+        <Icon icon={ChevronRight} size={14} color="#71717a" />
+      ) : null}
+    </>
   );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        className="flex-row items-center active:opacity-60"
+        hitSlop={6}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return <View className="flex-row items-center">{content}</View>;
 }
 
 function SeasonAccordion({

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -6,7 +6,7 @@ import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
-import { getCpu, getMem, getFs } from "@/services/glances-api";
+import { getCpu, getMem, getFs, getGpu } from "@/services/glances-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import {
@@ -16,7 +16,7 @@ import {
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { formatBytes } from "@/lib/utils";
-import type { GlancesFsItem } from "@/lib/types";
+import type { GlancesFsItem, GlancesGpuItem } from "@/lib/types";
 import type { ServiceInstance } from "@/store/config-store";
 
 const RING_SIZE = 80;
@@ -87,7 +87,8 @@ export function ServerStatsCard({ slotId }: WidgetComponentProps) {
   const allInstances = useEnabledInstances("glances");
   const instances = resolveBoundInstances(settings.instanceIds, allInstances);
 
-  const allHidden = !settings.showCpu && !settings.showRam && !settings.showDisks;
+  const allHidden =
+    !settings.showCpu && !settings.showRam && !settings.showGpu && !settings.showDisks;
 
   return (
     <Card>
@@ -148,24 +149,33 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
         refetchInterval: FAST_POLL,
         enabled: settings.showDisks,
       },
+      {
+        queryKey: ["glances", instance.id, "gpu"] as const,
+        queryFn: () => getGpu(instance.id),
+        refetchInterval: FAST_POLL,
+        enabled: settings.showGpu,
+      },
     ],
   });
-  const [cpuQuery, memQuery, fsQuery] = queries;
+  const [cpuQuery, memQuery, fsQuery, gpuQuery] = queries;
   const cpu = settings.showCpu ? cpuQuery.data : undefined;
   const mem = settings.showRam ? memQuery.data : undefined;
   const fs = settings.showDisks ? fsQuery.data : undefined;
+  const gpus = settings.showGpu ? gpuQuery.data : undefined;
 
   const isLoading =
     (settings.showCpu && cpuQuery.isLoading) ||
     (settings.showRam && memQuery.isLoading) ||
-    (settings.showDisks && fsQuery.isLoading);
-  const hasData = cpu || mem || (fs && fs.length > 0);
+    (settings.showDisks && fsQuery.isLoading) ||
+    (settings.showGpu && gpuQuery.isLoading);
+  const hasData = cpu || mem || (fs && fs.length > 0) || (gpus && gpus.length > 0);
   const showError =
     !isLoading &&
     !hasData &&
     ((settings.showCpu && cpuQuery.isError) ||
       (settings.showRam && memQuery.isError) ||
-      (settings.showDisks && fsQuery.isError));
+      (settings.showDisks && fsQuery.isError) ||
+      (settings.showGpu && gpuQuery.isError));
 
   return (
     <View className="gap-3">
@@ -190,6 +200,18 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
             </View>
           )}
 
+          {settings.showGpu && gpus && gpus.length > 0 && (
+            <View className="gap-3">
+              {gpus.map((gpu, idx) => (
+                <GpuRow
+                  key={gpu.gpu_id ?? idx}
+                  gpu={gpu}
+                  showName={gpus.length > 1}
+                />
+              ))}
+            </View>
+          )}
+
           {settings.showDisks && fs && fs.length > 0 && (
             <View className="gap-2">
               {fs.map((disk) => (
@@ -199,6 +221,29 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
           )}
         </View>
       )}
+    </View>
+  );
+}
+
+function GpuRow({ gpu, showName }: { gpu: GlancesGpuItem; showName: boolean }) {
+  // Glances reports null for backends that can't read a value (e.g. some AMD
+  // cards lack temperature/fan_speed). Skip rings whose value is missing.
+  const proc = typeof gpu.proc === "number" ? gpu.proc : null;
+  const mem = typeof gpu.mem === "number" ? gpu.mem : null;
+
+  if (proc === null && mem === null) return null;
+
+  return (
+    <View className="gap-2">
+      {showName && (
+        <Text className="text-zinc-500 text-xs" numberOfLines={1}>
+          {gpu.name || gpu.gpu_id}
+        </Text>
+      )}
+      <View className="flex-row justify-around">
+        {proc !== null && <RingChart percent={proc} label="GPU" />}
+        {mem !== null && <RingChart percent={mem} label="VRAM" />}
+      </View>
     </View>
   );
 }

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -1,14 +1,21 @@
 import { View, Text } from "react-native";
 import Svg, { Circle } from "react-native-svg";
-import { ServerCrash } from "lucide-react-native";
+import {
+  Cpu as CpuIcon,
+  MemoryStick,
+  Gpu as GpuIconSvg,
+  HardDrive,
+  ServerCrash,
+} from "lucide-react-native";
+import type { LucideIcon } from "lucide-react-native";
 import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
-import { ProgressBar } from "@/components/ui/progress-bar";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { getCpu, getMem, getFs, getGpu } from "@/services/glances-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useUiScale } from "@/hooks/use-ui-scale";
 import {
   SERVER_STATS_DEFAULT_SETTINGS,
   type ServerStatsSettingsValue,
@@ -19,10 +26,8 @@ import { formatBytes } from "@/lib/utils";
 import type { GlancesFsItem, GlancesGpuItem } from "@/lib/types";
 import type { ServiceInstance } from "@/store/config-store";
 
-const RING_SIZE = 80;
-const STROKE_WIDTH = 8;
-const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
-const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const RING_BASE = 60;
+const STROKE_WIDTH = 6;
 const FAST_POLL = 5000;
 
 function ringColor(percent: number): string {
@@ -37,43 +42,79 @@ function diskBarColor(percent: number): string {
   return "bg-success";
 }
 
-function RingChart({ percent, label }: { percent: number; label: string }) {
-  const filled = CIRCUMFERENCE * (1 - percent / 100);
+function diskTextColor(percent: number): string {
+  if (percent >= 85) return "text-red-400";
+  if (percent >= 70) return "text-amber-400";
+  return "text-success";
+}
+
+interface MetricRingProps {
+  percent: number;
+  label: string;
+  sublabel?: string;
+  icon: LucideIcon;
+}
+
+function MetricRing({ percent, label, sublabel, icon }: MetricRingProps) {
+  // Use numeric pixel size scaled by uiScale so the ring resizes with
+  // accessibility scaling — react-native-svg props are numeric, not rem.
+  const scale = useUiScale();
+  const size = Math.round(RING_BASE * scale);
+  const stroke = Math.max(4, Math.round(STROKE_WIDTH * scale));
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const filled = circumference * (1 - Math.min(Math.max(percent, 0), 100) / 100);
   const color = ringColor(percent);
 
   return (
-    <View className="items-center gap-1">
-      <View style={{ width: RING_SIZE, height: RING_SIZE }}>
-        <Svg width={RING_SIZE} height={RING_SIZE}>
+    <View className="items-center gap-1.5" style={{ minWidth: size + 8 }}>
+      <View style={{ width: size, height: size }}>
+        <Svg width={size} height={size}>
           <Circle
-            cx={RING_SIZE / 2}
-            cy={RING_SIZE / 2}
-            r={RADIUS}
-            stroke="#3f3f46"
-            strokeWidth={STROKE_WIDTH}
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            stroke="#27272a"
+            strokeWidth={stroke}
             fill="none"
           />
           <Circle
-            cx={RING_SIZE / 2}
-            cy={RING_SIZE / 2}
-            r={RADIUS}
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
             stroke={color}
-            strokeWidth={STROKE_WIDTH}
+            strokeWidth={stroke}
             fill="none"
-            strokeDasharray={`${CIRCUMFERENCE} ${CIRCUMFERENCE}`}
+            strokeDasharray={`${circumference} ${circumference}`}
             strokeDashoffset={filled}
             strokeLinecap="round"
             rotation="-90"
-            origin={`${RING_SIZE / 2}, ${RING_SIZE / 2}`}
+            origin={`${size / 2}, ${size / 2}`}
           />
         </Svg>
         <View className="absolute inset-0 items-center justify-center">
-          <Text style={{ color }} className="text-sm font-bold">
-            {percent.toFixed(0)}%
+          <Text style={{ color }} className="text-sm font-bold leading-none">
+            {percent.toFixed(0)}
+            <Text style={{ color }} className="text-[0.6rem] font-semibold">
+              %
+            </Text>
           </Text>
         </View>
       </View>
-      <Text className="text-zinc-400 text-xs">{label}</Text>
+      <View className="flex-row items-center gap-1">
+        <Icon icon={icon} size={11} color="#a1a1aa" />
+        <Text className="text-zinc-300 text-[0.7rem] font-semibold uppercase tracking-wider">
+          {label}
+        </Text>
+      </View>
+      {sublabel ? (
+        <Text
+          className="text-zinc-500 text-[0.65rem]"
+          numberOfLines={1}
+        >
+          {sublabel}
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -106,7 +147,7 @@ export function ServerStatsCard({ slotId }: WidgetComponentProps) {
           <Text className="text-zinc-500 text-sm">No Glances instances enabled</Text>
         </View>
       ) : (
-        <View className="gap-5">
+        <View className="gap-4">
           {instances.map((inst) => (
             <InstanceBlock
               key={inst.id}
@@ -177,6 +218,14 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
       (settings.showDisks && fsQuery.isError) ||
       (settings.showGpu && gpuQuery.isError));
 
+  const gpuRings = buildGpuRings(gpus);
+  const hasRings =
+    (settings.showCpu && cpu) ||
+    (settings.showRam && mem) ||
+    gpuRings.length > 0;
+  const hasDisks = settings.showDisks && fs && fs.length > 0;
+  const showDivider = hasRings && hasDisks;
+
   return (
     <View className="gap-3">
       {showName && (
@@ -192,74 +241,124 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
           <Text className="text-zinc-500 text-sm">Could not reach Glances</Text>
         </View>
       ) : (
-        <View className="gap-4">
-          {(settings.showCpu || settings.showRam) && (
-            <View className="flex-row justify-around">
-              {settings.showCpu && cpu && <RingChart percent={cpu.total} label="CPU" />}
-              {settings.showRam && mem && <RingChart percent={mem.percent} label="RAM" />}
-            </View>
-          )}
-
-          {settings.showGpu && gpus && gpus.length > 0 && (
-            <View className="gap-3">
-              {gpus.map((gpu, idx) => (
-                <GpuRow
-                  key={gpu.gpu_id ?? idx}
-                  gpu={gpu}
-                  showName={gpus.length > 1}
+        <>
+          {hasRings && (
+            <View className="flex-row flex-wrap justify-around gap-y-3">
+              {settings.showCpu && cpu && (
+                <MetricRing
+                  percent={cpu.total}
+                  label="CPU"
+                  icon={CpuIcon}
+                  sublabel={`${cpu.cpucore} ${cpu.cpucore === 1 ? "core" : "cores"}`}
+                />
+              )}
+              {settings.showRam && mem && (
+                <MetricRing
+                  percent={mem.percent}
+                  label="RAM"
+                  icon={MemoryStick}
+                  sublabel={`${formatBytes(mem.used)} / ${formatBytes(mem.total)}`}
+                />
+              )}
+              {gpuRings.map((ring) => (
+                <MetricRing
+                  key={ring.key}
+                  percent={ring.percent}
+                  label={ring.label}
+                  icon={GpuIconSvg}
+                  sublabel={ring.sublabel}
                 />
               ))}
             </View>
           )}
 
-          {settings.showDisks && fs && fs.length > 0 && (
+          {showDivider && <View className="h-px bg-border" />}
+
+          {hasDisks && (
             <View className="gap-2">
               {fs.map((disk) => (
                 <DiskRow key={disk.mnt_point} disk={disk} />
               ))}
             </View>
           )}
-        </View>
+        </>
       )}
     </View>
   );
 }
 
-function GpuRow({ gpu, showName }: { gpu: GlancesGpuItem; showName: boolean }) {
-  // Glances reports null for backends that can't read a value (e.g. some AMD
-  // cards lack temperature/fan_speed). Skip rings whose value is missing.
-  const proc = typeof gpu.proc === "number" ? gpu.proc : null;
-  const mem = typeof gpu.mem === "number" ? gpu.mem : null;
+interface GpuRingEntry {
+  key: string;
+  label: string;
+  percent: number;
+  sublabel?: string;
+}
 
-  if (proc === null && mem === null) return null;
+function buildGpuRings(gpus: GlancesGpuItem[] | undefined): GpuRingEntry[] {
+  if (!gpus || gpus.length === 0) return [];
+  const multi = gpus.length > 1;
+  const entries: GpuRingEntry[] = [];
+  gpus.forEach((gpu, idx) => {
+    const suffix = multi ? ` ${idx + 1}` : "";
+    const name = (gpu.name || gpu.gpu_id || "").trim();
+    if (typeof gpu.proc === "number") {
+      entries.push({
+        key: `${gpu.gpu_id ?? idx}-proc`,
+        label: `GPU${suffix}`,
+        percent: gpu.proc,
+        sublabel: !multi && name ? shortenGpuName(name) : undefined,
+      });
+    }
+    if (typeof gpu.mem === "number") {
+      entries.push({
+        key: `${gpu.gpu_id ?? idx}-mem`,
+        label: `VRAM${suffix}`,
+        percent: gpu.mem,
+      });
+    }
+  });
+  return entries;
+}
 
-  return (
-    <View className="gap-2">
-      {showName && (
-        <Text className="text-zinc-500 text-xs" numberOfLines={1}>
-          {gpu.name || gpu.gpu_id}
-        </Text>
-      )}
-      <View className="flex-row justify-around">
-        {proc !== null && <RingChart percent={proc} label="GPU" />}
-        {mem !== null && <RingChart percent={mem} label="VRAM" />}
-      </View>
-    </View>
-  );
+function shortenGpuName(name: string): string {
+  // Strip vendor noise so the sublabel stays inside the ring column. Common
+  // patterns: "NVIDIA GeForce RTX 3080", "AMD Radeon RX 6800", "Intel Arc A770".
+  return name
+    .replace(/^NVIDIA\s+/i, "")
+    .replace(/^AMD\s+/i, "")
+    .replace(/^Intel\s+/i, "")
+    .replace(/\s+\(.*\)$/, "")
+    .trim();
 }
 
 function DiskRow({ disk }: { disk: GlancesFsItem }) {
+  const mount = disk.mnt_point.replace(/^\/host/, "") || "/";
+  const pct = Math.min(Math.max(disk.percent, 0), 100);
   return (
     <View className="gap-1">
-      <View className="flex-row justify-between items-center">
-        <Text className="text-zinc-400 text-xs" numberOfLines={1}>
-          {disk.mnt_point.replace(/^\/host/, "") || "/"}
-        </Text>
-        <Text className="text-zinc-500 text-xs">
+      <View className="flex-row justify-between items-center gap-2">
+        <View className="flex-row items-center gap-1.5 flex-1 min-w-0">
+          <Icon icon={HardDrive} size={11} color="#a1a1aa" />
+          <Text
+            className="text-zinc-300 text-xs font-medium"
+            numberOfLines={1}
+          >
+            {mount}
+          </Text>
+        </View>
+        <Text className="text-zinc-500 text-[0.7rem]">
           {formatBytes(disk.used)} / {formatBytes(disk.size)}
         </Text>
+        <Text className={`text-xs font-semibold w-10 text-right ${diskTextColor(pct)}`}>
+          {pct.toFixed(0)}%
+        </Text>
       </View>
-      <ProgressBar progress={disk.percent / 100} color={diskBarColor(disk.percent)} />
+      <View className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+        <View
+          className={`h-full rounded-full ${diskBarColor(pct)}`}
+          style={{ width: `${pct}%` }}
+        />
+      </View>
     </View>
   );
 }

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -1,4 +1,5 @@
 import { View, Text, Pressable, Platform } from "react-native";
+import Animated, { LinearTransition } from "react-native-reanimated";
 import { useRouter } from "expo-router";
 import { ServiceLogo, hasServiceLogo } from "@/components/ui/service-logo";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,6 +16,11 @@ import {
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import type { ServiceInstanceHealthStatus } from "@/lib/types";
 import type { ServiceInstance } from "@/store/config-store";
+
+// Matches the spring used by the Services tab and the Status widget's
+// settings sheet — so when the user reorders kinds, the dashboard tile
+// rearrangement feels continuous with the surface they touched.
+const REORDER_LAYOUT = LinearTransition.springify().damping(18).stiffness(180).mass(0.7);
 
 const SERVICE_ROUTES: Partial<Record<ServiceId, string>> = {
   qbittorrent: "/(tabs)/downloads",
@@ -96,8 +102,11 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
           const route = SERVICE_ROUTES[entry.kindId];
 
           return (
-            <Pressable
+            <Animated.View
               key={`${entry.kindId}:${entry.instanceId}`}
+              layout={REORDER_LAYOUT}
+            >
+            <Pressable
               onPress={() => {
                 if (!route) return;
                 // Switch the active instance to the one tapped so the
@@ -133,6 +142,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
                 {entry.label}
               </Text>
             </Pressable>
+            </Animated.View>
           );
         })}
       </View>

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -4,7 +4,8 @@ import { ServiceLogo, hasServiceLogo } from "@/components/ui/service-logo";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
-import { ICON, SERVICE_IDS, type ServiceId } from "@/lib/constants";
+import { ICON, type ServiceId } from "@/lib/constants";
+import { applyServicesOrder } from "@/lib/services-order";
 import { useConfigStore } from "@/store/config-store";
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
@@ -40,6 +41,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   );
   const { data: services } = useServiceHealth();
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const servicesOrder = useConfigStore((s) => s.servicesOrder);
   const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
   const router = useRouter();
 
@@ -55,7 +57,10 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   }
 
   const entries: RenderEntry[] = [];
-  for (const kindId of SERVICE_IDS) {
+  // Honor the user-defined kind order (shared with the Services tab via
+  // store.servicesOrder). Kinds the user hasn't touched fall in at the end in
+  // canonical SERVICE_IDS order via applyServicesOrder.
+  for (const kindId of applyServicesOrder(servicesOrder)) {
     if (!hasServiceLogo(kindId)) continue;
     if (hiddenSet.has(kindId)) continue;
     const allInstances = (serviceInstances[kindId] ?? []).filter(

--- a/components/dashboard/widget-settings/draggable-kind-list.tsx
+++ b/components/dashboard/widget-settings/draggable-kind-list.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { View } from "react-native";
+import Animated, {
+  cancelAnimation,
+  LinearTransition,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from "react-native-reanimated";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { lightHaptic, mediumHaptic } from "@/lib/haptics";
+import type { ServiceId } from "@/lib/constants";
+
+// Long-press window before the row pops into drag mode. Shorter than the
+// platform default so the gesture feels responsive, but long enough that a
+// quick tap on a child Pressable (the existing arrow buttons) still resolves
+// as a tap and never accidentally activates drag.
+const ACTIVATE_AFTER_MS = 250;
+
+// Spring for the active row's settle on release. Tuned to match the spring
+// used on the arrow-button path elsewhere so the two interactions feel of one
+// piece.
+const SPRING = { damping: 18, stiffness: 220, mass: 0.7 } as const;
+
+// Layout transition used by *non-active* rows so they slide smoothly to their
+// new flex slots whenever the array reorders mid-drag. The active row gets
+// `layout={undefined}` so its JSX position can snap (the visible position is
+// already kept continuous by the translateY compensation in animatedStyle).
+const ROW_LAYOUT = LinearTransition.springify().damping(18).stiffness(220).mass(0.7);
+
+interface DraggableKindListProps {
+  items: ServiceId[];
+  onReorder: (next: ServiceId[]) => void;
+  renderItem: (id: ServiceId) => ReactNode;
+  // Gap between rows (px). Used to compute the swap-stride along with the
+  // measured row height, so the math agrees with the visual spacing.
+  gap?: number;
+}
+
+export function DraggableKindList({
+  items,
+  onReorder,
+  renderItem,
+  gap = 20,
+}: DraggableKindListProps) {
+  // First measured row height (incl. gap) — used as the swap stride. Rows in
+  // this list have similar heights, so a single stride is accurate enough and
+  // keeps the per-frame math cheap. Captured once and never updated mid-drag
+  // (re-measuring would shift swap thresholds out from under the user's
+  // finger when the instance picker mounts/unmounts inside a row).
+  const stride = useSharedValue(0);
+  const strideMeasured = useRef(false);
+
+  // Drag state, all kept on the UI thread so the per-frame animatedStyle math
+  // is cheap. `activeId` is the row currently being dragged; `dragStartIndex`
+  // is its index at drag start (constant during the gesture); `dragCurrentIndex`
+  // is its index in the *live-mutated* local list — updated via a
+  // useLayoutEffect AFTER React commits the reorder, so it stays in sync with
+  // the actually-rendered flex slot. `dragRequestedTarget` is what we've most
+  // recently asked the parent to reorder to; it dedupes rapid-fire onUpdates
+  // so we don't keep re-asking for the same target every frame. `translationY`
+  // is the cumulative pan offset.
+  const activeId = useSharedValue<string | null>(null);
+  const dragStartIndex = useSharedValue(-1);
+  const dragCurrentIndex = useSharedValue(-1);
+  const dragRequestedTarget = useSharedValue(-1);
+  const translationY = useSharedValue(0);
+
+  // Mirror of activeId on the JS thread, used to selectively disable the
+  // layout transition for the active row (LinearTransition would interfere
+  // with the translateY compensation when the row's flex slot changes
+  // mid-drag — see the comment near ROW_LAYOUT above).
+  const [activeIdState, setActiveIdState] = useState<ServiceId | null>(null);
+
+  // Local copy of the order — we mutate this live during a drag (as the user
+  // crosses row boundaries) and only commit the result to the parent's
+  // onReorder on release. That gives non-active rows real flex slot changes
+  // to animate (via ROW_LAYOUT) without hammering the store on every frame.
+  const [localItems, setLocalItems] = useState<ServiceId[]>(items);
+  const localItemsRef = useRef(localItems);
+  localItemsRef.current = localItems;
+
+  // Mirror activeIdState into a ref so setState updaters (which run before
+  // the next render exposes the new value) can read the most recent value.
+  const activeIdStateRef = useRef<ServiceId | null>(null);
+  activeIdStateRef.current = activeIdState;
+
+  // Pick up external changes to `items` when no drag is in progress. Skipping
+  // this sync during a drag keeps the user's in-flight reorder from being
+  // clobbered if the parent re-renders for any other reason.
+  useEffect(() => {
+    if (activeIdState === null) {
+      setLocalItems(items);
+    }
+  }, [items, activeIdState]);
+
+  // After every React commit, snap dragCurrentIndex on the UI thread to where
+  // the active row actually lives in the rendered list. Doing this in
+  // useLayoutEffect (synchronously between commit and paint) means the
+  // animatedStyle worklet's `delta = current - start` reads a value
+  // consistent with the new flex slot, so the active row's transform
+  // compensates for the slot change in the same frame and stays pinned under
+  // the finger.
+  useLayoutEffect(() => {
+    if (activeIdState === null) {
+      dragCurrentIndex.value = -1;
+      return;
+    }
+    const newIdx = localItems.indexOf(activeIdState);
+    if (newIdx !== -1) {
+      dragCurrentIndex.value = newIdx;
+    }
+    // dragCurrentIndex is a sharedValue with stable identity — intentionally
+    // excluded from the dep array. Re-runs are driven by the order/active
+    // changes that matter.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localItems, activeIdState]);
+
+  const liveReorderTo = (target: number) => {
+    setLocalItems((prev) => {
+      // Re-resolve `from` from the latest prev to handle rapid-fire requests
+      // safely (a second request arriving before the first has been
+      // committed would otherwise carry a stale `from`).
+      const currentId = activeIdStateRef.current;
+      if (currentId === null) return prev;
+      const from = prev.indexOf(currentId);
+      if (from === -1) return prev;
+      if (target < 0 || target >= prev.length) return prev;
+      if (from === target) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(target, 0, moved);
+      return next;
+    });
+  };
+
+  const commitToParent = () => {
+    const finalOrder = localItemsRef.current;
+    const same =
+      finalOrder.length === items.length &&
+      finalOrder.every((v, i) => v === items[i]);
+    if (!same) {
+      onReorder(finalOrder);
+      lightHaptic();
+    }
+  };
+
+  return (
+    <View style={{ gap }}>
+      {localItems.map((id, index) => (
+        <DraggableRow
+          key={id}
+          id={id}
+          index={index}
+          itemCount={localItems.length}
+          isActive={activeIdState === id}
+          activeId={activeId}
+          dragStartIndex={dragStartIndex}
+          dragCurrentIndex={dragCurrentIndex}
+          dragRequestedTarget={dragRequestedTarget}
+          translationY={translationY}
+          stride={stride}
+          onMeasure={(h) => {
+            if (strideMeasured.current) return;
+            if (h <= 0) return;
+            stride.value = h + gap;
+            strideMeasured.current = true;
+          }}
+          onActivate={() => {
+            setActiveIdState(id);
+            mediumHaptic();
+          }}
+          onSettled={() => {
+            // Commit to the parent FIRST and clear active state in the same
+            // microtask so React batches both into one render — that way the
+            // sync useEffect never sees "active cleared, parent still stale"
+            // and won't briefly revert localItems to the pre-drag order.
+            commitToParent();
+            setActiveIdState(null);
+          }}
+          onReorderRequest={liveReorderTo}
+        >
+          {renderItem(id)}
+        </DraggableRow>
+      ))}
+    </View>
+  );
+}
+
+interface DraggableRowProps {
+  id: ServiceId;
+  index: number;
+  itemCount: number;
+  isActive: boolean;
+  activeId: ReturnType<typeof useSharedValue<string | null>>;
+  dragStartIndex: ReturnType<typeof useSharedValue<number>>;
+  dragCurrentIndex: ReturnType<typeof useSharedValue<number>>;
+  dragRequestedTarget: ReturnType<typeof useSharedValue<number>>;
+  translationY: ReturnType<typeof useSharedValue<number>>;
+  stride: ReturnType<typeof useSharedValue<number>>;
+  onMeasure: (height: number) => void;
+  onActivate: () => void;
+  onSettled: () => void;
+  onReorderRequest: (target: number) => void;
+  children: ReactNode;
+}
+
+function DraggableRow({
+  id,
+  index,
+  itemCount,
+  isActive,
+  activeId,
+  dragStartIndex,
+  dragCurrentIndex,
+  dragRequestedTarget,
+  translationY,
+  stride,
+  onMeasure,
+  onActivate,
+  onSettled,
+  onReorderRequest,
+  children,
+}: DraggableRowProps) {
+  const gesture = Gesture.Pan()
+    .activateAfterLongPress(ACTIVATE_AFTER_MS)
+    .onStart(() => {
+      cancelAnimation(translationY);
+      activeId.value = id;
+      dragStartIndex.value = index;
+      dragCurrentIndex.value = index;
+      dragRequestedTarget.value = index;
+      translationY.value = 0;
+      runOnJS(onActivate)();
+    })
+    .onUpdate((e) => {
+      translationY.value = e.translationY;
+      const s = stride.value;
+      if (s <= 0) return;
+      // Target index = "where the user's finger would put this row if we
+      // dropped right now". Clamped to the array bounds.
+      const target = Math.min(
+        Math.max(dragStartIndex.value + Math.round(e.translationY / s), 0),
+        itemCount - 1,
+      );
+      // dragRequestedTarget dedupes rapid-fire requests so we don't keep
+      // asking the parent to reorder to the same slot every frame. The
+      // parent will update React state which propagates through
+      // useLayoutEffect → dragCurrentIndex; we deliberately do NOT touch
+      // dragCurrentIndex here so the animatedStyle's `delta` stays in sync
+      // with the actually-rendered flex slot, eliminating the 1-frame
+      // visual jump that would happen if we updated it eagerly on UI.
+      if (target !== dragRequestedTarget.value) {
+        dragRequestedTarget.value = target;
+        runOnJS(onReorderRequest)(target);
+      }
+    })
+    .onEnd(() => {
+      const s = stride.value > 0 ? stride.value : 1;
+      const delta = dragCurrentIndex.value - dragStartIndex.value;
+      // Spring translationY toward `delta * s` — that's the value at which the
+      // active row's transform offset (= translationY - delta * s) equals 0,
+      // so the row settles at its new natural slot. Clearing activeId only
+      // in the spring's completion callback keeps the row honoring its
+      // transform throughout the settle (without this the row jumps to 0
+      // transform the instant the gesture ends).
+      translationY.value = withSpring(delta * s, SPRING, (finished) => {
+        if (finished) {
+          activeId.value = null;
+          dragStartIndex.value = -1;
+          dragRequestedTarget.value = -1;
+          translationY.value = 0;
+          // dragCurrentIndex is cleared by the parent's useLayoutEffect when
+          // activeIdState flips to null. Don't touch it here so the
+          // animatedStyle keeps a valid delta until then.
+          runOnJS(onSettled)();
+        }
+      });
+    })
+    .onFinalize((_e, success) => {
+      // Gesture was cancelled (e.g. another gesture won the touch). Snap state
+      // back so the row doesn't get stuck mid-drag. The local list still has
+      // any live reorders the user performed before cancel — committing them
+      // matches what they actually saw on screen.
+      if (!success && activeId.value === id) {
+        activeId.value = null;
+        dragStartIndex.value = -1;
+        dragRequestedTarget.value = -1;
+        translationY.value = withSpring(0, SPRING);
+        runOnJS(onSettled)();
+      }
+    });
+
+  const animatedStyle = useAnimatedStyle(() => {
+    if (activeId.value === id) {
+      // Visual offset = finger translation - the natural-slot displacement
+      // already absorbed by live reorders. This keeps the row pinned under
+      // the finger regardless of how many slot boundaries the user has
+      // crossed.
+      const delta = dragCurrentIndex.value - dragStartIndex.value;
+      const offset = translationY.value - delta * stride.value;
+      return {
+        transform: [{ translateY: offset }, { scale: 1.03 }],
+        zIndex: 100,
+        elevation: 8,
+        opacity: 0.96,
+      };
+    }
+    return {
+      transform: [{ translateY: 0 }, { scale: 1 }],
+      zIndex: 1,
+      elevation: 0,
+      opacity: 1,
+    };
+  });
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View
+        // The active row gets no layout transition: its JSX slot can change
+        // mid-drag (because liveReorder mutates the array), and the
+        // translateY math above already keeps it visually continuous. Non-
+        // active rows DO animate their layout so the user sees them slide
+        // out of the way as the dragged row crosses slot boundaries.
+        layout={isActive ? undefined : ROW_LAYOUT}
+        style={animatedStyle}
+        onLayout={(e) => onMeasure(e.nativeEvent.layout.height)}
+      >
+        {children}
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/components/dashboard/widget-settings/server-stats-settings.tsx
+++ b/components/dashboard/widget-settings/server-stats-settings.tsx
@@ -14,6 +14,7 @@ export interface ServerStatsSettingsValue extends Record<string, unknown> {
   instanceIds: InstanceBindingValue;
   showCpu: boolean;
   showRam: boolean;
+  showGpu: boolean;
   showDisks: boolean;
 }
 
@@ -21,6 +22,7 @@ export const SERVER_STATS_DEFAULT_SETTINGS: ServerStatsSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
   showCpu: true,
   showRam: true,
+  showGpu: true,
   showDisks: true,
 };
 
@@ -53,6 +55,12 @@ export function ServerStatsSettings({ slotId }: WidgetSettingsComponentProps) {
             description="Ring chart of memory utilization"
             value={settings.showRam}
             onValueChange={(showRam) => update({ showRam })}
+          />
+          <Toggle
+            label="GPU usage"
+            description="Ring charts of GPU compute and VRAM (hidden if no GPU)"
+            value={settings.showGpu}
+            onValueChange={(showGpu) => update({ showGpu })}
           />
           <Toggle
             label="Disk usage"

--- a/components/dashboard/widget-settings/service-health-settings.tsx
+++ b/components/dashboard/widget-settings/service-health-settings.tsx
@@ -1,8 +1,11 @@
-import { View, Text } from "react-native";
+import { View, Text, Pressable } from "react-native";
+import { ArrowUp, ArrowDown } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
 import { Toggle } from "@/components/ui/toggle";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useConfigStore } from "@/store/config-store";
-import { SERVICE_IDS, SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
+import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
+import { applyServicesOrder } from "@/lib/services-order";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
   InstancePickerRow,
@@ -34,13 +37,35 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
     SERVICE_HEALTH_DEFAULT_SETTINGS,
   );
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const servicesOrder = useConfigStore((s) => s.servicesOrder);
+  const setServicesOrder = useConfigStore((s) => s.setServicesOrder);
 
-  // Only surface kinds the user has actually configured + enabled. Hiding a
-  // kind in app settings already removes it from the dashboard, so there's no
-  // point listing it here — the widget can't show what isn't reachable.
-  const configuredKinds = SERVICE_IDS.filter(
+  // Only surface kinds the user has actually configured + enabled, in the
+  // user-defined order. Hiding a kind in app settings already removes it from
+  // the dashboard, so there's no point listing it here — the widget can't
+  // show what isn't reachable. The order is the shared servicesOrder so the
+  // Status widget and the Services tab agree.
+  const fullOrder = applyServicesOrder(servicesOrder);
+  const configuredKinds = fullOrder.filter(
     (id) => (serviceInstances[id] ?? []).some((i) => i.enabled),
   );
+
+  // Move `id` left/right within the visible (configured) list, mapping the
+  // swap back onto the full order so disabled kinds interleaved between two
+  // configured ones don't sabotage the user's tap.
+  const moveKind = (id: ServiceId, direction: "up" | "down") => {
+    const visibleIdx = configuredKinds.indexOf(id);
+    if (visibleIdx === -1) return;
+    const target = direction === "up" ? visibleIdx - 1 : visibleIdx + 1;
+    if (target < 0 || target >= configuredKinds.length) return;
+    const otherId = configuredKinds[target];
+    const a = fullOrder.indexOf(id);
+    const b = fullOrder.indexOf(otherId);
+    if (a === -1 || b === -1) return;
+    const next = [...fullOrder];
+    [next[a], next[b]] = [next[b], next[a]];
+    setServicesOrder(next);
+  };
 
   if (configuredKinds.length === 0) {
     return (
@@ -66,25 +91,57 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
 
   return (
     <View className="px-4 py-2 gap-5">
-      {configuredKinds.map((id) => {
+      {configuredKinds.length > 1 && (
+        <Text className="text-zinc-500 text-xs">
+          Order is shared with the Services tab.
+        </Text>
+      )}
+      {configuredKinds.map((id, idx) => {
         const isShown = !hiddenSet.has(id);
         const instances = serviceInstances[id] ?? [];
         const enabledInstances = instances.filter((i) => i.enabled);
         const binding = settings.instances[id] ?? INSTANCE_BINDING_ALL;
+        const isFirst = idx === 0;
+        const isLast = idx === configuredKinds.length - 1;
+        const canReorder = configuredKinds.length > 1;
 
         return (
           <View key={id} className="gap-3">
-            <View className="bg-surface-light rounded-2xl border border-border px-4">
-              <Toggle
-                label={SERVICE_DEFAULTS[id].name}
-                description={
-                  enabledInstances.length === 1
-                    ? "1 instance enabled"
-                    : `${enabledInstances.length} instances enabled`
-                }
-                value={isShown}
-                onValueChange={(show) => toggleKind(id, show)}
-              />
+            <View className="flex-row items-center gap-2">
+              <View className="flex-1 bg-surface-light rounded-2xl border border-border px-4">
+                <Toggle
+                  label={SERVICE_DEFAULTS[id].name}
+                  description={
+                    enabledInstances.length === 1
+                      ? "1 instance enabled"
+                      : `${enabledInstances.length} instances enabled`
+                  }
+                  value={isShown}
+                  onValueChange={(show) => toggleKind(id, show)}
+                />
+              </View>
+              {canReorder && (
+                <View className="flex-col items-center">
+                  <Pressable
+                    onPress={() => moveKind(id, "up")}
+                    disabled={isFirst}
+                    hitSlop={6}
+                    className="p-1 active:opacity-60"
+                    style={{ opacity: isFirst ? 0.3 : 1 }}
+                  >
+                    <Icon icon={ArrowUp} size={16} color="#a1a1aa" />
+                  </Pressable>
+                  <Pressable
+                    onPress={() => moveKind(id, "down")}
+                    disabled={isLast}
+                    hitSlop={6}
+                    className="p-1 active:opacity-60"
+                    style={{ opacity: isLast ? 0.3 : 1 }}
+                  >
+                    <Icon icon={ArrowDown} size={16} color="#a1a1aa" />
+                  </Pressable>
+                </View>
+              )}
             </View>
             {isShown && enabledInstances.length > 1 && (
               <InstancePickerRow

--- a/components/dashboard/widget-settings/service-health-settings.tsx
+++ b/components/dashboard/widget-settings/service-health-settings.tsx
@@ -6,12 +6,14 @@ import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useConfigStore } from "@/store/config-store";
 import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
+import { lightHaptic } from "@/lib/haptics";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
   InstancePickerRow,
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { DraggableKindList } from "@/components/dashboard/widget-settings/draggable-kind-list";
 
 export interface ServiceHealthSettingsValue extends Record<string, unknown> {
   // Kinds the user has explicitly hidden on this widget. Kinds NOT in this
@@ -50,21 +52,36 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
     (id) => (serviceInstances[id] ?? []).some((i) => i.enabled),
   );
 
-  // Move `id` left/right within the visible (configured) list, mapping the
-  // swap back onto the full order so disabled kinds interleaved between two
-  // configured ones don't sabotage the user's tap.
+  // Project a reordered list of *configured* kinds back onto the full order,
+  // preserving the positions of any disabled/unconfigured kinds interleaved
+  // between them. Walk the full order in place: every slot occupied by a
+  // configured kind absorbs the next id from the new configured list, in
+  // order; non-configured slots pass through untouched.
+  const commitVisibleOrder = (nextConfigured: ServiceId[]) => {
+    const configuredSet = new Set(configuredKinds);
+    const nextFull = [...fullOrder];
+    let cursor = 0;
+    for (let i = 0; i < nextFull.length; i++) {
+      if (configuredSet.has(nextFull[i])) {
+        nextFull[i] = nextConfigured[cursor++];
+      }
+    }
+    setServicesOrder(nextFull);
+  };
+
+  // Arrow-button move: swap `id` with its previous/next visible neighbor. The
+  // arrows stay as a tap-only fallback alongside the drag handle so users who
+  // miss the long-press affordance (or have motor difficulty with drag) can
+  // still reorder. Drag-and-drop is the primary path; arrows are secondary.
   const moveKind = (id: ServiceId, direction: "up" | "down") => {
     const visibleIdx = configuredKinds.indexOf(id);
     if (visibleIdx === -1) return;
     const target = direction === "up" ? visibleIdx - 1 : visibleIdx + 1;
     if (target < 0 || target >= configuredKinds.length) return;
-    const otherId = configuredKinds[target];
-    const a = fullOrder.indexOf(id);
-    const b = fullOrder.indexOf(otherId);
-    if (a === -1 || b === -1) return;
-    const next = [...fullOrder];
-    [next[a], next[b]] = [next[b], next[a]];
-    setServicesOrder(next);
+    const next = [...configuredKinds];
+    [next[visibleIdx], next[target]] = [next[target], next[visibleIdx]];
+    lightHaptic();
+    commitVisibleOrder(next);
   };
 
   if (configuredKinds.length === 0) {
@@ -89,70 +106,81 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
     update({ instances: { ...settings.instances, [id]: value } });
   };
 
+  const renderRow = (id: ServiceId) => {
+    const isShown = !hiddenSet.has(id);
+    const instances = serviceInstances[id] ?? [];
+    const enabledInstances = instances.filter((i) => i.enabled);
+    const binding = settings.instances[id] ?? INSTANCE_BINDING_ALL;
+    const idx = configuredKinds.indexOf(id);
+    const isFirst = idx === 0;
+    const isLast = idx === configuredKinds.length - 1;
+    const canReorder = configuredKinds.length > 1;
+
+    return (
+      <View className="gap-3">
+        <View className="flex-row items-center gap-2">
+          <View className="flex-1 bg-surface-light rounded-2xl border border-border px-4">
+            <Toggle
+              label={SERVICE_DEFAULTS[id].name}
+              description={
+                enabledInstances.length === 1
+                  ? "1 instance enabled"
+                  : `${enabledInstances.length} instances enabled`
+              }
+              value={isShown}
+              onValueChange={(show) => toggleKind(id, show)}
+            />
+          </View>
+          {canReorder && (
+            <View className="flex-col items-center">
+              <Pressable
+                onPress={() => moveKind(id, "up")}
+                disabled={isFirst}
+                hitSlop={6}
+                className="p-1 active:opacity-60"
+                style={{ opacity: isFirst ? 0.3 : 1 }}
+              >
+                <Icon icon={ArrowUp} size={16} color="#a1a1aa" />
+              </Pressable>
+              <Pressable
+                onPress={() => moveKind(id, "down")}
+                disabled={isLast}
+                hitSlop={6}
+                className="p-1 active:opacity-60"
+                style={{ opacity: isLast ? 0.3 : 1 }}
+              >
+                <Icon icon={ArrowDown} size={16} color="#a1a1aa" />
+              </Pressable>
+            </View>
+          )}
+        </View>
+        {isShown && enabledInstances.length > 1 && (
+          <InstancePickerRow
+            serviceId={id}
+            value={binding}
+            onChange={(value) => setBinding(id, value)}
+          />
+        )}
+      </View>
+    );
+  };
+
   return (
     <View className="px-4 py-2 gap-5">
       {configuredKinds.length > 1 && (
         <Text className="text-zinc-500 text-xs">
-          Order is shared with the Services tab.
+          Long-press a row to drag it. Order is shared with the Services tab.
         </Text>
       )}
-      {configuredKinds.map((id, idx) => {
-        const isShown = !hiddenSet.has(id);
-        const instances = serviceInstances[id] ?? [];
-        const enabledInstances = instances.filter((i) => i.enabled);
-        const binding = settings.instances[id] ?? INSTANCE_BINDING_ALL;
-        const isFirst = idx === 0;
-        const isLast = idx === configuredKinds.length - 1;
-        const canReorder = configuredKinds.length > 1;
-
-        return (
-          <View key={id} className="gap-3">
-            <View className="flex-row items-center gap-2">
-              <View className="flex-1 bg-surface-light rounded-2xl border border-border px-4">
-                <Toggle
-                  label={SERVICE_DEFAULTS[id].name}
-                  description={
-                    enabledInstances.length === 1
-                      ? "1 instance enabled"
-                      : `${enabledInstances.length} instances enabled`
-                  }
-                  value={isShown}
-                  onValueChange={(show) => toggleKind(id, show)}
-                />
-              </View>
-              {canReorder && (
-                <View className="flex-col items-center">
-                  <Pressable
-                    onPress={() => moveKind(id, "up")}
-                    disabled={isFirst}
-                    hitSlop={6}
-                    className="p-1 active:opacity-60"
-                    style={{ opacity: isFirst ? 0.3 : 1 }}
-                  >
-                    <Icon icon={ArrowUp} size={16} color="#a1a1aa" />
-                  </Pressable>
-                  <Pressable
-                    onPress={() => moveKind(id, "down")}
-                    disabled={isLast}
-                    hitSlop={6}
-                    className="p-1 active:opacity-60"
-                    style={{ opacity: isLast ? 0.3 : 1 }}
-                  >
-                    <Icon icon={ArrowDown} size={16} color="#a1a1aa" />
-                  </Pressable>
-                </View>
-              )}
-            </View>
-            {isShown && enabledInstances.length > 1 && (
-              <InstancePickerRow
-                serviceId={id}
-                value={binding}
-                onChange={(value) => setBinding(id, value)}
-              />
-            )}
-          </View>
-        );
-      })}
+      {configuredKinds.length > 1 ? (
+        <DraggableKindList
+          items={configuredKinds}
+          onReorder={commitVisibleOrder}
+          renderItem={renderRow}
+        />
+      ) : (
+        renderRow(configuredKinds[0])
+      )}
     </View>
   );
 }

--- a/hooks/use-glances.ts
+++ b/hooks/use-glances.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCpu, getPerCpu, getLoad, getMem, getFs, getDiskIO } from "@/services/glances-api";
+import { getCpu, getPerCpu, getLoad, getMem, getFs, getDiskIO, getGpu } from "@/services/glances-api";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
 const FAST_POLL = 5000;
@@ -60,6 +60,16 @@ export function useGlancesDiskIO(instanceId?: string) {
   return useQuery({
     queryKey: ["glances", id, "diskio"],
     queryFn: () => getDiskIO(id ?? undefined),
+    refetchInterval: FAST_POLL,
+    enabled: enabled && !!id,
+  });
+}
+
+export function useGlancesGpu(instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("glances", instanceId);
+  return useQuery({
+    queryKey: ["glances", id, "gpu"],
+    queryFn: () => getGpu(id ?? undefined),
     refetchInterval: FAST_POLL,
     enabled: enabled && !!id,
   });

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -272,6 +272,84 @@ export function useUpdateMovieQualityProfile(instanceId?: string) {
   });
 }
 
+export function useUpdateMovieRootFolder(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("radarr", instanceId);
+  return useMutation({
+    mutationFn: ({
+      movieId,
+      rootFolderPath,
+      moveFiles,
+    }: {
+      movieId: number;
+      rootFolderPath: string;
+      moveFiles: boolean;
+    }) => {
+      const cached = queryClient.getQueryData<RadarrMovie>([
+        "radarr",
+        id,
+        "movie",
+        movieId,
+      ]);
+      if (!cached) throw new Error("Movie not loaded");
+      return updateMovie(
+        { ...cached, rootFolderPath },
+        id ?? undefined,
+        { moveFiles },
+      );
+    },
+    onMutate: async ({ movieId, rootFolderPath }) => {
+      await queryClient.cancelQueries({ queryKey: ["radarr", id, "movie", movieId] });
+      await queryClient.cancelQueries({ queryKey: ["radarr", id, "movies"] });
+
+      const prevDetail = queryClient.getQueryData<RadarrMovie>([
+        "radarr",
+        id,
+        "movie",
+        movieId,
+      ]);
+      const prevList = queryClient.getQueryData<RadarrMovie[]>([
+        "radarr",
+        id,
+        "movies",
+      ]);
+
+      if (prevDetail) {
+        queryClient.setQueryData<RadarrMovie>(
+          ["radarr", id, "movie", movieId],
+          { ...prevDetail, rootFolderPath },
+        );
+      }
+      if (prevList) {
+        queryClient.setQueryData<RadarrMovie[]>(
+          ["radarr", id, "movies"],
+          prevList.map((m) =>
+            m.id === movieId ? { ...m, rootFolderPath } : m,
+          ),
+        );
+      }
+
+      return { prevDetail, prevList };
+    },
+    onError: (err, { movieId }, context) => {
+      if (context?.prevDetail) {
+        queryClient.setQueryData(
+          ["radarr", id, "movie", movieId],
+          context.prevDetail,
+        );
+      }
+      if (context?.prevList) {
+        queryClient.setQueryData(["radarr", id, "movies"], context.prevList);
+      }
+      toastError("Failed to update root folder", err);
+    },
+    onSettled: (_data, _err, { movieId }) => {
+      queryClient.invalidateQueries({ queryKey: ["radarr", id, "movie", movieId] });
+      queryClient.invalidateQueries({ queryKey: ["radarr", id, "movies"] });
+    },
+  });
+}
+
 export function useRadarrQualityProfiles(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -288,6 +288,84 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
   });
 }
 
+export function useUpdateSeriesRootFolder(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
+  return useMutation({
+    mutationFn: ({
+      seriesId,
+      rootFolderPath,
+      moveFiles,
+    }: {
+      seriesId: number;
+      rootFolderPath: string;
+      moveFiles: boolean;
+    }) => {
+      const cached = queryClient.getQueryData<SonarrSeries>([
+        "sonarr",
+        id,
+        "series",
+        seriesId,
+      ]);
+      if (!cached) throw new Error("Series not loaded");
+      return updateSeries(
+        { ...cached, rootFolderPath },
+        id ?? undefined,
+        { moveFiles },
+      );
+    },
+    onMutate: async ({ seriesId, rootFolderPath }) => {
+      await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series"] });
+
+      const prevDetail = queryClient.getQueryData<SonarrSeries>([
+        "sonarr",
+        id,
+        "series",
+        seriesId,
+      ]);
+      const prevList = queryClient.getQueryData<SonarrSeries[]>([
+        "sonarr",
+        id,
+        "series",
+      ]);
+
+      if (prevDetail) {
+        queryClient.setQueryData<SonarrSeries>(
+          ["sonarr", id, "series", seriesId],
+          { ...prevDetail, rootFolderPath },
+        );
+      }
+      if (prevList) {
+        queryClient.setQueryData<SonarrSeries[]>(
+          ["sonarr", id, "series"],
+          prevList.map((s) =>
+            s.id === seriesId ? { ...s, rootFolderPath } : s,
+          ),
+        );
+      }
+
+      return { prevDetail, prevList };
+    },
+    onError: (err, { seriesId }, context) => {
+      if (context?.prevDetail) {
+        queryClient.setQueryData(
+          ["sonarr", id, "series", seriesId],
+          context.prevDetail,
+        );
+      }
+      if (context?.prevList) {
+        queryClient.setQueryData(["sonarr", id, "series"], context.prevList);
+      }
+      toastError("Failed to update root folder", err);
+    },
+    onSettled: (_data, _err, { seriesId }) => {
+      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
+    },
+  });
+}
+
 export function useSonarrQualityProfiles(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -106,6 +106,11 @@ export const STORAGE_KEYS = {
   hapticsEnabled: "app.hapticsEnabled",
   globalCustomHeaders: "app.globalCustomHeaders",
   uiScale: "app.uiScale",
+  // v17: user-defined display order for the Services tab tiles. Stored as a
+  // ServiceId[]; unknown ids in this list are ignored at render time, and
+  // any SERVICE_IDS missing from the list are appended in their canonical
+  // order — so adding a new service kind ships with a sensible default.
+  servicesOrder: "app.servicesOrder",
 } as const;
 
 // Whitelisted UI scale multipliers. Kept as a const so the schema and the

--- a/lib/services-order.ts
+++ b/lib/services-order.ts
@@ -1,0 +1,28 @@
+import { SERVICE_IDS, type ServiceId } from "@/lib/constants";
+
+const VALID = new Set<ServiceId>(SERVICE_IDS);
+
+/**
+ * Materialize the user's display order for service kinds: entries the user
+ * has explicitly ordered (via the Services tab Reorder mode or the Status
+ * widget settings) first, then any SERVICE_IDS missing from that list
+ * appended in canonical order. Unknown ids are dropped.
+ *
+ * Shared between the Services tab and the dashboard Status widget so both
+ * surfaces agree on one ordering preference.
+ */
+export function applyServicesOrder(order: readonly ServiceId[]): ServiceId[] {
+  const seen = new Set<ServiceId>();
+  const out: ServiceId[] = [];
+  for (const id of order) {
+    if (seen.has(id)) continue;
+    if (!VALID.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  for (const id of SERVICE_IDS) {
+    if (seen.has(id)) continue;
+    out.push(id);
+  }
+  return out;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -352,6 +352,8 @@ export interface SonarrSeries {
   genres?: string[];
   certification?: string;
   firstAired?: string;
+  nextAiring?: string;
+  previousAiring?: string;
   statistics?: {
     seasonCount: number;
     episodeFileCount: number;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1034,6 +1034,20 @@ export interface GlancesDiskIOItem {
   time_since_update: number;
 }
 
+export interface GlancesGpuItem {
+  key: string;
+  gpu_id: string;
+  name: string;
+  // mem is VRAM utilization percent (used / total * 100), not absolute bytes —
+  // Glances doesn't expose absolute VRAM via the GPU plugin. proc is GPU
+  // compute utilization percent. Both may be null on backends that can't
+  // report them (e.g. some AMD/Intel/ARM cards lack fan_speed/temperature).
+  mem: number | null;
+  proc: number | null;
+  temperature: number | null;
+  fan_speed: number | null;
+}
+
 // --- Bazarr Types ---
 
 export interface BazarrMissingSubtitle {

--- a/plugins/withDevVariant.js
+++ b/plugins/withDevVariant.js
@@ -1,0 +1,67 @@
+const { withAppBuildGradle, withStringsXml } = require("expo/config-plugins");
+
+/**
+ * Config plugin that wires the development variant into the Android project:
+ *
+ *  - applicationIdSuffix ".dev"  when APP_VARIANT=development, so dev installs as
+ *    com.dashboarr.app.dev and coexists side-by-side with the prod build.
+ *  - resValue app_name "Dashboarr Dev" / "Dashboarr" so the launcher icon labels
+ *    are visually distinguishable. The matching app_name entry in
+ *    strings.xml is removed to avoid a duplicate-resource error.
+ *  - Skips the com.google.gms.google-services plugin in dev, since
+ *    google-services.json only has a client for the prod package and FCM in dev
+ *    isn't worth a second Firebase registration. Push is no-op in dev;
+ *    lib/expo-push.ts already swallows the failure.
+ *
+ * The Gradle env-var conditional means the SAME prebuilt android/ project can
+ * produce both variants by toggling APP_VARIANT at gradlew invocation time —
+ * no second prebuild needed when switching.
+ */
+
+const VARIANT_MARKER = "applicationIdSuffix \".dev\"";
+
+function injectVariantBlock(buildGradle) {
+  if (buildGradle.includes(VARIANT_MARKER)) return buildGradle;
+
+  // Append the variant switch at the end of defaultConfig (anchored on the
+  // closing brace of the buildConfigField line we know is present).
+  buildGradle = buildGradle.replace(
+    /(buildConfigField\s+"String",\s+"REACT_NATIVE_RELEASE_LEVEL"[^\n]*\n)/,
+    `$1
+        if (System.getenv("APP_VARIANT") == "development") {
+            applicationIdSuffix ".dev"
+            resValue "string", "app_name", "Dashboarr Dev"
+        } else {
+            resValue "string", "app_name", "Dashboarr"
+        }
+`
+  );
+
+  // Wrap the google-services plugin application so dev builds don't fail when
+  // there's no matching client entry for com.dashboarr.app.dev.
+  buildGradle = buildGradle.replace(
+    /^apply plugin: 'com\.google\.gms\.google-services'\s*$/m,
+    `if (System.getenv("APP_VARIANT") != "development") {\n    apply plugin: 'com.google.gms.google-services'\n}`
+  );
+
+  return buildGradle;
+}
+
+function withDevVariant(config) {
+  config = withAppBuildGradle(config, (cfg) => {
+    cfg.modResults.contents = injectVariantBlock(cfg.modResults.contents);
+    return cfg;
+  });
+
+  config = withStringsXml(config, (cfg) => {
+    const strings = cfg.modResults?.resources?.string ?? [];
+    cfg.modResults.resources.string = strings.filter(
+      (entry) => entry?.$?.name !== "app_name"
+    );
+    return cfg;
+  });
+
+  return config;
+}
+
+module.exports = withDevVariant;

--- a/scripts/run-dev.js
+++ b/scripts/run-dev.js
@@ -3,13 +3,33 @@
 // produces the side-by-side dev build (different name/bundle id/scheme).
 // Used by `pnpm android:dev`, `pnpm ios:dev`, `pnpm start:dev`.
 const { spawnSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
 
 process.env.APP_VARIANT = "development";
 
-const cmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-const result = spawnSync(cmd, ["exec", "expo", ...process.argv.slice(2)], {
+// Resolve the local expo CLI binary from node_modules/.bin. Going through this
+// path (vs. `pnpm exec`) avoids PATH-resolution quirks on Windows where the
+// child shell can exit silently without invoking expo at all.
+const isWin = process.platform === "win32";
+const binName = isWin ? "expo.cmd" : "expo";
+const expoBin = path.resolve(__dirname, "..", "node_modules", ".bin", binName);
+
+if (!fs.existsSync(expoBin)) {
+  console.error(`[run-dev] expo binary not found at ${expoBin}`);
+  console.error(`[run-dev] Run \`pnpm install\` first.`);
+  process.exit(1);
+}
+
+const result = spawnSync(expoBin, process.argv.slice(2), {
   stdio: "inherit",
   env: process.env,
+  shell: isWin,
 });
+
+if (result.error) {
+  console.error(`[run-dev] failed to launch expo:`, result.error.message);
+  process.exit(1);
+}
 
 process.exit(result.status ?? 0);

--- a/services/glances-api.ts
+++ b/services/glances-api.ts
@@ -1,4 +1,4 @@
-import { serviceRequest } from "@/lib/http-client";
+import { serviceRequest, HttpError } from "@/lib/http-client";
 import type {
   GlancesCpu,
   GlancesMem,
@@ -6,6 +6,7 @@ import type {
   GlancesPerCpuItem,
   GlancesLoad,
   GlancesDiskIOItem,
+  GlancesGpuItem,
 } from "@/lib/types";
 
 // Per-instance routing: every function takes an optional `instanceId`.
@@ -54,4 +55,15 @@ export async function getFs(instanceId?: string): Promise<GlancesFsItem[]> {
 
 export function getDiskIO(instanceId?: string): Promise<GlancesDiskIOItem[]> {
   return serviceRequest<GlancesDiskIOItem[]>("glances", "/diskio", { instanceId });
+}
+
+export async function getGpu(instanceId?: string): Promise<GlancesGpuItem[]> {
+  // Hosts without a GPU return an empty list; if the plugin is disabled the
+  // endpoint can 404, so swallow that into [] rather than surfacing as error.
+  try {
+    return await serviceRequest<GlancesGpuItem[]>("glances", "/gpu", { instanceId });
+  } catch (e) {
+    if (e instanceof HttpError && e.status === 404) return [];
+    throw e;
+  }
 }

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -201,8 +201,10 @@ export function toggleMovieMonitored(
 export function updateMovie(
   movie: RadarrMovie,
   instanceId?: string,
+  options?: { moveFiles?: boolean },
 ): Promise<RadarrMovie> {
-  return serviceRequest<RadarrMovie>("radarr", `/movie/${movie.id}`, {
+  const query = options?.moveFiles ? "?moveFiles=true" : "";
+  return serviceRequest<RadarrMovie>("radarr", `/movie/${movie.id}${query}`, {
     method: "PUT",
     body: JSON.stringify(movie),
     instanceId,

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -220,8 +220,10 @@ export function toggleSeriesMonitored(
 export function updateSeries(
   series: SonarrSeries,
   instanceId?: string,
+  options?: { moveFiles?: boolean },
 ): Promise<SonarrSeries> {
-  return serviceRequest<SonarrSeries>("sonarr", `/series/${series.id}`, {
+  const query = options?.moveFiles ? "?moveFiles=true" : "";
+  return serviceRequest<SonarrSeries>("sonarr", `/series/${series.id}${query}`, {
     method: "PUT",
     body: JSON.stringify(series),
     instanceId,

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -48,8 +48,11 @@ import { generateInstanceId } from "@/lib/uuid";
  *         hydrate time on locally-persisted dashboards.
  *   v16 — added sabnzbd service entry (no schema change; defaultInstances()
  *         backfills the new id at import time, so this is a version stamp only).
+ *   v17 — added servicesOrder: ServiceId[] for the user-defined Services tab
+ *         tile order. Older exports lack the field; default to [] which the
+ *         render-side logic interprets as "use canonical SERVICE_IDS order".
  */
-export const CURRENT_CONFIG_VERSION = 16;
+export const CURRENT_CONFIG_VERSION = 17;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -328,6 +331,15 @@ const migrations: Record<number, (payload: any) => any> = {
   // defaultInstances() afterward, so older payloads that lack a sabnzbd entry
   // get the disabled default automatically — nothing to transform here.
   15: (payload) => ({ ...payload, version: 16 }),
+
+  // v16 → v17: added servicesOrder. Older payloads had no concept of a
+  // user-defined Services tab order — default to [] which the render-side
+  // logic treats as "fall back to canonical SERVICE_IDS order".
+  16: (payload) => ({
+    ...payload,
+    version: 17,
+    servicesOrder: Array.isArray(payload.servicesOrder) ? payload.servicesOrder : [],
+  }),
 };
 
 /**

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -354,5 +354,22 @@ export function validateExportPayload(raw: unknown): ExportPayload {
     payload.uiScale = raw.uiScale as ExportPayload["uiScale"];
   }
 
+  if (raw.servicesOrder !== undefined && raw.servicesOrder !== null) {
+    if (!Array.isArray(raw.servicesOrder)) throw new Error("Config servicesOrder is invalid");
+    if (raw.servicesOrder.length > SERVICE_IDS.length) {
+      throw new Error("Config servicesOrder has too many entries");
+    }
+    const seen = new Set<string>();
+    const order: ServiceId[] = [];
+    for (const id of raw.servicesOrder) {
+      if (typeof id !== "string") throw new Error("Config servicesOrder entry is invalid");
+      if (!SERVICE_ID_SET.has(id)) continue; // forward-compat: drop unknowns
+      if (seen.has(id)) continue;
+      seen.add(id);
+      order.push(id as ServiceId);
+    }
+    payload.servicesOrder = order;
+  }
+
   return payload;
 }

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -146,6 +146,10 @@ interface ConfigState {
 
   autoSwitchNetwork: boolean;
   homeNetworks: HomeNetwork[];
+  // v17: per-user display order for the Services tab. Unknown ids are skipped
+  // at render time; any SERVICE_IDS missing from the list fall in at the end
+  // in canonical order, so adding a new service kind never gets hidden.
+  servicesOrder: ServiceId[];
   // v14: per-user named dashboards. The active one is rendered. Each dashboard
   // owns an ordered list of WidgetSlot entries; per-widget settings live on
   // the slot, not in a global map keyed by WidgetId. This is what lets the
@@ -193,6 +197,8 @@ export interface ExportPayload {
   globalCustomHeaders?: Record<string, string>;
   // v12
   uiScale?: UiScale;
+  // v17 — user-defined Services tab tile order.
+  servicesOrder?: ServiceId[];
 }
 
 export type ExportStage = "preparing" | "encrypting" | "finalizing";
@@ -256,6 +262,7 @@ interface ConfigActions {
   setSlotSettings: (slotId: string, settings: WidgetSlotSettings) => void;
   resetSlotSettings: (slotId: string) => void;
 
+  setServicesOrder: (order: ServiceId[]) => void;
   setWolDevices: (devices: WakeOnLanDevice[]) => void;
   setHapticsEnabled: (enabled: boolean) => void;
   setGlobalCustomHeaders: (headers: Record<string, string>) => void;
@@ -446,6 +453,27 @@ function isServiceInstance(v: unknown): v is ServiceInstance {
   );
 }
 
+const VALID_SERVICE_IDS = new Set<string>(SERVICE_IDS);
+
+// Filter a raw stored list down to known ServiceIds, drop duplicates, and
+// preserve the user's chosen order. The list is allowed to be a partial
+// subset — render-time logic appends any SERVICE_IDS not present here at the
+// end in canonical order, so a user who only ever moved a single tile still
+// gets every service rendered.
+function sanitizeServicesOrder(raw: unknown): ServiceId[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: ServiceId[] = [];
+  for (const id of raw) {
+    if (typeof id !== "string") continue;
+    if (!VALID_SERVICE_IDS.has(id)) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id as ServiceId);
+  }
+  return out;
+}
+
 const VALID_WIDGET_IDS = new Set<string>(DASHBOARD_WIDGET_IDS);
 
 function normalizeWidgetIds(ids: string[]): WidgetId[] {
@@ -491,6 +519,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   secrets: emptyLegacySecrets(),
   autoSwitchNetwork: false,
   homeNetworks: [],
+  servicesOrder: [],
   dashboards: initialDashboards,
   activeDashboardId: initialDashboards[0].id,
   wolDevices: [],
@@ -764,6 +793,10 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       setString(STORAGE_KEYS.activeDashboardId, activeDashboardId);
     }
 
+    const servicesOrder = sanitizeServicesOrder(
+      getJSON<unknown>(STORAGE_KEYS.servicesOrder),
+    );
+
     const wolDevices = getJSON<WakeOnLanDevice[]>(STORAGE_KEYS.wolDevices) ?? [];
     const globalCustomHeaders =
       getJSON<Record<string, string>>(STORAGE_KEYS.globalCustomHeaders) ?? {};
@@ -809,6 +842,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       secrets,
       autoSwitchNetwork,
       homeNetworks,
+      servicesOrder,
       dashboards,
       activeDashboardId,
       wolDevices,
@@ -1040,6 +1074,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   setHomeNetworks: (networks) => {
     setJSON(STORAGE_KEYS.homeNetworks, networks);
     set({ homeNetworks: networks });
+  },
+
+  setServicesOrder: (order) => {
+    const sanitized = sanitizeServicesOrder(order);
+    setJSON(STORAGE_KEYS.servicesOrder, sanitized);
+    set({ servicesOrder: sanitized });
   },
 
   // --- Dashboards (v14+) ---
@@ -1322,6 +1362,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       activeInstance,
       autoSwitchNetwork,
       homeNetworks,
+      servicesOrder,
       dashboards,
       activeDashboardId,
       wolDevices,
@@ -1341,6 +1382,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       activeInstance,
       autoSwitchNetwork,
       homeNetworks,
+      servicesOrder,
       dashboards,
       activeDashboardId,
       backend: { url, sharedSecret, deviceId },
@@ -1507,6 +1549,8 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         ? payload.uiScale
         : DEFAULT_UI_SCALE;
     setJSON(STORAGE_KEYS.uiScale, importedUiScale);
+    const importedServicesOrder = sanitizeServicesOrder(payload.servicesOrder);
+    setJSON(STORAGE_KEYS.servicesOrder, importedServicesOrder);
 
     // Restore backend pairing (v2+)
     if (payload.backend?.url && payload.backend?.sharedSecret) {
@@ -1539,6 +1583,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       secrets: derivedSecrets,
       autoSwitchNetwork: payload.autoSwitchNetwork ?? false,
       homeNetworks: importedHomeNetworks,
+      servicesOrder: importedServicesOrder,
       dashboards: importedDashboards,
       activeDashboardId: importedActiveDashboardId,
       wolDevices: payload.wolDevices ?? [],

--- a/store/sort-store.ts
+++ b/store/sort-store.ts
@@ -9,7 +9,8 @@ export type MoviesSortKey =
   | "title-desc"
   | "year-desc"
   | "year-asc"
-  | "size-desc";
+  | "size-desc"
+  | "next-airing-asc";
 
 export type SeriesSortKey = MoviesSortKey;
 


### PR DESCRIPTION
Grouped follow-ups and small features sitting on this branch.

- Customizable Services tab tile order (#41 follow-up) + Status widget order
- Draggable reorder for service health settings
- Radarr/Sonarr root folder management with file move (#43)
- `next-airing-asc` sort for movies/series, `nextAiring` on SonarrSeries
- Glances GPU stats — compute %, VRAM % (#54)
- ServerStatsCard metrics + UI pass
- Android dev variant + run-dev script fix

Config schema bumped — migration added.

## Test plan
- [x] Reorder services tab tiles, kill app, confirm order persists
- [x] Drag service health rows in settings, confirm new order on dashboard
- [x] Change Radarr/Sonarr root folder with move enabled, verify files relocate
- [x] Sort series by next airing, spot-check order
- [x] Glances card shows GPU rows when available
- [x] Import a pre-migration config export, confirm it loads