### PR TITLE
feat: option to ignore invalid TLS certificates (#23)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy GitHub Pages
+
+# Publishes the static landing page in docs/ to GitHub Pages.
+# Only runs when files under docs/ change — this replaces the legacy
+# "deploy from branch" mode, which rebuilt on EVERY push to main
+# regardless of whether the site actually changed.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
+  # Allow a manual redeploy from the Actions tab when needed.
+  workflow_dispatch:
+
+# One deployment at a time; never cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload docs/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ dist/
 web-build/
 android/
 ios/
+# The above ignore the prebuilt root native projects (CNG regenerates them).
+# In-tree local Expo modules keep their native sources in git, so un-ignore
+# those — otherwise the android/ and ios/ rules above would silently drop them.
+!modules/*/android/
+!modules/*/android/**
+!modules/*/ios/
+!modules/*/ios/**
 .env
 .env.local
 .claude/

--- a/app.config.ts
+++ b/app.config.ts
@@ -97,6 +97,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "./plugins/withCleartextTraffic",
     "./plugins/withDevVariant",
     "./plugins/withFmtConstevalFix",
+    "./plugins/withInsecureTls",
     [
       "expo-location",
       {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -928,6 +928,7 @@ function ServiceEditor({
     localUrl: "",
     remoteUrl: "",
     useRemote: false,
+    ignoreCertErrors: false,
   };
 
   const [name, setName] = useState(config.name);
@@ -1200,6 +1201,14 @@ function ServiceEditor({
           value={config.useRemote}
           onValueChange={(v) =>
             updateInstance(serviceId, instanceId, { useRemote: v })
+          }
+        />
+        <Toggle
+          label="Allow invalid certificates"
+          description="Skip TLS certificate checks for this server, accepting self-signed or otherwise invalid certs. Only enable for servers you trust on a network you control."
+          value={config.ignoreCertErrors ?? false}
+          onValueChange={(v) =>
+            updateInstance(serviceId, instanceId, { ignoreCertErrors: v })
           }
         />
       </Card>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ import { useBackendHealth } from "@/hooks/use-backend-health";
 import { useAppUpdateCheck } from "@/hooks/use-app-update-check";
 import { useNetworkAutoSwitch } from "@/hooks/use-network";
 import { pushConfigSnapshot } from "@/services/backend-api";
+import { syncInsecureHosts } from "@/lib/insecure-tls";
 import { ErrorBoundary, SilentErrorBoundary } from "@/components/common/error-boundary";
 import { ToastContainer } from "@/components/ui/toast";
 import { WorkspaceIntroOverlay } from "@/components/onboarding/workspace-intro-overlay";
@@ -163,6 +164,24 @@ function UiScaleBridge() {
   return null;
 }
 
+// Keeps the native TLS-bypass allowlist in lockstep with config: which hosts
+// the user opted out of certificate validation for. Pushes once on hydrate and
+// again on every config change (the sync itself dedupes, so unrelated changes
+// are cheap). Without this the native module would never learn the allowlist
+// and every connection would validate certs normally.
+function InsecureTlsBridge() {
+  const configHydrated = useConfigStore((s) => s.hydrated);
+
+  useEffect(() => {
+    if (!configHydrated) return;
+    syncInsecureHosts();
+    const unsub = useConfigStore.subscribe(syncInsecureHosts);
+    return unsub;
+  }, [configHydrated]);
+
+  return null;
+}
+
 function ConfigSyncBridge() {
   const sharedSecret = useBackendStore((s) => s.sharedSecret);
   const backendHydrated = useBackendStore((s) => s.hydrated);
@@ -264,6 +283,9 @@ export default function RootLayout() {
               </SilentErrorBoundary>
               <SilentErrorBoundary label="config-sync">
                 <ConfigSyncBridge />
+              </SilentErrorBoundary>
+              <SilentErrorBoundary label="insecure-tls">
+                <InsecureTlsBridge />
               </SilentErrorBoundary>
               <SilentErrorBoundary label="ui-scale">
                 <UiScaleBridge />

--- a/lib/insecure-tls.test.ts
+++ b/lib/insecure-tls.test.ts
@@ -1,0 +1,90 @@
+// insecure-tls.ts imports the config store (for syncInsecureHosts), which pulls
+// in AsyncStorage/SecureStore at module load — native modules absent in the
+// jest-expo node env. Shim them; these tests only exercise the pure
+// computeInsecureHosts helper.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { computeInsecureHosts } from "./insecure-tls";
+import type { ServiceId } from "@/lib/constants";
+import type { ServiceInstance } from "@/store/config-store";
+
+const inst = (overrides: Partial<ServiceInstance>): ServiceInstance => ({
+  id: Math.random().toString(36).slice(2),
+  enabled: true,
+  name: "svc",
+  localUrl: "",
+  remoteUrl: "",
+  useRemote: false,
+  ignoreCertErrors: false,
+  ...overrides,
+});
+
+// computeInsecureHosts iterates Object.values, so a partial record is enough.
+const services = (
+  map: Partial<Record<ServiceId, ServiceInstance[]>>,
+): Record<ServiceId, ServiceInstance[]> =>
+  map as Record<ServiceId, ServiceInstance[]>;
+
+describe("computeInsecureHosts", () => {
+  it("returns empty when no instance opts in", () => {
+    expect(
+      computeInsecureHosts(
+        services({ radarr: [inst({ localUrl: "https://radarr.example.com" })] }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("collects both local and remote hosts of opted-in instances", () => {
+    expect(
+      computeInsecureHosts(
+        services({
+          radarr: [
+            inst({
+              ignoreCertErrors: true,
+              localUrl: "https://192.168.1.50:7878",
+              remoteUrl: "https://radarr.example.com",
+            }),
+          ],
+        }),
+      ),
+    ).toEqual(["192.168.1.50", "radarr.example.com"]);
+  });
+
+  it("parses scheme-less URLs and lowercases the host", () => {
+    expect(
+      computeInsecureHosts(
+        services({ sonarr: [inst({ ignoreCertErrors: true, localUrl: "NAS.Local:8989" })] }),
+      ),
+    ).toEqual(["nas.local"]);
+  });
+
+  it("dedupes hosts shared across instances and ignores blank/garbage URLs", () => {
+    expect(
+      computeInsecureHosts(
+        services({
+          radarr: [inst({ ignoreCertErrors: true, localUrl: "https://nas.local:7878" })],
+          sonarr: [
+            inst({ ignoreCertErrors: true, localUrl: "https://nas.local:8989", remoteUrl: "   " }),
+          ],
+          prowlarr: [inst({ ignoreCertErrors: false, localUrl: "https://other.local" })],
+        }),
+      ),
+    ).toEqual(["nas.local"]);
+  });
+});

--- a/lib/insecure-tls.ts
+++ b/lib/insecure-tls.ts
@@ -1,0 +1,55 @@
+import { setInsecureHosts } from "@/modules/insecure-tls";
+import { normalizeServiceUrl } from "@/lib/url-validation";
+import type { ServiceId } from "@/lib/constants";
+import type { ServiceInstance } from "@/store/config-store";
+import { useConfigStore } from "@/store/config-store";
+
+// Pull the bare hostname out of a (possibly scheme-less) service URL.
+// Returns null for blanks and unparseable values rather than throwing — a
+// half-typed URL in the editor shouldn't crash the sync.
+function hostOf(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const host = new URL(normalizeServiceUrl(trimmed)).hostname.toLowerCase();
+    return host.length > 0 ? host : null;
+  } catch {
+    return null;
+  }
+}
+
+// Collect the set of hostnames belonging to instances the user opted into
+// "ignore certificate errors". Both the local and remote URLs are included —
+// either may be the active one depending on the network, and the native layer
+// keys purely on hostname, so listing both keeps the bypass working after an
+// auto-switch without re-syncing.
+export function computeInsecureHosts(
+  serviceInstances: Record<ServiceId, ServiceInstance[]>,
+): string[] {
+  const hosts = new Set<string>();
+  for (const list of Object.values(serviceInstances)) {
+    for (const inst of list) {
+      if (!inst.ignoreCertErrors) continue;
+      const local = hostOf(inst.localUrl);
+      if (local) hosts.add(local);
+      const remote = hostOf(inst.remoteUrl);
+      if (remote) hosts.add(remote);
+    }
+  }
+  return Array.from(hosts).sort();
+}
+
+// Last allowlist pushed to native, serialized — lets us skip redundant bridge
+// calls when an unrelated config change fires the store subscription.
+let lastSynced = "";
+
+// Recompute the allowlist from current config and push it to the native module
+// if it changed. Safe to call on every config mutation. No-ops when the native
+// module is absent (Expo Go / web / pre-rebuild binary).
+export function syncInsecureHosts(): void {
+  const hosts = computeInsecureHosts(useConfigStore.getState().serviceInstances);
+  const serialized = hosts.join(",");
+  if (serialized === lastSynced) return;
+  lastSynced = serialized;
+  setInsecureHosts(hosts);
+}

--- a/modules/insecure-tls/android/.gitignore
+++ b/modules/insecure-tls/android/.gitignore
@@ -1,0 +1,5 @@
+build/
+.gradle/
+.cxx/
+local.properties
+*.iml

--- a/modules/insecure-tls/android/build.gradle
+++ b/modules/insecure-tls/android/build.gradle
@@ -13,3 +13,7 @@ android {
     versionName '1.0.0'
   }
 }
+
+dependencies {
+  implementation 'com.facebook.react:react-android'
+}

--- a/modules/insecure-tls/android/build.gradle
+++ b/modules/insecure-tls/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.insecuretls'
+version = '1.0.0'
+
+android {
+  namespace "expo.modules.insecuretls"
+  defaultConfig {
+    versionCode 1
+    versionName '1.0.0'
+  }
+}

--- a/modules/insecure-tls/android/src/main/AndroidManifest.xml
+++ b/modules/insecure-tls/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/modules/insecure-tls/android/src/main/java/expo/modules/insecuretls/InsecureHostStore.kt
+++ b/modules/insecure-tls/android/src/main/java/expo/modules/insecuretls/InsecureHostStore.kt
@@ -1,0 +1,23 @@
+package expo.modules.insecuretls
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Holds the set of hostnames the user opted into "ignore TLS certificate
+ * errors" for. Written from the JS thread via the module's `setInsecureHosts`,
+ * read from OkHttp's connection threads inside [HostAwareSSLSocketFactory] and
+ * the hostname verifier. An [AtomicReference] to an immutable set gives a
+ * lock-free read/replace.
+ */
+object InsecureHostStore {
+  private val hosts = AtomicReference<Set<String>>(emptySet())
+
+  fun setHosts(list: List<String>) {
+    hosts.set(list.map { it.lowercase() }.toSet())
+  }
+
+  fun isInsecure(host: String?): Boolean {
+    if (host.isNullOrEmpty()) return false
+    return hosts.get().contains(host.lowercase())
+  }
+}

--- a/modules/insecure-tls/android/src/main/java/expo/modules/insecuretls/InsecureTlsClientFactory.kt
+++ b/modules/insecure-tls/android/src/main/java/expo/modules/insecuretls/InsecureTlsClientFactory.kt
@@ -1,0 +1,132 @@
+package expo.modules.insecuretls
+
+import com.facebook.react.modules.network.OkHttpClientFactory
+import com.facebook.react.modules.network.OkHttpClientProvider
+import okhttp3.OkHttpClient
+import java.net.InetAddress
+import java.net.Socket
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Supplies React Native's networking stack with an OkHttpClient that skips TLS
+ * trust evaluation for hosts in [InsecureHostStore] — and only those hosts.
+ *
+ * Per-host (not global) is the whole point: OkHttp passes the target host to
+ * `SSLSocketFactory.createSocket(...)`, so [HostAwareSSLSocketFactory] can hand
+ * back a trust-all socket for an allowlisted host and a fully-validating one
+ * for everything else. Hostname verification is bypassed for the same hosts so
+ * a self-signed cert whose CN/SAN doesn't match still connects.
+ *
+ * Installed from MainApplication.onCreate (see plugins/withInsecureTls.js) so
+ * the factory is set before RN's NetworkingModule builds its client — and again
+ * from the module's OnCreate as a backstop.
+ */
+class InsecureTlsClientFactory : OkHttpClientFactory {
+  override fun createNewNetworkModuleClient(): OkHttpClient {
+    val socketFactory = HostAwareSSLSocketFactory(systemDefaultTrustManager())
+    // OkHttp's default hostname verifier, captured so non-allowlisted hosts
+    // keep normal verification.
+    val defaultVerifier = OkHttpClient().hostnameVerifier
+    val verifier = HostnameVerifier { hostname, session ->
+      if (InsecureHostStore.isInsecure(hostname)) true
+      else defaultVerifier.verify(hostname, session)
+    }
+    return OkHttpClientProvider.createClientBuilder()
+      // The trust manager passed here only feeds OkHttp's certificate-chain
+      // cleaner (used by CertificatePinner, which we don't configure). Actual
+      // handshake trust is governed per-host by `socketFactory`.
+      .sslSocketFactory(socketFactory, TRUST_ALL)
+      .hostnameVerifier(verifier)
+      .build()
+  }
+
+  companion object {
+    private val TRUST_ALL = object : X509TrustManager {
+      override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+      override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+      override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    @JvmStatic
+    fun install() {
+      OkHttpClientProvider.setOkHttpClientFactory(InsecureTlsClientFactory())
+    }
+
+    private fun systemDefaultTrustManager(): X509TrustManager {
+      val tmf =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+      tmf.init(null as KeyStore?)
+      return tmf.trustManagers.first { it is X509TrustManager } as X509TrustManager
+    }
+  }
+}
+
+/**
+ * Branches per target host: a trust-all SSLContext for allowlisted hosts, the
+ * platform default otherwise. The host arrives via the `createSocket` overloads
+ * OkHttp calls, so the decision is made fresh for every connection.
+ */
+private class HostAwareSSLSocketFactory(
+  defaultTrustManager: X509TrustManager,
+) : SSLSocketFactory() {
+  private val defaultFactory: SSLSocketFactory =
+    SSLContext.getInstance("TLS").apply {
+      init(null, arrayOf<TrustManager>(defaultTrustManager), SecureRandom())
+    }.socketFactory
+
+  private val trustAllFactory: SSLSocketFactory =
+    SSLContext.getInstance("TLS").apply {
+      init(null, arrayOf<TrustManager>(TRUST_ALL), SecureRandom())
+    }.socketFactory
+
+  private fun factoryFor(host: String?): SSLSocketFactory =
+    if (InsecureHostStore.isInsecure(host)) trustAllFactory else defaultFactory
+
+  override fun getDefaultCipherSuites(): Array<String> = defaultFactory.defaultCipherSuites
+
+  override fun getSupportedCipherSuites(): Array<String> = defaultFactory.supportedCipherSuites
+
+  // The overload OkHttp uses to upgrade a connected socket to TLS — `host` is
+  // the request's target hostname.
+  override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket =
+    factoryFor(host).createSocket(s, host, port, autoClose)
+
+  override fun createSocket(host: String, port: Int): Socket =
+    factoryFor(host).createSocket(host, port)
+
+  override fun createSocket(
+    host: String,
+    port: Int,
+    localHost: InetAddress,
+    localPort: Int,
+  ): Socket = factoryFor(host).createSocket(host, port, localHost, localPort)
+
+  override fun createSocket(host: InetAddress, port: Int): Socket =
+    factoryFor(host.hostName).createSocket(host, port)
+
+  override fun createSocket(
+    address: InetAddress,
+    port: Int,
+    localAddress: InetAddress,
+    localPort: Int,
+  ): Socket = factoryFor(address.hostName).createSocket(address, port, localAddress, localPort)
+
+  // OkHttp doesn't use the no-arg path; default to the validating factory.
+  override fun createSocket(): Socket = defaultFactory.createSocket()
+
+  private companion object {
+    val TRUST_ALL = object : X509TrustManager {
+      override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+      override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+      override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+  }
+}

--- a/modules/insecure-tls/android/src/main/java/expo/modules/insecuretls/InsecureTlsModule.kt
+++ b/modules/insecure-tls/android/src/main/java/expo/modules/insecuretls/InsecureTlsModule.kt
@@ -1,0 +1,22 @@
+package expo.modules.insecuretls
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class InsecureTlsModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("InsecureTls")
+
+    // Backstop install — the primary install runs from MainApplication.onCreate
+    // (plugins/withInsecureTls.js) so the OkHttp factory is in place before
+    // NetworkingModule constructs its client. Idempotent: setOkHttpClientFactory
+    // just swaps the static factory reference.
+    OnCreate {
+      InsecureTlsClientFactory.install()
+    }
+
+    Function("setInsecureHosts") { hosts: List<String> ->
+      InsecureHostStore.setHosts(hosts)
+    }
+  }
+}

--- a/modules/insecure-tls/expo-module.config.json
+++ b/modules/insecure-tls/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["InsecureTlsModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.insecuretls.InsecureTlsModule"]
+  }
+}

