### PR TITLE
fix(settings): keep Android back inside settings when viewing instances

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -653,6 +653,19 @@ function InstanceList({
 
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
+  // Intercept Android hardware back / swipe-back so it returns to the main
+  // settings list instead of popping the Settings tab (which would land on
+  // the dashboard).
+  useFocusEffect(
+    useCallback(() => {
+      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+        onBack();
+        return true;
+      });
+      return () => sub.remove();
+    }, [onBack]),
+  );
+
   const handleAdd = () => {
     // First instance for a kind takes the kind's default name; subsequent ones
     // are auto-numbered to a unique label so the user has something to edit


### PR DESCRIPTION
The settings screen switches between three views via component state (main list → instance list → instance editor). `ServiceEditor` already intercepts the Android back gesture, but `InstanceList` did not — so swiping back from a service's instance list popped the Settings tab and landed on the Dashboard.

Adds the same `useFocusEffect` + `BackHandler` pattern to `InstanceList` so back returns to the main settings list.