### PR TITLE
fix(qbittorrent): accept HTTP 204 login response from qBittorrent 5.2.0+

### DIFF
--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -462,7 +462,10 @@ async function runConnectionProbe(
 
   switch (serviceId) {
     case "qbittorrent": {
-      // Cookie-session auth — body "Ok." = success, anything else = bad creds.
+      // Cookie-session auth. Older qBittorrent replies 200 with body "Ok." on
+      // success and "Fails." on bad creds; qBittorrent 5.2.0+ replies 204 No
+      // Content (empty body) on success — changelog "WEBAPI: Send 204 when
+      // WebAPI response contains no data". Accept either success shape.
       const url = buildUrl(baseUrl, defaults.apiBasePath, "/auth/login");
       const headers = makeHeaders({
         "Content-Type": "application/x-www-form-urlencoded",
@@ -473,6 +476,7 @@ async function runConnectionProbe(
         return { kind: "unreachable", message: `Server error ${res.status}` };
       if (res.status === 401 || res.status === 403)
         return { kind: "auth_failed", message: "Wrong username or password" };
+      if (res.status === 204) return { kind: "ok" };
       if (!res.ok)
         return { kind: "unreachable", message: `Unexpected status ${res.status}` };
       const text = (await res.text()).trim();

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -100,8 +100,15 @@ export async function qbLogin(instanceId?: string): Promise<boolean> {
 
   if (!response.ok) return false;
 
-  const text = await response.text();
-  if (text !== "Ok.") return false;
+  // qBittorrent 5.2.0+ replies 204 No Content (empty body) on a successful
+  // login — changelog "WEBAPI: Send 204 when WebAPI response contains no
+  // data". Older builds reply 200 with body "Ok."; a rejected login replies
+  // 200 with "Fails.". Treat 204 as success and only validate the body on a
+  // 200 so newer servers stop being misread as auth failures.
+  if (response.status !== 204) {
+    const text = await response.text();
+    if (text.trim() !== "Ok.") return false;
+  }
 
   // Try to extract the SID so we can attach it as a Cookie header. If we
   // can't read Set-Cookie (iOS always strips it; Android usually does because


### PR DESCRIPTION
qBittorrent 5.2.0 changed `/auth/login` to return **204 No Content** (empty body) on success instead of `200` with body `Ok.` (changelog: *"WEBAPI: Send 204 when WebAPI response contains no data"*). Both the auth path (`qbLogin`) and the Test Connection probe validated the body `== "Ok."`, so a 204 was misread as an auth failure ("Wrong username or password") even though the server accepted the credentials and issued the session cookie — hence login working in the browser but not the app.

Accept 204 as success in both paths; older servers (`200 "Ok."`) keep working, and `200 "Fails."`/`403` are still treated as failures. Session cookie rename to `QBT_SID_<port>` needs no change — it falls through to the native cookie-jar path already in use.