--- a/modules/insecure-tls/index.ts
+++ b/modules/insecure-tls/index.ts
@@ -1,0 +1,26 @@
+import { requireOptionalNativeModule } from "expo-modules-core";
+
+// Native binding for the per-host TLS-validation bypass. The module exposes a
+// single imperative call: push the set of hostnames the user has opted into
+// "ignore certificate errors" for, and the native layer (iOS NSURLSession
+// challenge handler / Android OkHttp socket factory) skips trust evaluation
+// for exactly those hosts and no others.
+//
+// `requireOptionalNativeModule` returns null when the native module isn't
+// present — Expo Go, web, or a JS bundle running against a binary built before
+// this module existed. Callers go through `lib/insecure-tls.ts`, which no-ops
+// in that case, so the app still runs (just without the bypass).
+interface InsecureTlsNativeModule {
+  // Replaces the allowlist wholesale. Hosts are lowercased hostnames without
+  // scheme or port (e.g. "192.168.1.50", "nas.local").
+  setInsecureHosts(hosts: string[]): void;
+}
+
+const nativeModule =
+  requireOptionalNativeModule<InsecureTlsNativeModule>("InsecureTls");
+
+export const isInsecureTlsAvailable = nativeModule != null;
+
+export function setInsecureHosts(hosts: string[]): void {
+  nativeModule?.setInsecureHosts(hosts);
+}

