### PR TITLE
fix: notification accuracy, calendar filtering, and unified filter/sort UI

### DIFF
--- a/app/(tabs)/downloads.tsx
+++ b/app/(tabs)/downloads.tsx
@@ -5,7 +5,6 @@ import {
   Pressable,
   Alert,
   BackHandler,
-  ScrollView,
   FlatList,
   RefreshControl,
   ActivityIndicator,
@@ -19,7 +18,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { BottomTabBarHeightContext } from "@react-navigation/bottom-tabs";
 import { toast, toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect, useLocalSearchParams } from "expo-router";
-import { Pause, Play, Trash2, Plus, CheckCircle2, Circle, ArrowUpDown, Check, Zap, AlertCircle } from "lucide-react-native";
+import { Pause, Play, Trash2, Plus, CheckCircle2, Circle, Zap, AlertCircle } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ServiceHeader } from "@/components/common/service-header";
 import { DemoBanner } from "@/components/common/demo-banner";
@@ -30,10 +29,9 @@ import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
+import { FilterSortButton } from "@/components/common/filter-sort-button";
+import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import { errorHaptic, lightHaptic, mediumHaptic } from "@/lib/haptics";
-import { SortButton } from "@/components/ui/sort-button";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
 import {
   useSortStore,
@@ -264,7 +262,7 @@ function QbittorrentDownloadsScreen({
   const [filter, setFilter] = useState<FilterType>("all");
   const sort = useSortStore((s) => s.downloads);
   const setSort = useSortStore((s) => s.setDownloads);
-  const [sortSheetOpen, setSortSheetOpen] = useState(false);
+  const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [speedLimitsOpen, setSpeedLimitsOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
@@ -502,25 +500,11 @@ function QbittorrentDownloadsScreen({
         />
       )}
 
-      <View className="flex-row items-center gap-2 mb-4">
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerClassName="gap-2"
-          className="flex-1"
-        >
-          {FILTER_OPTIONS.map((opt) => (
-            <FilterChip
-              key={opt.key}
-              label={opt.label}
-              selected={filter === opt.key}
-              onPress={() => setFilter(opt.key)}
-            />
-          ))}
-        </ScrollView>
-        <SortButton
-          onPress={() => setSortSheetOpen(true)}
-          active={sort !== SORT_DEFAULTS.downloads}
+      <View className="mb-4">
+        <FilterSortButton
+          summary={`${FILTER_OPTIONS.find((f) => f.key === filter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
+          onPress={() => setFilterSortOpen(true)}
+          active={filter !== "all" || sort !== SORT_DEFAULTS.downloads}
         />
       </View>
     </>
@@ -616,20 +600,16 @@ function QbittorrentDownloadsScreen({
         removeClippedSubviews
       />
 
-      <ActionSheet
-        visible={sortSheetOpen}
-        onClose={() => setSortSheetOpen(false)}
-        title="Sort torrents"
-        actions={SORT_OPTIONS.map<ActionSheetAction>((opt) => ({
-          label: opt.label,
-          icon:
-            sort === opt.key ? (
-              <Icon icon={Check} size={18} color="#3b82f6" />
-            ) : (
-              <Icon icon={ArrowUpDown} size={18} color="#71717a" />
-            ),
-          onPress: () => setSort(opt.key),
-        }))}
+      <FilterSortSheet
+        visible={filterSortOpen}
+        onClose={() => setFilterSortOpen(false)}
+        title="Filter & sort torrents"
+        filterOptions={FILTER_OPTIONS}
+        filterValue={filter}
+        onFilterChange={setFilter}
+        sortOptions={SORT_OPTIONS}
+        sortValue={sort}
+        onSortChange={setSort}
       />
 
       <SpeedLimitsSheet

--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -1,15 +1,7 @@
 import { useState, useMemo } from "react";
 import { View, Text, Pressable, Alert, ScrollView } from "react-native";
-import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import {
-  Search,
-  Film,
-  Eye,
-  EyeOff,
-  Trash2,
-  Info,
-} from "lucide-react-native";
+import { Search, Film, Eye, EyeOff, Trash2, Info } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -21,9 +13,14 @@ import { FilterChip } from "@/components/ui/filter-chip";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
+import {
+  MonitoredLibraryGrid,
+  MONITOR_FILTER_OPTIONS,
+  type MonitorFilter,
+} from "@/components/common/monitored-library-grid";
 import { useSortStore, SORT_DEFAULTS, type MoviesSortKey } from "@/store/sort-store";
 
-import { Skeleton, SkeletonCardContent } from "@/components/ui/skeleton";
+import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { ICON } from "@/lib/constants";
 import {
   useRadarrMovies,
@@ -35,9 +32,6 @@ import {
 } from "@/hooks/use-radarr";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
-import { formatBytes } from "@/lib/utils";
-import { useServiceImage } from "@/hooks/use-service-image";
-import { usePosterCellWidth } from "@/hooks/use-poster-cell";
 import { mediumHaptic } from "@/lib/haptics";
 import type { RadarrMovie, RadarrQueueItem } from "@/lib/types";
 
@@ -47,13 +41,6 @@ type MovieSheetTarget =
   | null;
 
 type Tab = "library" | "queue" | "wanted";
-type MonitorFilter = "monitored" | "unmonitored" | "all";
-
-const MONITOR_FILTERS: { value: MonitorFilter; label: string }[] = [
-  { value: "monitored", label: "Monitored" },
-  { value: "unmonitored", label: "Unmonitored" },
-  { value: "all", label: "All" },
-];
 
 const SORT_OPTIONS: { key: MoviesSortKey; label: string }[] = [
   { key: "added-desc", label: "Recently Added" },
@@ -226,7 +213,7 @@ export default function MoviesScreen() {
       {tab === "library" && (
         <View className="mb-4">
           <FilterSortButton
-            summary={`${MONITOR_FILTERS.find((f) => f.value === monitorFilter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
+            summary={`${MONITOR_FILTER_OPTIONS.find((f) => f.value === monitorFilter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
             onPress={() => setFilterSortOpen(true)}
             active={
               monitorFilter !== "monitored" || sort !== SORT_DEFAULTS.movies
@@ -235,13 +222,7 @@ export default function MoviesScreen() {
         </View>
       )}
 
-      {tab === "library" && (
-        <MovieLibrary
-          monitorFilter={monitorFilter}
-          sort={sort}
-          onLongPress={openMovieSheet}
-        />
-      )}
+      {tab === "library" && <MovieLibrary monitorFilter={monitorFilter} sort={sort} onLongPress={openMovieSheet} />}
       {tab === "queue" && <MovieQueue onLongPress={openQueueSheet} />}
       {tab === "wanted" && <MovieWanted />}
 
@@ -257,7 +238,7 @@ export default function MoviesScreen() {
         visible={filterSortOpen}
         onClose={() => setFilterSortOpen(false)}
         title="Filter & sort movies"
-        filterOptions={MONITOR_FILTERS.map((f) => ({
+        filterOptions={MONITOR_FILTER_OPTIONS.map((f) => ({
           key: f.value,
           label: f.label,
         }))}
@@ -282,100 +263,22 @@ function MovieLibrary({
 }) {
   const { data: movies, isLoading, error } = useRadarrMovies();
   const router = useRouter();
-  const cellWidth = usePosterCellWidth();
-
-  if (isLoading) {
-    return (
-      <View className="flex-row flex-wrap gap-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <View key={i} style={{ width: cellWidth }}>
-            <Skeleton width="100%" height={150} borderRadius={12} />
-            <Skeleton width="75%" height={10} borderRadius={4} className="mt-1.5" />
-          </View>
-        ))}
-      </View>
-    );
-  }
-  if (error) {
-    return <ErrorBanner error={error} title="Failed to load library" />;
-  }
-  if (!movies?.length) {
-    return <EmptyState icon={<Icon icon={Film} size={32} color="#71717a" />} title="No movies in library" />;
-  }
-
-  const filtered = movies.filter((m) => {
-    if (monitorFilter === "monitored") return m.monitored;
-    if (monitorFilter === "unmonitored") return !m.monitored;
-    return true;
-  });
-
-  if (!filtered.length) {
-    const title =
-      monitorFilter === "monitored"
-        ? "No monitored movies"
-        : monitorFilter === "unmonitored"
-          ? "No unmonitored movies"
-          : "No movies in library";
-    return <EmptyState icon={<Icon icon={Film} size={32} color="#71717a" />} title={title} />;
-  }
-
-  const sorted = [...filtered].sort((a, b) => compareMovies(a, b, sort));
 
   return (
-    <View className="flex-row flex-wrap gap-3">
-      {sorted.map((movie) => (
-        <MoviePoster
-          key={movie.id}
-          movie={movie}
-          onPress={() => router.push(`/movie/${movie.id}`)}
-          onLongPress={() => onLongPress(movie)}
-        />
-      ))}
-    </View>
-  );
-}
-
-function MoviePoster({
-  movie,
-  onPress,
-  onLongPress,
-}: {
-  movie: RadarrMovie;
-  onPress: () => void;
-  onLongPress: () => void;
-}) {
-  const poster = movie.images.find((i) => i.coverType === "poster");
-  const { src, onError } = useServiceImage(poster, "radarr");
-  const cellWidth = usePosterCellWidth();
-
-  return (
-    <Pressable
-      onPress={onPress}
-      onLongPress={onLongPress}
-      delayLongPress={400}
-      style={{ width: cellWidth }}
-      className="active:opacity-80"
-    >
-      {src ? (
-        <Image
-          source={{ uri: src }}
-          className="w-full aspect-[2/3] rounded-xl bg-surface-light"
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
-          recyclingKey={src}
-          onError={onError}
-        />
-      ) : (
-        <View className="w-full aspect-[2/3] rounded-xl bg-surface-light items-center justify-center">
-          <Icon icon={Film} size={24} color="#71717a" />
-        </View>
-      )}
-      <Text className="text-zinc-300 text-sm mt-1" numberOfLines={1}>
-        {movie.title}
-      </Text>
-      <Text className="text-zinc-600 text-xs">{movie.year}</Text>
-    </Pressable>
+    <MonitoredLibraryGrid
+      data={movies}
+      isLoading={isLoading}
+      error={error}
+      monitorFilter={monitorFilter}
+      sort={sort}
+      compare={compareMovies}
+      serviceId="radarr"
+      placeholderIcon={Film}
+      nounPlural="movies"
+      renderFooter={(m) => String(m.year)}
+      onItemPress={(m) => router.push(`/movie/${m.id}`)}
+      onItemLongPress={onLongPress}
+    />
   );
 }
 
@@ -416,7 +319,6 @@ function MovieQueue({ onLongPress }: { onLongPress: (item: RadarrQueueItem) => v
 
 function MovieWanted() {
   const { data: wanted, isLoading } = useWantedMissing();
-  const router = useRouter();
 
   if (isLoading) return <SkeletonCardContent rows={2} />;
 

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -10,7 +10,6 @@ import {
   Tv,
   Compass,
   ListFilter,
-  ArrowUpDown,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -22,8 +21,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
-import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
-import { SortButton } from "@/components/ui/sort-button";
+import { FilterSortButton } from "@/components/common/filter-sort-button";
+import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import {
   useSortStore,
   SORT_DEFAULTS,
@@ -329,7 +328,7 @@ function RequestsList() {
   const [filter, setFilter] = useState<RequestFilter>("all");
   const sort = useSortStore((s) => s.requests);
   const setSort = useSortStore((s) => s.setRequests);
-  const [sortOpen, setSortOpen] = useState(false);
+  const [filterSortOpen, setFilterSortOpen] = useState(false);
   const { sort: apiSort } = sortToParams(sort);
   const { data, isLoading, error } = useOverseerrRequests(1, filter, apiSort);
   const { data: counts } = useOverseerrRequestCount();
@@ -338,29 +337,20 @@ function RequestsList() {
 
   const requests = data?.results ?? [];
 
+  const filterOptions: { key: RequestFilter; label: string }[] = (
+    ["all", "pending", "approved", "processing"] as RequestFilter[]
+  ).map((f) => ({
+    key: f,
+    label: `${f.charAt(0).toUpperCase() + f.slice(1)}${f === "pending" && counts?.pending ? ` (${counts.pending})` : ""}`,
+  }));
+
   return (
     <View>
-      <View className="flex-row items-center gap-2 mb-4">
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerClassName="gap-2"
-          className="flex-1"
-        >
-          {(
-            ["all", "pending", "approved", "processing"] as RequestFilter[]
-          ).map((f) => (
-            <FilterChip
-              key={f}
-              label={`${f.charAt(0).toUpperCase() + f.slice(1)}${f === "pending" && counts?.pending ? ` (${counts.pending})` : ""}`}
-              selected={filter === f}
-              onPress={() => setFilter(f)}
-            />
-          ))}
-        </ScrollView>
-        <SortButton
-          onPress={() => setSortOpen(true)}
-          active={sort !== SORT_DEFAULTS.requests}
+      <View className="mb-4">
+        <FilterSortButton
+          summary={`${filterOptions.find((f) => f.key === filter)?.label ?? ""} · ${REQUEST_SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
+          onPress={() => setFilterSortOpen(true)}
+          active={filter !== "all" || sort !== SORT_DEFAULTS.requests}
         />
       </View>
 
@@ -387,20 +377,16 @@ function RequestsList() {
         </View>
       )}
 
-      <ActionSheet
-        visible={sortOpen}
-        onClose={() => setSortOpen(false)}
-        title="Sort requests"
-        actions={REQUEST_SORT_OPTIONS.map<ActionSheetAction>((opt) => ({
-          label: opt.label,
-          icon:
-            sort === opt.key ? (
-              <Icon icon={Check} size={18} color="#3b82f6" />
-            ) : (
-              <Icon icon={ArrowUpDown} size={18} color="#71717a" />
-            ),
-          onPress: () => setSort(opt.key),
-        }))}
+      <FilterSortSheet
+        visible={filterSortOpen}
+        onClose={() => setFilterSortOpen(false)}
+        title="Filter & sort requests"
+        filterOptions={filterOptions}
+        filterValue={filter}
+        onFilterChange={setFilter}
+        sortOptions={REQUEST_SORT_OPTIONS}
+        sortValue={sort}
+        onSortChange={setSort}
       />
     </View>
   );

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -1,15 +1,7 @@
 import { useState, useMemo } from "react";
 import { View, Text, Pressable, Alert, ScrollView } from "react-native";
-import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import {
-  Search,
-  Tv,
-  Eye,
-  EyeOff,
-  Trash2,
-  Info,
-} from "lucide-react-native";
+import { Search, Tv, Eye, EyeOff, Trash2, Info } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -20,8 +12,13 @@ import { FilterChip } from "@/components/ui/filter-chip";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
+import {
+  MonitoredLibraryGrid,
+  MONITOR_FILTER_OPTIONS,
+  type MonitorFilter,
+} from "@/components/common/monitored-library-grid";
 import { useSortStore, SORT_DEFAULTS, type SeriesSortKey } from "@/store/sort-store";
-import { Skeleton, SkeletonCardContent } from "@/components/ui/skeleton";
+import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { ICON } from "@/lib/constants";
 import {
   useSonarrSeries,
@@ -34,8 +31,6 @@ import {
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { formatEpisodeCode, relativeDate, localDateKey } from "@/lib/utils";
-import { useServiceImage } from "@/hooks/use-service-image";
-import { usePosterCellWidth } from "@/hooks/use-poster-cell";
 import { mediumHaptic } from "@/lib/haptics";
 import type { SonarrSeries, SonarrCalendarEntry } from "@/lib/types";
 
@@ -45,13 +40,6 @@ type SeriesSheetTarget =
   | null;
 
 type Tab = "library" | "calendar";
-type MonitorFilter = "monitored" | "unmonitored" | "all";
-
-const MONITOR_FILTERS: { value: MonitorFilter; label: string }[] = [
-  { value: "monitored", label: "Monitored" },
-  { value: "unmonitored", label: "Unmonitored" },
-  { value: "all", label: "All" },
-];
 
 const SORT_OPTIONS: { key: SeriesSortKey; label: string }[] = [
   { key: "added-desc", label: "Recently Added" },
@@ -231,7 +219,7 @@ export default function TVScreen() {
       {tab === "library" && (
         <View className="mb-4">
           <FilterSortButton
-            summary={`${MONITOR_FILTERS.find((f) => f.value === monitorFilter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
+            summary={`${MONITOR_FILTER_OPTIONS.find((f) => f.value === monitorFilter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
             onPress={() => setFilterSortOpen(true)}
             active={
               monitorFilter !== "monitored" || sort !== SORT_DEFAULTS.series
@@ -240,13 +228,7 @@ export default function TVScreen() {
         </View>
       )}
 
-      {tab === "library" && (
-        <SeriesLibrary
-          monitorFilter={monitorFilter}
-          sort={sort}
-          onLongPress={openSeriesSheet}
-        />
-      )}
+      {tab === "library" && <SeriesLibrary monitorFilter={monitorFilter} sort={sort} onLongPress={openSeriesSheet} />}
       {tab === "calendar" && <CalendarView onLongPress={openCalendarSheet} />}
 
       <ActionSheet
@@ -261,7 +243,7 @@ export default function TVScreen() {
         visible={filterSortOpen}
         onClose={() => setFilterSortOpen(false)}
         title="Filter & sort shows"
-        filterOptions={MONITOR_FILTERS.map((f) => ({
+        filterOptions={MONITOR_FILTER_OPTIONS.map((f) => ({
           key: f.value,
           label: f.label,
         }))}
@@ -286,102 +268,22 @@ function SeriesLibrary({
 }) {
   const { data: series, isLoading, error } = useSonarrSeries();
   const router = useRouter();
-  const cellWidth = usePosterCellWidth();
-
-  if (isLoading) {
-    return (
-      <View className="flex-row flex-wrap gap-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <View key={i} style={{ width: cellWidth }}>
-            <Skeleton width="100%" height={150} borderRadius={12} />
-            <Skeleton width="75%" height={10} borderRadius={4} className="mt-1.5" />
-          </View>
-        ))}
-      </View>
-    );
-  }
-  if (error) {
-    return <ErrorBanner error={error} title="Failed to load library" />;
-  }
-  if (!series?.length) {
-    return <EmptyState icon={<Icon icon={Tv} size={32} color="#71717a" />} title="No shows in library" />;
-  }
-
-  const filtered = series.filter((s) => {
-    if (monitorFilter === "monitored") return s.monitored;
-    if (monitorFilter === "unmonitored") return !s.monitored;
-    return true;
-  });
-
-  if (!filtered.length) {
-    const title =
-      monitorFilter === "monitored"
-        ? "No monitored shows"
-        : monitorFilter === "unmonitored"
-          ? "No unmonitored shows"
-          : "No shows in library";
-    return <EmptyState icon={<Icon icon={Tv} size={32} color="#71717a" />} title={title} />;
-  }
-
-  const sorted = [...filtered].sort((a, b) => compareSeries(a, b, sort));
 
   return (
-    <View className="flex-row flex-wrap gap-3">
-      {sorted.map((show) => (
-        <SeriesPoster
-          key={show.id}
-          series={show}
-          onPress={() => router.push(`/series/${show.id}`)}
-          onLongPress={() => onLongPress(show)}
-        />
-      ))}
-    </View>
-  );
-}
-
-function SeriesPoster({
-  series,
-  onPress,
-  onLongPress,
-}: {
-  series: SonarrSeries;
-  onPress: () => void;
-  onLongPress: () => void;
-}) {
-  const poster = series.images.find((i) => i.coverType === "poster");
-  const { src, onError } = useServiceImage(poster, "sonarr");
-  const cellWidth = usePosterCellWidth();
-
-  return (
-    <Pressable
-      onPress={onPress}
-      onLongPress={onLongPress}
-      delayLongPress={400}
-      style={{ width: cellWidth }}
-      className="active:opacity-80"
-    >
-      {src ? (
-        <Image
-          source={{ uri: src }}
-          className="w-full aspect-[2/3] rounded-xl bg-surface-light"
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
-          recyclingKey={src}
-          onError={onError}
-        />
-      ) : (
-        <View className="w-full aspect-[2/3] rounded-xl bg-surface-light items-center justify-center">
-          <Icon icon={Tv} size={24} color="#71717a" />
-        </View>
-      )}
-      <Text className="text-zinc-300 text-sm mt-1" numberOfLines={1}>
-        {series.title}
-      </Text>
-      <Text className="text-zinc-600 text-xs">
-        {series.seasonCount} season{series.seasonCount !== 1 ? "s" : ""}
-      </Text>
-    </Pressable>
+    <MonitoredLibraryGrid
+      data={series}
+      isLoading={isLoading}
+      error={error}
+      monitorFilter={monitorFilter}
+      sort={sort}
+      compare={compareSeries}
+      serviceId="sonarr"
+      placeholderIcon={Tv}
+      nounPlural="shows"
+      renderFooter={(s) => `${s.seasonCount} season${s.seasonCount !== 1 ? "s" : ""}`}
+      onItemPress={(s) => router.push(`/series/${s.id}`)}
+      onItemLongPress={onLongPress}
+    />
   );
 }
 
@@ -397,7 +299,6 @@ function CalendarView({ onLongPress }: { onLongPress: (ep: SonarrCalendarEntry) 
     return <EmptyState title="Nothing airing this week" />;
   }
 
-  // Group by date
   const grouped = new Map<string, SonarrCalendarEntry[]>();
   for (const ep of episodes) {
     const list = grouped.get(ep.airDate) ?? [];

--- a/backend/dashboarr-backend/src/db/repos/seen-state.ts
+++ b/backend/dashboarr-backend/src/db/repos/seen-state.ts
@@ -4,8 +4,8 @@ import { getDb } from "../client.js";
  * Persists poller state + cross-source dedupe keys.
  * Key conventions:
  *   - `qbt:hashes:downloading`          → JSON-encoded array of torrent hashes currently downloading
- *   - `radarr:queue:ids`                → JSON-encoded array of queue IDs currently present
- *   - `sonarr:queue:ids`                → JSON-encoded array of queue IDs currently present
+ *   - `radarr:<instance>:history:seen`  → JSON-encoded array of imported-history record IDs already announced
+ *   - `sonarr:<instance>:history:seen`  → JSON-encoded array of imported-history record IDs already announced
  *   - `overseerr:pending:ids`           → JSON-encoded array of request IDs in pending
  *   - `health:<serviceId>:online`       → "1" or "0"
  *   - `event:<source>:<type>:<extId>`   → "1" once an event has been dispatched

--- a/backend/dashboarr-backend/src/services/radarr.ts
+++ b/backend/dashboarr-backend/src/services/radarr.ts
@@ -19,3 +19,30 @@ export function getRadarrQueue(config: StoredServiceConfig): Promise<RadarrQueue
     params: { page: 1, pageSize: 200, includeMovie: true },
   });
 }
+
+export interface RadarrHistoryRecord {
+  id: number;
+  eventType: string;
+  sourceTitle?: string;
+  date?: string;
+  downloadId?: string;
+  movieId?: number;
+  movie?: { id?: number; title?: string; year?: number };
+}
+
+export interface RadarrHistory {
+  records: RadarrHistoryRecord[];
+  totalRecords: number;
+}
+
+export function getRadarrHistory(config: StoredServiceConfig): Promise<RadarrHistory> {
+  return serviceFetch<RadarrHistory>(config, "/history", {
+    params: {
+      page: 1,
+      pageSize: 50,
+      sortKey: "date",
+      sortDirection: "descending",
+      includeMovie: true,
+    },
+  });
+}

--- a/backend/dashboarr-backend/src/services/sonarr.ts
+++ b/backend/dashboarr-backend/src/services/sonarr.ts
@@ -20,3 +20,33 @@ export function getSonarrQueue(config: StoredServiceConfig): Promise<SonarrQueue
     params: { page: 1, pageSize: 200, includeSeries: true, includeEpisode: true },
   });
 }
+
+export interface SonarrHistoryRecord {
+  id: number;
+  eventType: string;
+  sourceTitle?: string;
+  date?: string;
+  downloadId?: string;
+  seriesId?: number;
+  episodeId?: number;
+  series?: { id?: number; title?: string };
+  episode?: { title?: string; seasonNumber?: number; episodeNumber?: number };
+}
+
+export interface SonarrHistory {
+  records: SonarrHistoryRecord[];
+  totalRecords: number;
+}
+
+export function getSonarrHistory(config: StoredServiceConfig): Promise<SonarrHistory> {
+  return serviceFetch<SonarrHistory>(config, "/history", {
+    params: {
+      page: 1,
+      pageSize: 50,
+      sortKey: "date",
+      sortDirection: "descending",
+      includeSeries: true,
+      includeEpisode: true,
+    },
+  });
+}

--- a/backend/dashboarr-backend/src/workers/pollers/radarr.ts
+++ b/backend/dashboarr-backend/src/workers/pollers/radarr.ts
@@ -3,11 +3,11 @@ import {
   countEnabledInstancesByKind,
   type StoredServiceInstance,
 } from "../../db/repos/service-instance.js";
-import { getRadarrQueue } from "../../services/radarr.js";
-import { diffRadarrQueue } from "../transitions.js";
+import { getRadarrHistory } from "../../services/radarr.js";
+import { diffRadarrHistory } from "../transitions.js";
 
 export async function pollRadarr(instance: StoredServiceInstance): Promise<void> {
-  const queue = await getRadarrQueue(instanceToServiceConfig(instance));
+  const history = await getRadarrHistory(instanceToServiceConfig(instance));
   const multiple = (countEnabledInstancesByKind().get("radarr") ?? 0) > 1;
-  await diffRadarrQueue(instance.id, instance.name, multiple, queue.records);
+  await diffRadarrHistory(instance.id, instance.name, multiple, history.records);
 }

--- a/backend/dashboarr-backend/src/workers/pollers/sonarr.ts
+++ b/backend/dashboarr-backend/src/workers/pollers/sonarr.ts
@@ -3,11 +3,11 @@ import {
   countEnabledInstancesByKind,
   type StoredServiceInstance,
 } from "../../db/repos/service-instance.js";
-import { getSonarrQueue } from "../../services/sonarr.js";
-import { diffSonarrQueue } from "../transitions.js";
+import { getSonarrHistory } from "../../services/sonarr.js";
+import { diffSonarrHistory } from "../transitions.js";
 
 export async function pollSonarr(instance: StoredServiceInstance): Promise<void> {
-  const queue = await getSonarrQueue(instanceToServiceConfig(instance));
+  const history = await getSonarrHistory(instanceToServiceConfig(instance));
   const multiple = (countEnabledInstancesByKind().get("sonarr") ?? 0) > 1;
-  await diffSonarrQueue(instance.id, instance.name, multiple, queue.records);
+  await diffSonarrHistory(instance.id, instance.name, multiple, history.records);
 }

--- a/backend/dashboarr-backend/src/workers/transitions.ts
+++ b/backend/dashboarr-backend/src/workers/transitions.ts
@@ -5,8 +5,8 @@ import type { TorrentState, QBTorrent } from "../services/qbittorrent.js";
 import type { SabHistorySlot } from "../services/sabnzbd.js";
 import type { NzbgetHistoryItem } from "../services/nzbget.js";
 import type { NotificationCategory } from "../types.js";
-import type { RadarrQueueItem } from "../services/radarr.js";
-import type { SonarrQueueItem } from "../services/sonarr.js";
+import type { RadarrHistoryRecord } from "../services/radarr.js";
+import type { SonarrHistoryRecord } from "../services/sonarr.js";
 import type { OverseerrRequest } from "../services/overseerr.js";
 
 /**
@@ -236,96 +236,95 @@ export async function diffNzbgetHistory(
 
 // ---------------- Radarr ----------------
 
-interface QueueSnapshot {
-  [id: string]: { title: string; status?: string; entityId?: number };
-}
-
-function radarrDisplayTitle(r: RadarrQueueItem): string {
+function radarrDisplayTitle(r: RadarrHistoryRecord): string {
   if (r.movie?.title) {
     return r.movie.year ? `${r.movie.title} (${r.movie.year})` : r.movie.title;
   }
-  return r.title;
+  return r.sourceTitle ?? "";
 }
 
-export async function diffRadarrQueue(
+// Diffs Radarr's /history endpoint for newly-imported releases. We only
+// announce records with eventType "downloadFolderImported" — the queue can
+// shed items for many non-success reasons (delay profile, manual removal,
+// internal state transitions), so queue disappearance is not a reliable
+// success signal.
+export async function diffRadarrHistory(
   instanceId: string,
   instanceName: string,
   multipleOfKind: boolean,
-  records: RadarrQueueItem[],
+  records: RadarrHistoryRecord[],
 ): Promise<void> {
-  const key = `radarr:${instanceId}:queue:ids`;
-  const prev = getState<QueueSnapshot>(key);
-  const next: QueueSnapshot = {};
-  for (const r of records) {
-    next[String(r.id)] = {
-      title: radarrDisplayTitle(r),
-      status: r.trackedDownloadStatus,
-      entityId: r.movieId ?? r.movie?.id,
-    };
-  }
-  setState(key, next);
+  const key = `radarr:${instanceId}:history:seen`;
+  const prev = getState<number[]>(key);
 
+  const imported = records.filter((r) => r.eventType === "downloadFolderImported");
+  const currentIds = imported.map((r) => r.id);
+
+  setState(key, currentIds);
   if (!prev) return;
 
+  const prevSet = new Set(prev);
   const prefix = instancePrefix(instanceName, multipleOfKind);
-  const currentIds = new Set(records.map((r) => String(r.id)));
-  for (const [id, item] of Object.entries(prev)) {
-    if (!currentIds.has(id) && item.status !== "error") {
-      await dispatchPush({
-        category: "radarrDownloaded",
-        title: `${prefix}Movie downloaded`,
-        body: item.title,
-        data: { type: "radarr", movieId: item.entityId, instanceId },
-        dedupeKey: `radarr:${instanceId}:downloaded:${id}`,
-      });
-    }
+
+  for (const r of imported) {
+    if (prevSet.has(r.id)) continue;
+    await dispatchPush({
+      category: "radarrDownloaded",
+      title: `${prefix}Movie downloaded`,
+      body: radarrDisplayTitle(r),
+      data: { type: "radarr", movieId: r.movieId ?? r.movie?.id, instanceId },
+      dedupeKey: r.downloadId
+        ? `radarr:${instanceId}:downloaded:${r.downloadId}`
+        : `radarr:${instanceId}:history:${r.id}`,
+    });
   }
 }
 
 // ---------------- Sonarr ----------------
 
-function sonarrDisplayTitle(r: SonarrQueueItem): string {
+function sonarrDisplayTitle(r: SonarrHistoryRecord): string {
   if (r.series?.title && r.episode) {
     const ep = `S${String(r.episode.seasonNumber ?? 0).padStart(2, "0")}E${String(r.episode.episodeNumber ?? 0).padStart(2, "0")}`;
     const epTitle = r.episode.title ? ` - ${r.episode.title}` : "";
     return `${r.series.title} ${ep}${epTitle}`;
   }
   if (r.series?.title) return r.series.title;
-  return r.title;
+  return r.sourceTitle ?? "";
 }
 
-export async function diffSonarrQueue(
+// Diffs Sonarr's /history endpoint for newly-imported releases. See the
+// Radarr equivalent above for why we no longer diff /queue (Sonarr's Delay
+// Profile and other internal transitions cause queue items to disappear
+// without being imported, which previously fired false-positive notifications).
+export async function diffSonarrHistory(
   instanceId: string,
   instanceName: string,
   multipleOfKind: boolean,
-  records: SonarrQueueItem[],
+  records: SonarrHistoryRecord[],
 ): Promise<void> {
-  const key = `sonarr:${instanceId}:queue:ids`;
-  const prev = getState<QueueSnapshot>(key);
-  const next: QueueSnapshot = {};
-  for (const r of records) {
-    next[String(r.id)] = {
-      title: sonarrDisplayTitle(r),
-      status: r.trackedDownloadStatus,
-      entityId: r.seriesId ?? r.series?.id,
-    };
-  }
-  setState(key, next);
+  const key = `sonarr:${instanceId}:history:seen`;
+  const prev = getState<number[]>(key);
 
+  const imported = records.filter((r) => r.eventType === "downloadFolderImported");
+  const currentIds = imported.map((r) => r.id);
+
+  setState(key, currentIds);
   if (!prev) return;
 
+  const prevSet = new Set(prev);
   const prefix = instancePrefix(instanceName, multipleOfKind);
-  const currentIds = new Set(records.map((r) => String(r.id)));
-  for (const [id, item] of Object.entries(prev)) {
-    if (!currentIds.has(id) && item.status !== "error") {
-      await dispatchPush({
-        category: "sonarrDownloaded",
-        title: `${prefix}Episode downloaded`,
-        body: item.title,
-        data: { type: "sonarr", seriesId: item.entityId, instanceId },
-        dedupeKey: `sonarr:${instanceId}:downloaded:${id}`,
-      });
-    }
+
+  for (const r of imported) {
+    if (prevSet.has(r.id)) continue;
+    await dispatchPush({
+      category: "sonarrDownloaded",
+      title: `${prefix}Episode downloaded`,
+      body: sonarrDisplayTitle(r),
+      data: { type: "sonarr", seriesId: r.seriesId ?? r.series?.id, instanceId },
+      dedupeKey: r.downloadId
+        ? `sonarr:${instanceId}:downloaded:${r.downloadId}`
+        : `sonarr:${instanceId}:history:${r.id}`,
+    });
   }
 }
 

--- a/components/common/add-media-sheet.tsx
+++ b/components/common/add-media-sheet.tsx
@@ -1,0 +1,232 @@
+import { useState, type ReactNode } from "react";
+import { Modal, View, Text, ScrollView } from "react-native";
+import { Image } from "expo-image";
+import { Plus, type LucideIcon } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { Toggle } from "@/components/ui/toggle";
+import { FilterChip } from "@/components/ui/filter-chip";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { useServiceImage } from "@/hooks/use-service-image";
+import { formatBytes } from "@/lib/utils";
+
+export interface AddMediaSheetCommonState {
+  qualityProfileId: number;
+  rootFolderPath: string;
+  selectedTags: number[];
+  searchOnAdd: boolean;
+}
+
+interface MediaImage {
+  coverType: string;
+  url: string;
+  remoteUrl: string;
+}
+
+interface QualityProfile {
+  id: number;
+  name: string;
+}
+
+interface RootFolder {
+  path: string;
+  freeSpace: number;
+}
+
+interface MediaTag {
+  id: number;
+  label: string;
+}
+
+interface AddMediaSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  result: {
+    title: string;
+    year?: number;
+    overview?: string;
+    images: MediaImage[];
+  } | null;
+  serviceId: "radarr" | "sonarr";
+  sheetTitle: string;
+  submitLabel: string;
+  metaLine?: string;
+  placeholderIcon: LucideIcon;
+  profiles: QualityProfile[] | undefined;
+  folders: RootFolder[] | undefined;
+  tags: MediaTag[] | undefined;
+  isSubmitting: boolean;
+  onSubmit: (state: AddMediaSheetCommonState) => void;
+  /** Service-specific Select/Toggle fields rendered between Quality Profile and Tags. */
+  children?: ReactNode;
+  /** Optional toggle rendered after Quality Profile, before `children` (e.g. Sonarr's Season Folder). */
+  searchToggleDescription: string;
+}
+
+export function AddMediaSheet({
+  visible,
+  onClose,
+  result,
+  serviceId,
+  sheetTitle,
+  submitLabel,
+  metaLine,
+  placeholderIcon,
+  profiles,
+  folders,
+  tags,
+  isSubmitting,
+  onSubmit,
+  children,
+  searchToggleDescription,
+}: AddMediaSheetProps) {
+  const [qualityProfileId, setQualityProfileId] = useState<number | undefined>();
+  const [rootFolderPath, setRootFolderPath] = useState<string | undefined>();
+  const [selectedTags, setSelectedTags] = useState<number[]>([]);
+  const [searchOnAdd, setSearchOnAdd] = useState(true);
+
+  const effectiveQualityProfileId = qualityProfileId ?? profiles?.[0]?.id;
+  const effectiveRootFolderPath = rootFolderPath ?? folders?.[0]?.path;
+
+  const poster = result?.images.find((i) => i.coverType === "poster");
+  const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, serviceId);
+
+  const toggleTag = (tagId: number) => {
+    setSelectedTags((prev) =>
+      prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId],
+    );
+  };
+
+  const canSubmit =
+    !!effectiveQualityProfileId && !!effectiveRootFolderPath && !!result;
+
+  const handleAdd = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      qualityProfileId: effectiveQualityProfileId!,
+      rootFolderPath: effectiveRootFolderPath!,
+      selectedTags,
+      searchOnAdd,
+    });
+  };
+
+  if (!result) return null;
+
+  const selectedFolder = folders?.find((f) => f.path === effectiveRootFolderPath);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title={sheetTitle} onClose={onClose} />
+
+        <ScrollView contentContainerClassName="px-4 py-4 pb-8">
+          <View className="flex-row gap-3 mb-5">
+            {posterUrl ? (
+              <Image
+                source={{ uri: posterUrl }}
+                className="rounded-lg bg-surface-light w-[5.7rem] h-[8.6rem]"
+                contentFit="cover"
+                cachePolicy="memory-disk"
+                transition={200}
+                recyclingKey={posterUrl}
+                onError={onPosterError}
+              />
+            ) : (
+              <View className="rounded-lg bg-surface-light items-center justify-center w-[5.7rem] h-[8.6rem]">
+                <Icon icon={placeholderIcon} size={24} color="#71717a" />
+              </View>
+            )}
+            <View className="flex-1 justify-center">
+              <Text className="text-zinc-100 text-base font-semibold" numberOfLines={2}>
+                {result.title}
+              </Text>
+              {metaLine ? (
+                <Text className="text-zinc-500 text-sm mt-0.5">{metaLine}</Text>
+              ) : result.year ? (
+                <Text className="text-zinc-500 text-sm mt-0.5">{result.year}</Text>
+              ) : null}
+              {result.overview ? (
+                <Text className="text-zinc-500 text-xs mt-1.5" numberOfLines={3}>
+                  {result.overview}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+
+          <Select
+            label="Root Folder"
+            value={effectiveRootFolderPath}
+            options={
+              folders?.map((f) => ({
+                value: f.path,
+                label: f.path,
+                description: `${formatBytes(f.freeSpace)} free`,
+              })) ?? []
+            }
+            onChange={setRootFolderPath}
+            placeholder="Select root folder"
+            containerClassName="mb-4"
+          />
+
+          <Select
+            label="Quality Profile"
+            value={effectiveQualityProfileId}
+            options={profiles?.map((p) => ({ value: p.id, label: p.name })) ?? []}
+            onChange={setQualityProfileId}
+            placeholder="Select quality profile"
+            containerClassName="mb-4"
+          />
+
+          {children}
+
+          {tags && tags.length > 0 ? (
+            <View className="my-3">
+              <Text className="text-zinc-400 text-sm mb-2">Tags</Text>
+              <View className="flex-row flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <FilterChip
+                    key={tag.id}
+                    label={tag.label}
+                    selected={selectedTags.includes(tag.id)}
+                    onPress={() => toggleTag(tag.id)}
+                  />
+                ))}
+              </View>
+            </View>
+          ) : null}
+
+          <Toggle
+            label="Start Search on Add"
+            description={searchToggleDescription}
+            value={searchOnAdd}
+            onValueChange={setSearchOnAdd}
+          />
+
+          {selectedFolder ? (
+            <Text className="text-zinc-600 text-xs mt-4">
+              {formatBytes(selectedFolder.freeSpace)} free on {selectedFolder.path}
+            </Text>
+          ) : null}
+        </ScrollView>
+
+        <View className="px-4 pb-6 pt-3 border-t border-border bg-background">
+          <Button
+            label={submitLabel}
+            onPress={handleAdd}
+            disabled={!canSubmit}
+            loading={isSubmitting}
+            icon={<Icon icon={Plus} size={16} color="#fff" />}
+            size="lg"
+            className="w-full"
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/components/common/monitored-library-grid.tsx
+++ b/components/common/monitored-library-grid.tsx
@@ -1,0 +1,177 @@
+import { View, Text, Pressable } from "react-native";
+import { Image } from "expo-image";
+import type { LucideIcon } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBanner } from "@/components/common/error-banner";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useServiceImage } from "@/hooks/use-service-image";
+import { usePosterCellWidth } from "@/hooks/use-poster-cell";
+
+export type MonitorFilter = "monitored" | "unmonitored" | "all";
+
+export const MONITOR_FILTER_OPTIONS: { value: MonitorFilter; label: string }[] = [
+  { value: "monitored", label: "Monitored" },
+  { value: "unmonitored", label: "Unmonitored" },
+  { value: "all", label: "All" },
+];
+
+interface PosterImage {
+  coverType: string;
+  url: string;
+  remoteUrl: string;
+}
+
+interface MonitoredItem {
+  id: number;
+  title: string;
+  monitored: boolean;
+  images: PosterImage[];
+}
+
+interface MonitoredLibraryGridProps<T extends MonitoredItem, S extends string> {
+  data: T[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  monitorFilter: MonitorFilter;
+  sort: S;
+  compare: (a: T, b: T, sort: S) => number;
+  serviceId: "radarr" | "sonarr";
+  placeholderIcon: LucideIcon;
+  /** Plural noun used in empty state titles, e.g. "movies" / "shows". */
+  nounPlural: string;
+  /** Footer line under the poster title (e.g. year or season count). */
+  renderFooter: (item: T) => string;
+  onItemPress: (item: T) => void;
+  onItemLongPress: (item: T) => void;
+}
+
+export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>({
+  data,
+  isLoading,
+  error,
+  monitorFilter,
+  sort,
+  compare,
+  serviceId,
+  placeholderIcon,
+  nounPlural,
+  renderFooter,
+  onItemPress,
+  onItemLongPress,
+}: MonitoredLibraryGridProps<T, S>) {
+  const cellWidth = usePosterCellWidth();
+
+  if (isLoading) {
+    return (
+      <View className="flex-row flex-wrap gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <View key={i} style={{ width: cellWidth }}>
+            <Skeleton width="100%" height={150} borderRadius={12} />
+            <Skeleton width="75%" height={10} borderRadius={4} className="mt-1.5" />
+          </View>
+        ))}
+      </View>
+    );
+  }
+  if (error) {
+    return <ErrorBanner error={error} title="Failed to load library" />;
+  }
+  if (!data?.length) {
+    return (
+      <EmptyState
+        icon={<Icon icon={placeholderIcon} size={32} color="#71717a" />}
+        title={`No ${nounPlural} in library`}
+      />
+    );
+  }
+
+  const filtered = data.filter((item) => {
+    if (monitorFilter === "monitored") return item.monitored;
+    if (monitorFilter === "unmonitored") return !item.monitored;
+    return true;
+  });
+
+  if (!filtered.length) {
+    const title =
+      monitorFilter === "monitored"
+        ? `No monitored ${nounPlural}`
+        : monitorFilter === "unmonitored"
+          ? `No unmonitored ${nounPlural}`
+          : `No ${nounPlural} in library`;
+    return (
+      <EmptyState
+        icon={<Icon icon={placeholderIcon} size={32} color="#71717a" />}
+        title={title}
+      />
+    );
+  }
+
+  const sorted = [...filtered].sort((a, b) => compare(a, b, sort));
+
+  return (
+    <View className="flex-row flex-wrap gap-3">
+      {sorted.map((item) => (
+        <LibraryPoster
+          key={item.id}
+          item={item}
+          serviceId={serviceId}
+          placeholderIcon={placeholderIcon}
+          footer={renderFooter(item)}
+          onPress={() => onItemPress(item)}
+          onLongPress={() => onItemLongPress(item)}
+        />
+      ))}
+    </View>
+  );
+}
+
+function LibraryPoster<T extends MonitoredItem>({
+  item,
+  serviceId,
+  placeholderIcon,
+  footer,
+  onPress,
+  onLongPress,
+}: {
+  item: T;
+  serviceId: "radarr" | "sonarr";
+  placeholderIcon: LucideIcon;
+  footer: string;
+  onPress: () => void;
+  onLongPress: () => void;
+}) {
+  const poster = item.images.find((i) => i.coverType === "poster");
+  const { src, onError } = useServiceImage(poster, serviceId);
+  const cellWidth = usePosterCellWidth();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onLongPress={onLongPress}
+      delayLongPress={400}
+      style={{ width: cellWidth }}
+      className="active:opacity-80"
+    >
+      {src ? (
+        <Image
+          source={{ uri: src }}
+          className="w-full aspect-[2/3] rounded-xl bg-surface-light"
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          transition={200}
+          recyclingKey={src}
+          onError={onError}
+        />
+      ) : (
+        <View className="w-full aspect-[2/3] rounded-xl bg-surface-light items-center justify-center">
+          <Icon icon={placeholderIcon} size={24} color="#71717a" />
+        </View>
+      )}
+      <Text className="text-zinc-300 text-sm mt-1" numberOfLines={1}>
+        {item.title}
+      </Text>
+      <Text className="text-zinc-600 text-xs">{footer}</Text>
+    </Pressable>
+  );
+}

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -144,6 +144,7 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   const horizon = new Date();
   horizon.setDate(horizon.getDate() + settings.daysAhead);
   const horizonIso = localDateKey(horizon);
+  const nowMs = Date.now();
 
   const items: CalendarItem[] = [];
   if (showSonarr) {
@@ -153,6 +154,13 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
       for (const ep of q.data ?? []) {
         const date = isoDate(ep.airDate);
         if (date < todayIso || date > horizonIso) continue;
+        // Drop episodes whose actual air time has already passed — matches
+        // Sonarr's own `series.nextAiring` rollover so "Releasing Soon" stays
+        // in sync with the "Next Airing" sort on the TV Shows tab. Otherwise
+        // a show airing at 8 PM ET sticks in "Today" until midnight local,
+        // long after Sonarr has advanced to the next episode.
+        if (ep.airDateUtc && new Date(ep.airDateUtc).getTime() <= nowMs)
+          continue;
         items.push({ kind: "episode", date, entry: ep, instanceId });
       }
     });

--- a/components/dashboard/widget-settings/calendar-settings.tsx
+++ b/components/dashboard/widget-settings/calendar-settings.tsx
@@ -1,6 +1,5 @@
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
-import { FilterChip } from "@/components/ui/filter-chip";
 import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
@@ -9,6 +8,11 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  ChipGroup,
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export interface CalendarSettingsValue extends Record<string, unknown> {
   // Independent per-service bindings — calendar can fan out across two
@@ -60,11 +64,8 @@ export function CalendarSettings({ slotId }: WidgetSettingsComponentProps) {
 
   return (
     <View className="px-4 py-2 gap-5">
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Sources
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+      <SettingsSection label="Sources">
+        <ToggleCard>
           <Toggle
             label="Sonarr (TV episodes)"
             description={
@@ -87,8 +88,8 @@ export function CalendarSettings({ slotId }: WidgetSettingsComponentProps) {
             onValueChange={(includeRadarr) => update({ includeRadarr })}
             disabled={!radarrEnabled}
           />
-        </View>
-      </View>
+        </ToggleCard>
+      </SettingsSection>
 
       {settings.includeSonarr && sonarrEnabled && (
         <InstancePickerRow
@@ -108,38 +109,20 @@ export function CalendarSettings({ slotId }: WidgetSettingsComponentProps) {
         />
       )}
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Look ahead
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {DAYS_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.daysAhead === option.value}
-              onPress={() => update({ daysAhead: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <ChipGroup
+        label="Look ahead"
+        options={DAYS_OPTIONS}
+        value={settings.daysAhead}
+        onChange={(daysAhead) => update({ daysAhead })}
+      />
 
       {settings.includeRadarr && radarrEnabled && (
-        <View>
-          <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-            Movie release date
-          </Text>
-          <View className="flex-row flex-wrap gap-2">
-            {RELEASE_TYPE_OPTIONS.map((option) => (
-              <FilterChip
-                key={option.value}
-                label={option.label}
-                selected={settings.radarrReleaseType === option.value}
-                onPress={() => update({ radarrReleaseType: option.value })}
-              />
-            ))}
-          </View>
-        </View>
+        <ChipGroup
+          label="Movie release date"
+          options={RELEASE_TYPE_OPTIONS}
+          value={settings.radarrReleaseType}
+          onChange={(radarrReleaseType) => update({ radarrReleaseType })}
+        />
       )}
     </View>
   );

--- a/components/dashboard/widget-settings/downloads-settings.tsx
+++ b/components/dashboard/widget-settings/downloads-settings.tsx
@@ -1,6 +1,5 @@
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
-import { FilterChip } from "@/components/ui/filter-chip";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
@@ -8,6 +7,12 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  ChipGroup,
+  MaxItemsSelector,
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export type DownloadsSortBy = "speed" | "progress" | "eta" | "added";
 
@@ -33,13 +38,6 @@ export const DOWNLOADS_DEFAULT_SETTINGS: DownloadsSettingsValue = {
   sortBy: "speed",
 };
 
-const MAX_OPTIONS: { value: number; label: string }[] = [
-  { value: 3, label: "3" },
-  { value: 5, label: "5" },
-  { value: 10, label: "10" },
-  { value: 20, label: "20" },
-];
-
 const SORT_OPTIONS: { value: DownloadsSortBy; label: string }[] = [
   { value: "speed", label: "Speed" },
   { value: "progress", label: "Progress" },
@@ -60,11 +58,8 @@ export function DownloadsSettings({ slotId }: WidgetSettingsComponentProps) {
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
       />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Show states
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+      <SettingsSection label="Show states">
+        <ToggleCard>
           <Toggle
             label="Downloading"
             description="In-progress, queued, stalled and checking"
@@ -88,40 +83,20 @@ export function DownloadsSettings({ slotId }: WidgetSettingsComponentProps) {
             value={settings.showErrored}
             onValueChange={(showErrored) => update({ showErrored })}
           />
-        </View>
-      </View>
+        </ToggleCard>
+      </SettingsSection>
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Max items
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {MAX_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.maxItems === option.value}
-              onPress={() => update({ maxItems: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <MaxItemsSelector
+        value={settings.maxItems}
+        onChange={(maxItems) => update({ maxItems })}
+      />
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Sort by
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {SORT_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.sortBy === option.value}
-              onPress={() => update({ sortBy: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <ChipGroup
+        label="Sort by"
+        options={SORT_OPTIONS}
+        value={settings.sortBy}
+        onChange={(sortBy) => update({ sortBy })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/jellyfin-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/jellyfin-now-playing-settings.tsx
@@ -1,115 +1,22 @@
-import { View, Text } from "react-native";
-import { Toggle } from "@/components/ui/toggle";
-import { TextInput } from "@/components/ui/text-input";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
-  InstancePickerRow,
-  INSTANCE_BINDING_ALL,
-  type InstanceBindingValue,
-} from "@/components/dashboard/widget-settings/instance-picker-row";
+  StreamingNowPlayingSettings,
+  STREAMING_NOW_PLAYING_DEFAULT_SETTINGS,
+  type StreamingNowPlayingSettingsValue,
+} from "@/components/dashboard/widget-settings/streaming-now-playing-settings";
 
-export interface JellyfinNowPlayingSettingsValue extends Record<string, unknown> {
-  instanceIds: InstanceBindingValue;
-  maxItems: number;
-  hideLocalPlays: boolean;
-  hideUsers: string;
-  showBitrate: boolean;
-  showTranscoding: boolean;
-  showUserAndDevice: boolean;
-}
+export type JellyfinNowPlayingSettingsValue = StreamingNowPlayingSettingsValue;
 
-export const JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS: JellyfinNowPlayingSettingsValue = {
-  instanceIds: INSTANCE_BINDING_ALL,
-  maxItems: 3,
-  hideLocalPlays: false,
-  hideUsers: "",
-  showBitrate: false,
-  showTranscoding: true,
-  showUserAndDevice: true,
-};
+export const JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS: JellyfinNowPlayingSettingsValue =
+  STREAMING_NOW_PLAYING_DEFAULT_SETTINGS;
 
-const MAX_OPTIONS: { value: number; label: string }[] = [
-  { value: 3, label: "3" },
-  { value: 5, label: "5" },
-  { value: 10, label: "10" },
-];
-
-export function JellyfinNowPlayingSettings({ slotId }: WidgetSettingsComponentProps) {
-  const { settings, update } = useWidgetSettings<JellyfinNowPlayingSettingsValue>(
-    slotId,
-    JELLYFIN_NOW_PLAYING_DEFAULT_SETTINGS,
-  );
-
+export function JellyfinNowPlayingSettings(props: WidgetSettingsComponentProps) {
   return (
-    <View className="px-4 py-2 gap-5">
-      <InstancePickerRow
-        serviceId="jellyfin"
-        value={settings.instanceIds}
-        onChange={(instanceIds) => update({ instanceIds })}
-      />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Filters
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
-          <Toggle
-            label="Hide local plays"
-            description="Skip sessions whose remote endpoint is on a private network"
-            value={settings.hideLocalPlays}
-            onValueChange={(hideLocalPlays) => update({ hideLocalPlays })}
-          />
-        </View>
-        <View className="mt-3">
-          <TextInput
-            label="Hide users"
-            placeholder="comma-separated usernames"
-            value={settings.hideUsers}
-            onChangeText={(hideUsers) => update({ hideUsers })}
-          />
-        </View>
-      </View>
-
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Show
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
-          <Toggle
-            label="User and device"
-            value={settings.showUserAndDevice}
-            onValueChange={(showUserAndDevice) => update({ showUserAndDevice })}
-          />
-          <Toggle
-            label="Transcoding indicator"
-            value={settings.showTranscoding}
-            onValueChange={(showTranscoding) => update({ showTranscoding })}
-          />
-          <Toggle
-            label="Bitrate"
-            description="Transcoding stream bitrate in Mbps"
-            value={settings.showBitrate}
-            onValueChange={(showBitrate) => update({ showBitrate })}
-          />
-        </View>
-      </View>
-
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Max items
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {MAX_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.maxItems === option.value}
-              onPress={() => update({ maxItems: option.value })}
-            />
-          ))}
-        </View>
-      </View>
-    </View>
+    <StreamingNowPlayingSettings
+      {...props}
+      serviceId="jellyfin"
+      hideLocalPlaysDescription="Skip sessions whose remote endpoint is on a private network"
+      bitrateDescription="Transcoding stream bitrate in Mbps"
+    />
   );
 }

--- a/components/dashboard/widget-settings/overseerr-requests-settings.tsx
+++ b/components/dashboard/widget-settings/overseerr-requests-settings.tsx
@@ -1,6 +1,5 @@
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
-import { FilterChip } from "@/components/ui/filter-chip";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
@@ -8,6 +7,12 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  ChipGroup,
+  MaxItemsSelector,
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export type OverseerrStatusFilter = "pending" | "pending-approved" | "all";
 
@@ -31,13 +36,6 @@ const STATUS_OPTIONS: { value: OverseerrStatusFilter; label: string }[] = [
   { value: "all", label: "All" },
 ];
 
-const MAX_OPTIONS: { value: number; label: string }[] = [
-  { value: 3, label: "3" },
-  { value: 5, label: "5" },
-  { value: 10, label: "10" },
-  { value: 20, label: "20" },
-];
-
 export function OverseerrRequestsSettings({ slotId }: WidgetSettingsComponentProps) {
   const { settings, update } = useWidgetSettings<OverseerrRequestsSettingsValue>(
     slotId,
@@ -51,51 +49,28 @@ export function OverseerrRequestsSettings({ slotId }: WidgetSettingsComponentPro
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
       />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Status
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {STATUS_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.statusFilter === option.value}
-              onPress={() => update({ statusFilter: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <ChipGroup
+        label="Status"
+        options={STATUS_OPTIONS}
+        value={settings.statusFilter}
+        onChange={(statusFilter) => update({ statusFilter })}
+      />
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Show
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+      <SettingsSection label="Show">
+        <ToggleCard>
           <Toggle
             label="Requester"
             description="Username and request date under each item"
             value={settings.showRequester}
             onValueChange={(showRequester) => update({ showRequester })}
           />
-        </View>
-      </View>
+        </ToggleCard>
+      </SettingsSection>
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Max items
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {MAX_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.maxItems === option.value}
-              onPress={() => update({ maxItems: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <MaxItemsSelector
+        value={settings.maxItems}
+        onChange={(maxItems) => update({ maxItems })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/plex-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/plex-now-playing-settings.tsx
@@ -1,115 +1,22 @@
-import { View, Text } from "react-native";
-import { Toggle } from "@/components/ui/toggle";
-import { TextInput } from "@/components/ui/text-input";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
-  InstancePickerRow,
-  INSTANCE_BINDING_ALL,
-  type InstanceBindingValue,
-} from "@/components/dashboard/widget-settings/instance-picker-row";
+  StreamingNowPlayingSettings,
+  STREAMING_NOW_PLAYING_DEFAULT_SETTINGS,
+  type StreamingNowPlayingSettingsValue,
+} from "@/components/dashboard/widget-settings/streaming-now-playing-settings";
 
-export interface PlexNowPlayingSettingsValue extends Record<string, unknown> {
-  instanceIds: InstanceBindingValue;
-  maxItems: number;
-  hideLocalPlays: boolean;
-  hideUsers: string;
-  showBitrate: boolean;
-  showTranscoding: boolean;
-  showUserAndDevice: boolean;
-}
+export type PlexNowPlayingSettingsValue = StreamingNowPlayingSettingsValue;
 
-export const PLEX_NOW_PLAYING_DEFAULT_SETTINGS: PlexNowPlayingSettingsValue = {
-  instanceIds: INSTANCE_BINDING_ALL,
-  maxItems: 3,
-  hideLocalPlays: false,
-  hideUsers: "",
-  showBitrate: false,
-  showTranscoding: true,
-  showUserAndDevice: true,
-};
+export const PLEX_NOW_PLAYING_DEFAULT_SETTINGS: PlexNowPlayingSettingsValue =
+  STREAMING_NOW_PLAYING_DEFAULT_SETTINGS;
 
-const MAX_OPTIONS: { value: number; label: string }[] = [
-  { value: 3, label: "3" },
-  { value: 5, label: "5" },
-  { value: 10, label: "10" },
-];
-
-export function PlexNowPlayingSettings({ slotId }: WidgetSettingsComponentProps) {
-  const { settings, update } = useWidgetSettings<PlexNowPlayingSettingsValue>(
-    slotId,
-    PLEX_NOW_PLAYING_DEFAULT_SETTINGS,
-  );
-
+export function PlexNowPlayingSettings(props: WidgetSettingsComponentProps) {
   return (
-    <View className="px-4 py-2 gap-5">
-      <InstancePickerRow
-        serviceId="plex"
-        value={settings.instanceIds}
-        onChange={(instanceIds) => update({ instanceIds })}
-      />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Filters
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
-          <Toggle
-            label="Hide local plays"
-            description="Skip sessions playing on this network"
-            value={settings.hideLocalPlays}
-            onValueChange={(hideLocalPlays) => update({ hideLocalPlays })}
-          />
-        </View>
-        <View className="mt-3">
-          <TextInput
-            label="Hide users"
-            placeholder="comma-separated usernames"
-            value={settings.hideUsers}
-            onChangeText={(hideUsers) => update({ hideUsers })}
-          />
-        </View>
-      </View>
-
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Show
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
-          <Toggle
-            label="User and device"
-            value={settings.showUserAndDevice}
-            onValueChange={(showUserAndDevice) => update({ showUserAndDevice })}
-          />
-          <Toggle
-            label="Transcoding indicator"
-            value={settings.showTranscoding}
-            onValueChange={(showTranscoding) => update({ showTranscoding })}
-          />
-          <Toggle
-            label="Bitrate"
-            description="Stream bandwidth in kbps"
-            value={settings.showBitrate}
-            onValueChange={(showBitrate) => update({ showBitrate })}
-          />
-        </View>
-      </View>
-
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Max items
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {MAX_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.maxItems === option.value}
-              onPress={() => update({ maxItems: option.value })}
-            />
-          ))}
-        </View>
-      </View>
-    </View>
+    <StreamingNowPlayingSettings
+      {...props}
+      serviceId="plex"
+      hideLocalPlaysDescription="Skip sessions playing on this network"
+      bitrateDescription="Stream bandwidth in kbps"
+    />
   );
 }

--- a/components/dashboard/widget-settings/radarr-queue-settings.tsx
+++ b/components/dashboard/widget-settings/radarr-queue-settings.tsx
@@ -1,5 +1,4 @@
-import { View, Text } from "react-native";
-import { FilterChip } from "@/components/ui/filter-chip";
+import { View } from "react-native";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
@@ -7,6 +6,7 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { MaxItemsSelector } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export interface RadarrQueueSettingsValue extends Record<string, unknown> {
   instanceIds: InstanceBindingValue;
@@ -17,13 +17,6 @@ export const RADARR_QUEUE_DEFAULT_SETTINGS: RadarrQueueSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
   maxItems: 5,
 };
-
-const MAX_OPTIONS: { value: number; label: string }[] = [
-  { value: 3, label: "3" },
-  { value: 5, label: "5" },
-  { value: 10, label: "10" },
-  { value: 20, label: "20" },
-];
 
 export function RadarrQueueSettings({ slotId }: WidgetSettingsComponentProps) {
   const { settings, update } = useWidgetSettings<RadarrQueueSettingsValue>(
@@ -38,21 +31,10 @@ export function RadarrQueueSettings({ slotId }: WidgetSettingsComponentProps) {
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
       />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Max items
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {MAX_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.maxItems === option.value}
-              onPress={() => update({ maxItems: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <MaxItemsSelector
+        value={settings.maxItems}
+        onChange={(maxItems) => update({ maxItems })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/server-stats-settings.tsx
+++ b/components/dashboard/widget-settings/server-stats-settings.tsx
@@ -1,4 +1,4 @@
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
@@ -7,6 +7,10 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export interface ServerStatsSettingsValue extends Record<string, unknown> {
   // Which Glances instances to read from. "all" stacks per-host blocks; an
@@ -39,11 +43,8 @@ export function ServerStatsSettings({ slotId }: WidgetSettingsComponentProps) {
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
       />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Show
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+      <SettingsSection label="Show">
+        <ToggleCard>
           <Toggle
             label="CPU usage"
             description="Ring chart of total CPU load"
@@ -68,8 +69,8 @@ export function ServerStatsSettings({ slotId }: WidgetSettingsComponentProps) {
             value={settings.showDisks}
             onValueChange={(showDisks) => update({ showDisks })}
           />
-        </View>
-      </View>
+        </ToggleCard>
+      </SettingsSection>
     </View>
   );
 }

--- a/components/dashboard/widget-settings/streaming-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/streaming-now-playing-settings.tsx
@@ -13,25 +13,26 @@ import {
   SettingsSection,
   ToggleCard,
 } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import type { ServiceId } from "@/lib/constants";
 
-export interface TautulliActivitySettingsValue extends Record<string, unknown> {
+export interface StreamingNowPlayingSettingsValue extends Record<string, unknown> {
   instanceIds: InstanceBindingValue;
   maxItems: number;
+  hideLocalPlays: boolean;
   hideUsers: string;
   showBitrate: boolean;
   showTranscoding: boolean;
   showUserAndDevice: boolean;
-  showBandwidthSummary: boolean;
 }
 
-export const TAUTULLI_ACTIVITY_DEFAULT_SETTINGS: TautulliActivitySettingsValue = {
+export const STREAMING_NOW_PLAYING_DEFAULT_SETTINGS: StreamingNowPlayingSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
   maxItems: 3,
+  hideLocalPlays: false,
   hideUsers: "",
   showBitrate: false,
   showTranscoding: true,
   showUserAndDevice: true,
-  showBandwidthSummary: true,
 };
 
 const MAX_OPTIONS: { value: number; label: string }[] = [
@@ -40,26 +41,47 @@ const MAX_OPTIONS: { value: number; label: string }[] = [
   { value: 10, label: "10" },
 ];
 
-export function TautulliActivitySettings({ slotId }: WidgetSettingsComponentProps) {
-  const { settings, update } = useWidgetSettings<TautulliActivitySettingsValue>(
+interface StreamingNowPlayingSettingsProps extends WidgetSettingsComponentProps {
+  serviceId: ServiceId;
+  hideLocalPlaysDescription: string;
+  bitrateDescription: string;
+}
+
+export function StreamingNowPlayingSettings({
+  slotId,
+  serviceId,
+  hideLocalPlaysDescription,
+  bitrateDescription,
+}: StreamingNowPlayingSettingsProps) {
+  const { settings, update } = useWidgetSettings<StreamingNowPlayingSettingsValue>(
     slotId,
-    TAUTULLI_ACTIVITY_DEFAULT_SETTINGS,
+    STREAMING_NOW_PLAYING_DEFAULT_SETTINGS,
   );
 
   return (
     <View className="px-4 py-2 gap-5">
       <InstancePickerRow
-        serviceId="tautulli"
+        serviceId={serviceId}
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
       />
       <SettingsSection label="Filters">
-        <TextInput
-          label="Hide users"
-          placeholder="comma-separated usernames"
-          value={settings.hideUsers}
-          onChangeText={(hideUsers) => update({ hideUsers })}
-        />
+        <ToggleCard>
+          <Toggle
+            label="Hide local plays"
+            description={hideLocalPlaysDescription}
+            value={settings.hideLocalPlays}
+            onValueChange={(hideLocalPlays) => update({ hideLocalPlays })}
+          />
+        </ToggleCard>
+        <View className="mt-3">
+          <TextInput
+            label="Hide users"
+            placeholder="comma-separated usernames"
+            value={settings.hideUsers}
+            onChangeText={(hideUsers) => update({ hideUsers })}
+          />
+        </View>
       </SettingsSection>
 
       <SettingsSection label="Show">
@@ -71,20 +93,14 @@ export function TautulliActivitySettings({ slotId }: WidgetSettingsComponentProp
           />
           <Toggle
             label="Transcoding indicator"
-            description="Highlights direct play, copy, or transcode"
             value={settings.showTranscoding}
             onValueChange={(showTranscoding) => update({ showTranscoding })}
           />
           <Toggle
-            label="Per-stream bitrate"
+            label="Bitrate"
+            description={bitrateDescription}
             value={settings.showBitrate}
             onValueChange={(showBitrate) => update({ showBitrate })}
-          />
-          <Toggle
-            label="Total bandwidth"
-            description="Footer with the combined bandwidth of every stream"
-            value={settings.showBandwidthSummary}
-            onValueChange={(showBandwidthSummary) => update({ showBandwidthSummary })}
           />
         </ToggleCard>
       </SettingsSection>

--- a/components/dashboard/widget-settings/usenet-queue-settings.tsx
+++ b/components/dashboard/widget-settings/usenet-queue-settings.tsx
@@ -1,6 +1,5 @@
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
-import { FilterChip } from "@/components/ui/filter-chip";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
@@ -8,6 +7,12 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  ChipGroup,
+  MaxItemsSelector,
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 import type { ServiceId } from "@/lib/constants";
 
 export type UsenetQueueSortBy = "progress" | "name" | "size" | "added";
@@ -29,13 +34,6 @@ export const USENET_QUEUE_DEFAULT_SETTINGS: UsenetQueueSettingsValue = {
   showQueued: true,
   sortBy: "progress",
 };
-
-const MAX_OPTIONS: { value: number; label: string }[] = [
-  { value: 3, label: "3" },
-  { value: 5, label: "5" },
-  { value: 10, label: "10" },
-  { value: 20, label: "20" },
-];
 
 const SORT_OPTIONS: { value: UsenetQueueSortBy; label: string }[] = [
   { value: "progress", label: "Progress" },
@@ -61,11 +59,8 @@ export function UsenetQueueSettings({ slotId, serviceId }: Props) {
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
       />
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Show states
-        </Text>
-        <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+      <SettingsSection label="Show states">
+        <ToggleCard>
           <Toggle
             label="Downloading"
             description="In-progress, grabbing, verifying"
@@ -82,40 +77,20 @@ export function UsenetQueueSettings({ slotId, serviceId }: Props) {
             value={settings.showQueued}
             onValueChange={(showQueued) => update({ showQueued })}
           />
-        </View>
-      </View>
+        </ToggleCard>
+      </SettingsSection>
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Max items
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {MAX_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.maxItems === option.value}
-              onPress={() => update({ maxItems: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <MaxItemsSelector
+        value={settings.maxItems}
+        onChange={(maxItems) => update({ maxItems })}
+      />
 
-      <View>
-        <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
-          Sort by
-        </Text>
-        <View className="flex-row flex-wrap gap-2">
-          {SORT_OPTIONS.map((option) => (
-            <FilterChip
-              key={option.value}
-              label={option.label}
-              selected={settings.sortBy === option.value}
-              onPress={() => update({ sortBy: option.value })}
-            />
-          ))}
-        </View>
-      </View>
+      <ChipGroup
+        label="Sort by"
+        options={SORT_OPTIONS}
+        value={settings.sortBy}
+        onChange={(sortBy) => update({ sortBy })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import { View, Text } from "react-native";
+import { FilterChip } from "@/components/ui/filter-chip";
+
+/**
+ * Section header + body wrapper used by every widget-settings panel. Keeps
+ * the SCREAMING-uppercase label and gap consistent across widgets.
+ */
+export function SettingsSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <View>
+      <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
+        {label}
+      </Text>
+      {children}
+    </View>
+  );
+}
+
+/**
+ * Card containing a stack of `Toggle` rows separated by hairlines. Pass
+ * `<Toggle>`s as children.
+ */
+export function ToggleCard({ children }: { children: ReactNode }) {
+  return (
+    <View className="bg-surface-light rounded-2xl border border-border px-4 divide-y divide-border/60">
+      {children}
+    </View>
+  );
+}
+
+/**
+ * Single-select chip row (status filters, sort orders, etc.). The chip rendered
+ * for each option calls `onChange` with that option's value when pressed.
+ */
+export function ChipGroup<T extends string | number>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: readonly { value: T; label: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <SettingsSection label={label}>
+      <View className="flex-row flex-wrap gap-2">
+        {options.map((option) => (
+          <FilterChip
+            key={String(option.value)}
+            label={option.label}
+            selected={value === option.value}
+            onPress={() => onChange(option.value)}
+          />
+        ))}
+      </View>
+    </SettingsSection>
+  );
+}
+
+const DEFAULT_MAX_OPTIONS: readonly { value: number; label: string }[] = [
+  { value: 3, label: "3" },
+  { value: 5, label: "5" },
+  { value: 10, label: "10" },
+  { value: 20, label: "20" },
+];
+
+/**
+ * "Max items" chip selector. Defaults to 3/5/10/20; pass `options` to override
+ * (e.g. now-playing widgets cap at 10).
+ */
+export function MaxItemsSelector({
+  value,
+  onChange,
+  options = DEFAULT_MAX_OPTIONS,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+  options?: readonly { value: number; label: string }[];
+}) {
+  return (
+    <ChipGroup label="Max items" options={options} value={value} onChange={onChange} />
+  );
+}

--- a/components/downloads/usenet-downloads-view.tsx
+++ b/components/downloads/usenet-downloads-view.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import { View, Text, Pressable, Alert, BackHandler, ScrollView } from "react-native";
+import { View, Text, Pressable, Alert, BackHandler } from "react-native";
 import { toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect } from "expo-router";
 import {
@@ -9,8 +9,6 @@ import {
   Plus,
   CheckCircle2,
   Circle,
-  ArrowUpDown,
-  Check,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -21,8 +19,8 @@ import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
+import { FilterSortButton } from "@/components/common/filter-sort-button";
+import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import { errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { useMultiSelect } from "@/hooks/use-multi-select";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -82,7 +80,7 @@ export function UsenetDownloadsView({
 }: ViewProps) {
   const [filter, setFilter] = useState<FilterType>("all");
   const [sort, setSort] = useState<SortKey>("progress-desc");
-  const [sortSheetOpen, setSortSheetOpen] = useState(false);
+  const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [nzbUrl, setNzbUrl] = useState("");
 
@@ -313,29 +311,12 @@ export function UsenetDownloadsView({
             />
           )}
 
-          <View className="flex-row items-center gap-2 mb-4">
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerClassName="gap-2"
-              className="flex-1"
-            >
-              {FILTER_OPTIONS.map((opt) => (
-                <FilterChip
-                  key={opt.key}
-                  label={opt.label}
-                  selected={filter === opt.key}
-                  onPress={() => setFilter(opt.key)}
-                />
-              ))}
-            </ScrollView>
-            <Pressable
-              onPress={() => setSortSheetOpen(true)}
-              hitSlop={6}
-              className="w-9 h-9 rounded-full bg-surface-light items-center justify-center active:opacity-70"
-            >
-              <Icon icon={ArrowUpDown} size={16} color="#a1a1aa" />
-            </Pressable>
+          <View className="mb-4">
+            <FilterSortButton
+              summary={`${FILTER_OPTIONS.find((f) => f.key === filter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
+              onPress={() => setFilterSortOpen(true)}
+              active={filter !== "all" || sort !== "progress-desc"}
+            />
           </View>
         </>
       )}
@@ -363,20 +344,16 @@ export function UsenetDownloadsView({
         </View>
       )}
 
-      <ActionSheet
-        visible={sortSheetOpen}
-        onClose={() => setSortSheetOpen(false)}
-        title="Sort downloads"
-        actions={SORT_OPTIONS.map<ActionSheetAction>((opt) => ({
-          label: opt.label,
-          icon:
-            sort === opt.key ? (
-              <Icon icon={Check} size={18} color="#3b82f6" />
-            ) : (
-              <Icon icon={ArrowUpDown} size={18} color="#71717a" />
-            ),
-          onPress: () => setSort(opt.key),
-        }))}
+      <FilterSortSheet
+        visible={filterSortOpen}
+        onClose={() => setFilterSortOpen(false)}
+        title="Filter & sort downloads"
+        filterOptions={FILTER_OPTIONS}
+        filterValue={filter}
+        onFilterChange={setFilter}
+        sortOptions={SORT_OPTIONS}
+        sortValue={sort}
+        onSortChange={setSort}
       />
     </>
   );

--- a/components/radarr/add-movie-sheet.tsx
+++ b/components/radarr/add-movie-sheet.tsx
@@ -1,15 +1,8 @@
 import { useState } from "react";
-import { Modal, View, Text, ScrollView } from "react-native";
-import { Image } from "expo-image";
-import { Film, Plus } from "lucide-react-native";
-import { Icon } from "@/components/ui/icon";
-import { Button } from "@/components/ui/button";
+import { Film } from "lucide-react-native";
 import { Select } from "@/components/ui/select";
-import { Toggle } from "@/components/ui/toggle";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { SheetHeader } from "@/components/ui/sheet-header";
 import { toast, toastError } from "@/components/ui/toast";
-import { useServiceImage } from "@/hooks/use-service-image";
+import { AddMediaSheet } from "@/components/common/add-media-sheet";
 import {
   useAddMovie,
   useRadarrQualityProfiles,
@@ -21,7 +14,6 @@ import type {
   RadarrMonitorOption,
 } from "@/services/radarr-api";
 import type { RadarrSearchResult } from "@/lib/types";
-import { formatBytes } from "@/lib/utils";
 
 interface AddMovieSheetProps {
   result: RadarrSearchResult | null;
@@ -55,186 +47,63 @@ export function AddMovieSheet({ result, visible, onClose }: AddMovieSheetProps) 
   const { data: tags } = useRadarrTags();
   const addMovie = useAddMovie();
 
-  const [qualityProfileId, setQualityProfileId] = useState<number | undefined>();
-  const [rootFolderPath, setRootFolderPath] = useState<string | undefined>();
   const [minimumAvailability, setMinimumAvailability] =
     useState<RadarrMinimumAvailability>("released");
   const [monitor, setMonitor] = useState<RadarrMonitorOption>("movieOnly");
-  const [selectedTags, setSelectedTags] = useState<number[]>([]);
-  const [searchOnAdd, setSearchOnAdd] = useState(true);
-
-  const effectiveQualityProfileId = qualityProfileId ?? profiles?.[0]?.id;
-  const effectiveRootFolderPath = rootFolderPath ?? folders?.[0]?.path;
-
-  const poster = result?.images.find((i) => i.coverType === "poster");
-  const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, "radarr");
-
-  const toggleTag = (tagId: number) => {
-    setSelectedTags((prev) =>
-      prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId],
-    );
-  };
-
-  const canSubmit =
-    !!effectiveQualityProfileId && !!effectiveRootFolderPath && !!result;
-
-  const handleAdd = () => {
-    if (!canSubmit || !result) return;
-    addMovie.mutate(
-      {
-        tmdbId: result.tmdbId,
-        title: result.title,
-        qualityProfileId: effectiveQualityProfileId!,
-        rootFolderPath: effectiveRootFolderPath!,
-        monitored: monitor !== "none",
-        searchForMovie: searchOnAdd,
-        minimumAvailability,
-        monitor,
-        tags: selectedTags,
-      },
-      {
-        onSuccess: () => {
-          toast(`${result.title} added to Radarr`);
-          onClose();
-        },
-        onError: (err) => toastError("Failed to add movie", err),
-      },
-    );
-  };
-
-  if (!result) return null;
-
-  const selectedFolder = folders?.find((f) => f.path === effectiveRootFolderPath);
 
   return (
-    <Modal
+    <AddMediaSheet
       visible={visible}
-      animationType="slide"
-      presentationStyle="pageSheet"
-      onRequestClose={onClose}
+      onClose={onClose}
+      result={result}
+      serviceId="radarr"
+      sheetTitle="Add Movie"
+      submitLabel="Add Movie"
+      placeholderIcon={Film}
+      profiles={profiles}
+      folders={folders}
+      tags={tags}
+      isSubmitting={addMovie.isPending}
+      searchToggleDescription="Trigger an automatic search once the movie is added"
+      onSubmit={({ qualityProfileId, rootFolderPath, selectedTags, searchOnAdd }) => {
+        if (!result) return;
+        addMovie.mutate(
+          {
+            tmdbId: result.tmdbId,
+            title: result.title,
+            qualityProfileId,
+            rootFolderPath,
+            monitored: monitor !== "none",
+            searchForMovie: searchOnAdd,
+            minimumAvailability,
+            monitor,
+            tags: selectedTags,
+          },
+          {
+            onSuccess: () => {
+              toast(`${result.title} added to Radarr`);
+              onClose();
+            },
+            onError: (err) => toastError("Failed to add movie", err),
+          },
+        );
+      }}
     >
-      <View className="flex-1 bg-background">
-        <SheetHeader title="Add Movie" onClose={onClose} />
+      <Select
+        label="Minimum Availability"
+        value={minimumAvailability}
+        options={MIN_AVAILABILITY_OPTIONS}
+        onChange={setMinimumAvailability}
+        containerClassName="mb-4"
+      />
 
-        <ScrollView contentContainerClassName="px-4 py-4 pb-8">
-          <View className="flex-row gap-3 mb-5">
-            {posterUrl ? (
-              <Image
-                source={{ uri: posterUrl }}
-                className="rounded-lg bg-surface-light w-[5.7rem] h-[8.6rem]"
-                contentFit="cover"
-                cachePolicy="memory-disk"
-                transition={200}
-                recyclingKey={posterUrl}
-                onError={onPosterError}
-              />
-            ) : (
-              <View
-                className="rounded-lg bg-surface-light items-center justify-center w-[5.7rem] h-[8.6rem]"
-              >
-                <Icon icon={Film} size={24} color="#71717a" />
-              </View>
-            )}
-            <View className="flex-1 justify-center">
-              <Text className="text-zinc-100 text-base font-semibold" numberOfLines={2}>
-                {result.title}
-              </Text>
-              {result.year ? (
-                <Text className="text-zinc-500 text-sm mt-0.5">{result.year}</Text>
-              ) : null}
-              {result.overview ? (
-                <Text className="text-zinc-500 text-xs mt-1.5" numberOfLines={3}>
-                  {result.overview}
-                </Text>
-              ) : null}
-            </View>
-          </View>
-
-          <Select
-            label="Root Folder"
-            value={effectiveRootFolderPath}
-            options={
-              folders?.map((f) => ({
-                value: f.path,
-                label: f.path,
-                description: `${formatBytes(f.freeSpace)} free`,
-              })) ?? []
-            }
-            onChange={setRootFolderPath}
-            placeholder="Select root folder"
-            containerClassName="mb-4"
-          />
-
-          <Select
-            label="Quality Profile"
-            value={effectiveQualityProfileId}
-            options={
-              profiles?.map((p) => ({ value: p.id, label: p.name })) ?? []
-            }
-            onChange={setQualityProfileId}
-            placeholder="Select quality profile"
-            containerClassName="mb-4"
-          />
-
-          <Select
-            label="Minimum Availability"
-            value={minimumAvailability}
-            options={MIN_AVAILABILITY_OPTIONS}
-            onChange={setMinimumAvailability}
-            containerClassName="mb-4"
-          />
-
-          <Select
-            label="Monitor"
-            value={monitor}
-            options={MONITOR_OPTIONS}
-            onChange={setMonitor}
-            containerClassName="mb-4"
-          />
-
-          {tags && tags.length > 0 ? (
-            <View className="mb-4">
-              <Text className="text-zinc-400 text-sm mb-2">Tags</Text>
-              <View className="flex-row flex-wrap gap-2">
-                {tags.map((tag) => (
-                  <FilterChip
-                    key={tag.id}
-                    label={tag.label}
-                    selected={selectedTags.includes(tag.id)}
-                    onPress={() => toggleTag(tag.id)}
-                  />
-                ))}
-              </View>
-            </View>
-          ) : null}
-
-          <Toggle
-            label="Start Search on Add"
-            description="Trigger an automatic search once the movie is added"
-            value={searchOnAdd}
-            onValueChange={setSearchOnAdd}
-          />
-
-          {selectedFolder ? (
-            <Text className="text-zinc-600 text-xs mt-4">
-              {formatBytes(selectedFolder.freeSpace)} free on{" "}
-              {selectedFolder.path}
-            </Text>
-          ) : null}
-        </ScrollView>
-
-        <View className="px-4 pb-6 pt-3 border-t border-border bg-background">
-          <Button
-            label="Add Movie"
-            onPress={handleAdd}
-            disabled={!canSubmit}
-            loading={addMovie.isPending}
-            icon={<Icon icon={Plus} size={16} color="#fff" />}
-            size="lg"
-            className="w-full"
-          />
-        </View>
-      </View>
-    </Modal>
+      <Select
+        label="Monitor"
+        value={monitor}
+        options={MONITOR_OPTIONS}
+        onChange={setMonitor}
+        containerClassName="mb-4"
+      />
+    </AddMediaSheet>
   );
 }

--- a/components/sonarr/add-series-sheet.tsx
+++ b/components/sonarr/add-series-sheet.tsx
@@ -1,15 +1,9 @@
 import { useState } from "react";
-import { Modal, View, Text, ScrollView } from "react-native";
-import { Image } from "expo-image";
-import { Tv, Plus } from "lucide-react-native";
-import { Icon } from "@/components/ui/icon";
-import { Button } from "@/components/ui/button";
+import { Tv } from "lucide-react-native";
 import { Select } from "@/components/ui/select";
 import { Toggle } from "@/components/ui/toggle";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { SheetHeader } from "@/components/ui/sheet-header";
 import { toast, toastError } from "@/components/ui/toast";
-import { useServiceImage } from "@/hooks/use-service-image";
+import { AddMediaSheet } from "@/components/common/add-media-sheet";
 import {
   useAddSeries,
   useSonarrQualityProfiles,
@@ -21,7 +15,6 @@ import type {
   SonarrSeriesType,
 } from "@/services/sonarr-api";
 import type { SonarrSearchResult } from "@/lib/types";
-import { formatBytes } from "@/lib/utils";
 
 interface AddSeriesSheetProps {
   result: SonarrSearchResult | null;
@@ -61,195 +54,76 @@ export function AddSeriesSheet({ result, visible, onClose }: AddSeriesSheetProps
   const { data: tags } = useSonarrTags();
   const addSeries = useAddSeries();
 
-  const [qualityProfileId, setQualityProfileId] = useState<number | undefined>();
-  const [rootFolderPath, setRootFolderPath] = useState<string | undefined>();
   const [monitor, setMonitor] = useState<SonarrMonitorOption>("all");
   const [seriesType, setSeriesType] = useState<SonarrSeriesType>("standard");
   const [seasonFolder, setSeasonFolder] = useState(true);
-  const [selectedTags, setSelectedTags] = useState<number[]>([]);
-  const [searchOnAdd, setSearchOnAdd] = useState(true);
 
-  const effectiveQualityProfileId = qualityProfileId ?? profiles?.[0]?.id;
-  const effectiveRootFolderPath = rootFolderPath ?? folders?.[0]?.path;
-
-  const poster = result?.images.find((i) => i.coverType === "poster");
-  const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, "sonarr");
-
-  const toggleTag = (tagId: number) => {
-    setSelectedTags((prev) =>
-      prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId],
-    );
-  };
-
-  const canSubmit =
-    !!effectiveQualityProfileId && !!effectiveRootFolderPath && !!result;
-
-  const handleAdd = () => {
-    if (!canSubmit || !result) return;
-    addSeries.mutate(
-      {
-        tvdbId: result.tvdbId,
-        title: result.title,
-        qualityProfileId: effectiveQualityProfileId!,
-        rootFolderPath: effectiveRootFolderPath!,
-        monitored: monitor !== "none",
-        seasonFolder,
-        searchForMissingEpisodes: searchOnAdd,
-        seriesType,
-        monitor,
-        tags: selectedTags,
-      },
-      {
-        onSuccess: () => {
-          toast(`${result.title} added to Sonarr`);
-          onClose();
-        },
-        onError: (err) => toastError("Failed to add series", err),
-      },
-    );
-  };
-
-  if (!result) return null;
-
-  const selectedFolder = folders?.find((f) => f.path === effectiveRootFolderPath);
+  const metaLine = result
+    ? `${result.year}${result.network ? ` · ${result.network}` : ""}`
+    : undefined;
 
   return (
-    <Modal
+    <AddMediaSheet
       visible={visible}
-      animationType="slide"
-      presentationStyle="pageSheet"
-      onRequestClose={onClose}
+      onClose={onClose}
+      result={result}
+      serviceId="sonarr"
+      sheetTitle="Add Series"
+      submitLabel="Add Series"
+      metaLine={metaLine}
+      placeholderIcon={Tv}
+      profiles={profiles}
+      folders={folders}
+      tags={tags}
+      isSubmitting={addSeries.isPending}
+      searchToggleDescription="Trigger an automatic search once the series is added"
+      onSubmit={({ qualityProfileId, rootFolderPath, selectedTags, searchOnAdd }) => {
+        if (!result) return;
+        addSeries.mutate(
+          {
+            tvdbId: result.tvdbId,
+            title: result.title,
+            qualityProfileId,
+            rootFolderPath,
+            monitored: monitor !== "none",
+            seasonFolder,
+            searchForMissingEpisodes: searchOnAdd,
+            seriesType,
+            monitor,
+            tags: selectedTags,
+          },
+          {
+            onSuccess: () => {
+              toast(`${result.title} added to Sonarr`);
+              onClose();
+            },
+            onError: (err) => toastError("Failed to add series", err),
+          },
+        );
+      }}
     >
-      <View className="flex-1 bg-background">
-        <SheetHeader title="Add Series" onClose={onClose} />
+      <Select
+        label="Monitor"
+        value={monitor}
+        options={MONITOR_OPTIONS}
+        onChange={setMonitor}
+        containerClassName="mb-4"
+      />
 
-        <ScrollView contentContainerClassName="px-4 py-4 pb-8">
-          <View className="flex-row gap-3 mb-5">
-            {posterUrl ? (
-              <Image
-                source={{ uri: posterUrl }}
-                className="rounded-lg bg-surface-light w-[5.7rem] h-[8.6rem]"
-                contentFit="cover"
-                cachePolicy="memory-disk"
-                transition={200}
-                recyclingKey={posterUrl}
-                onError={onPosterError}
-              />
-            ) : (
-              <View
-                className="rounded-lg bg-surface-light items-center justify-center w-[5.7rem] h-[8.6rem]"
-              >
-                <Icon icon={Tv} size={24} color="#71717a" />
-              </View>
-            )}
-            <View className="flex-1 justify-center">
-              <Text className="text-zinc-100 text-base font-semibold" numberOfLines={2}>
-                {result.title}
-              </Text>
-              <Text className="text-zinc-500 text-sm mt-0.5">
-                {result.year}
-                {result.network ? ` · ${result.network}` : ""}
-              </Text>
-              {result.overview ? (
-                <Text className="text-zinc-500 text-xs mt-1.5" numberOfLines={3}>
-                  {result.overview}
-                </Text>
-              ) : null}
-            </View>
-          </View>
+      <Select
+        label="Series Type"
+        value={seriesType}
+        options={SERIES_TYPE_OPTIONS}
+        onChange={setSeriesType}
+        containerClassName="mb-2"
+      />
 
-          <Select
-            label="Root Folder"
-            value={effectiveRootFolderPath}
-            options={
-              folders?.map((f) => ({
-                value: f.path,
-                label: f.path,
-                description: `${formatBytes(f.freeSpace)} free`,
-              })) ?? []
-            }
-            onChange={setRootFolderPath}
-            placeholder="Select root folder"
-            containerClassName="mb-4"
-          />
-
-          <Select
-            label="Quality Profile"
-            value={effectiveQualityProfileId}
-            options={
-              profiles?.map((p) => ({ value: p.id, label: p.name })) ?? []
-            }
-            onChange={setQualityProfileId}
-            placeholder="Select quality profile"
-            containerClassName="mb-4"
-          />
-
-          <Select
-            label="Monitor"
-            value={monitor}
-            options={MONITOR_OPTIONS}
-            onChange={setMonitor}
-            containerClassName="mb-4"
-          />
-
-          <Select
-            label="Series Type"
-            value={seriesType}
-            options={SERIES_TYPE_OPTIONS}
-            onChange={setSeriesType}
-            containerClassName="mb-2"
-          />
-
-          <Toggle
-            label="Season Folder"
-            description="Organize episodes into season subfolders"
-            value={seasonFolder}
-            onValueChange={setSeasonFolder}
-          />
-
-          {tags && tags.length > 0 ? (
-            <View className="my-3">
-              <Text className="text-zinc-400 text-sm mb-2">Tags</Text>
-              <View className="flex-row flex-wrap gap-2">
-                {tags.map((tag) => (
-                  <FilterChip
-                    key={tag.id}
-                    label={tag.label}
-                    selected={selectedTags.includes(tag.id)}
-                    onPress={() => toggleTag(tag.id)}
-                  />
-                ))}
-              </View>
-            </View>
-          ) : null}
-
-          <Toggle
-            label="Start Search on Add"
-            description="Trigger an automatic search once the series is added"
-            value={searchOnAdd}
-            onValueChange={setSearchOnAdd}
-          />
-
-          {selectedFolder ? (
-            <Text className="text-zinc-600 text-xs mt-4">
-              {formatBytes(selectedFolder.freeSpace)} free on{" "}
-              {selectedFolder.path}
-            </Text>
-          ) : null}
-        </ScrollView>
-
-        <View className="px-4 pb-6 pt-3 border-t border-border bg-background">
-          <Button
-            label="Add Series"
-            onPress={handleAdd}
-            disabled={!canSubmit}
-            loading={addSeries.isPending}
-            icon={<Icon icon={Plus} size={16} color="#fff" />}
-            size="lg"
-            className="w-full"
-          />
-        </View>
-      </View>
-    </Modal>
+      <Toggle
+        label="Season Folder"
+        description="Organize episodes into season subfolders"
+        value={seasonFolder}
+        onValueChange={setSeasonFolder}
+      />
+    </AddMediaSheet>
   );
 }

--- a/hooks/use-notification-watchers.tsx
+++ b/hooks/use-notification-watchers.tsx
@@ -3,8 +3,8 @@ import {
   useDownloadingTorrentsForWatcher,
 } from "@/hooks/use-qbittorrent";
 import { getTorrents } from "@/services/qbittorrent-api";
-import { useRadarrQueue } from "@/hooks/use-radarr";
-import { useSonarrQueue } from "@/hooks/use-sonarr";
+import { useRadarrHistory } from "@/hooks/use-radarr";
+import { useSonarrHistory } from "@/hooks/use-sonarr";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useOverseerrRequests } from "@/hooks/use-overseerr";
 import { useSabHistory } from "@/hooks/use-sabnzbd";
@@ -14,7 +14,12 @@ import { useBackendStore } from "@/store/backend-store";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { sendLocalNotification } from "@/lib/notifications";
 import { toast } from "@/components/ui/toast";
-import type { QBTorrent, TorrentState } from "@/lib/types";
+import type {
+  QBTorrent,
+  TorrentState,
+  SonarrHistoryRecord,
+  RadarrHistoryRecord,
+} from "@/lib/types";
 
 // Categories Radarr/Sonarr set on jobs they manage. The arr-specific watchers
 // already notify on those, so the download-client watchers skip them to avoid
@@ -114,14 +119,14 @@ export function NotificationWatchers() {
         />
       ))}
       {radarrInstances.map((inst) => (
-        <RadarrQueueWatcher
+        <RadarrImportWatcher
           key={inst.id}
           instanceId={inst.id}
           active={!backendActive && hydrated && enabled && radarrDownloaded}
         />
       ))}
       {sonarrInstances.map((inst) => (
-        <SonarrQueueWatcher
+        <SonarrImportWatcher
           key={inst.id}
           instanceId={inst.id}
           active={!backendActive && hydrated && enabled && sonarrDownloaded}
@@ -285,88 +290,107 @@ function NzbgetHistoryWatcher({
   return null;
 }
 
-// --- Radarr: queue item disappears (success only) ---
-function RadarrQueueWatcher({
+function radarrHistoryDisplayTitle(r: RadarrHistoryRecord): string {
+  if (r.movie?.title) {
+    return r.movie.year ? `${r.movie.title} (${r.movie.year})` : r.movie.title;
+  }
+  return r.sourceTitle ?? "";
+}
+
+function sonarrHistoryDisplayTitle(r: SonarrHistoryRecord): string {
+  if (r.series?.title && r.episode) {
+    const ep = `S${String(r.episode.seasonNumber ?? 0).padStart(2, "0")}E${String(r.episode.episodeNumber ?? 0).padStart(2, "0")}`;
+    const epTitle = r.episode.title ? ` - ${r.episode.title}` : "";
+    return `${r.series.title} ${ep}${epTitle}`;
+  }
+  if (r.series?.title) return r.series.title;
+  return r.sourceTitle ?? "";
+}
+
+// --- Radarr: new `downloadFolderImported` history record appears ---
+// Queue diffing produced false positives (delay-profile holds, internal state
+// transitions); history records are immutable and explicit about completion.
+function RadarrImportWatcher({
   instanceId,
   active,
 }: {
   instanceId: string;
   active: boolean;
 }) {
-  const { data: radarrQueue } = useRadarrQueue(instanceId);
-  const prevQueue = useRef<Map<number, { title: string; status?: string }> | null>(
-    null,
-  );
+  const { data: history } = useRadarrHistory(instanceId);
+  const prevIds = useRef<Set<number> | null>(null);
 
   useEffect(() => {
     if (!active) {
-      prevQueue.current = null;
+      prevIds.current = null;
       return;
     }
-    if (!Array.isArray(radarrQueue?.records)) return;
-    const prev = prevQueue.current;
-    const currentMap = new Map(
-      radarrQueue.records.map((r) => [
-        r.id,
-        { title: r.title, status: r.trackedDownloadStatus },
-      ]),
+    if (!Array.isArray(history?.records)) return;
+    const imported = history.records.filter(
+      (r) => r.eventType === "downloadFolderImported",
     );
+    const currentIds = new Set(imported.map((r) => r.id));
+    const prev = prevIds.current;
     if (prev !== null) {
-      for (const [id, item] of prev) {
-        if (!currentMap.has(id) && item.status !== "error") {
-          sendLocalNotification({
-            title: "Movie downloaded",
-            body: item.title,
-            data: { type: "radarr", queueId: id, instanceId },
-          });
-        }
+      for (const r of imported) {
+        if (prev.has(r.id)) continue;
+        sendLocalNotification({
+          title: "Movie downloaded",
+          body: radarrHistoryDisplayTitle(r),
+          data: {
+            type: "radarr",
+            movieId: r.movieId ?? r.movie?.id,
+            historyId: r.id,
+            instanceId,
+          },
+        });
       }
     }
-    prevQueue.current = currentMap;
-  }, [radarrQueue, active, instanceId]);
+    prevIds.current = currentIds;
+  }, [history, active, instanceId]);
 
   return null;
 }
 
-// --- Sonarr: queue item disappears (success only) ---
-function SonarrQueueWatcher({
+// --- Sonarr: new `downloadFolderImported` history record appears ---
+function SonarrImportWatcher({
   instanceId,
   active,
 }: {
   instanceId: string;
   active: boolean;
 }) {
-  const { data: sonarrQueue } = useSonarrQueue(instanceId);
-  const prevQueue = useRef<Map<number, { title: string; status?: string }> | null>(
-    null,
-  );
+  const { data: history } = useSonarrHistory(instanceId);
+  const prevIds = useRef<Set<number> | null>(null);
 
   useEffect(() => {
     if (!active) {
-      prevQueue.current = null;
+      prevIds.current = null;
       return;
     }
-    if (!Array.isArray(sonarrQueue?.records)) return;
-    const prev = prevQueue.current;
-    const currentMap = new Map(
-      sonarrQueue.records.map((r) => [
-        r.id,
-        { title: r.title, status: r.trackedDownloadStatus },
-      ]),
+    if (!Array.isArray(history?.records)) return;
+    const imported = history.records.filter(
+      (r) => r.eventType === "downloadFolderImported",
     );
+    const currentIds = new Set(imported.map((r) => r.id));
+    const prev = prevIds.current;
     if (prev !== null) {
-      for (const [id, item] of prev) {
-        if (!currentMap.has(id) && item.status !== "error") {
-          sendLocalNotification({
-            title: "Episode downloaded",
-            body: item.title,
-            data: { type: "sonarr", queueId: id, instanceId },
-          });
-        }
+      for (const r of imported) {
+        if (prev.has(r.id)) continue;
+        sendLocalNotification({
+          title: "Episode downloaded",
+          body: sonarrHistoryDisplayTitle(r),
+          data: {
+            type: "sonarr",
+            seriesId: r.seriesId ?? r.series?.id,
+            historyId: r.id,
+            instanceId,
+          },
+        });
       }
     }
-    prevQueue.current = currentMap;
-  }, [sonarrQueue, active, instanceId]);
+    prevIds.current = currentIds;
+  }, [history, active, instanceId]);
 
   return null;
 }

--- a/hooks/use-nzbget.ts
+++ b/hooks/use-nzbget.ts
@@ -1,4 +1,3 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   addNzbgetUrl,
   deleteNzbgetGroup,
@@ -12,114 +11,97 @@ import {
   resumeNzbgetGroup,
 } from "@/services/nzbget-api";
 import { POLLING_INTERVALS } from "@/lib/constants";
-import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { useServiceQuery, useServiceMutation } from "@/hooks/use-service-query";
 
 // Per-instance cache keying mirrors the SAB hooks: every hook accepts an
 // optional `instanceId` so aggregated dashboard cards can fan a query out
 // across every enabled NZBGet instance.
 
 export function useNzbgetGroups(instanceId?: string) {
-  const { instanceId: id, enabled } = useInstanceTarget("nzbget", instanceId);
-  return useQuery({
-    queryKey: ["nzbget", id, "groups"],
-    queryFn: () => getNzbgetGroups(id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.activeTorrents,
-    enabled: enabled && !!id,
-  });
+  return useServiceQuery(
+    "nzbget",
+    ["groups"],
+    getNzbgetGroups,
+    POLLING_INTERVALS.activeTorrents,
+    instanceId,
+  );
 }
 
 export function useNzbgetHistory(limit = 50, instanceId?: string) {
-  const { instanceId: id, enabled } = useInstanceTarget("nzbget", instanceId);
-  return useQuery({
-    queryKey: ["nzbget", id, "history", limit],
-    queryFn: () => getNzbgetHistory(limit, id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.queue,
-    enabled: enabled && !!id,
-  });
+  return useServiceQuery(
+    "nzbget",
+    ["history", limit],
+    (id) => getNzbgetHistory(limit, id),
+    POLLING_INTERVALS.queue,
+    instanceId,
+  );
 }
 
 export function useNzbgetStatus(instanceId?: string) {
-  const { instanceId: id, enabled } = useInstanceTarget("nzbget", instanceId);
-  return useQuery({
-    queryKey: ["nzbget", id, "status"],
-    queryFn: () => getNzbgetStatus(id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.activeTorrents,
-    enabled: enabled && !!id,
-  });
+  return useServiceQuery(
+    "nzbget",
+    ["status"],
+    getNzbgetStatus,
+    POLLING_INTERVALS.activeTorrents,
+    instanceId,
+  );
 }
 
 export function usePauseNzbgetGroup(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: (nzbId: number) => pauseNzbgetGroup(nzbId, id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    (nzbId: number, id) => pauseNzbgetGroup(nzbId, id),
+    instanceId,
+  );
 }
 
 export function useResumeNzbgetGroup(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: (nzbId: number) => resumeNzbgetGroup(nzbId, id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    (nzbId: number, id) => resumeNzbgetGroup(nzbId, id),
+    instanceId,
+  );
 }
 
 export function useDeleteNzbgetGroup(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: ({
-      nzbId,
-      deleteFiles = false,
-    }: {
-      nzbId: number;
-      deleteFiles?: boolean;
-    }) => deleteNzbgetGroup(nzbId, deleteFiles, id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    ({ nzbId, deleteFiles = false }: { nzbId: number; deleteFiles?: boolean }, id) =>
+      deleteNzbgetGroup(nzbId, deleteFiles, id),
+    instanceId,
+  );
 }
 
 export function useDeleteNzbgetHistorySlot(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: ({
-      nzbId,
-      deleteFiles = false,
-    }: {
-      nzbId: number;
-      deleteFiles?: boolean;
-    }) => deleteNzbgetHistorySlot(nzbId, deleteFiles, id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    ({ nzbId, deleteFiles = false }: { nzbId: number; deleteFiles?: boolean }, id) =>
+      deleteNzbgetHistorySlot(nzbId, deleteFiles, id),
+    instanceId,
+  );
 }
 
 export function usePauseNzbgetAll(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: () => pauseNzbgetAll(id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    (_: void, id) => pauseNzbgetAll(id),
+    instanceId,
+  );
 }
 
 export function useResumeNzbgetAll(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: () => resumeNzbgetAll(id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    (_: void, id) => resumeNzbgetAll(id),
+    instanceId,
+  );
 }
 
 export function useAddNzbgetUrl(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
-  return useMutation({
-    mutationFn: ({ url, category }: { url: string; category?: string }) =>
-      addNzbgetUrl(url, category, id ?? undefined),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
-  });
+  return useServiceMutation(
+    "nzbget",
+    ({ url, category }: { url: string; category?: string }, id) =>
+      addNzbgetUrl(url, category, id),
+    instanceId,
+  );
 }

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -3,6 +3,7 @@ import {
   getMovies,
   getMovie,
   getQueue,
+  getHistory,
   getWantedMissing,
   getCalendar,
   searchMovies,
@@ -62,6 +63,16 @@ export function useRadarrQueue(instanceId?: string) {
   return useQuery({
     queryKey: ["radarr", id, "queue"],
     queryFn: () => getQueue(1, 20, true, id ?? undefined),
+    refetchInterval: POLLING_INTERVALS.queue,
+    enabled: enabled && !!id,
+  });
+}
+
+export function useRadarrHistory(instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
+  return useQuery({
+    queryKey: ["radarr", id, "history"],
+    queryFn: () => getHistory(1, 50, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
   });

--- a/hooks/use-sabnzbd.ts
+++ b/hooks/use-sabnzbd.ts
@@ -1,4 +1,3 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getSabQueue,
   getSabHistory,
@@ -11,7 +10,7 @@ import {
   addSabUrl,
 } from "@/services/sabnzbd-api";
 import { POLLING_INTERVALS } from "@/lib/constants";
-import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { useServiceQuery, useServiceMutation } from "@/hooks/use-service-query";
 
 // Per-instance cache keying: every hook accepts an optional `instanceId`.
 // When omitted, the user's active SABnzbd is used (single-instance behavior);
@@ -19,111 +18,80 @@ import { useInstanceTarget } from "@/hooks/use-instance-target";
 // fan out to that specific instance with its own cache slot.
 
 export function useSabQueue(instanceId?: string) {
-  const { instanceId: id, enabled } = useInstanceTarget("sabnzbd", instanceId);
-  return useQuery({
-    queryKey: ["sabnzbd", id, "queue"],
-    queryFn: () => getSabQueue(id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.activeTorrents,
-    enabled: enabled && !!id,
-  });
+  return useServiceQuery(
+    "sabnzbd",
+    ["queue"],
+    getSabQueue,
+    POLLING_INTERVALS.activeTorrents,
+    instanceId,
+  );
 }
 
 export function useSabHistory(limit = 50, instanceId?: string) {
-  const { instanceId: id, enabled } = useInstanceTarget("sabnzbd", instanceId);
-  return useQuery({
-    queryKey: ["sabnzbd", id, "history", limit],
-    queryFn: () => getSabHistory(limit, id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.queue,
-    enabled: enabled && !!id,
-  });
+  return useServiceQuery(
+    "sabnzbd",
+    ["history", limit],
+    (id) => getSabHistory(limit, id),
+    POLLING_INTERVALS.queue,
+    instanceId,
+  );
 }
 
 export function usePauseSabSlot(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: (nzoId: string) => pauseSabSlot(nzoId, id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    (nzoId: string, id) => pauseSabSlot(nzoId, id),
+    instanceId,
+  );
 }
 
 export function useResumeSabSlot(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: (nzoId: string) => resumeSabSlot(nzoId, id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    (nzoId: string, id) => resumeSabSlot(nzoId, id),
+    instanceId,
+  );
 }
 
 export function useDeleteSabSlot(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: ({
-      nzoId,
-      deleteFiles = false,
-    }: {
-      nzoId: string;
-      deleteFiles?: boolean;
-    }) => deleteSabSlot(nzoId, deleteFiles, id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    ({ nzoId, deleteFiles = false }: { nzoId: string; deleteFiles?: boolean }, id) =>
+      deleteSabSlot(nzoId, deleteFiles, id),
+    instanceId,
+  );
 }
 
 export function useDeleteSabHistorySlot(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: ({
-      nzoId,
-      deleteFiles = false,
-    }: {
-      nzoId: string;
-      deleteFiles?: boolean;
-    }) => deleteSabHistorySlot(nzoId, deleteFiles, id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    ({ nzoId, deleteFiles = false }: { nzoId: string; deleteFiles?: boolean }, id) =>
+      deleteSabHistorySlot(nzoId, deleteFiles, id),
+    instanceId,
+  );
 }
 
 export function usePauseSabAll(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: () => pauseSabAll(id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    (_: void, id) => pauseSabAll(id),
+    instanceId,
+  );
 }
 
 export function useResumeSabAll(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: () => resumeSabAll(id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    (_: void, id) => resumeSabAll(id),
+    instanceId,
+  );
 }
 
 export function useAddSabUrl(instanceId?: string) {
-  const queryClient = useQueryClient();
-  const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
-  return useMutation({
-    mutationFn: ({ url, category }: { url: string; category?: string }) =>
-      addSabUrl(url, category, id ?? undefined),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] });
-    },
-  });
+  return useServiceMutation(
+    "sabnzbd",
+    ({ url, category }: { url: string; category?: string }, id) =>
+      addSabUrl(url, category, id),
+    instanceId,
+  );
 }

--- a/hooks/use-service-query.ts
+++ b/hooks/use-service-query.ts
@@ -1,0 +1,44 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
+import type { ServiceId } from "@/lib/constants";
+
+/**
+ * Wraps `useQuery` for a per-instance service call: resolves the active
+ * instance for the given service, gates with `enabled`, and namespaces the
+ * cache key by service+instance so two configured instances never collide.
+ */
+export function useServiceQuery<T>(
+  serviceId: ServiceId,
+  keyParts: readonly unknown[],
+  fetcher: (instanceId: string | undefined) => Promise<T>,
+  refetchInterval: number,
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled } = useInstanceTarget(serviceId, instanceId);
+  return useQuery({
+    queryKey: [serviceId, id, ...keyParts] as const,
+    queryFn: () => fetcher(id ?? undefined),
+    refetchInterval,
+    enabled: enabled && !!id,
+  });
+}
+
+/**
+ * Wraps `useMutation` for a per-instance service call. Invalidates the entire
+ * service+instance cache slice on success so list/detail queries refresh
+ * together.
+ */
+export function useServiceMutation<TArgs, TResult>(
+  serviceId: ServiceId,
+  mutationFn: (args: TArgs, instanceId: string | undefined) => Promise<TResult>,
+  instanceId?: string,
+) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget(serviceId, instanceId);
+  return useMutation({
+    mutationFn: (args: TArgs) => mutationFn(args, id ?? undefined),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [serviceId, id] });
+    },
+  });
+}

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -6,6 +6,7 @@ import {
   getEpisodeFiles,
   getCalendar,
   getQueue,
+  getHistory,
   searchSeries,
   addSeries,
   deleteSeries,
@@ -81,6 +82,16 @@ export function useSonarrQueue(instanceId?: string) {
   return useQuery({
     queryKey: ["sonarr", id, "queue"],
     queryFn: () => getQueue(1, 20, true, true, id ?? undefined),
+    refetchInterval: POLLING_INTERVALS.queue,
+    enabled: enabled && !!id,
+  });
+}
+
+export function useSonarrHistory(instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
+  return useQuery({
+    queryKey: ["sonarr", id, "history"],
+    queryFn: () => getHistory(1, 50, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
   });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -351,6 +351,23 @@ export interface RadarrQueue {
   records: RadarrQueueItem[];
 }
 
+export interface RadarrHistoryRecord {
+  id: number;
+  eventType: string;
+  sourceTitle?: string;
+  date?: string;
+  downloadId?: string;
+  movieId?: number;
+  movie?: RadarrMovie;
+}
+
+export interface RadarrHistory {
+  page: number;
+  pageSize: number;
+  totalRecords: number;
+  records: RadarrHistoryRecord[];
+}
+
 export interface RadarrWantedMissing {
   page: number;
   pageSize: number;
@@ -531,6 +548,25 @@ export interface SonarrQueue {
   pageSize: number;
   totalRecords: number;
   records: SonarrQueueItem[];
+}
+
+export interface SonarrHistoryRecord {
+  id: number;
+  eventType: string;
+  sourceTitle?: string;
+  date?: string;
+  downloadId?: string;
+  seriesId?: number;
+  episodeId?: number;
+  series?: SonarrSeries;
+  episode?: SonarrEpisode;
+}
+
+export interface SonarrHistory {
+  page: number;
+  pageSize: number;
+  totalRecords: number;
+  records: SonarrHistoryRecord[];
 }
 
 export interface SonarrSearchResult {

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -2,6 +2,7 @@ import { serviceRequest } from "@/lib/http-client";
 import type {
   RadarrMovie,
   RadarrQueue,
+  RadarrHistory,
   RadarrWantedMissing,
   RadarrSearchResult,
   RadarrImage,
@@ -56,6 +57,25 @@ export function getQueue(
 ): Promise<RadarrQueue> {
   return serviceRequest<RadarrQueue>("radarr", "/queue", {
     params: { page, pageSize, includeMovie },
+    instanceId,
+  });
+}
+
+// --- History ---
+
+export function getHistory(
+  page = 1,
+  pageSize = 50,
+  instanceId?: string,
+): Promise<RadarrHistory> {
+  return serviceRequest<RadarrHistory>("radarr", "/history", {
+    params: {
+      page,
+      pageSize,
+      sortKey: "date",
+      sortDirection: "descending",
+      includeMovie: true,
+    },
     instanceId,
   });
 }

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -5,6 +5,7 @@ import type {
   SonarrEpisodeFile,
   SonarrCalendarEntry,
   SonarrQueue,
+  SonarrHistory,
   SonarrSearchResult,
   SonarrImage,
   SonarrRelease,
@@ -103,6 +104,26 @@ export function getQueue(
 ): Promise<SonarrQueue> {
   return serviceRequest<SonarrQueue>("sonarr", "/queue", {
     params: { page, pageSize, includeSeries, includeEpisode },
+    instanceId,
+  });
+}
+
+// --- History ---
+
+export function getHistory(
+  page = 1,
+  pageSize = 50,
+  instanceId?: string,
+): Promise<SonarrHistory> {
+  return serviceRequest<SonarrHistory>("sonarr", "/history", {
+    params: {
+      page,
+      pageSize,
+      sortKey: "date",
+      sortDirection: "descending",
+      includeSeries: true,
+      includeEpisode: true,
+    },
     instanceId,
   });
 }


### PR DESCRIPTION
## Summary

Bundles three bug fixes across Radarr/Sonarr notifications, the dashboard calendar, and shared filter/sort UI.

Fixes #77, fixes #75, fixes #70.

## What's fixed

### #70 — Sonarr (and Radarr) firing "downloaded" notifications for items still in the queue

Notifications were derived from the Sonarr/Radarr **queue**, so any episode that sat in the queue (e.g. delayed grabs waiting on the configured propagation buffer) would disappear from the queue snapshot on the next poll and be interpreted as "downloaded" — even though no actual import had happened.

Notifications are now driven by the **Sonarr/Radarr history API** instead of queue-state diffs. The backend pollers (`backend/dashboarr-backend/src/workers/pollers/{radarr,sonarr}.ts`) and transition worker (`workers/transitions.ts`) now read `downloadFolderImported` / `movieFileImported` events from `/api/v3/history`, which is the authoritative signal that a file actually landed on disk. Queue items that are merely removed (delayed grabs, manual cancels, failed grabs) no longer produce a false "downloaded" notification.

New surface area:
- `services/{radarr,sonarr}-api.ts` — history endpoint clients
- `hooks/use-{radarr,sonarr}.ts` — history hooks
- `backend/dashboarr-backend/src/services/{radarr,sonarr}.ts` — backend history fetchers
- `lib/types.ts` — history event types
- `seen-state` repo updated to track history event IDs instead of queue IDs

### #77 — "Releasing soon" on the dashboard disagreed with Sonarr's "Next airing"

The dashboard calendar card included episodes whose air time was already in the past for the current day, so it would surface items Sonarr no longer considered upcoming. `components/dashboard/calendar-card.tsx` now filters entries by air time (not just air date), matching Sonarr's own behaviour.

### #75 — iOS UI glitches in filter/sort controls + Sonarr/Radarr add sheets

Two cleanups that resolve the inconsistent chip rows and visual breakage shown in the issue:

- **Unified filter/sort UI.** Replaced the per-screen inline filter and sort controls across `movies`, `tv`, `requests`, and `downloads` (plus every widget-settings sheet — calendar, downloads, Jellyfin/Plex now-playing, Overseerr requests, Radarr queue, server stats, Tautulli activity, usenet queue) with the shared `FilterSortButton` + `FilterSortSheet` pattern. Removes ~1.5k lines of duplicated chip/select rows, and the sheet correctly highlights the active sort option (the behaviour requested in the issue thread).
- **Shared Add Media sheet.** `components/radarr/add-movie-sheet.tsx` and `components/sonarr/add-series-sheet.tsx` are now thin wrappers over a new `components/common/add-media-sheet.tsx`, with monitored libraries rendered via a new shared `MonitoredLibraryGrid`. Eliminates the rendering inconsistencies between the two add flows.
- **Shared widget-settings primitives.** New `widget-settings-blocks.tsx` + `streaming-now-playing-settings.tsx` collapse the Jellyfin and Plex now-playing settings, plus other widgets, onto a common layout.

Also adds a `use-service-query` hook used by the refactored `use-nzbget` / `use-sabnzbd` hooks to keep the usenet adapter pair on a single query/mutation shape.