### PR TITLE
fix: stop health probes from showing healthy services as offline

### DIFF
--- a/hooks/use-service-health.ts
+++ b/hooks/use-service-health.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { checkInstanceHealth } from "@/lib/http-client";
+import { qbHealthCheck } from "@/services/qbittorrent-api";
 import { useConfigStore } from "@/store/config-store";
 import { SERVICE_IDS, POLLING_INTERVALS, SERVICE_DEFAULTS } from "@/lib/constants";
 import type {
@@ -46,6 +47,21 @@ export function useServiceHealth() {
                   instanceName: inst.name,
                   online: false,
                   status: "offline",
+                };
+              }
+              // qBittorrent routes through its own session-aware probe so the
+              // poll doesn't POST /auth/login every cycle — that was racing
+              // with the app's qbLogin cookie cache and tripping qBT's
+              // brute-force lockout on transient hiccups (see #105, #106).
+              if (id === "qbittorrent") {
+                const start = Date.now();
+                const status = await qbHealthCheck(inst.id);
+                return {
+                  instanceId: inst.id,
+                  instanceName: inst.name,
+                  online: status !== "offline",
+                  status,
+                  responseTime: status === "ok" ? Date.now() - start : undefined,
                 };
               }
               const result = await checkInstanceHealth(id, inst.id);

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -582,8 +582,11 @@ async function runConnectionProbe(
     }
 
     case "jellyfin": {
-      // /Users/Me requires X-Emby-Token; bad token → 401.
-      const url = buildUrl(baseUrl, defaults.apiBasePath, "/Users/Me");
+      // /System/Info validates auth without needing a user-bound token —
+      // /Users/Me returns 400 for server-wide API keys because they lack a
+      // user context. /System/Info accepts both API keys and user tokens, so
+      // it matches every Jellyfin auth shape this app supports.
+      const url = buildUrl(baseUrl, defaults.apiBasePath, "/System/Info");
       const headers = makeHeaders();
       if (apiKey) headers.set("X-Emby-Token", apiKey);
       const res = await fetch(url, { method: "GET", headers, signal });

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -248,6 +248,33 @@ export async function qbClearSession(instanceId?: string): Promise<void> {
   }
 }
 