--- a/modules/insecure-tls/ios/InsecureTls.podspec
+++ b/modules/insecure-tls/ios/InsecureTls.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name           = 'InsecureTls'
+  s.version        = '1.0.0'
+  s.summary        = 'Per-host TLS certificate validation bypass for Dashboarr'
+  s.description    = 'Lets the user opt specific self-hosted hosts out of TLS certificate validation (self-signed / invalid certs).'
+  s.author         = 'Dashboarr'
+  s.homepage       = 'https://github.com/RenzoBeux/Dashboarr'
+  s.platforms      = { :ios => '15.1' }
+  s.swift_version  = '5.9'
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/insecure-tls/ios/InsecureTlsModule.swift
+++ b/modules/insecure-tls/ios/InsecureTlsModule.swift
@@ -1,0 +1,139 @@
+import ExpoModulesCore
+import ObjectiveC.runtime
+
+// MARK: - Allowlist store
+
+// Holds the set of hostnames the user opted into "ignore TLS certificate
+// errors" for. Written from the JS thread via `setInsecureHosts`, read from
+// NSURLSession's delegate queue inside the swizzled challenge handler — hence
+// the lock.
+final class InsecureTlsHostStore {
+  static let shared = InsecureTlsHostStore()
+  private let lock = NSLock()
+  private var hosts = Set<String>()
+
+  func set(_ newHosts: [String]) {
+    let normalized = Set(newHosts.map { $0.lowercased() })
+    lock.lock()
+    hosts = normalized
+    lock.unlock()
+  }
+
+  func contains(_ host: String) -> Bool {
+    let key = host.lowercased()
+    lock.lock()
+    defer { lock.unlock() }
+    return hosts.contains(key)
+  }
+}
+
+// MARK: - Swizzle
+
+// Block IMP for `-URLSession:didReceiveChallenge:completionHandler:`. Blocks
+// installed via `imp_implementationWithBlock` receive `self` as the first arg
+// and omit `_cmd`, so using `Any` for the receiver sidesteps the Swift
+// self-type mismatch you'd hit feeding a Swift instance method's IMP onto a
+// different class.
+private typealias ChallengeBlock = @convention(block) (
+  Any,
+  URLSession,
+  URLAuthenticationChallenge,
+  @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+) -> Void
+
+// C-function shape of the original IMP, used to chain to RN's implementation
+// if it already had one (includes the `_cmd` selector arg).
+private typealias ChallengeIMP = @convention(c) (
+  Any,
+  Selector,
+  URLSession,
+  URLAuthenticationChallenge,
+  @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+) -> Void
+
+// Used only to read the canonical Objective-C type encoding for the method we
+// add — more robust than hardcoding "v@:@@@?".
+private final class InsecureTlsSignatureProvider: NSObject {
+  @objc(URLSession:didReceiveChallenge:completionHandler:)
+  func urlSession(
+    _ session: URLSession,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {}
+}
+
+enum InsecureTlsSwizzler {
+  private static var installed = false
+  private static var originalIMP: IMP?
+  private static let selector = NSSelectorFromString(
+    "URLSession:didReceiveChallenge:completionHandler:"
+  )
+
+  // Installs an auth-challenge handler on RN's HTTP request handler class so
+  // server-trust challenges for allowlisted hosts are accepted. React Native's
+  // `fetch`/XHR all flow through RCTHTTPRequestHandler, so this covers every
+  // request the app makes via the JS networking stack. Idempotent.
+  static func installIfNeeded() {
+    guard !installed else { return }
+    installed = true
+
+    guard let cls = NSClassFromString("RCTHTTPRequestHandler") else {
+      // New-architecture or future RN rename — without the class there's
+      // nothing to patch; secure default behavior remains in force.
+      return
+    }
+
+    let block: ChallengeBlock = { receiver, session, challenge, completionHandler in
+      let space = challenge.protectionSpace
+      if space.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+        let trust = space.serverTrust,
+        InsecureTlsHostStore.shared.contains(space.host)
+      {
+        completionHandler(.useCredential, URLCredential(trust: trust))
+        return
+      }
+      // Not an allowlisted host (or not a server-trust challenge): preserve
+      // RN's original behavior when it had one, otherwise let the system
+      // perform its normal validation — which rejects untrusted certs.
+      if let original = originalIMP {
+        let fn = unsafeBitCast(original, to: ChallengeIMP.self)
+        fn(receiver, selector, session, challenge, completionHandler)
+      } else {
+        completionHandler(.performDefaultHandling, nil)
+      }
+    }
+    let newIMP = imp_implementationWithBlock(block)
+
+    if let existing = class_getInstanceMethod(cls, selector) {
+      // RN already handles the challenge — swap implementations so our handler
+      // runs first and can chain to the original for non-allowlisted hosts.
+      originalIMP = method_setImplementation(existing, newIMP)
+    } else {
+      // RN leaves server-trust to the default handler — add ours as the
+      // session-level handler so NSURLSession routes trust challenges to it.
+      let types =
+        method_getTypeEncoding(
+          class_getInstanceMethod(InsecureTlsSignatureProvider.self, selector)!
+        )
+      class_addMethod(cls, selector, newIMP, types)
+    }
+  }
+}
+
+// MARK: - Expo module
+
+public class InsecureTlsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("InsecureTls")
+
+    // Runs during module registration at app start — before the JS bundle
+    // issues any network request, so the handler is in place by first fetch.
+    OnCreate {
+      InsecureTlsSwizzler.installIfNeeded()
+    }
+
+    Function("setInsecureHosts") { (hosts: [String]) in
+      InsecureTlsHostStore.shared.set(hosts)
+    }
+  }
+}

