### PR TITLE
fix: calendar header overflow at large font (#99) + qBittorrent all-time totals (#104)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -366,19 +366,24 @@ export default function CalendarScreen() {
 
   return (
     <ScreenWrapper refreshing={refreshing} onRefresh={onRefresh}>
-      {/* Month header */}
-      <View className="flex-row items-center justify-between mb-3">
-        <View className="flex-row items-center gap-1">
-          <Pressable onPress={() => goMonth(-1)} className="p-2 active:opacity-70">
-            <Icon icon={ChevronLeft} size={ICON.LG} color="#a1a1aa" />
-          </Pressable>
-          <Text className="text-zinc-100 text-lg font-bold min-w-[12rem] text-center">
-            {MONTH_NAMES[month]} {year}
-          </Text>
-          <Pressable onPress={() => goMonth(1)} className="p-2 active:opacity-70">
-            <Icon icon={ChevronRight} size={ICON.LG} color="#a1a1aa" />
-          </Pressable>
-        </View>
+      {/* Month header. The month label uses `flex-1` (not a fixed min-width)
+          so chevrons + label + Today pill stay on-screen at every uiScale.
+          The previous `min-w-[12rem]` was hard-coded for scale 1.0 and pushed
+          Today off the right edge at 1.3 — see #99. `numberOfLines={1}` keeps
+          the label on a single line if it ever still runs out of room. */}
+      <View className="flex-row items-center mb-3 gap-1">
+        <Pressable onPress={() => goMonth(-1)} className="p-2 active:opacity-70">
+          <Icon icon={ChevronLeft} size={ICON.LG} color="#a1a1aa" />
+        </Pressable>
+        <Text
+          className="text-zinc-100 text-lg font-bold flex-1 text-center"
+          numberOfLines={1}
+        >
+          {MONTH_NAMES[month]} {year}
+        </Text>
+        <Pressable onPress={() => goMonth(1)} className="p-2 active:opacity-70">
+          <Icon icon={ChevronRight} size={ICON.LG} color="#a1a1aa" />
+        </Pressable>
         <Pressable
           onPress={goToday}
           className="px-3 py-1.5 rounded-lg bg-primary/20 active:opacity-70"

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -4,7 +4,7 @@ import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getTransferInfo } from "@/services/qbittorrent-api";
+import { getServerState } from "@/services/qbittorrent-api";
 import { getSabQueue } from "@/services/sabnzbd-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
@@ -36,13 +36,16 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     ? resolveBoundInstances(settings.sabInstanceIds, allSabInstances)
     : [];
 
-  // Fan out across the resolved instances and sum their transfer counters so
-  // a single Speed pill represents the whole stack at a glance. Each instance
-  // keeps its own cache slot via the [serviceId, instanceId, …] queryKey shape.
+  // Fan out across the resolved instances and sum their counters so a single
+  // Speed pill represents the whole stack at a glance. Each instance keeps
+  // its own cache slot via the [serviceId, instanceId, …] queryKey shape.
+  // Uses /sync/maindata (server_state) instead of /transfer/info because
+  // only server_state carries lifetime totals (alltime_dl/alltime_ul) — the
+  // dashboard "X GB total" used to reset when qBit restarted (#104).
   const qbitQueries = useQueries({
     queries: qbitInstances.map((inst) => ({
-      queryKey: ["qbittorrent", inst.id, "transfer"] as const,
-      queryFn: () => getTransferInfo(inst.id),
+      queryKey: ["qbittorrent", inst.id, "serverState"] as const,
+      queryFn: () => getServerState(inst.id),
       refetchInterval: POLLING_INTERVALS.transferSpeed,
     })),
   });
@@ -98,8 +101,10 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     if (!q.data) continue;
     dlSpeed += q.data.dl_info_speed;
     upSpeed += q.data.up_info_speed;
-    dlTotal += q.data.dl_info_data;
-    upTotal += q.data.up_info_data;
+    // Lifetime totals — persist across qBit restarts. See #104 and the
+    // QBServerState comment in lib/types.ts.
+    dlTotal += q.data.alltime_dl;
+    upTotal += q.data.alltime_ul;
   }
   for (const q of sabQueries) {
     if (!q.data) continue;

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -95,16 +95,21 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
 
   let dlSpeed = 0;
   let upSpeed = 0;
-  let dlTotal = 0;
-  let upTotal = 0;
+  let dlAlltime = 0;
+  let upAlltime = 0;
+  let dlSession = 0;
+  let upSession = 0;
   for (const q of qbitQueries) {
     if (!q.data) continue;
     dlSpeed += q.data.dl_info_speed;
     upSpeed += q.data.up_info_speed;
-    // Lifetime totals — persist across qBit restarts. See #104 and the
-    // QBServerState comment in lib/types.ts.
-    dlTotal += q.data.alltime_dl;
-    upTotal += q.data.alltime_ul;
+    // server_state carries both counters — alltime persists across restarts,
+    // session resets on each qBit start. The widget's `totalsScope` setting
+    // picks which subtitle(s) to render (see #104).
+    dlAlltime += q.data.alltime_dl;
+    upAlltime += q.data.alltime_ul;
+    dlSession += q.data.dl_info_data;
+    upSession += q.data.up_info_data;
   }
   for (const q of sabQueries) {
     if (!q.data) continue;
@@ -119,31 +124,54 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   // would silently understate the stack and confuse the user. The settings
   // toggle warns about this; the card just stops showing the misleading number.
   const showDlTotal = sabInstances.length === 0;
+  const scope = settings.totalsScope;
+
+  const dlTotalLines = buildTotalLines(scope, dlAlltime, dlSession);
+  const upTotalLines = buildTotalLines(scope, upAlltime, upSession);
 
   return (
     <Card className="flex-row gap-3">
       <SpeedPill
         direction="down"
         speed={formatSpeed(dlSpeed)}
-        total={showDlTotal ? formatBytes(dlTotal) : null}
+        totalLines={showDlTotal ? dlTotalLines : []}
       />
       <SpeedPill
         direction="up"
         speed={formatSpeed(upSpeed)}
-        total={formatBytes(upTotal)}
+        totalLines={upTotalLines}
       />
     </Card>
   );
 }
 
+function buildTotalLines(
+  scope: SpeedStatsSettingsValue["totalsScope"],
+  alltime: number,
+  session: number,
+): { label: string; value: string }[] {
+  switch (scope) {
+    case "session":
+      return [{ label: "session", value: formatBytes(session) }];
+    case "both":
+      return [
+        { label: "all-time", value: formatBytes(alltime) },
+        { label: "session", value: formatBytes(session) },
+      ];
+    case "alltime":
+    default:
+      return [{ label: "total", value: formatBytes(alltime) }];
+  }
+}
+
 function SpeedPill({
   direction,
   speed,
-  total,
+  totalLines,
 }: {
   direction: "down" | "up";
   speed: string;
-  total: string | null;
+  totalLines: { label: string; value: string }[];
 }) {
   const isDown = direction === "down";
   const ArrowIcon = isDown ? ArrowDown : ArrowUp;
@@ -155,9 +183,11 @@ function SpeedPill({
       <Icon icon={ArrowIcon} size={18} color={isDown ? "#3b82f6" : "#22c55e"} />
       <View>
         <Text className={`text-lg font-bold ${colorClass}`}>{speed}</Text>
-        {total !== null && (
-          <Text className="text-zinc-500 text-xs">{total} total</Text>
-        )}
+        {totalLines.map((line) => (
+          <Text key={line.label} className="text-zinc-500 text-xs">
+            {line.value} {line.label}
+          </Text>
+        ))}
       </View>
     </View>
   );

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -150,12 +150,16 @@ function buildTotalLines(
   alltime: number,
   session: number,
 ): { label: string; value: string }[] {
+  // Labels stay short ("total"/"session") so they fit inside the pill at
+  // uiScale 1.3 — longer words like "all-time" overflow the 50%-width pill
+  // even with min-w-0 + ellipsize. In Both mode the two rows are adjacent,
+  // so "total" reads unambiguously as "lifetime" against the "session" row.
   switch (scope) {
     case "session":
       return [{ label: "session", value: formatBytes(session) }];
     case "both":
       return [
-        { label: "all-time", value: formatBytes(alltime) },
+        { label: "total", value: formatBytes(alltime) },
         { label: "session", value: formatBytes(session) },
       ];
     case "alltime":
@@ -181,10 +185,24 @@ function SpeedPill({
   return (
     <View className={`flex-1 flex-row items-center gap-3 rounded-xl p-3 ${bgClass}`}>
       <Icon icon={ArrowIcon} size={18} color={isDown ? "#3b82f6" : "#22c55e"} />
-      <View>
-        <Text className={`text-lg font-bold ${colorClass}`}>{speed}</Text>
+      {/* `flex-1 min-w-0` is what lets the text column actually shrink inside
+          the flex row — without min-w-0 a long subtitle (e.g. "1.23 TB
+          session" at uiScale 1.3) keeps the intrinsic width and pushes the
+          pill past 50% of the card. numberOfLines={1} then ellipsizes the
+          worst-case string cleanly. */}
+      <View className="flex-1 min-w-0">
+        <Text
+          className={`text-lg font-bold ${colorClass}`}
+          numberOfLines={1}
+        >
+          {speed}
+        </Text>
         {totalLines.map((line) => (
-          <Text key={line.label} className="text-zinc-500 text-xs">
+          <Text
+            key={line.label}
+            className="text-zinc-500 text-xs"
+            numberOfLines={1}
+          >
             {line.value} {line.label}
           </Text>
         ))}

--- a/components/dashboard/widget-settings/speed-stats-settings.tsx
+++ b/components/dashboard/widget-settings/speed-stats-settings.tsx
@@ -12,6 +12,21 @@ import {
   resolveBoundInstances,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { ChipGroup } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+
+// Which counter the "X GB total" subtitle reflects on the pill.
+//   alltime — qBittorrent's lifetime totals (alltime_dl/alltime_ul). Survives
+//             qBit restarts. Default — matches qB's own User Statistics view.
+//   session — per-session totals (dl_info_data/up_info_data). Resets every
+//             time qBit restarts. Old pre-#104 behavior.
+//   both    — render both rows stacked under the speed.
+export type SpeedStatsTotalsScope = "alltime" | "session" | "both";
+
+const TOTALS_SCOPE_OPTIONS: readonly { value: SpeedStatsTotalsScope; label: string }[] = [
+  { value: "alltime", label: "All-time" },
+  { value: "session", label: "Session" },
+  { value: "both", label: "Both" },
+];
 
 export interface SpeedStatsSettingsValue extends Record<string, unknown> {
   // Which qBittorrent instances to graph. "all" sums every enabled instance's
@@ -24,12 +39,15 @@ export interface SpeedStatsSettingsValue extends Record<string, unknown> {
   // Which SAB instances to fold in when `includeSab` is on. Same shape as
   // `instanceIds`; "all" auto-includes newly-added SAB instances.
   sabInstanceIds: InstanceBindingValue;
+  // Which transfer-counter the subtitle reflects. See SpeedStatsTotalsScope.
+  totalsScope: SpeedStatsTotalsScope;
 }
 
 export const SPEED_STATS_DEFAULT_SETTINGS: SpeedStatsSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
   includeSab: false,
   sabInstanceIds: INSTANCE_BINDING_ALL,
+  totalsScope: "alltime",
 };
 
 export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -74,6 +92,15 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
           serviceId="qbittorrent"
           value={settings.instanceIds}
           onChange={(instanceIds) => update({ instanceIds })}
+        />
+      )}
+
+      {qbitInstances.length > 0 && (
+        <ChipGroup
+          label="Totals shown"
+          options={TOTALS_SCOPE_OPTIONS}
+          value={settings.totalsScope}
+          onChange={(totalsScope) => update({ totalsScope })}
         />
       )}
 

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -27,6 +27,23 @@ const DEMO_QB_TRANSFER_INFO = {
   connection_status: "connected",
 };
 
+// /sync/maindata response shape — the Speed Stats widget reads the all-time
+// counters (alltime_dl/alltime_ul) so demo mode shows realistic lifetime
+// totals rather than just the small session deltas above.
+const DEMO_QB_MAINDATA = {
+  rid: 0,
+  full_update: true,
+  server_state: {
+    alltime_dl: 891289600000,
+    alltime_ul: 892323840000,
+    dl_info_speed: 5242880,
+    dl_info_data: 107374182400,
+    up_info_speed: 1048576,
+    up_info_data: 21474836480,
+    connection_status: "connected",
+  },
+};
+
 const DEMO_QB_TORRENTS = [
   {
     hash: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
@@ -991,6 +1008,7 @@ export function getDemoResponse(
     }
     case "qbittorrent": {
       if (normalized === "/transfer/info") return DEMO_QB_TRANSFER_INFO;
+      if (normalized.startsWith("/sync/maindata")) return DEMO_QB_MAINDATA;
       if (normalized.startsWith("/torrents/info")) return DEMO_QB_TORRENTS;
       if (normalized.startsWith("/torrents/files")) return [];
       if (normalized.startsWith("/torrents/trackers")) return [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,23 @@ export interface QBTransferInfo {
   connection_status: "connected" | "firewalled" | "disconnected";
 }
 
+// Subset of qBittorrent's /sync/maindata `server_state` we care about. Unlike
+// /transfer/info — which only exposes per-session counters (`*_info_data`)
+// that reset on every qBit restart — server_state also carries lifetime
+// totals (`alltime_dl`, `alltime_ul`). The Speed Stats widget uses the
+// lifetime values so the dashboard "X GB total" persists across restarts;
+// see #104. The endpoint returns many more fields (free disk, ratio, etc.)
+// that we omit until something else needs them.
+export interface QBServerState {
+  alltime_dl: number;
+  alltime_ul: number;
+  dl_info_speed: number;
+  dl_info_data: number;
+  up_info_speed: number;
+  up_info_data: number;
+  connection_status: "connected" | "firewalled" | "disconnected";
+}
+
 // qBittorrent 5.0 renamed `pausedUP`/`pausedDL` to `stoppedUP`/`stoppedDL`.
 // Both are kept here so the app works against 4.x and 5.x servers.
 export type TorrentState =

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -6,6 +6,7 @@ import { SERVICE_DEFAULTS, SECRET_PREFIX } from "@/lib/constants";
 import { getDemoResponse } from "@/lib/demo-data";
 import type {
   QBTransferInfo,
+  QBServerState,
   QBTorrent,
   QBTorrentFile,
   QBTorrentTracker,
@@ -279,6 +280,23 @@ export async function qbHealthCheck(
 
 export function getTransferInfo(instanceId?: string): Promise<QBTransferInfo> {
   return qbRequest<QBTransferInfo>("/transfer/info", undefined, instanceId);
+}
+
+// Fetches qBittorrent's server-wide state via /sync/maindata. Unlike
+// /transfer/info this exposes lifetime totals (alltime_dl, alltime_ul), used
+// by the Speed Stats widget so totals survive a qBit restart (#104). The
+// /sync/maindata response also carries torrents/categories — we discard them
+// here. `rid=0` always asks for a full snapshot; we don't track rid because
+// every call is independent.
+export async function getServerState(
+  instanceId?: string,
+): Promise<QBServerState> {
+  const data = await qbRequest<{ server_state: QBServerState }>(
+    "/sync/maindata?rid=0",
+    undefined,
+    instanceId,
+  );
+  return data.server_state;
 }
 
 // --- Torrents ---


### PR DESCRIPTION
## Summary
Two unrelated UI/data fixes bundled together (refs #99, #104):

- **#99 — Calendar header overflow at large font.** At uiScale 1.3 the month label's hard-coded `min-w-[12rem]` pushed the Today pill off the right edge on iOS. Replaced with `flex-1` + `numberOfLines={1}` so chevrons, label, and Today pill all stay on-screen at every scale.
- **#104 — qBittorrent "X GB total" reset on restart.** The Speed Stats widget read `dl_info_data`/`up_info_data` from `/transfer/info`, which are session-only counters that reset whenever qBit restarts. Switched to `/sync/maindata` (server_state carries both session and lifetime counters in one call). Added a **Totals shown** widget setting with three options:
  - **All-time** (default) — lifetime totals (`alltime_dl`/`alltime_ul`), matches qB's User Statistics dialog
  - **Session** — pre-fix behavior, resets on each qBit restart
  - **Both** — renders both rows stacked under the speed

  Existing widgets pick up the new field via the standard defaults-merge in `useWidgetSettings`, so no migration is needed. Pill text column also gets `flex-1 min-w-0` + `numberOfLines={1}` so the longer Both-mode subtitles don't overflow at uiScale 1.3.