### PR TITLE
fix: qBittorrent auth races and Downloads cover persistence

### DIFF
--- a/hooks/use-torrent-poster-map.ts
+++ b/hooks/use-torrent-poster-map.ts
@@ -1,14 +1,46 @@
 import { useMemo } from "react";
-import { useRadarrQueue } from "@/hooks/use-radarr";
-import { useSonarrQueue } from "@/hooks/use-sonarr";
+import { useRadarrQueue, useRadarrHistory } from "@/hooks/use-radarr";
+import { useSonarrQueue, useSonarrHistory } from "@/hooks/use-sonarr";
 import { getRadarrPoster } from "@/services/radarr-api";
 import { getSonarrPoster } from "@/services/sonarr-api";
+import { getJSON, setJSON } from "@/store/storage";
+import { STORAGE_KEYS } from "@/lib/constants";
 
 export interface TorrentPosterEntry {
   posterUrl: string | null;
   title: string;
   mediaType: "movie" | "tv";
   routeId: number; // movie.id or series.id, for navigation
+}
+
+// Sticky hash→entry mapping. The *arr queue only lists in-flight downloads, so
+// without persistence the Downloads widget cover would vanish the moment
+// Radarr/Sonarr imports a finished file (#88). The cache is populated
+// additively from the live queue, the *arr history (covers recent completions
+// from previous sessions), and any prior persisted snapshot — so seeding
+// torrents keep their posters across app launches.
+const stickyPosterCache = new Map<string, TorrentPosterEntry>();
+let cacheHydrated = false;
+
+function hydrateCacheOnce(): void {
+  if (cacheHydrated) return;
+  cacheHydrated = true;
+  const stored = getJSON<Record<string, TorrentPosterEntry>>(
+    STORAGE_KEYS.torrentPosterCache,
+  );
+  if (!stored) return;
+  for (const [hash, entry] of Object.entries(stored)) {
+    if (entry && typeof entry === "object") {
+      stickyPosterCache.set(hash, entry);
+    }
+  }
+}
+
+function persistCache(): void {
+  setJSON(
+    STORAGE_KEYS.torrentPosterCache,
+    Object.fromEntries(stickyPosterCache),
+  );
 }
 
 /**
@@ -22,13 +54,16 @@ export interface TorrentPosterEntry {
 export function useTorrentPosterMap(): Map<string, TorrentPosterEntry> {
   const { data: radarrQueue } = useRadarrQueue();
   const { data: sonarrQueue } = useSonarrQueue();
+  const { data: radarrHistory } = useRadarrHistory();
+  const { data: sonarrHistory } = useSonarrHistory();
 
   return useMemo(() => {
-    const map = new Map<string, TorrentPosterEntry>();
+    hydrateCacheOnce();
+    const sizeBefore = stickyPosterCache.size;
 
     for (const item of radarrQueue?.records ?? []) {
       if (!item.downloadId || !item.movie) continue;
-      map.set(item.downloadId.toLowerCase(), {
+      stickyPosterCache.set(item.downloadId.toLowerCase(), {
         posterUrl: getRadarrPoster(item.movie.images),
         title: item.movie.title,
         mediaType: "movie",
@@ -38,7 +73,7 @@ export function useTorrentPosterMap(): Map<string, TorrentPosterEntry> {
 
     for (const item of sonarrQueue?.records ?? []) {
       if (!item.downloadId || !item.series) continue;
-      map.set(item.downloadId.toLowerCase(), {
+      stickyPosterCache.set(item.downloadId.toLowerCase(), {
         posterUrl: getSonarrPoster(item.series.images),
         title: item.series.title,
         mediaType: "tv",
@@ -46,6 +81,37 @@ export function useTorrentPosterMap(): Map<string, TorrentPosterEntry> {
       });
     }
 
-    return map;
-  }, [radarrQueue, sonarrQueue]);
+    // History backfills the cold-start gap: torrents that finished in a
+    // previous session won't appear in the queue, but their grab/import event
+    // is still in history with the same `downloadId` (== torrent hash). Only
+    // records that already include the embedded movie/series get used; older
+    // events without the embed are skipped.
+    for (const record of radarrHistory?.records ?? []) {
+      if (!record.downloadId || !record.movie) continue;
+      const key = record.downloadId.toLowerCase();
+      if (stickyPosterCache.has(key)) continue;
+      stickyPosterCache.set(key, {
+        posterUrl: getRadarrPoster(record.movie.images),
+        title: record.movie.title,
+        mediaType: "movie",
+        routeId: record.movie.id,
+      });
+    }
+
+    for (const record of sonarrHistory?.records ?? []) {
+      if (!record.downloadId || !record.series) continue;
+      const key = record.downloadId.toLowerCase();
+      if (stickyPosterCache.has(key)) continue;
+      stickyPosterCache.set(key, {
+        posterUrl: getSonarrPoster(record.series.images),
+        title: record.series.title,
+        mediaType: "tv",
+        routeId: record.series.id,
+      });
+    }
+
+    if (stickyPosterCache.size > sizeBefore) persistCache();
+
+    return new Map(stickyPosterCache);
+  }, [radarrQueue, sonarrQueue, radarrHistory, sonarrHistory]);
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -131,6 +131,12 @@ export const STORAGE_KEYS = {
   // first dismissal; the Settings → About → "Show workspace tour" row
   // resets it to false so users can replay.
   workspaceIntroSeen: "app.onboarding.workspaceIntroSeen",
+  // Sticky hash→poster mapping for the Downloads widget. The *arr queue only
+  // lists in-flight downloads, so without persistence the cover would vanish
+  // the instant Radarr/Sonarr imports the file (#88). Populated additively
+  // from queue + history; survives cold starts so seeding torrents still
+  // render their posters on app open.
+  torrentPosterCache: "app.torrentPosterCache",
 } as const;
 
 // Whitelisted UI scale multipliers. Kept as a const so the schema and the

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -127,10 +127,23 @@ async function ensureAuth(instanceId: string): Promise<void> {
   if (await getCookie(instanceId)) return;
   const entry = getEntry(instanceId);
   if (entry.loginPromise) {
-    await entry.loginPromise;
+    // Waiters must propagate the leader's outcome — otherwise a failed login
+    // returns void to the waiter, which then sends an unauth'd request and
+    // surfaces an opaque 403 (or worse, silently recovers via the retry path
+    // while the *leader* shows "auth failed" — see #87).
+    const ok = await entry.loginPromise;
+    if (!ok) throw new Error("qBittorrent authentication failed");
     return;
   }
-  const p = qbLogin(instanceId);
+  // Single retry with brief backoff: qBittorrent 5.x can transiently return a
+  // non-Ok login response under concurrent first-time auth (e.g. cold boot
+  // race when several widgets mount at once). qBT's default anti-bruteforce
+  // is 5 failed auths/min, so one retry is well under the threshold.
+  const p = (async (): Promise<boolean> => {
+    if (await qbLogin(instanceId)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+    return qbLogin(instanceId);
+  })();
   entry.loginPromise = p;
   try {
     const ok = await p;


### PR DESCRIPTION
## Summary
- `ensureAuth` waiters now propagate the leader's login result; `qbLogin` gets one 200ms-delayed retry on transient failure (refs #87).
- Torrent → poster map is now sticky and AsyncStorage-persisted, additively merged from queue + *arr history so covers survive download completion, app restarts, and cold starts (refs #88).

Issues left open intentionally — needs on-device testing before closing.

## Test plan
- [ ] iOS: Downloads widget shows covers for finished/seeding torrents, including after force-quit + relaunch.
- [ ] iOS: open the qBittorrent widget cold; no "authentication failed" toast on first mount.
- [ ] iOS: open a torrent detail screen repeatedly; loads reliably.