--- a/plugins/withInsecureTls.js
+++ b/plugins/withInsecureTls.js
@@ -1,0 +1,51 @@
+const { withMainApplication } = require("expo/config-plugins");
+
+// Installs the per-host TLS-bypass OkHttp factory (from the local
+// `insecure-tls` Expo module) into MainApplication.onCreate.
+//
+// Why here and not just the module's OnCreate: React Native's NetworkingModule
+// builds its OkHttpClient via OkHttpClientProvider.createClient() the first
+// time JS makes a request, and that snapshots whatever factory is set at that
+// moment — OkHttpClientProvider does NOT rebuild the client when the factory
+// changes later. Setting the factory in Application.onCreate (which runs at
+// process start, before any JS) guarantees it's in place first. The factory
+// itself reads the allowlist lazily per-connection, so installing it early
+// with an empty allowlist is fine — `setInsecureHosts` fills it in later.
+const IMPORT_LINE = "import expo.modules.insecuretls.InsecureTlsClientFactory";
+const INSTALL_CALL = "InsecureTlsClientFactory.install()";
+
+function withInsecureTls(config) {
+  return withMainApplication(config, (config) => {
+    let contents = config.modResults.contents;
+
+    if (contents.includes(INSTALL_CALL)) {
+      return config; // already patched
+    }
+
+    // Add the import after the package declaration.
+    if (!contents.includes(IMPORT_LINE)) {
+      contents = contents.replace(
+        /^(package .+\n)/m,
+        `$1\n${IMPORT_LINE}\n`,
+      );
+    }
+
+    // Install the factory as the first thing after super.onCreate(), before
+    // loadReactNative(...) wires up the networking module.
+    const onCreateAnchor = "super.onCreate()";
+    if (!contents.includes(onCreateAnchor)) {
+      throw new Error(
+        "withInsecureTls: could not find `super.onCreate()` in MainApplication",
+      );
+    }
+    contents = contents.replace(
+      onCreateAnchor,
+      `${onCreateAnchor}\n    ${INSTALL_CALL}`,
+    );
+
+    config.modResults.contents = contents;
+    return config;
+  });
+}
+
+module.exports = withInsecureTls;

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -88,8 +88,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         attaches (auto-attach mode keeps the full set). Runtime fallback:
  *         when a dashboard has no entry for a kind, resolve to the first
  *         attached+enabled instance of that kind.
