### PR TITLE
feat: auto-prefix http:// to service URLs if protocol is missing

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -919,7 +919,12 @@ function ServiceEditor({
 
   const handleTest = async () => {
     setTesting(true);
-    const testUrl = config.useRemote ? remoteUrl : localUrl;
+    const rawTestUrl = config.useRemote ? remoteUrl : localUrl;
+    const testUrl = normalizeServiceUrl(rawTestUrl);
+    if (testUrl !== rawTestUrl) {
+      if (config.useRemote) setRemoteUrl(testUrl);
+      else setLocalUrl(testUrl);
+    }
     const responseTime = await pingService(serviceId, testUrl || undefined, instanceId);
     setTesting(false);
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -40,7 +40,7 @@ import { pingService } from "@/lib/http-client";
 import { qbClearSession } from "@/services/qbittorrent-api";
 import { SERVICE_IDS, SERVICE_DEFAULTS } from "@/lib/constants";
 import type { ServiceId } from "@/lib/constants";
-import { validateServiceUrl } from "@/lib/url-validation";
+import { validateServiceUrl, normalizeServiceUrl } from "@/lib/url-validation";
 import { brrrHaptic } from "@/lib/haptics";
 import { AppVersionCard } from "@/components/common/app-version-card";
 import {
@@ -859,12 +859,18 @@ function ServiceEditor({
       toast("Name cannot be empty", "error");
       return;
     }
-    const localResult = validateServiceUrl(localUrl, "local");
+
+    const normLocal = normalizeServiceUrl(localUrl);
+    const normRemote = normalizeServiceUrl(remoteUrl);
+    setLocalUrl(normLocal);
+    setRemoteUrl(normRemote);
+
+    const localResult = validateServiceUrl(normLocal, "local");
     if (localResult.kind === "invalid") {
       toast(localResult.message, "error");
       return;
     }
-    const remoteResult = validateServiceUrl(remoteUrl, "remote");
+    const remoteResult = validateServiceUrl(normRemote, "remote");
     if (remoteResult.kind === "invalid") {
       toast(remoteResult.message, "error");
       return;
@@ -890,8 +896,8 @@ function ServiceEditor({
 
     updateInstance(serviceId, instanceId, {
       name: trimmedName,
-      localUrl,
-      remoteUrl,
+      localUrl: normLocal,
+      remoteUrl: normRemote,
     });
     if (isQB) {
       await updateInstanceSecrets(instanceId, {
@@ -977,6 +983,7 @@ function ServiceEditor({
           placeholder="http://192.168.1.100:8080"
           value={localUrl}
           onChangeText={setLocalUrl}
+          onBlur={() => setLocalUrl(normalizeServiceUrl(localUrl))}
           keyboardType="url"
         />
         <TextInput
@@ -984,6 +991,7 @@ function ServiceEditor({
           placeholder="https://service.mydomain.com"
           value={remoteUrl}
           onChangeText={setRemoteUrl}
+          onBlur={() => setRemoteUrl(normalizeServiceUrl(remoteUrl))}
           keyboardType="url"
         />
         <Toggle

--- a/app/backend.tsx
+++ b/app/backend.tsx
@@ -19,6 +19,7 @@ import {
   unregisterDevice,
 } from "@/services/backend-api";
 import { getExpoPushToken, hasProjectId } from "@/lib/expo-push";
+import { normalizeServiceUrl } from "@/lib/url-validation";
 
 type Mode = "summary" | "scanning" | "manual";
 
@@ -62,12 +63,14 @@ export default function BackendScreen() {
   const handleClaim = useCallback(
     async (token: string, urlOverride?: string) => {
       if (claimingRef.current) return;
-      const trimmedUrl = (urlOverride ?? backendUrl).trim().replace(/\/$/, "");
+      const rawUrl = urlOverride ?? backendUrl;
+      const trimmedUrl = normalizeServiceUrl(rawUrl).replace(/\/$/, "");
       if (!trimmedUrl) {
         toast("Enter the backend URL first", "error");
         setMode("summary");
         return;
       }
+      setBackendUrl(trimmedUrl);
       claimingRef.current = true;
       setBusy(true);
       try {
@@ -285,6 +288,7 @@ export default function BackendScreen() {
                   placeholder="http://192.168.1.50:4000"
                   value={backendUrl}
                   onChangeText={setBackendUrl}
+                  onBlur={() => setBackendUrl(normalizeServiceUrl(backendUrl))}
                   keyboardType="url"
                   autoCapitalize="none"
                 />

--- a/lib/url-validation.test.ts
+++ b/lib/url-validation.test.ts
@@ -1,4 +1,4 @@
-import { validateServiceUrl } from "./url-validation";
+import { validateServiceUrl, normalizeServiceUrl } from "./url-validation";
 
 describe("validateServiceUrl", () => {
   describe("empty input", () => {
@@ -72,5 +72,30 @@ describe("validateServiceUrl", () => {
         kind: "ok",
       });
     });
+  });
+});
+
+describe("normalizeServiceUrl", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalizeServiceUrl("")).toBe("");
+    expect(normalizeServiceUrl("  ")).toBe("");
+  });
+
+  it("leaves http:// URLs alone", () => {
+    expect(normalizeServiceUrl("http://localhost:8989")).toBe("http://localhost:8989");
+  });
+
+  it("leaves https:// URLs alone", () => {
+    expect(normalizeServiceUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("prepends http:// to hostnames", () => {
+    expect(normalizeServiceUrl("localhost:8989")).toBe("http://localhost:8989");
+    expect(normalizeServiceUrl("192.168.1.100:8080")).toBe("http://192.168.1.100:8080");
+    expect(normalizeServiceUrl("my-service.local")).toBe("http://my-service.local");
+  });
+
+  it("trims input", () => {
+    expect(normalizeServiceUrl("  localhost:8989  ")).toBe("http://localhost:8989");
   });
 });

--- a/lib/url-validation.ts
+++ b/lib/url-validation.ts
@@ -46,3 +46,14 @@ export function validateServiceUrl(
 
   return { kind: "ok" };
 }
+
+/**
+ * Auto-prefix `http://` if no protocol is present. This helps users who type
+ * just `192.168.1.10:8080` or `localhost:8989`.
+ */
+export function normalizeServiceUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed === "") return "";
+  if (/^[a-z]+:\/\//i.test(trimmed)) return trimmed;
+  return `http://${trimmed}`;
+}


### PR DESCRIPTION
I saw that unless I typed `http://` in front of `localhost:port` the providers failed the connection test. Just typing `localhost:port` should be enough now, as well as default `http://` prefix for local network.

Added `normalizeServiceUrl` helper to `lib/url-validation.ts` and integrated it into `ServiceEditor` and `BackendScreen`. This improves UX by allowing users to type `localhost:8989` or IP addresses without explicitly prepending `http://`. Included unit tests for the normalization logic.