### PR TITLE
fix: correct Bazarr history endpoints (#85)

### DIFF
--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -973,8 +973,8 @@ export function getDemoResponse(
     case "bazarr": {
       if (normalized.startsWith("/movies/wanted")) return DEMO_BAZARR_WANTED_MOVIES;
       if (normalized.startsWith("/episodes/wanted")) return DEMO_BAZARR_WANTED_EPISODES;
-      if (normalized.startsWith("/history/movies")) return DEMO_BAZARR_HISTORY;
-      if (normalized.startsWith("/history/series")) return DEMO_BAZARR_HISTORY;
+      if (normalized.startsWith("/movies/history")) return DEMO_BAZARR_HISTORY;
+      if (normalized.startsWith("/episodes/history")) return DEMO_BAZARR_HISTORY;
       if (normalized.startsWith("/providers")) return DEMO_BAZARR_PROVIDERS;
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
       return undefined;

--- a/services/bazarr-api.ts
+++ b/services/bazarr-api.ts
@@ -39,7 +39,7 @@ export function getMovieHistory(
   length = 25,
   instanceId?: string,
 ): Promise<BazarrHistoryResponse> {
-  return serviceRequest<BazarrHistoryResponse>("bazarr", "/history/movies", {
+  return serviceRequest<BazarrHistoryResponse>("bazarr", "/movies/history", {
     params: { start, length },
     instanceId,
   });
@@ -50,7 +50,7 @@ export function getEpisodeHistory(
   length = 25,
   instanceId?: string,
 ): Promise<BazarrHistoryResponse> {
-  return serviceRequest<BazarrHistoryResponse>("bazarr", "/history/series", {
+  return serviceRequest<BazarrHistoryResponse>("bazarr", "/episodes/history", {
     params: { start, length },
     instanceId,
   });


### PR DESCRIPTION
## Summary
- Bazarr's subtitle history lives at `/api/movies/history` and `/api/episodes/history` (see `bazarr/api/movies/history.py` and `bazarr/api/episodes/history.py` on master). We were hitting `/api/history/movies` and `/api/history/series`, which don't exist, so the History tab was always empty.
- Updated `services/bazarr-api.ts` and the matching demo-data router.

Closes #85.

## Test plan
- [ ] Open Bazarr → History tab on a real instance with prior downloads; entries appear, sorted newest first.
- [ ] Demo mode History tab still renders sample data.