+ *   v23 — per-instance `ignoreCertErrors` on ServiceConfig (opt a server out
+ *         of TLS certificate validation). Pure version stamp — optional field,
+ *         absence means false.
  */
-export const CURRENT_CONFIG_VERSION = 22;
+export const CURRENT_CONFIG_VERSION = 23;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -492,6 +495,12 @@ const migrations: Record<number, (payload: any) => any> = {
     const { activeInstance: _drop, ...rest } = payload;
     return { ...rest, version: 22, dashboards };
   },
+
+  // v22 → v23: per-instance `ignoreCertErrors` (opt a server out of TLS
+  // certificate validation). Pure version stamp — the field is optional and
+  // absent means false, so older exports are already correct. The schema
+  // validator (coerceServiceInstance) coerces the field on import.
+  22: (payload) => ({ ...payload, version: 23 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -245,6 +245,26 @@ describe("validateExportPayload — service instance coercion", () => {
     expect(result.services.radarr[0].name).toBe("Radarr 4K");
     expect(result.services.radarr[1].name).toBe("Radarr 1080p");
   });
+
+  it("round-trips ignoreCertErrors=true (v23)", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      services: { radarr: [validInstance({ ignoreCertErrors: true })] },
+    });
+    expect(result.services.radarr[0].ignoreCertErrors).toBe(true);
+  });
+
+  it("defaults ignoreCertErrors to false when absent or non-boolean", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      services: {
+        radarr: [validInstance()],
+        sonarr: [validInstance({ id: "uuid-s", ignoreCertErrors: "yes" })],
+      },
+    });
+    expect(result.services.radarr[0].ignoreCertErrors).toBe(false);
+    expect(result.services.sonarr[0].ignoreCertErrors).toBe(false);
+  });
 });
 
 describe("validateExportPayload — service IDs (forward-compat silent drop)", () => {

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -74,6 +74,9 @@ function coerceServiceInstance(v: unknown): ServiceInstance | null {
     localUrl: v.localUrl,
     remoteUrl: v.remoteUrl,
     useRemote: v.useRemote,
+    // v23: optional. Coerce to a strict boolean so a missing/garbage value
+    // (older exports, hand-edited files) lands on the secure default.
+    ignoreCertErrors: v.ignoreCertErrors === true,
   };
 }
 

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -76,6 +76,12 @@ export interface ServiceConfig {
   localUrl: string;
   remoteUrl: string;
   useRemote: boolean;
+  // v23: opt this server out of TLS certificate validation (accept self-signed
+  // / otherwise-invalid certs). Per-instance and off by default. The hostnames
+  // of instances with this on are pushed to the native layer (see
+  // lib/insecure-tls.ts), which bypasses trust evaluation for exactly those
+  // hosts. Absent/undefined behaves like false.
+  ignoreCertErrors?: boolean;
 }
 
 // A configured service instance: a ServiceConfig plus a stable UUID `id` that
@@ -418,6 +424,7 @@ function defaultServiceConfig(id: ServiceId): ServiceConfig {
     localUrl: "",
     remoteUrl: "",
     useRemote: false,
+    ignoreCertErrors: false,
   };
 }
 


