### PR TITLE
fix(Glances): guard optional CPU/memory fields to prevent toFixed crash

### DIFF
--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -33,6 +33,17 @@ function usageTextColor(percent: number): string {
   return "text-success";
 }
 
+// Glances returns different shapes per host OS — macOS/Windows omit several
+// fields (most notably `iowait`). Use these helpers so a missing value renders
+// as a dash instead of crashing with "undefined.toFixed".
+function fmt(n: number | null | undefined, dp: number): string {
+  return typeof n === "number" && Number.isFinite(n) ? n.toFixed(dp) : "—";
+}
+
+function pct(n: number | null | undefined): number {
+  return typeof n === "number" && Number.isFinite(n) ? n : 0;
+}
+
 export default function GlancesScreen() {
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["glances"]]);
@@ -64,8 +75,8 @@ function CpuCard() {
       <CardHeader>
         <CardTitle>CPU</CardTitle>
         {cpu && (
-          <Text className={`text-2xl font-bold ${usageTextColor(cpu.total)}`}>
-            {cpu.total.toFixed(1)}%
+          <Text className={`text-2xl font-bold ${usageTextColor(pct(cpu.total))}`}>
+            {fmt(cpu.total, 1)}%
           </Text>
         )}
       </CardHeader>
@@ -76,13 +87,21 @@ function CpuCard() {
         <EmptyState title="No data" />
       ) : (
         <View className="gap-4">
-          <ProgressBar progress={cpu.total / 100} color={usageBarColor(cpu.total)} />
+          <ProgressBar progress={pct(cpu.total) / 100} color={usageBarColor(pct(cpu.total))} />
 
           <View className="flex-row gap-3">
-            <StatPill label="User" value={`${cpu.user.toFixed(1)}%`} />
-            <StatPill label="System" value={`${cpu.system.toFixed(1)}%`} />
-            <StatPill label="I/O Wait" value={`${cpu.iowait.toFixed(1)}%`} />
-            <StatPill label="Cores" value={String(cpu.cpucore)} />
+            {typeof cpu.user === "number" && (
+              <StatPill label="User" value={`${fmt(cpu.user, 1)}%`} />
+            )}
+            {typeof cpu.system === "number" && (
+              <StatPill label="System" value={`${fmt(cpu.system, 1)}%`} />
+            )}
+            {typeof cpu.iowait === "number" && (
+              <StatPill label="I/O Wait" value={`${fmt(cpu.iowait, 1)}%`} />
+            )}
+            {typeof cpu.cpucore === "number" && (
+              <StatPill label="Cores" value={String(cpu.cpucore)} />
+            )}
           </View>
 
           {load && (
@@ -91,9 +110,9 @@ function CpuCard() {
                 Load Average
               </Text>
               <View className="flex-row gap-3">
-                <StatPill label="1 min" value={load.min1.toFixed(2)} />
-                <StatPill label="5 min" value={load.min5.toFixed(2)} />
-                <StatPill label="15 min" value={load.min15.toFixed(2)} />
+                <StatPill label="1 min" value={fmt(load.min1, 2)} />
+                <StatPill label="5 min" value={fmt(load.min5, 2)} />
+                <StatPill label="15 min" value={fmt(load.min15, 2)} />
               </View>
             </View>
           )}
@@ -111,12 +130,12 @@ function CpuCard() {
                     </Text>
                     <View className="flex-1">
                       <ProgressBar
-                        progress={core.total / 100}
-                        color={usageBarColor(core.total)}
+                        progress={pct(core.total) / 100}
+                        color={usageBarColor(pct(core.total))}
                       />
                     </View>
-                    <Text className={`text-xs font-medium w-10 text-right ${usageTextColor(core.total)}`}>
-                      {core.total.toFixed(0)}%
+                    <Text className={`text-xs font-medium w-10 text-right ${usageTextColor(pct(core.total))}`}>
+                      {fmt(core.total, 0)}%
                     </Text>
                   </View>
                 ))}
@@ -137,8 +156,8 @@ function MemoryCard() {
       <CardHeader>
         <CardTitle>Memory</CardTitle>
         {mem && (
-          <Text className={`text-2xl font-bold ${usageTextColor(mem.percent)}`}>
-            {mem.percent.toFixed(1)}%
+          <Text className={`text-2xl font-bold ${usageTextColor(pct(mem.percent))}`}>
+            {fmt(mem.percent, 1)}%
           </Text>
         )}
       </CardHeader>
@@ -149,7 +168,7 @@ function MemoryCard() {
         <EmptyState title="No data" />
       ) : (
         <View className="gap-4">
-          <ProgressBar progress={mem.percent / 100} color={usageBarColor(mem.percent)} />
+          <ProgressBar progress={pct(mem.percent) / 100} color={usageBarColor(pct(mem.percent))} />
 
           <View className="flex-row gap-3 flex-wrap">
             <StatPill label="Used" value={formatBytes(mem.used)} />
@@ -157,11 +176,21 @@ function MemoryCard() {
             <StatPill label="Total" value={formatBytes(mem.total)} />
           </View>
 
-          <View className="flex-row gap-3 flex-wrap">
-            <StatPill label="Available" value={formatBytes(mem.available)} />
-            <StatPill label="Cached" value={formatBytes(mem.cached)} />
-            <StatPill label="Buffers" value={formatBytes(mem.buffers)} />
-          </View>
+          {(typeof mem.available === "number" ||
+            typeof mem.cached === "number" ||
+            typeof mem.buffers === "number") && (
+            <View className="flex-row gap-3 flex-wrap">
+              {typeof mem.available === "number" && (
+                <StatPill label="Available" value={formatBytes(mem.available)} />
+              )}
+              {typeof mem.cached === "number" && (
+                <StatPill label="Cached" value={formatBytes(mem.cached)} />
+              )}
+              {typeof mem.buffers === "number" && (
+                <StatPill label="Buffers" value={formatBytes(mem.buffers)} />
+              )}
+            </View>
+          )}
         </View>
       )}
     </Card>
@@ -213,7 +242,7 @@ function GpuDetail({ gpu }: { gpu: GlancesGpuItem }) {
           <View className="flex-row justify-between mb-1">
             <Text className="text-zinc-500 text-xs">Compute</Text>
             <Text className={`text-xs font-medium ${usageTextColor(proc)}`}>
-              {proc.toFixed(1)}%
+              {fmt(proc, 1)}%
             </Text>
           </View>
           <ProgressBar progress={proc / 100} color={usageBarColor(proc)} />
@@ -225,7 +254,7 @@ function GpuDetail({ gpu }: { gpu: GlancesGpuItem }) {
           <View className="flex-row justify-between mb-1">
             <Text className="text-zinc-500 text-xs">VRAM</Text>
             <Text className={`text-xs font-medium ${usageTextColor(mem)}`}>
-              {mem.toFixed(1)}%
+              {fmt(mem, 1)}%
             </Text>
           </View>
           <ProgressBar progress={mem / 100} color={usageBarColor(mem)} />
@@ -235,10 +264,10 @@ function GpuDetail({ gpu }: { gpu: GlancesGpuItem }) {
       {(typeof gpu.temperature === "number" || typeof gpu.fan_speed === "number") && (
         <View className="flex-row gap-3 flex-wrap mt-1">
           {typeof gpu.temperature === "number" && (
-            <StatPill label="Temp" value={`${gpu.temperature.toFixed(0)}°C`} />
+            <StatPill label="Temp" value={`${fmt(gpu.temperature, 0)}°C`} />
           )}
           {typeof gpu.fan_speed === "number" && (
-            <StatPill label="Fan" value={`${gpu.fan_speed.toFixed(0)} RPM`} />
+            <StatPill label="Fan" value={`${fmt(gpu.fan_speed, 0)} RPM`} />
           )}
         </View>
       )}
@@ -284,11 +313,11 @@ function DiskDetail({ disk }: { disk: GlancesFsItem }) {
           </Text>
           <Text className="text-zinc-600 text-xs">{disk.device_name}</Text>
         </View>
-        <Text className={`text-sm font-bold ${usageTextColor(disk.percent)}`}>
-          {disk.percent.toFixed(1)}%
+        <Text className={`text-sm font-bold ${usageTextColor(pct(disk.percent))}`}>
+          {fmt(disk.percent, 1)}%
         </Text>
       </View>
-      <ProgressBar progress={disk.percent / 100} color={usageBarColor(disk.percent)} className="mb-1.5" />
+      <ProgressBar progress={pct(disk.percent) / 100} color={usageBarColor(pct(disk.percent))} className="mb-1.5" />
       <View className="flex-row gap-3">
         <Text className="text-zinc-500 text-xs">Used {formatBytes(disk.used)}</Text>
         <Text className="text-zinc-500 text-xs">Free {formatBytes(disk.free)}</Text>

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -63,8 +63,10 @@ function MetricRing({ percent, label, sublabel, icon }: MetricRingProps) {
   const stroke = Math.max(4, Math.round(STROKE_WIDTH * scale));
   const radius = (size - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
-  const filled = circumference * (1 - Math.min(Math.max(percent, 0), 100) / 100);
-  const color = ringColor(percent);
+  const safePercent =
+    typeof percent === "number" && Number.isFinite(percent) ? percent : 0;
+  const filled = circumference * (1 - Math.min(Math.max(safePercent, 0), 100) / 100);
+  const color = ringColor(safePercent);
 
   return (
     <View className="items-center gap-1.5" style={{ minWidth: size + 8 }}>
@@ -94,7 +96,7 @@ function MetricRing({ percent, label, sublabel, icon }: MetricRingProps) {
         </Svg>
         <View className="absolute inset-0 items-center justify-center">
           <Text style={{ color }} className="text-sm font-bold leading-none">
-            {percent.toFixed(0)}
+            {safePercent.toFixed(0)}
             <Text style={{ color }} className="text-[0.6rem] font-semibold">
               %
             </Text>
@@ -249,7 +251,11 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
                   percent={cpu.total}
                   label="CPU"
                   icon={CpuIcon}
-                  sublabel={`${cpu.cpucore} ${cpu.cpucore === 1 ? "core" : "cores"}`}
+                  sublabel={
+                    typeof cpu.cpucore === "number"
+                      ? `${cpu.cpucore} ${cpu.cpucore === 1 ? "core" : "cores"}`
+                      : undefined
+                  }
                 />
               )}
               {settings.showRam && mem && (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1106,22 +1106,25 @@ export interface JellyfinSession {
 // --- Glances Types ---
 
 export interface GlancesCpu {
+  // Only `total` is guaranteed across platforms — Glances computes it itself.
+  // The rest depend on the host OS: macOS/Windows omit `iowait`, and some
+  // older builds/proxies may drop other fields too.
   total: number;
-  user: number;
-  system: number;
-  idle: number;
-  iowait: number;
-  cpucore: number;
+  user?: number;
+  system?: number;
+  idle?: number;
+  iowait?: number;
+  cpucore?: number;
 }
 
 export interface GlancesMem {
   total: number;
   used: number;
   free: number;
-  available: number;
+  available?: number;
   percent: number;
-  cached: number;
-  buffers: number;
+  cached?: number;
+  buffers?: number;
 }
 
 export interface GlancesFsItem {
@@ -1137,9 +1140,9 @@ export interface GlancesFsItem {
 export interface GlancesPerCpuItem {
   cpu_number: number;
   total: number;
-  user: number;
-  system: number;
-  idle: number;
+  user?: number;
+  system?: number;
+  idle?: number;
 }
 
 export interface GlancesLoad {


### PR DESCRIPTION
## Summary
- Glances omits fields like `iowait` and several `mem` subfields on macOS/Windows, crashing the Glances tab and dashboard widget on `undefined.toFixed`.
- Marked the affected fields optional in `GlancesCpu` / `GlancesMem` / `GlancesPerCpuItem` and render them defensively (dash fallback + guarded pills).
- `MetricRing` in the server-stats card also coerces non-finite percent to 0.

Closes #102

## Test plan
- [ ] Open Glances tab against a macOS host — no crash, missing fields render as `—` / are hidden.
- [ ] Open Glances tab against a Linux host — all pills still render with full values.
- [ ] Dashboard server-stats widget renders without crash on both hosts.