+/**
+ * Health-probe variant used by the polling health hook. Unlike the form-driven
+ * Test Connection flow (which POSTs to /auth/login on every check), this reuses
+ * the cached SID via qbRequest so the probe doesn't:
+ *   • create parallel sessions that race against the app's own qbLogin cookie
+ *   • count against qBittorrent's brute-force lockout (5 failed logins / min)
+ *     when a transient network blip flips one probe into a "Fails." response
+ * If the cached session is missing or expired, qbRequest's 403 recovery does
+ * exactly one re-login — same as a real API call — so a genuinely-broken
+ * credential still surfaces as auth_failed.
+ */
+export async function qbHealthCheck(
+  instanceId: string,
+): Promise<"ok" | "auth_failed" | "offline"> {
+  try {
+    const version = await qbRequest<string>("/app/version", undefined, instanceId);
+    if (typeof version === "string" && version.length > 0) return "ok";
+    return "offline";
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("authentication failed") || msg.includes(": 403")) {
+      return "auth_failed";
+    }
+    return "offline";
+  }
+}
+
 // --- Transfer Info ---
 
 export function getTransferInfo(instanceId?: string): Promise<QBTransferInfo> {

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -1,0 +1,125 @@
+// Mock the storage layer before importing the store — config-store imports
+// storage.ts at module load, which pulls in AsyncStorage/SecureStore. Both are
+// native modules that aren't available in the jest-expo node environment, so
+// we replace them with no-op shims. Tests below only exercise pure in-memory
+// state via the store's getters/setters, so no persistence is needed.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { useConfigStore } from "./config-store";
+
+// Smoke-test that getActiveUrl always returns a fetch-safe URL, even when the
+// persisted value lacks a scheme. See #106 — health probes were failing on
+// schemeless stored URLs because fetch parses `192.168.x.x:7878` as
+// `scheme=192.168.x.x:, path=7878` and throws "Invalid URL". The editor's
+// onBlur prepends http://, but historical/migrated values can lack it, so the
+// store-level read has to normalize on the way out.
+
+const INSTANCE_ID = "00000000-0000-0000-0000-000000000001";
+
+function seed(overrides: {
+  localUrl?: string;
+  remoteUrl?: string;
+  useRemote?: boolean;
+  autoSwitchNetwork?: boolean;
+  networkAwayFromHome?: boolean;
+}) {
+  useConfigStore.setState({
+    serviceInstances: {
+      ...useConfigStore.getState().serviceInstances,
+      radarr: [
+        {
+          id: INSTANCE_ID,
+          enabled: true,
+          name: "Radarr",
+          localUrl: overrides.localUrl ?? "",
+          remoteUrl: overrides.remoteUrl ?? "",
+          useRemote: overrides.useRemote ?? false,
+        },
+      ],
+    },
+    activeInstance: {
+      ...useConfigStore.getState().activeInstance,
+      radarr: INSTANCE_ID,
+    },
+    autoSwitchNetwork: overrides.autoSwitchNetwork ?? false,
+    networkAwayFromHome: overrides.networkAwayFromHome ?? false,
+  } as Partial<ReturnType<typeof useConfigStore.getState>>);
+}
+
+describe("getActiveUrl — URL normalization on read (#106)", () => {
+  it("prepends http:// to a schemeless localUrl", () => {
+    seed({ localUrl: "192.168.1.10:7878" });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(
+      "http://192.168.1.10:7878",
+    );
+  });
+
+  it("prepends http:// to a schemeless remoteUrl when useRemote is on", () => {
+    seed({ remoteUrl: "radarr.example.com", useRemote: true });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(
+      "http://radarr.example.com",
+    );
+  });
+
+  it("leaves http:// URLs alone", () => {
+    seed({ localUrl: "http://192.168.1.10:7878" });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(
+      "http://192.168.1.10:7878",
+    );
+  });
+
+  it("leaves https:// URLs alone", () => {
+    seed({ remoteUrl: "https://radarr.example.com", useRemote: true });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(
+      "https://radarr.example.com",
+    );
+  });
+
+  it("returns an empty string for an empty localUrl (still falsy for callers)", () => {
+    seed({ localUrl: "" });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe("");
+  });
+
+  it("picks remoteUrl when auto-switch decides we're away from home", () => {
+    seed({
+      localUrl: "192.168.1.10:7878",
+      remoteUrl: "radarr.example.com",
+      useRemote: false,
+      autoSwitchNetwork: true,
+      networkAwayFromHome: true,
+    });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(
+      "http://radarr.example.com",
+    );
+  });
+
+  it("returns an empty string when the instance is missing", () => {
+    useConfigStore.setState({
+      serviceInstances: {
+        ...useConfigStore.getState().serviceInstances,
+        radarr: [],
+      },
+      activeInstance: {
+        ...useConfigStore.getState().activeInstance,
+        radarr: null,
+      },
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe("");
+  });
+});

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -47,6 +47,7 @@ import { useBackendStore } from "@/store/backend-store";
 import { queryClient } from "@/lib/query-client";
 import type { ServiceId, WidgetId } from "@/lib/constants";
 import { normalizeBssid } from "@/lib/wifi";
+import { normalizeServiceUrl } from "@/lib/url-validation";
 import { generateInstanceId } from "@/lib/uuid";
 
 export interface WakeOnLanDevice {
@@ -1902,7 +1903,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     const useRemote =
       inst.useRemote ||
       (state.autoSwitchNetwork && state.networkAwayFromHome);
-    return useRemote ? inst.remoteUrl : inst.localUrl;
+    // Normalize on read so every consumer (serviceRequest, pingService, health
+    // probes, widgets) sees a scheme-prefixed URL even when the stored value
+    // was saved without one. The editor's onBlur normalizes on edit, but
+    // historical/migrated values can lack http://, which causes fetch to
+    // throw "Invalid URL" — see #106.
+    return normalizeServiceUrl(useRemote ? inst.remoteUrl : inst.localUrl);
   },
 
   getActiveDashboard: () => {


### PR DESCRIPTION
## Summary
Three bugs introduced by v1.6.1's tri-state health probe (refs #105, #106):

- **Jellyfin**: probe hit `/Users/Me`, which returns HTTP 400 for server-wide API keys (they lack a user context). Switched to `/System/Info`, which validates auth against any valid token shape.
- **qBittorrent**: probe POSTed `/auth/login` on every poll cycle, racing the app's own `qbLogin` cookie cache and tripping qBT's 5-fail/min brute-force lockout on any transient hiccup — widgets kept working via cached sessions while the dot showed red. Polling now routes through a new `qbHealthCheck` that reuses the cached SID via `qbRequest`. The Test Connection button is unchanged since it's user-initiated and one-off.
- **Schemeless URLs**: stored `localUrl`/`remoteUrl` without `http://` made `fetch` throw "Invalid URL" in the health probe, even though the editor's Test Connection auto-normalized and reported "connected". `getActiveUrl` now normalizes on read so every consumer (probes, real API requests, widgets) sees a scheme-prefixed URL.

## Test plan
- [ ] Jellyfin with a server API key: dashboard dot turns green; Test Connection succeeds
- [ ] qBittorrent: dashboard dot stays green during normal use; Test Connection still validates creds
- [ ] qBittorrent with wrong password: dot turns orange (auth_failed) after first failed poll
- [ ] Instance with a schemeless stored URL: dashboard dot turns green after upgrade (no re-save needed)
- [ ] Service genuinely offline: dot turns red