### PR DESCRIPTION
Closes #23.

Adds a per-service **"Allow invalid certificates"** toggle (Settings → service editor) so self-hosted services with self-signed/invalid certs can be reached over HTTPS. Per-host by design — the native layer bypasses TLS validation only for hosts you explicitly opt in, never globally.

## How it works
- **`modules/insecure-tls`** (new local Expo module) — `setInsecureHosts(hosts)`:
  - **iOS**: swizzles `RCTHTTPRequestHandler`'s `URLSession:didReceiveChallenge:`, accepting server trust only when the challenge host is allowlisted; everything else uses default validation.
  - **Android**: custom `OkHttpClientFactory` whose host-aware `SSLSocketFactory` uses a trust-all context only for allowlisted hosts (OkHttp passes the target host to `createSocket`), with a matching hostname verifier.
- **`plugins/withInsecureTls.js`** installs the OkHttp factory in `MainApplication.onCreate`, before RN's `NetworkingModule` builds its client.
- **Config**: `ServiceConfig.ignoreCertErrors` (v22→v23 migration + schema coercion + export/import round-trip). `_layout` pushes the allowlist of opted-in hosts (local + remote) to native on every config change; updates apply on the next request.
- `.gitignore`: un-ignore in-tree module native sources (the root `android/`/`ios/` rules were excluding them).

## Notes
- Requires a fresh native build (new fingerprint runtime) — **cannot ship via OTA**.