### PR TITLE
Enhancements: tags, qBit share limits, search-missing, episode actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,12 @@ Notes:
 - Pull-to-refresh on all screens
 - Haptic feedback on key interactions
 
+## Confirmations & Dialogs — MUST follow
+
+- **Never use React Native's native `Alert.alert` (or any OS-native dialog) for confirmations.** It looks out of place against the app's dark, styled UI. Always use the styled **`ConfirmModal`** from `components/common/confirm-modal.tsx` — state-driven (`visible` + `onConfirm` / `onCancel`), with `tone="danger"` for destructive actions and an optional `icon`. Reference: the "Search Missing" confirm in `app/(tabs)/tv.tsx` and the delete confirms in `app/series/[id].tsx` / `app/movie/[id].tsx`.
+- `ConfirmModal` is a two-button (cancel + confirm) dialog. For **3+ choices** (e.g. "Delete" vs "Delete + Files"), use the styled **`ActionSheet`** (`components/ui/action-sheet.tsx`) instead — never a multi-button native `Alert`.
+- For transient success/error feedback, use the **`toast`** / **`toastError`** helpers from `components/ui/toast.tsx`, not `Alert`.
+
 ## UI Scale (Accessibility) — MUST follow when writing any new UI
 
 The app exposes a global UI scale preference (1.0 / 1.15 / 1.3) wired via NativeWind v4's reactive `rem` observable. `app/_layout.tsx` calls `rem.set(14 * uiScale)` whenever the setting changes, which scales every rem-based style across the running app with no remount. **Every new UI element must scale with this setting.** The rules:

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,14 +1,11 @@
 import { useState, useMemo } from "react";
 import { View, Text, Pressable, ScrollView } from "react-native";
-import { Image } from "expo-image";
 import { useRouter } from "expo-router";
 import { useQueries } from "@tanstack/react-query";
 import {
   ChevronLeft,
   ChevronRight,
   ChevronDown,
-  Tv,
-  Film,
   Eye,
   EyeOff,
   Check,
@@ -28,8 +25,8 @@ import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
+import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { formatEpisodeCode, localDateKey } from "@/lib/utils";
-import { useServiceImage } from "@/hooks/use-service-image";
 import { lightHaptic } from "@/lib/haptics";
 import { getBoolean, setBoolean, getString, setString } from "@/store/storage";
 import type { ServiceId } from "@/lib/constants";
@@ -611,44 +608,15 @@ function EpisodeRow({
   episode: SonarrCalendarEntry;
   onPress: () => void;
 }) {
-  const poster = episode.series.images.find((i) => i.coverType === "poster");
-  const { src, onError } = useServiceImage(poster, "sonarr");
-
   return (
-    <Card onPress={onPress}>
-      <View className="flex-row items-center gap-3">
-        {src ? (
-          <Image
-            source={{ uri: src }}
-            className="w-10 h-14 rounded-lg bg-surface-light"
-            contentFit="cover"
-            cachePolicy="memory-disk"
-            transition={200}
-            recyclingKey={src}
-            onError={onError}
-          />
-        ) : (
-          <View className="w-10 h-14 rounded-lg bg-surface-light items-center justify-center">
-            <Icon icon={Tv} size={16} color="#71717a" />
-          </View>
-        )}
-        <View
-          className={`w-1 h-10 rounded-full ${
-            episode.hasFile ? "bg-success" : "bg-zinc-600"
-          }`}
-        />
-        <View className="flex-1">
-          <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
-            {episode.series.title}
-          </Text>
-          <Text className="text-zinc-500 text-xs">
-            {formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} —{" "}
-            {episode.title}
-          </Text>
-        </View>
-        <Icon icon={Tv} size={14} color="#22c55e" />
-      </View>
-    </Card>
+    <CalendarEventRow
+      images={episode.series.images}
+      service="sonarr"
+      title={episode.series.title}
+      subtitle={`${formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} — ${episode.title}`}
+      hasFile={episode.hasFile}
+      onPress={onPress}
+    />
   );
 }
 
@@ -659,44 +627,15 @@ function MovieRow({
   movie: RadarrMovie;
   onPress: () => void;
 }) {
-  const releaseType = getMovieReleaseType(movie);
-  const poster = movie.images.find((i) => i.coverType === "poster");
-  const { src, onError } = useServiceImage(poster, "radarr");
-
   return (
-    <Card onPress={onPress}>
-      <View className="flex-row items-center gap-3">
-        {src ? (
-          <Image
-            source={{ uri: src }}
-            className="w-10 h-14 rounded-lg bg-surface-light"
-            contentFit="cover"
-            cachePolicy="memory-disk"
-            transition={200}
-            recyclingKey={src}
-            onError={onError}
-          />
-        ) : (
-          <View className="w-10 h-14 rounded-lg bg-surface-light items-center justify-center">
-            <Icon icon={Film} size={16} color="#71717a" />
-          </View>
-        )}
-        <View
-          className={`w-1 h-10 rounded-full ${
-            movie.hasFile ? "bg-success" : "bg-zinc-600"
-          }`}
-        />
-        <View className="flex-1">
-          <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
-            {movie.title}
-          </Text>
-          <Text className="text-zinc-500 text-xs">
-            {movie.year} — {releaseType}
-          </Text>
-        </View>
-        <Icon icon={Film} size={14} color="#f59e0b" />
-      </View>
-    </Card>
+    <CalendarEventRow
+      images={movie.images}
+      service="radarr"
+      title={movie.title}
+      subtitle={`${movie.year} — ${getMovieReleaseType(movie)}`}
+      hasFile={movie.hasFile}
+      onPress={onPress}
+    />
   );
 }
 

--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -1,5 +1,6 @@
-import { View, Text } from "react-native";
-import { Cpu, MemoryStick, HardDrive, Activity, Gpu } from "lucide-react-native";
+import { View, Text, Pressable } from "react-native";
+import Animated, { FadeIn } from "react-native-reanimated";
+import { HardDrive, Activity, Gpu, ChevronDown, ChevronUp, Container } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -15,11 +16,14 @@ import {
   useGlancesFs,
   useGlancesDiskIO,
   useGlancesGpu,
+  useGlancesContainers,
 } from "@/hooks/use-glances";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
+import { useGlancesUiStore } from "@/store/glances-ui-store";
+import { lightHaptic } from "@/lib/haptics";
 import { formatBytes, formatSpeed } from "@/lib/utils";
-import type { GlancesFsItem, GlancesDiskIOItem, GlancesGpuItem } from "@/lib/types";
+import type { GlancesFsItem, GlancesDiskIOItem, GlancesGpuItem, GlancesContainerItem } from "@/lib/types";
 
 function usageBarColor(percent: number): string {
   if (percent >= 85) return "bg-red-500";
@@ -58,6 +62,7 @@ export default function GlancesScreen() {
         <GpuCard />
         <DisksCard />
         <DiskIOCard />
+        <ContainersCard />
       </View>
     </ScreenWrapper>
   );
@@ -67,6 +72,8 @@ function CpuCard() {
   const { data: cpu, isLoading: cpuLoading } = useGlancesCpu();
   const { data: perCpu, isLoading: perCpuLoading } = useGlancesPerCpu();
   const { data: load, isLoading: loadLoading } = useGlancesLoad();
+  const perCoreExpanded = useGlancesUiStore((s) => s.perCoreExpanded);
+  const setPerCoreExpanded = useGlancesUiStore((s) => s.setPerCoreExpanded);
 
   const isLoading = cpuLoading || perCpuLoading || loadLoading;
 
@@ -119,27 +126,46 @@ function CpuCard() {
 
           {perCpu && perCpu.length > 0 && (
             <View>
-              <Text className="text-zinc-500 text-xs font-semibold uppercase tracking-wider mb-2">
-                Per Core
-              </Text>
-              <View className="gap-1.5">
-                {perCpu.map((core) => (
-                  <View key={core.cpu_number} className="flex-row items-center gap-2">
-                    <Text className="text-zinc-500 text-xs w-10">
-                      Core {core.cpu_number}
-                    </Text>
-                    <View className="flex-1">
-                      <ProgressBar
-                        progress={pct(core.total) / 100}
-                        color={usageBarColor(pct(core.total))}
-                      />
+              <Pressable
+                onPress={() => {
+                  lightHaptic();
+                  setPerCoreExpanded(!perCoreExpanded);
+                }}
+                className="flex-row items-center justify-between active:opacity-70"
+              >
+                <Text className="text-zinc-500 text-xs font-semibold uppercase tracking-wider">
+                  Per Core
+                </Text>
+                <View className="flex-row items-center gap-2">
+                  <Text className="text-zinc-600 text-xs">{perCpu.length} cores</Text>
+                  <Icon
+                    icon={perCoreExpanded ? ChevronUp : ChevronDown}
+                    size={16}
+                    color="#71717a"
+                  />
+                </View>
+              </Pressable>
+
+              {perCoreExpanded && (
+                <Animated.View entering={FadeIn.duration(150)} className="gap-1.5 mt-2">
+                  {perCpu.map((core) => (
+                    <View key={core.cpu_number} className="flex-row items-center gap-2">
+                      <Text className="text-zinc-500 text-xs w-10">
+                        Core {core.cpu_number}
+                      </Text>
+                      <View className="flex-1">
+                        <ProgressBar
+                          progress={pct(core.total) / 100}
+                          color={usageBarColor(pct(core.total))}
+                        />
+                      </View>
+                      <Text className={`text-xs font-medium w-10 text-right ${usageTextColor(pct(core.total))}`}>
+                        {fmt(core.total, 0)}%
+                      </Text>
                     </View>
-                    <Text className={`text-xs font-medium w-10 text-right ${usageTextColor(pct(core.total))}`}>
-                      {fmt(core.total, 0)}%
-                    </Text>
-                  </View>
-                ))}
-              </View>
+                  ))}
+                </Animated.View>
+              )}
             </View>
           )}
         </View>
@@ -374,6 +400,127 @@ function DiskIORow({ drive }: { drive: GlancesDiskIOItem }) {
         <Text className="text-zinc-400 text-xs">R {formatSpeed(readRate)}</Text>
         <Text className="text-zinc-400 text-xs">W {formatSpeed(writeRate)}</Text>
       </View>
+    </View>
+  );
+}
+
+// Glances reports the raw engine status string (running, paused, exited, …).
+// Map each to a dot + text color so the list reads as a status board.
+function containerStatusStyle(status: string): { dot: string; text: string } {
+  const s = status.toLowerCase();
+  if (s === "running" || s === "healthy") return { dot: "bg-success", text: "text-success" };
+  if (s === "dead" || s === "unhealthy") return { dot: "bg-red-500", text: "text-red-400" };
+  if (["paused", "restarting", "created", "removing", "starting"].includes(s)) {
+    return { dot: "bg-amber-500", text: "text-amber-400" };
+  }
+  // exited / stopped / unknown — neutral "not running".
+  return { dot: "bg-zinc-600", text: "text-zinc-500" };
+}
+
+// Docker sends image as a single-element list of comma-joined tags; Podman and
+// some builds send a plain string. Collapse both to one readable tag.
+function containerImage(image: GlancesContainerItem["image"]): string {
+  if (!image) return "";
+  const joined = Array.isArray(image) ? image.join(", ") : image;
+  return joined.split(",")[0]?.trim() ?? "";
+}
+
+function isContainerRunning(status: string): boolean {
+  const s = status.toLowerCase();
+  return s === "running" || s === "healthy" || s === "starting";
+}
+
+function ContainersCard() {
+  const { data: containers, isLoading } = useGlancesContainers();
+  const expanded = useGlancesUiStore((s) => s.containersExpanded);
+  const setExpanded = useGlancesUiStore((s) => s.setContainersExpanded);
+
+  // Hide entirely when the host has no container engine — getContainers swallows
+  // the plugin's 404 into [], so an empty list isn't an error condition.
+  if (!isLoading && (!containers || containers.length === 0)) return null;
+
+  const runningCount = containers?.filter((c) => isContainerRunning(c.status)).length ?? 0;
+
+  return (
+    <Card>
+      <Pressable
+        onPress={() => {
+          lightHaptic();
+          setExpanded(!expanded);
+        }}
+        className="flex-row items-center justify-between active:opacity-70"
+      >
+        <View className="flex-row items-center gap-2">
+          <Icon icon={Container} size={18} color="#a1a1aa" />
+          <CardTitle>Containers</CardTitle>
+        </View>
+        <View className="flex-row items-center gap-2">
+          {containers && (
+            <Text className="text-zinc-500 text-xs">
+              {runningCount}/{containers.length} running
+            </Text>
+          )}
+          <Icon icon={expanded ? ChevronUp : ChevronDown} size={18} color="#71717a" />
+        </View>
+      </Pressable>
+
+      {isLoading ? (
+        <View className="mt-4">
+          <SkeletonCardContent rows={3} />
+        </View>
+      ) : expanded ? (
+        <Animated.View entering={FadeIn.duration(150)} className="gap-3 mt-4">
+          {/* Running first, then by name — keeps the active set at the top. */}
+          {[...containers!]
+            .sort((a, b) => {
+              const ra = isContainerRunning(a.status) ? 0 : 1;
+              const rb = isContainerRunning(b.status) ? 0 : 1;
+              return ra - rb || a.name.localeCompare(b.name);
+            })
+            .map((c) => (
+              <ContainerRow key={c.id || c.name} container={c} />
+            ))}
+        </Animated.View>
+      ) : null}
+    </Card>
+  );
+}
+
+function ContainerRow({ container }: { container: GlancesContainerItem }) {
+  const style = containerStatusStyle(container.status);
+  const running = isContainerRunning(container.status);
+  const image = containerImage(container.image);
+  const cpu = typeof container.cpu_percent === "number" ? container.cpu_percent : null;
+  const mem = typeof container.memory_usage === "number" ? container.memory_usage : null;
+
+  return (
+    <View className="flex-row items-center gap-3">
+      <View className={`w-2 h-2 rounded-full ${style.dot}`} />
+      <View className="flex-1 mr-2">
+        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
+          {container.name}
+        </Text>
+        <View className="flex-row items-center gap-2">
+          <Text className={`text-xs ${style.text}`}>{container.status}</Text>
+          {image ? (
+            <Text className="text-zinc-600 text-xs flex-1" numberOfLines={1}>
+              {image}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+      {running && (cpu !== null || mem !== null) && (
+        <View className="items-end">
+          {cpu !== null && (
+            <Text className={`text-xs font-medium ${usageTextColor(cpu)}`}>
+              {fmt(cpu, 1)}%
+            </Text>
+          )}
+          {mem !== null && (
+            <Text className="text-zinc-500 text-xs">{formatBytes(mem)}</Text>
+          )}
+        </View>
+      )}
     </View>
   );
 }

--- a/app/(tabs)/jellyfin.tsx
+++ b/app/(tabs)/jellyfin.tsx
@@ -98,15 +98,14 @@ export default function JellyfinScreen() {
   const [recentSortOpen, setRecentSortOpen] = useState(false);
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["jellyfin"]]);
-  const { horizontalPadding } = usePosterCellLayout();
   const bottomPadding = useScreenBottomPadding();
   const uiScale = useUiScale();
 
   const jellyfinHealth = healthData?.find((s) => s.id === "jellyfin");
 
-  // pt-2 = 0.5rem; matched at runtime so accessibility scale applies.
+  // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
+  // here. pt = 0.5rem, matched at runtime so accessibility scale applies.
   const contentContainerStyle = {
-    paddingHorizontal: horizontalPadding,
     paddingTop: 7 * uiScale,
     paddingBottom: bottomPadding,
   };

--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -40,7 +40,6 @@ import {
 } from "@/hooks/use-radarr";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
-import { usePosterCellLayout } from "@/hooks/use-poster-cell";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { mediumHaptic } from "@/lib/haptics";
 import { BAR_KIND_COLOR, cornerColorFor, radarrBarKind } from "@/lib/arr-poster-status";
@@ -116,7 +115,6 @@ export default function MoviesScreen() {
   const router = useRouter();
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["radarr"]]);
-  const { horizontalPadding } = usePosterCellLayout();
   const bottomPadding = useScreenBottomPadding();
   const uiScale = useUiScale();
 
@@ -196,9 +194,9 @@ export default function MoviesScreen() {
     setSheetTarget({ kind: "queue", item });
   };
 
-  // pt-2 = 0.5rem; matched at runtime so accessibility scale applies.
+  // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
+  // here. pt = 0.5rem, matched at runtime so accessibility scale applies.
   const contentContainerStyle = {
-    paddingHorizontal: horizontalPadding,
     paddingTop: 7 * uiScale,
     paddingBottom: bottomPadding,
   };

--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -43,6 +43,7 @@ import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { usePosterCellLayout } from "@/hooks/use-poster-cell";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { mediumHaptic } from "@/lib/haptics";
+import { BAR_KIND_COLOR, cornerColorFor, radarrBarKind } from "@/lib/arr-poster-status";
 import type { RadarrMovie, RadarrQueueItem } from "@/lib/types";
 
 type MovieSheetTarget =
@@ -321,7 +322,13 @@ function MovieLibrary({
   contentContainerStyle: React.ComponentProps<typeof MonitoredLibraryGrid>["contentContainerStyle"];
 }) {
   const { data: movies, isLoading, error } = useRadarrMovies();
+  const { data: queue } = useRadarrQueue();
   const router = useRouter();
+
+  const downloading = useMemo(
+    () => new Set((queue?.records ?? []).map((r) => r.movieId)),
+    [queue],
+  );
 
   return (
     <MonitoredLibraryGrid
@@ -335,6 +342,10 @@ function MovieLibrary({
       placeholderIcon={Film}
       nounPlural="movies"
       renderFooter={(m) => String(m.year)}
+      posterStatus={(m) => ({
+        barColor: BAR_KIND_COLOR[radarrBarKind(m, downloading.has(m.id))],
+        cornerColor: cornerColorFor(m.status),
+      })}
       onItemPress={(m) => router.push(`/movie/${m.id}`)}
       onItemLongPress={onLongPress}
       ListHeaderComponent={listHeader}

--- a/app/(tabs)/plex.tsx
+++ b/app/(tabs)/plex.tsx
@@ -92,15 +92,14 @@ export default function PlexScreen() {
   const [recentSortOpen, setRecentSortOpen] = useState(false);
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["plex"]]);
-  const { horizontalPadding } = usePosterCellLayout();
   const bottomPadding = useScreenBottomPadding();
   const uiScale = useUiScale();
 
   const plexHealth = healthData?.find((s) => s.id === "plex");
 
-  // pt-2 = 0.5rem; matched at runtime so accessibility scale applies.
+  // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
+  // here. pt = 0.5rem, matched at runtime so accessibility scale applies.
   const contentContainerStyle = {
-    paddingHorizontal: horizontalPadding,
     paddingTop: 7 * uiScale,
     paddingBottom: bottomPadding,
   };

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -30,12 +30,14 @@ import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { ICON } from "@/lib/constants";
 import {
   useSonarrSeries,
+  useSonarrQueue,
   useSonarrCalendar,
   useSearchForSeries,
   useSearchForEpisodes,
   useToggleSeriesMonitored,
   useDeleteSeries,
 } from "@/hooks/use-sonarr";
+import { BAR_KIND_COLOR, cornerColorFor, sonarrBarKind } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { usePosterCellLayout } from "@/hooks/use-poster-cell";
@@ -329,7 +331,13 @@ function SeriesLibrary({
   contentContainerStyle: React.ComponentProps<typeof MonitoredLibraryGrid>["contentContainerStyle"];
 }) {
   const { data: series, isLoading, error } = useSonarrSeries();
+  const { data: queue } = useSonarrQueue();
   const router = useRouter();
+
+  const downloading = useMemo(
+    () => new Set((queue?.records ?? []).map((r) => r.seriesId)),
+    [queue],
+  );
 
   return (
     <MonitoredLibraryGrid
@@ -343,6 +351,10 @@ function SeriesLibrary({
       placeholderIcon={Tv}
       nounPlural="shows"
       renderFooter={(s) => `${s.seasonCount} season${s.seasonCount !== 1 ? "s" : ""}`}
+      posterStatus={(s) => ({
+        barColor: BAR_KIND_COLOR[sonarrBarKind(s, downloading.has(s.id))],
+        cornerColor: cornerColorFor(s.status),
+      })}
       onItemPress={(s) => router.push(`/series/${s.id}`)}
       onItemLongPress={onLongPress}
       ListHeaderComponent={listHeader}

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -40,7 +40,6 @@ import {
 import { BAR_KIND_COLOR, cornerColorFor, sonarrBarKind } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
-import { usePosterCellLayout } from "@/hooks/use-poster-cell";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { formatEpisodeCode, relativeDate, localDateKey } from "@/lib/utils";
 import { mediumHaptic } from "@/lib/haptics";
@@ -102,7 +101,6 @@ export default function TVScreen() {
   const router = useRouter();
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["sonarr"]]);
-  const { horizontalPadding } = usePosterCellLayout();
   const bottomPadding = useScreenBottomPadding();
   const uiScale = useUiScale();
 
@@ -206,9 +204,9 @@ export default function TVScreen() {
     setSheetTarget({ kind: "calendar", item: ep });
   };
 
-  // pt-2 = 0.5rem; matched at runtime so accessibility scale applies.
+  // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
+  // here. pt = 0.5rem, matched at runtime so accessibility scale applies.
   const contentContainerStyle = {
-    paddingHorizontal: horizontalPadding,
     paddingTop: 7 * uiScale,
     paddingBottom: bottomPadding,
   };

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -32,6 +32,7 @@ import {
   ActionSheet,
   type ActionSheetAction,
 } from "@/components/ui/action-sheet";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import {
@@ -126,6 +127,7 @@ export default function TVScreen() {
   const setSort = useSortStore((s) => s.setSeries);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [sheetTarget, setSheetTarget] = useState<SeriesSheetTarget>(null);
+  const [missingConfirmOpen, setMissingConfirmOpen] = useState(false);
   const router = useRouter();
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["sonarr"]]);
@@ -242,14 +244,7 @@ export default function TVScreen() {
 
   const handleSearchMissing = () => {
     mediumHaptic();
-    Alert.alert(
-      "Search Missing Episodes",
-      "Sonarr will search every monitored missing episode in your library. This can queue a lot of grabs at once.",
-      [
-        { text: "Cancel", style: "cancel" },
-        { text: "Search", onPress: () => searchMissing.mutate() },
-      ],
-    );
+    setMissingConfirmOpen(true);
   };
 
   // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
@@ -371,6 +366,19 @@ export default function TVScreen() {
         sortOptions={SORT_OPTIONS.map((o) => ({ key: o.key, label: o.label }))}
         sortValue={sort}
         onSortChange={setSort}
+      />
+
+      <ConfirmModal
+        visible={missingConfirmOpen}
+        title="Search Missing Episodes"
+        message="Sonarr will search every monitored missing episode in your library. This can queue a lot of grabs at once."
+        icon={ScanSearch}
+        confirmLabel="Search"
+        onConfirm={() => {
+          setMissingConfirmOpen(false);
+          searchMissing.mutate();
+        }}
+        onCancel={() => setMissingConfirmOpen(false)}
       />
     </ScreenWrapper>
   );

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -348,7 +348,15 @@ function SeriesLibrary({
       serviceId="sonarr"
       placeholderIcon={Tv}
       nounPlural="shows"
-      renderFooter={(s) => `${s.seasonCount} season${s.seasonCount !== 1 ? "s" : ""}`}
+      renderFooter={(s) => {
+        // Sonarr v3 /series has no top-level seasonCount; read statistics (or
+        // count non-special seasons), matching app/series/[id].tsx.
+        const count =
+          s.statistics?.seasonCount ??
+          s.seasons.filter((x) => x.seasonNumber > 0).length ??
+          0;
+        return `${count} season${count !== 1 ? "s" : ""}`;
+      }}
       posterStatus={(s) => ({
         barColor: BAR_KIND_COLOR[sonarrBarKind(s, downloading.has(s.id))],
         cornerColor: cornerColorFor(s.status),

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -9,15 +9,29 @@ import {
   type RefreshControlProps,
 } from "react-native";
 import { useRouter } from "expo-router";
-import { Search, Tv, Eye, EyeOff, Trash2, Info } from "lucide-react-native";
+import {
+  Search,
+  Tv,
+  Eye,
+  EyeOff,
+  Trash2,
+  Info,
+  ScanSearch,
+} from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
-import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
+import {
+  ScreenWrapper,
+  useScreenBottomPadding,
+} from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
 import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterChip } from "@/components/ui/filter-chip";
-import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
+import {
+  ActionSheet,
+  type ActionSheetAction,
+} from "@/components/ui/action-sheet";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import {
@@ -25,7 +39,11 @@ import {
   MONITOR_FILTER_OPTIONS,
   type MonitorFilter,
 } from "@/components/common/monitored-library-grid";
-import { useSortStore, SORT_DEFAULTS, type SeriesSortKey } from "@/store/sort-store";
+import {
+  useSortStore,
+  SORT_DEFAULTS,
+  type SeriesSortKey,
+} from "@/store/sort-store";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { ICON } from "@/lib/constants";
 import {
@@ -34,10 +52,15 @@ import {
   useSonarrCalendar,
   useSearchForSeries,
   useSearchForEpisodes,
+  useSearchAllMissingEpisodes,
   useToggleSeriesMonitored,
   useDeleteSeries,
 } from "@/hooks/use-sonarr";
-import { BAR_KIND_COLOR, cornerColorFor, sonarrBarKind } from "@/lib/arr-poster-status";
+import {
+  BAR_KIND_COLOR,
+  cornerColorFor,
+  sonarrBarKind,
+} from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useUiScale } from "@/hooks/use-ui-scale";
@@ -62,7 +85,11 @@ const SORT_OPTIONS: { key: SeriesSortKey; label: string }[] = [
   { key: "size-desc", label: "Size: Largest First" },
 ];
 
-function compareSeries(a: SonarrSeries, b: SonarrSeries, sort: SeriesSortKey): number {
+function compareSeries(
+  a: SonarrSeries,
+  b: SonarrSeries,
+  sort: SeriesSortKey,
+): number {
   switch (sort) {
     case "added-desc":
       return new Date(b.added).getTime() - new Date(a.added).getTime();
@@ -93,7 +120,8 @@ function compareSeries(a: SonarrSeries, b: SonarrSeries, sort: SeriesSortKey): n
 
 export default function TVScreen() {
   const [tab, setTab] = useState<Tab>("library");
-  const [monitorFilter, setMonitorFilter] = useState<MonitorFilter>("monitored");
+  const [monitorFilter, setMonitorFilter] =
+    useState<MonitorFilter>("monitored");
   const sort = useSortStore((s) => s.series);
   const setSort = useSortStore((s) => s.setSeries);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
@@ -106,6 +134,7 @@ export default function TVScreen() {
 
   const searchSeries = useSearchForSeries();
   const searchEpisodes = useSearchForEpisodes();
+  const searchMissing = useSearchAllMissingEpisodes();
   const toggleMonitor = useToggleSeriesMonitored();
   const deleteMutation = useDeleteSeries();
 
@@ -178,7 +207,14 @@ export default function TVScreen() {
         onPress: () => router.push(`/series/${ep.seriesId}`),
       },
     ];
-  }, [sheetTarget, searchSeries, searchEpisodes, toggleMonitor, deleteMutation, router]);
+  }, [
+    sheetTarget,
+    searchSeries,
+    searchEpisodes,
+    toggleMonitor,
+    deleteMutation,
+    router,
+  ]);
 
   const sheetTitle =
     sheetTarget?.kind === "series"
@@ -204,6 +240,18 @@ export default function TVScreen() {
     setSheetTarget({ kind: "calendar", item: ep });
   };
 
+  const handleSearchMissing = () => {
+    mediumHaptic();
+    Alert.alert(
+      "Search Missing Episodes",
+      "Sonarr will search every monitored missing episode in your library. This can queue a lot of grabs at once.",
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Search", onPress: () => searchMissing.mutate() },
+      ],
+    );
+  };
+
   // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
   // here. pt = 0.5rem, matched at runtime so accessibility scale applies.
   const contentContainerStyle = {
@@ -224,13 +272,28 @@ export default function TVScreen() {
   const header = (
     <>
       <View className="flex-row items-center justify-between">
-        <ServiceHeader name="TV Shows" online={sonarrHealth?.online} serviceId="sonarr" />
-        <Pressable
-          onPress={() => router.push("/series/search")}
-          className="p-2 active:opacity-70"
-        >
-          <Icon icon={Search} size={ICON.LG} color="#a1a1aa" />
-        </Pressable>
+        <ServiceHeader
+          name="TV Shows"
+          online={sonarrHealth?.online}
+          serviceId="sonarr"
+        />
+        <View className="flex-row items-center">
+          <Pressable
+            onPress={handleSearchMissing}
+            disabled={searchMissing.isPending}
+            className="p-2 active:opacity-70"
+            accessibilityLabel="Search all missing episodes"
+          >
+            <Icon icon={ScanSearch} size={ICON.LG} color="#a1a1aa" />
+          </Pressable>
+          <Pressable
+            onPress={() => router.push("/series/search")}
+            className="p-2 active:opacity-70"
+            accessibilityLabel="Add series"
+          >
+            <Icon icon={Search} size={ICON.LG} color="#a1a1aa" />
+          </Pressable>
+        </View>
       </View>
 
       <ScrollView
@@ -326,7 +389,9 @@ function SeriesLibrary({
   onLongPress: (series: SonarrSeries) => void;
   listHeader: React.ReactElement;
   refreshControl: React.ReactElement<RefreshControlProps>;
-  contentContainerStyle: React.ComponentProps<typeof MonitoredLibraryGrid>["contentContainerStyle"];
+  contentContainerStyle: React.ComponentProps<
+    typeof MonitoredLibraryGrid
+  >["contentContainerStyle"];
 }) {
   const { data: series, isLoading, error } = useSonarrSeries();
   const { data: queue } = useSonarrQueue();
@@ -370,7 +435,11 @@ function SeriesLibrary({
   );
 }
 
-function CalendarView({ onLongPress }: { onLongPress: (ep: SonarrCalendarEntry) => void }) {
+function CalendarView({
+  onLongPress,
+}: {
+  onLongPress: (ep: SonarrCalendarEntry) => void;
+}) {
   const { data: episodes, isLoading, error } = useSonarrCalendar();
   const router = useRouter();
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,7 @@ import { rem } from "nativewind";
 import { useConfigStore } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
 import { useSortStore } from "@/store/sort-store";
+import { useGlancesUiStore } from "@/store/glances-ui-store";
 import { useIntroStore } from "@/store/intro-store";
 import { queryClient } from "@/lib/query-client";
 import { configureNotifications } from "@/lib/notifications";
@@ -222,6 +223,7 @@ export default function RootLayout() {
   const demoMode = useConfigStore((s) => s.demoMode);
   const hydrateBackend = useBackendStore((s) => s.hydrate);
   const hydrateSort = useSortStore((s) => s.hydrate);
+  const hydrateGlancesUi = useGlancesUiStore((s) => s.hydrate);
   const hydrateIntro = useIntroStore((s) => s.hydrate);
   const introHydrated = useIntroStore((s) => s.hydrated);
   const introSeen = useIntroStore((s) => s.workspaceIntroSeen);
@@ -239,9 +241,10 @@ export default function RootLayout() {
   useEffect(() => {
     if (hydrated) {
       hydrateSort();
+      hydrateGlancesUi();
       hydrateIntro();
     }
-  }, [hydrated, hydrateSort, hydrateIntro]);
+  }, [hydrated, hydrateSort, hydrateGlancesUi, hydrateIntro]);
 
   // Intro overlay visibility: never auto-open during Demo Mode (user is
   // exploring fake data; an overlay on top would be noise). Re-mounts when

--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -37,6 +37,7 @@ import {
   useUpdateMovieQualityProfile,
   useRadarrRootFolders,
   useUpdateMovieRootFolder,
+  useRadarrTags,
 } from "@/hooks/use-radarr";
 import { useServiceImage } from "@/hooks/use-service-image";
 import {
@@ -61,6 +62,7 @@ export default function MovieDetailScreen() {
   const updateProfile = useUpdateMovieQualityProfile(instanceId);
   const { data: rootFolders } = useRadarrRootFolders(instanceId);
   const updateRootFolder = useUpdateMovieRootFolder(instanceId);
+  const { data: tags } = useRadarrTags(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
@@ -104,6 +106,11 @@ export default function MovieDetailScreen() {
   const qualityProfileName = qualityProfiles?.find(
     (p) => p.id === movie.qualityProfileId,
   )?.name;
+
+  const tagLabels =
+    movie.tags
+      ?.map((tagId) => tags?.find((t) => t.id === tagId)?.label)
+      .filter((label): label is string => !!label) ?? [];
 
   const handleToggleMonitor = () => {
     toggleMonitored.mutate({ movieId: movie.id, monitored: !movie.monitored });
@@ -227,6 +234,21 @@ export default function MovieDetailScreen() {
               >
                 {movie.genres.map((g) => (
                   <Badge key={g} label={g} variant="default" />
+                ))}
+              </ScrollView>
+            </View>
+          ) : null}
+
+          {tagLabels.length > 0 ? (
+            <View className="mb-5">
+              <SectionLabel>Tags</SectionLabel>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerClassName="gap-2"
+              >
+                {tagLabels.map((label) => (
+                  <Badge key={label} label={label} variant="info" />
                 ))}
               </ScrollView>
             </View>

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -37,6 +37,7 @@ import {
   useSonarrEpisodes,
   useSonarrEpisodeFiles,
   useToggleEpisodeMonitored,
+  useDeleteEpisodeFile,
   useToggleSeriesMonitored,
   useDeleteSeries,
   useSonarrQualityProfiles,
@@ -67,7 +68,11 @@ export default function SeriesDetailScreen() {
     instanceId?: string;
   }>();
   const router = useRouter();
-  const { data: series, isLoading, error } = useSonarrSeriesById(Number(id), instanceId);
+  const {
+    data: series,
+    isLoading,
+    error,
+  } = useSonarrSeriesById(Number(id), instanceId);
   const { data: episodes } = useSonarrEpisodes(Number(id), instanceId);
   const { data: episodeFiles } = useSonarrEpisodeFiles(Number(id), instanceId);
   const toggleSeries = useToggleSeriesMonitored(instanceId);
@@ -81,7 +86,9 @@ export default function SeriesDetailScreen() {
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
   const [rootFolderVisible, setRootFolderVisible] = useState(false);
-  const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(null);
+  const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(
+    null,
+  );
   const [pendingDelete, setPendingDelete] = useState<DeleteMode>(null);
 
   const episodeFileMap = useMemo(() => {
@@ -108,7 +115,11 @@ export default function SeriesDetailScreen() {
     return (
       <ScreenWrapper>
         <BackHeader />
-        <ErrorBanner error={error} title="Failed to load series" className="mt-4" />
+        <ErrorBanner
+          error={error}
+          title="Failed to load series"
+          className="mt-4"
+        />
       </ScreenWrapper>
     );
   }
@@ -570,9 +581,7 @@ function AboutRow({
       >
         {value}
       </Text>
-      {onPress ? (
-        <Icon icon={ChevronRight} size={14} color="#71717a" />
-      ) : null}
+      {onPress ? <Icon icon={ChevronRight} size={14} color="#71717a" /> : null}
     </>
   );
 
@@ -689,67 +698,103 @@ function EpisodeRow({
 }) {
   const router = useRouter();
   const toggleMonitored = useToggleEpisodeMonitored(instanceId);
+  const deleteFile = useDeleteEpisodeFile(instanceId);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const mediaInfo = episodeFile?.mediaInfo;
 
   return (
-    <View className="flex-row items-center py-1.5 border-b border-border/30">
-      <View
-        className={`w-1.5 h-6 rounded-full mr-2 ${
-          episode.hasFile ? "bg-success" : "bg-zinc-600"
-        }`}
-      />
-      <View className="flex-1">
-        <Text className="text-zinc-300 text-xs" numberOfLines={1}>
-          {formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} —{" "}
-          {episode.title}
-        </Text>
-        {mediaInfo ? (
-          <Text className="text-zinc-600 text-xs">
-            {formatResolution(mediaInfo.resolution)} · {mediaInfo.videoCodec} ·{" "}
-            {mediaInfo.audioCodec} {formatAudioChannels(mediaInfo.audioChannels)}
-            {mediaInfo.videoDynamicRangeType
-              ? ` · ${mediaInfo.videoDynamicRangeType}`
-              : ""}
-          </Text>
-        ) : episode.airDate ? (
-          <Text className="text-zinc-600 text-xs">{episode.airDate}</Text>
-        ) : null}
-      </View>
-      <Pressable
-        onPress={() =>
-          router.push(
-            `/series/releases/${seriesId}?episodeId=${episode.id}${
-              instanceId ? `&instanceId=${instanceId}` : ""
-            }`,
-          )
-        }
-        hitSlop={6}
-        className="p-1 active:opacity-70 mr-1"
-      >
-        <Icon icon={Search} size={12} color="#a1a1aa" />
-      </Pressable>
-      <Pressable
-        onPress={() =>
-          toggleMonitored.mutate({
-            episodeId: episode.id,
-            monitored: !episode.monitored,
-          })
-        }
-        disabled={toggleMonitored.isPending}
-        className={`p-1 active:opacity-70 ${toggleMonitored.isPending ? "opacity-50" : ""}`}
-        hitSlop={6}
-        accessibilityRole="button"
-        accessibilityLabel={
-          episode.monitored ? "Monitored — tap to unmonitor" : "Not monitored — tap to monitor"
-        }
-      >
-        <Icon
-          icon={Bookmark}
-          size={14}
-          color={episode.monitored ? "#3b82f6" : "#52525b"}
-          fill={episode.monitored ? "#3b82f6" : "transparent"}
+    <>
+      <View className="flex-row items-center py-1.5 border-b border-border/30">
+        <View
+          className={`w-1.5 h-6 rounded-full mr-2 ${
+            episode.hasFile ? "bg-success" : "bg-zinc-600"
+          }`}
         />
-      </Pressable>
-    </View>
+        <View className="flex-1">
+          <Text className="text-zinc-300 text-xs" numberOfLines={1}>
+            {formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} —{" "}
+            {episode.title}
+          </Text>
+          {mediaInfo ? (
+            <Text className="text-zinc-600 text-xs">
+              {formatResolution(mediaInfo.resolution)} · {mediaInfo.videoCodec}{" "}
+              · {mediaInfo.audioCodec}{" "}
+              {formatAudioChannels(mediaInfo.audioChannels)}
+              {mediaInfo.videoDynamicRangeType
+                ? ` · ${mediaInfo.videoDynamicRangeType}`
+                : ""}
+            </Text>
+          ) : episode.airDate ? (
+            <Text className="text-zinc-600 text-xs">{episode.airDate}</Text>
+          ) : null}
+        </View>
+        <Pressable
+          onPress={() =>
+            router.push(
+              `/series/releases/${seriesId}?episodeId=${episode.id}${
+                instanceId ? `&instanceId=${instanceId}` : ""
+              }`,
+            )
+          }
+          hitSlop={6}
+          className="p-1 active:opacity-70 mr-1"
+        >
+          <Icon icon={Search} size={12} color="#a1a1aa" />
+        </Pressable>
+        {episodeFile ? (
+          <Pressable
+            onPress={() => setConfirmDelete(true)}
+            disabled={deleteFile.isPending}
+            hitSlop={6}
+            className={`p-1 active:opacity-70 mr-1 ${deleteFile.isPending ? "opacity-50" : ""}`}
+            accessibilityRole="button"
+            accessibilityLabel="Delete episode file"
+          >
+            <Icon icon={Trash2} size={12} color="#ef4444" />
+          </Pressable>
+        ) : null}
+        <Pressable
+          onPress={() =>
+            toggleMonitored.mutate({
+              episodeId: episode.id,
+              monitored: !episode.monitored,
+            })
+          }
+          disabled={toggleMonitored.isPending}
+          className={`p-1 active:opacity-70 ${toggleMonitored.isPending ? "opacity-50" : ""}`}
+          hitSlop={6}
+          accessibilityRole="button"
+          accessibilityLabel={
+            episode.monitored
+              ? "Monitored — tap to unmonitor"
+              : "Not monitored — tap to monitor"
+          }
+        >
+          <Icon
+            icon={Bookmark}
+            size={14}
+            color={episode.monitored ? "#3b82f6" : "#52525b"}
+            fill={episode.monitored ? "#3b82f6" : "transparent"}
+          />
+        </Pressable>
+      </View>
+
+      <ConfirmModal
+        visible={confirmDelete}
+        title="Delete Episode File"
+        message={`Delete the file for ${formatEpisodeCode(
+          episode.seasonNumber,
+          episode.episodeNumber,
+        )}? The episode stays in the library but will be marked missing.`}
+        icon={Trash2}
+        tone="danger"
+        confirmLabel="Delete"
+        onConfirm={() => {
+          setConfirmDelete(false);
+          if (episodeFile) deleteFile.mutate(episodeFile.id);
+        }}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </>
   );
 }

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -655,7 +655,8 @@ function SeasonAccordion({
       {expanded && episodes && (
         <View className="mt-3 gap-1">
           {episodes
-            .sort((a, b) => a.episodeNumber - b.episodeNumber)
+            // Descending (latest episode first) to match Sonarr's web UI.
+            .sort((a, b) => b.episodeNumber - a.episodeNumber)
             .map((ep) => (
               <EpisodeRow
                 key={ep.id}

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -31,7 +31,10 @@ import { ExpandableText } from "@/components/common/expandable-text";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ProgressBar } from "@/components/ui/progress-bar";
-import { ActionSheet } from "@/components/ui/action-sheet";
+import {
+  ActionSheet,
+  type ActionSheetAction,
+} from "@/components/ui/action-sheet";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import {
   useSonarrSeriesById,
@@ -702,8 +705,39 @@ function EpisodeRow({
   const toggleMonitored = useToggleEpisodeMonitored(instanceId);
   const searchEpisode = useSearchForEpisodes(instanceId);
   const deleteFile = useDeleteEpisodeFile(instanceId);
+  const [sheetOpen, setSheetOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const mediaInfo = episodeFile?.mediaInfo;
+
+  // Search/delete live in the "⋯" sheet so the row stays uncluttered and the
+  // automatic-vs-interactive search distinction reads clearly as labeled rows.
+  const episodeActions: ActionSheetAction[] = [
+    {
+      label: "Automatic Search",
+      icon: <Icon icon={Search} size={20} color="#a1a1aa" />,
+      onPress: () => searchEpisode.mutate([episode.id]),
+    },
+    {
+      label: "Interactive Search",
+      icon: <Icon icon={UserSearch} size={20} color="#a1a1aa" />,
+      onPress: () =>
+        router.push(
+          `/series/releases/${seriesId}?episodeId=${episode.id}${
+            instanceId ? `&instanceId=${instanceId}` : ""
+          }`,
+        ),
+    },
+    ...(episodeFile
+      ? [
+          {
+            label: "Delete File",
+            icon: <Icon icon={Trash2} size={20} color="#ef4444" />,
+            variant: "danger" as const,
+            onPress: () => setConfirmDelete(true),
+          },
+        ]
+      : []),
+  ];
 
   return (
     <>
@@ -731,44 +765,7 @@ function EpisodeRow({
             <Text className="text-zinc-600 text-xs">{episode.airDate}</Text>
           ) : null}
         </View>
-        <View className="flex-row items-center gap-0.5">
-          <Pressable
-            onPress={() => searchEpisode.mutate([episode.id])}
-            disabled={searchEpisode.isPending}
-            hitSlop={8}
-            className={`p-1.5 active:opacity-70 ${searchEpisode.isPending ? "opacity-50" : ""}`}
-            accessibilityRole="button"
-            accessibilityLabel="Automatic search"
-          >
-            <Icon icon={Search} size={18} color="#a1a1aa" />
-          </Pressable>
-          <Pressable
-            onPress={() =>
-              router.push(
-                `/series/releases/${seriesId}?episodeId=${episode.id}${
-                  instanceId ? `&instanceId=${instanceId}` : ""
-                }`,
-              )
-            }
-            hitSlop={8}
-            className="p-1.5 active:opacity-70"
-            accessibilityRole="button"
-            accessibilityLabel="Interactive search"
-          >
-            <Icon icon={UserSearch} size={18} color="#a1a1aa" />
-          </Pressable>
-          {episodeFile ? (
-            <Pressable
-              onPress={() => setConfirmDelete(true)}
-              disabled={deleteFile.isPending}
-              hitSlop={8}
-              className={`p-1.5 active:opacity-70 ${deleteFile.isPending ? "opacity-50" : ""}`}
-              accessibilityRole="button"
-              accessibilityLabel="Delete episode file"
-            >
-              <Icon icon={Trash2} size={18} color="#ef4444" />
-            </Pressable>
-          ) : null}
+        <View className="flex-row items-center gap-1">
           <Pressable
             onPress={() =>
               toggleMonitored.mutate({
@@ -777,7 +774,7 @@ function EpisodeRow({
               })
             }
             disabled={toggleMonitored.isPending}
-            className={`p-1.5 active:opacity-70 ${toggleMonitored.isPending ? "opacity-50" : ""}`}
+            className={`p-2 active:opacity-70 ${toggleMonitored.isPending ? "opacity-50" : ""}`}
             hitSlop={8}
             accessibilityRole="button"
             accessibilityLabel={
@@ -793,8 +790,25 @@ function EpisodeRow({
               fill={episode.monitored ? "#3b82f6" : "transparent"}
             />
           </Pressable>
+          <Pressable
+            onPress={() => setSheetOpen(true)}
+            hitSlop={8}
+            className="p-2 active:opacity-70"
+            accessibilityRole="button"
+            accessibilityLabel="Episode actions"
+          >
+            <Icon icon={MoreHorizontal} size={18} color="#a1a1aa" />
+          </Pressable>
         </View>
       </View>
+
+      <ActionSheet
+        visible={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        title={formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)}
+        subtitle={episode.title}
+        actions={episodeActions}
+      />
 
       <ConfirmModal
         visible={confirmDelete}

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   Check,
   Search,
+  UserSearch,
   Trash2,
   Bookmark,
   MoreHorizontal,
@@ -38,6 +39,7 @@ import {
   useSonarrEpisodeFiles,
   useToggleEpisodeMonitored,
   useDeleteEpisodeFile,
+  useSearchForEpisodes,
   useToggleSeriesMonitored,
   useDeleteSeries,
   useSonarrQualityProfiles,
@@ -698,6 +700,7 @@ function EpisodeRow({
 }) {
   const router = useRouter();
   const toggleMonitored = useToggleEpisodeMonitored(instanceId);
+  const searchEpisode = useSearchForEpisodes(instanceId);
   const deleteFile = useDeleteEpisodeFile(instanceId);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const mediaInfo = episodeFile?.mediaInfo;
@@ -728,55 +731,69 @@ function EpisodeRow({
             <Text className="text-zinc-600 text-xs">{episode.airDate}</Text>
           ) : null}
         </View>
-        <Pressable
-          onPress={() =>
-            router.push(
-              `/series/releases/${seriesId}?episodeId=${episode.id}${
-                instanceId ? `&instanceId=${instanceId}` : ""
-              }`,
-            )
-          }
-          hitSlop={6}
-          className="p-1 active:opacity-70 mr-1"
-        >
-          <Icon icon={Search} size={12} color="#a1a1aa" />
-        </Pressable>
-        {episodeFile ? (
+        <View className="flex-row items-center gap-0.5">
           <Pressable
-            onPress={() => setConfirmDelete(true)}
-            disabled={deleteFile.isPending}
-            hitSlop={6}
-            className={`p-1 active:opacity-70 mr-1 ${deleteFile.isPending ? "opacity-50" : ""}`}
+            onPress={() => searchEpisode.mutate([episode.id])}
+            disabled={searchEpisode.isPending}
+            hitSlop={8}
+            className={`p-1.5 active:opacity-70 ${searchEpisode.isPending ? "opacity-50" : ""}`}
             accessibilityRole="button"
-            accessibilityLabel="Delete episode file"
+            accessibilityLabel="Automatic search"
           >
-            <Icon icon={Trash2} size={12} color="#ef4444" />
+            <Icon icon={Search} size={18} color="#a1a1aa" />
           </Pressable>
-        ) : null}
-        <Pressable
-          onPress={() =>
-            toggleMonitored.mutate({
-              episodeId: episode.id,
-              monitored: !episode.monitored,
-            })
-          }
-          disabled={toggleMonitored.isPending}
-          className={`p-1 active:opacity-70 ${toggleMonitored.isPending ? "opacity-50" : ""}`}
-          hitSlop={6}
-          accessibilityRole="button"
-          accessibilityLabel={
-            episode.monitored
-              ? "Monitored — tap to unmonitor"
-              : "Not monitored — tap to monitor"
-          }
-        >
-          <Icon
-            icon={Bookmark}
-            size={14}
-            color={episode.monitored ? "#3b82f6" : "#52525b"}
-            fill={episode.monitored ? "#3b82f6" : "transparent"}
-          />
-        </Pressable>
+          <Pressable
+            onPress={() =>
+              router.push(
+                `/series/releases/${seriesId}?episodeId=${episode.id}${
+                  instanceId ? `&instanceId=${instanceId}` : ""
+                }`,
+              )
+            }
+            hitSlop={8}
+            className="p-1.5 active:opacity-70"
+            accessibilityRole="button"
+            accessibilityLabel="Interactive search"
+          >
+            <Icon icon={UserSearch} size={18} color="#a1a1aa" />
+          </Pressable>
+          {episodeFile ? (
+            <Pressable
+              onPress={() => setConfirmDelete(true)}
+              disabled={deleteFile.isPending}
+              hitSlop={8}
+              className={`p-1.5 active:opacity-70 ${deleteFile.isPending ? "opacity-50" : ""}`}
+              accessibilityRole="button"
+              accessibilityLabel="Delete episode file"
+            >
+              <Icon icon={Trash2} size={18} color="#ef4444" />
+            </Pressable>
+          ) : null}
+          <Pressable
+            onPress={() =>
+              toggleMonitored.mutate({
+                episodeId: episode.id,
+                monitored: !episode.monitored,
+              })
+            }
+            disabled={toggleMonitored.isPending}
+            className={`p-1.5 active:opacity-70 ${toggleMonitored.isPending ? "opacity-50" : ""}`}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={
+              episode.monitored
+                ? "Monitored — tap to unmonitor"
+                : "Not monitored — tap to monitor"
+            }
+          >
+            <Icon
+              icon={Bookmark}
+              size={18}
+              color={episode.monitored ? "#3b82f6" : "#52525b"}
+              fill={episode.monitored ? "#3b82f6" : "transparent"}
+            />
+          </Pressable>
+        </View>
       </View>
 
       <ConfirmModal

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -43,6 +43,7 @@ import {
   useUpdateSeriesQualityProfile,
   useSonarrRootFolders,
   useUpdateSeriesRootFolder,
+  useSonarrTags,
 } from "@/hooks/use-sonarr";
 import {
   formatEpisodeCode,
@@ -75,6 +76,7 @@ export default function SeriesDetailScreen() {
   const updateProfile = useUpdateSeriesQualityProfile(instanceId);
   const { data: rootFolders } = useSonarrRootFolders(instanceId);
   const updateRootFolder = useUpdateSeriesRootFolder(instanceId);
+  const { data: tags } = useSonarrTags(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
@@ -129,6 +131,11 @@ export default function SeriesDetailScreen() {
   const qualityProfileName = qualityProfiles?.find(
     (p) => p.id === series.qualityProfileId,
   )?.name;
+
+  const tagLabels =
+    series.tags
+      ?.map((tagId) => tags?.find((t) => t.id === tagId)?.label)
+      .filter((label): label is string => !!label) ?? [];
 
   const handleToggleMonitor = () => {
     toggleSeries.mutate({ seriesId: series.id, monitored: !series.monitored });
@@ -236,6 +243,21 @@ export default function SeriesDetailScreen() {
               >
                 {series.genres.map((g) => (
                   <Badge key={g} label={g} variant="default" />
+                ))}
+              </ScrollView>
+            </View>
+          ) : null}
+
+          {tagLabels.length > 0 ? (
+            <View className="mb-5">
+              <SectionLabel>Tags</SectionLabel>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerClassName="gap-2"
+              >
+                {tagLabels.map((label) => (
+                  <Badge key={label} label={label} variant="info" />
                 ))}
               </ScrollView>
             </View>

--- a/app/torrent/[hash].tsx
+++ b/app/torrent/[hash].tsx
@@ -1,6 +1,14 @@
+import { useState } from "react";
 import { View, Text, Alert, ActivityIndicator } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { Pause, Play, Trash2, ArrowDown, ArrowUp } from "lucide-react-native";
+import {
+  Pause,
+  Play,
+  Trash2,
+  ArrowDown,
+  ArrowUp,
+  Gauge,
+} from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
@@ -9,6 +17,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Button } from "@/components/ui/button";
+import { ShareLimitsSheet } from "@/components/qbittorrent/share-limits-sheet";
 import {
   useTorrent,
   useTorrentFiles,
@@ -29,19 +38,26 @@ export default function TorrentDetailScreen() {
   const pauseMutation = usePauseTorrent();
   const resumeMutation = useResumeTorrent();
   const deleteMutation = useDeleteTorrent();
+  const [shareLimitsOpen, setShareLimitsOpen] = useState(false);
 
   if (!torrent) {
     return (
       <ScreenWrapper>
         <BackHeader />
         {error ? (
-          <ErrorBanner error={error} title="Failed to load torrent" className="mt-4" />
+          <ErrorBanner
+            error={error}
+            title="Failed to load torrent"
+            className="mt-4"
+          />
         ) : isLoading ? (
           <View className="items-center justify-center mt-10">
             <ActivityIndicator color="#3b82f6" />
           </View>
         ) : (
-          <Text className="text-zinc-400 text-center mt-10">Torrent not found</Text>
+          <Text className="text-zinc-400 text-center mt-10">
+            Torrent not found
+          </Text>
         )}
       </ScreenWrapper>
     );
@@ -72,106 +88,153 @@ export default function TorrentDetailScreen() {
   };
 
   return (
-    <ScreenWrapper>
-      <BackHeader />
-      {/* Header */}
-      <Text className="text-zinc-100 text-lg font-bold mb-1">
-        {torrent.name}
-      </Text>
-      <Badge
-        label={torrent.state}
-        variant={isPaused ? "paused" : "downloading"}
-        className="self-start mb-4"
-      />
+    <>
+      <ScreenWrapper>
+        <BackHeader />
+        {/* Header */}
+        <Text className="text-zinc-100 text-lg font-bold mb-1">
+          {torrent.name}
+        </Text>
+        <Badge
+          label={torrent.state}
+          variant={isPaused ? "paused" : "downloading"}
+          className="self-start mb-4"
+        />
 
-      {/* Progress */}
-      <Card className="mb-4">
-        <ProgressBar progress={torrent.progress} showLabel className="mb-3" />
-        <View className="flex-row justify-between">
-          <View className="flex-row items-center gap-1">
-            <Icon icon={ArrowDown} size={14} color="#3b82f6" />
-            <Text className="text-zinc-300 text-sm">
-              {formatSpeed(torrent.dlspeed)}
-            </Text>
-          </View>
-          <View className="flex-row items-center gap-1">
-            <Icon icon={ArrowUp} size={14} color="#22c55e" />
-            <Text className="text-zinc-300 text-sm">
-              {formatSpeed(torrent.upspeed)}
-            </Text>
-          </View>
-          {torrent.eta > 0 && torrent.eta < 8640000 && (
-            <Text className="text-zinc-400 text-sm">ETA {formatEta(torrent.eta)}</Text>
-          )}
-        </View>
-      </Card>
-
-      {/* Info */}
-      <Card className="mb-4 gap-2">
-        <InfoRow label="Size" value={formatBytes(torrent.size)} />
-        <InfoRow label="Downloaded" value={formatBytes(torrent.downloaded)} />
-        <InfoRow label="Uploaded" value={formatBytes(torrent.uploaded)} />
-        <InfoRow label="Ratio" value={torrent.ratio.toFixed(2)} />
-        <InfoRow label="Seeds" value={String(torrent.num_seeds)} />
-        <InfoRow label="Peers" value={String(torrent.num_leechs)} />
-        <InfoRow label="Save Path" value={torrent.save_path} />
-      </Card>
-
-      {/* Files */}
-      {files && files.length > 0 && (
+        {/* Progress */}
         <Card className="mb-4">
-          <Text className="text-zinc-400 text-xs font-semibold uppercase mb-2">
-            Files ({files.length})
-          </Text>
-          {files.slice(0, 10).map((file) => (
-            <View key={file.index} className="py-1.5 border-b border-border/50">
-              <Text className="text-zinc-300 text-xs" numberOfLines={1}>
-                {file.name}
-              </Text>
-              <Text className="text-zinc-500 text-xs">
-                {formatBytes(file.size)} — {Math.round(file.progress * 100)}%
+          <ProgressBar progress={torrent.progress} showLabel className="mb-3" />
+          <View className="flex-row justify-between">
+            <View className="flex-row items-center gap-1">
+              <Icon icon={ArrowDown} size={14} color="#3b82f6" />
+              <Text className="text-zinc-300 text-sm">
+                {formatSpeed(torrent.dlspeed)}
               </Text>
             </View>
-          ))}
-          {files.length > 10 && (
-            <Text className="text-zinc-500 text-xs mt-2">
-              +{files.length - 10} more files
-            </Text>
-          )}
+            <View className="flex-row items-center gap-1">
+              <Icon icon={ArrowUp} size={14} color="#22c55e" />
+              <Text className="text-zinc-300 text-sm">
+                {formatSpeed(torrent.upspeed)}
+              </Text>
+            </View>
+            {torrent.eta > 0 && torrent.eta < 8640000 && (
+              <Text className="text-zinc-400 text-sm">
+                ETA {formatEta(torrent.eta)}
+              </Text>
+            )}
+          </View>
         </Card>
-      )}
 
-      {/* Actions */}
-      <View className="flex-row gap-3">
+        {/* Info */}
+        <Card className="mb-4 gap-2">
+          <InfoRow label="Size" value={formatBytes(torrent.size)} />
+          <InfoRow label="Downloaded" value={formatBytes(torrent.downloaded)} />
+          <InfoRow label="Uploaded" value={formatBytes(torrent.uploaded)} />
+          <InfoRow label="Ratio" value={torrent.ratio.toFixed(2)} />
+          <InfoRow
+            label="Ratio Limit"
+            value={formatRatioLimit(torrent.ratio_limit)}
+          />
+          <InfoRow
+            label="Seed Time Limit"
+            value={formatSeedTimeLimit(torrent.seeding_time_limit)}
+          />
+          <InfoRow label="Seeds" value={String(torrent.num_seeds)} />
+          <InfoRow label="Peers" value={String(torrent.num_leechs)} />
+          <InfoRow label="Save Path" value={torrent.save_path} />
+        </Card>
+
+        {/* Files */}
+        {files && files.length > 0 && (
+          <Card className="mb-4">
+            <Text className="text-zinc-400 text-xs font-semibold uppercase mb-2">
+              Files ({files.length})
+            </Text>
+            {files.slice(0, 10).map((file) => (
+              <View
+                key={file.index}
+                className="py-1.5 border-b border-border/50"
+              >
+                <Text className="text-zinc-300 text-xs" numberOfLines={1}>
+                  {file.name}
+                </Text>
+                <Text className="text-zinc-500 text-xs">
+                  {formatBytes(file.size)} — {Math.round(file.progress * 100)}%
+                </Text>
+              </View>
+            ))}
+            {files.length > 10 && (
+              <Text className="text-zinc-500 text-xs mt-2">
+                +{files.length - 10} more files
+              </Text>
+            )}
+          </Card>
+        )}
+
+        {/* Actions */}
+        <View className="flex-row gap-3">
+          <Button
+            label={isPaused ? "Resume" : "Pause"}
+            variant="outline"
+            onPress={() =>
+              isPaused
+                ? resumeMutation.mutate([hash])
+                : pauseMutation.mutate([hash])
+            }
+            loading={pauseMutation.isPending || resumeMutation.isPending}
+            icon={
+              isPaused ? (
+                <Icon icon={Play} size={16} color="#3b82f6" />
+              ) : (
+                <Icon icon={Pause} size={16} color="#f59e0b" />
+              )
+            }
+            className="flex-1"
+          />
+          <Button
+            label="Delete"
+            variant="danger"
+            onPress={handleDelete}
+            loading={deleteMutation.isPending}
+            icon={<Icon icon={Trash2} size={16} color="white" />}
+            className="flex-1"
+          />
+        </View>
+
         <Button
-          label={isPaused ? "Resume" : "Pause"}
+          label="Share Limits"
           variant="outline"
-          onPress={() =>
-            isPaused
-              ? resumeMutation.mutate([hash])
-              : pauseMutation.mutate([hash])
-          }
-          loading={pauseMutation.isPending || resumeMutation.isPending}
-          icon={
-            isPaused ? (
-              <Icon icon={Play} size={16} color="#3b82f6" />
-            ) : (
-              <Icon icon={Pause} size={16} color="#f59e0b" />
-            )
-          }
-          className="flex-1"
+          onPress={() => setShareLimitsOpen(true)}
+          icon={<Icon icon={Gauge} size={16} color="#a1a1aa" />}
+          className="mt-3"
         />
-        <Button
-          label="Delete"
-          variant="danger"
-          onPress={handleDelete}
-          loading={deleteMutation.isPending}
-          icon={<Icon icon={Trash2} size={16} color="white" />}
-          className="flex-1"
-        />
-      </View>
-    </ScreenWrapper>
+      </ScreenWrapper>
+
+      <ShareLimitsSheet
+        visible={shareLimitsOpen}
+        onClose={() => setShareLimitsOpen(false)}
+        hash={hash}
+        ratioLimit={torrent.ratio_limit ?? -2}
+        seedingTimeLimit={torrent.seeding_time_limit ?? -2}
+      />
+    </>
   );
+}
+
+// Share-limit sentinels from qBittorrent: -2 = use global, -1 = no limit.
+function formatRatioLimit(limit: number | undefined): string {
+  if (limit === undefined || limit === -2) return "Global";
+  if (limit === -1) return "Unlimited";
+  return limit.toFixed(2);
+}
+
+function formatSeedTimeLimit(minutes: number | undefined): string {
+  if (minutes === undefined || minutes === -2) return "Global";
+  if (minutes === -1) return "Unlimited";
+  if (minutes < 60) return `${minutes} min`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m ? `${h}h ${m}m` : `${h}h`;
 }
 
 function InfoRow({ label, value }: { label: string; value: string }) {

--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -1,0 +1,155 @@
+import { View, Text, Pressable } from "react-native";
+import { Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
+import { Tv, Film, Check, Download, type LucideIcon } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { useServiceImage } from "@/hooks/use-service-image";
+import { useUiScale } from "@/hooks/use-ui-scale";
+
+interface PosterImage {
+  coverType: string;
+  url: string;
+  remoteUrl: string;
+}
+
+// Row geometry (dp at scale 1.0; multiplied by uiScale at render). Matches the
+// backdrop-row proportions the dashboard used before.
+const ROW_HEIGHT = 64;
+const POSTER_W = 44;
+const POSTER_H = 56;
+
+// Downloaded vs not-yet-downloaded. The calendar lists *upcoming* releases, so
+// "not downloaded" is expected (not an error) — keep it neutral, not alarming.
+const DOWNLOADED = "#22c55e";
+const PENDING = "#52525b";
+
+const SERVICE_FALLBACK: Record<"sonarr" | "radarr", LucideIcon> = {
+  sonarr: Tv,
+  radarr: Film,
+};
+
+export interface CalendarEventRowProps {
+  images: PosterImage[];
+  service: "sonarr" | "radarr";
+  title: string;
+  subtitle: string;
+  /** Drives the status indicators: green when downloaded, gray when missing. */
+  hasFile: boolean;
+  onPress: () => void;
+}
+
+/**
+ * Shared "releasing soon" row used by both the Calendar tab (SelectedDayList)
+ * and the dashboard "Releasing Soon" card so they stay visually in lockstep.
+ *
+ * The backdrop (fanart) fills the row behind a left→right scrim; a colored left
+ * spine plus a status badge make it scannable at a glance: green check when the
+ * episode/movie is downloaded, a neutral download glyph when it still isn't.
+ */
+export function CalendarEventRow({
+  images,
+  service,
+  title,
+  subtitle,
+  hasFile,
+  onPress,
+}: CalendarEventRowProps) {
+  const scale = useUiScale();
+  const rowHeight = Math.round(ROW_HEIGHT * scale);
+  const posterW = Math.round(POSTER_W * scale);
+  const posterH = Math.round(POSTER_H * scale);
+
+  const poster = images.find((i) => i.coverType === "poster");
+  const fanart = images.find((i) => i.coverType === "fanart");
+  const { src: posterSrc, onError: onPosterError } = useServiceImage(poster, service);
+  const { src: backdropSrc, onError: onBackdropError } = useServiceImage(fanart, service);
+
+  const FallbackIcon = SERVICE_FALLBACK[service];
+  const statusColor = hasFile ? DOWNLOADED : PENDING;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className="active:opacity-80 overflow-hidden rounded-xl bg-surface-light"
+      style={{ height: rowHeight }}
+    >
+      {backdropSrc ? (
+        <Image
+          source={{ uri: backdropSrc }}
+          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          transition={200}
+          recyclingKey={backdropSrc}
+          onError={onBackdropError}
+        />
+      ) : null}
+
+      {/* Left→right dark scrim so the title stays legible over any backdrop. */}
+      <LinearGradient
+        colors={[
+          "rgba(15, 15, 17, 0.94)",
+          "rgba(15, 15, 17, 0.78)",
+          "rgba(15, 15, 17, 0.5)",
+        ]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 0 }}
+        style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+      />
+
+      {/* Status spine — quick scan cue down the list. */}
+      <View
+        className="absolute left-0 top-0 bottom-0 w-1"
+        style={{ backgroundColor: statusColor }}
+      />
+
+      <View className="flex-row items-center h-full pl-3 pr-3 gap-3">
+        <View
+          className="rounded-md overflow-hidden bg-surface"
+          style={{ width: posterW, height: posterH }}
+        >
+          {posterSrc ? (
+            <Image
+              source={{ uri: posterSrc }}
+              style={{ width: "100%", height: "100%" }}
+              contentFit="cover"
+              cachePolicy="memory-disk"
+              transition={200}
+              recyclingKey={posterSrc}
+              onError={onPosterError}
+            />
+          ) : (
+            <View className="w-full h-full items-center justify-center">
+              <Icon icon={FallbackIcon} size={18} color="#71717a" />
+            </View>
+          )}
+        </View>
+
+        <View className="flex-1">
+          <Text className="text-zinc-50 text-sm font-semibold" numberOfLines={1}>
+            {title}
+          </Text>
+          <Text className="text-zinc-300 text-xs" numberOfLines={1}>
+            {subtitle}
+          </Text>
+        </View>
+
+        {/* Status badge — explicit downloaded / not-yet state. */}
+        <View
+          className="w-7 h-7 rounded-full items-center justify-center"
+          style={{
+            backgroundColor: hasFile
+              ? "rgba(34, 197, 94, 0.2)"
+              : "rgba(255, 255, 255, 0.12)",
+          }}
+        >
+          <Icon
+            icon={hasFile ? Check : Download}
+            size={14}
+            color={hasFile ? DOWNLOADED : "#d4d4d8"}
+          />
+        </View>
+      </View>
+    </Pressable>
+  );
+}

--- a/components/common/monitored-library-grid.tsx
+++ b/components/common/monitored-library-grid.tsx
@@ -16,6 +16,13 @@ import { ErrorBanner } from "@/components/common/error-banner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { usePosterCellLayout } from "@/hooks/use-poster-cell";
+import { useUiScale } from "@/hooks/use-ui-scale";
+
+/** Sonarr/Radarr-style poster overlay: bottom status bar + top-right corner triangle. */
+export interface PosterStatus {
+  barColor: string | null;
+  cornerColor: string | null;
+}
 
 export type MonitorFilter = "monitored" | "unmonitored" | "all";
 
@@ -51,6 +58,12 @@ interface MonitoredLibraryGridProps<T extends MonitoredItem, S extends string> {
   nounPlural: string;
   /** Footer line under the poster title (e.g. year or season count). */
   renderFooter: (item: T) => string;
+  /**
+   * Sonarr/Radarr-style status overlay for each poster (bottom color bar +
+   * corner triangle). Computed at the screen level since it needs the download
+   * queue. Omit to render plain posters.
+   */
+  posterStatus?: (item: T) => PosterStatus;
   onItemPress: (item: T) => void;
   onItemLongPress: (item: T) => void;
   /**
@@ -80,6 +93,7 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
   placeholderIcon,
   nounPlural,
   renderFooter,
+  posterStatus,
   onItemPress,
   onItemLongPress,
   ListHeaderComponent,
@@ -148,6 +162,7 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
           serviceId={serviceId}
           placeholderIcon={placeholderIcon}
           footer={renderFooter(item)}
+          status={posterStatus?.(item)}
           onPress={() => onItemPress(item)}
           onLongPress={() => onItemLongPress(item)}
         />
@@ -172,6 +187,7 @@ function LibraryPoster<T extends MonitoredItem>({
   serviceId,
   placeholderIcon,
   footer,
+  status,
   onPress,
   onLongPress,
 }: {
@@ -179,6 +195,7 @@ function LibraryPoster<T extends MonitoredItem>({
   serviceId: "radarr" | "sonarr";
   placeholderIcon: LucideIcon;
   footer: string;
+  status?: PosterStatus;
   onPress: () => void;
   onLongPress: () => void;
 }) {
@@ -194,25 +211,59 @@ function LibraryPoster<T extends MonitoredItem>({
       style={{ width: cellWidth }}
       className="active:opacity-80"
     >
-      {src ? (
-        <Image
-          source={{ uri: src }}
-          className="w-full aspect-[2/3] rounded-xl bg-surface-light"
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
-          recyclingKey={src}
-          onError={onError}
-        />
-      ) : (
-        <View className="w-full aspect-[2/3] rounded-xl bg-surface-light items-center justify-center">
-          <Icon icon={placeholderIcon} size={24} color="#71717a" />
-        </View>
-      )}
+      <View className="relative w-full aspect-[2/3] rounded-xl overflow-hidden bg-surface-light">
+        {src ? (
+          <Image
+            source={{ uri: src }}
+            className="w-full h-full"
+            contentFit="cover"
+            cachePolicy="memory-disk"
+            transition={200}
+            recyclingKey={src}
+            onError={onError}
+          />
+        ) : (
+          <View className="w-full h-full items-center justify-center">
+            <Icon icon={placeholderIcon} size={24} color="#71717a" />
+          </View>
+        )}
+        {status?.cornerColor ? <PosterCornerTriangle color={status.cornerColor} /> : null}
+        {status?.barColor ? (
+          <View
+            className="absolute bottom-0 left-0 right-0 h-1.5"
+            style={{ backgroundColor: status.barColor }}
+          />
+        ) : null}
+      </View>
       <Text className="text-zinc-300 text-sm mt-1" numberOfLines={1}>
         {item.title}
       </Text>
       <Text className="text-zinc-600 text-xs">{footer}</Text>
     </Pressable>
+  );
+}
+
+/**
+ * Top-right corner triangle, replicating the *arr poster ribbon. Built with the
+ * border-trick (a box with two adjacent borders, the others transparent). Size
+ * is multiplied by the UI scale so it grows with the accessibility setting.
+ */
+function PosterCornerTriangle({ color }: { color: string }) {
+  const uiScale = useUiScale();
+  const size = Math.round(20 * uiScale);
+  // Mirrors Sonarr's CSS (border-width: 0 N N 0; right border colored, bottom
+  // transparent) → right-angle at the top-right corner.
+  return (
+    <View
+      className="absolute top-0 right-0"
+      style={{
+        width: 0,
+        height: 0,
+        borderRightWidth: size,
+        borderBottomWidth: size,
+        borderRightColor: color,
+        borderBottomColor: "transparent",
+      }}
+    />
   );
 }

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -23,20 +23,9 @@ import {
   getDateOffset,
   localDateKey,
 } from "@/lib/utils";
-import {
-  getCalendar as getSonarrCalendar,
-  getSonarrPoster,
-  getSonarrFanart,
-} from "@/services/sonarr-api";
-import {
-  getCalendar as getRadarrCalendar,
-  getRadarrPoster,
-  getRadarrFanart,
-} from "@/services/radarr-api";
-import {
-  MediaBackdropRow,
-  BACKDROP_ROW_HEIGHT,
-} from "@/components/dashboard/media-backdrop-row";
+import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
+import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
+import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
 import type { SonarrCalendarEntry, RadarrMovie } from "@/lib/types";
 
@@ -265,11 +254,7 @@ function CalendarSkeleton() {
           <Skeleton width={80} height={12} borderRadius={4} />
           <View className="gap-2">
             {Array.from({ length: 2 }).map((_, rowIdx) => (
-              <Skeleton
-                key={rowIdx}
-                height={BACKDROP_ROW_HEIGHT}
-                borderRadius={12}
-              />
+              <Skeleton key={rowIdx} width="100%" height={72} borderRadius={12} />
             ))}
           </View>
         </View>
@@ -300,15 +285,6 @@ function titleOf(item: CalendarItem): string {
   return item.kind === "episode" ? item.entry.series.title : item.movie.title;
 }
 
-function StatusDot({ hasFile }: { hasFile: boolean }) {
-  return (
-    <View
-      className="w-2 h-2 rounded-full"
-      style={{ backgroundColor: hasFile ? "#22c55e" : "#52525b" }}
-    />
-  );
-}
-
 function EpisodeRow({
   entry,
   onPress,
@@ -317,13 +293,12 @@ function EpisodeRow({
   onPress: () => void;
 }) {
   return (
-    <MediaBackdropRow
-      posterUrl={getSonarrPoster(entry.series.images)}
-      backdropUrl={getSonarrFanart(entry.series.images)}
+    <CalendarEventRow
+      images={entry.series.images}
+      service="sonarr"
       title={entry.series.title}
       subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
-      rightAccessory={<StatusDot hasFile={entry.hasFile} />}
-      mediaType="tv"
+      hasFile={entry.hasFile}
       onPress={onPress}
     />
   );
@@ -337,13 +312,12 @@ function MovieRow({
   onPress: () => void;
 }) {
   return (
-    <MediaBackdropRow
-      posterUrl={getRadarrPoster(movie.images)}
-      backdropUrl={getRadarrFanart(movie.images)}
+    <CalendarEventRow
+      images={movie.images}
+      service="radarr"
       title={movie.title}
       subtitle={movie.year ? `${movie.year} • Movie` : "Movie"}
-      rightAccessory={<StatusDot hasFile={movie.hasFile} />}
-      mediaType="movie"
+      hasFile={movie.hasFile}
       onPress={onPress}
     />
   );

--- a/components/qbittorrent/share-limits-sheet.tsx
+++ b/components/qbittorrent/share-limits-sheet.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from "react";
+import { Modal, View, Text, Platform, ScrollView } from "react-native";
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
+import { cssInterop } from "nativewind";
+import { Percent, Clock } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { TextInput } from "@/components/ui/text-input";
+import { Button } from "@/components/ui/button";
+import { FilterChip } from "@/components/ui/filter-chip";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { toast, toastError } from "@/components/ui/toast";
+import { useSetShareLimits } from "@/hooks/use-qbittorrent";
+
+cssInterop(KeyboardAwareScrollView, {
+  className: "style",
+  contentContainerClassName: "contentContainerStyle",
+});
+
+// qBittorrent share-limit sentinels, shared by setShareLimits and the
+// /torrents/info response: -2 = use global limit, -1 = no limit.
+const GLOBAL = -2;
+const UNLIMITED = -1;
+
+type ShareMode = "global" | "unlimited" | "custom";
+
+interface ShareLimitsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  hash: string;
+  // Current per-torrent limits (ratio_limit / seeding_time_limit). The seeding
+  // limit is in minutes.
+  ratioLimit: number;
+  seedingTimeLimit: number;
+}
+
+function deriveMode(ratio: number, time: number): ShareMode {
+  if (ratio === GLOBAL && time === GLOBAL) return "global";
+  if (ratio === UNLIMITED && time === UNLIMITED) return "unlimited";
+  return "custom";
+}
+
+// "" → null (no limit for this dimension); invalid → NaN; otherwise the number.
+function parseNonNegative(input: string): number | null {
+  const t = input.trim();
+  if (t === "") return null;
+  const n = Number(t);
+  if (!Number.isFinite(n) || n < 0) return NaN;
+  return n;
+}
+
+export function ShareLimitsSheet({
+  visible,
+  onClose,
+  hash,
+  ratioLimit,
+  seedingTimeLimit,
+}: ShareLimitsSheetProps) {
+  const setShare = useSetShareLimits();
+
+  const [mode, setMode] = useState<ShareMode>("global");
+  const [ratio, setRatio] = useState("");
+  const [minutes, setMinutes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the form from the torrent's current limits whenever the sheet opens.
+  useEffect(() => {
+    if (!visible) return;
+    setMode(deriveMode(ratioLimit, seedingTimeLimit));
+    setRatio(ratioLimit >= 0 ? String(ratioLimit) : "");
+    setMinutes(seedingTimeLimit >= 0 ? String(seedingTimeLimit) : "");
+    setError(null);
+  }, [visible, ratioLimit, seedingTimeLimit]);
+
+  const handleSave = async () => {
+    let ratioVal = GLOBAL;
+    let timeVal = GLOBAL;
+
+    if (mode === "unlimited") {
+      ratioVal = UNLIMITED;
+      timeVal = UNLIMITED;
+    } else if (mode === "custom") {
+      const r = parseNonNegative(ratio);
+      const m = parseNonNegative(minutes);
+      if (Number.isNaN(r) || Number.isNaN(m)) {
+        setError("Enter a positive number, or leave blank for no limit.");
+        return;
+      }
+      ratioVal = r === null ? UNLIMITED : r;
+      timeVal = m === null ? UNLIMITED : Math.round(m);
+    }
+    setError(null);
+
+    try {
+      await setShare.mutateAsync({
+        hashes: [hash],
+        ratioLimit: ratioVal,
+        seedingTimeLimit: timeVal,
+      });
+      toast("Share limits saved", "success");
+      onClose();
+    } catch (err) {
+      toastError("Failed to save share limits", err);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Share Limits" onClose={onClose} />
+
+        <KeyboardAwareScrollView
+          contentContainerClassName="px-4 py-4 pb-8"
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode={
+            Platform.OS === "ios" ? "interactive" : "on-drag"
+          }
+          bottomOffset={20}
+        >
+          <Card className="mb-4 gap-3">
+            <Text className="text-zinc-300 text-sm font-semibold">
+              Stop seeding when
+            </Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerClassName="gap-2"
+            >
+              <FilterChip
+                label="Global"
+                selected={mode === "global"}
+                onPress={() => setMode("global")}
+              />
+              <FilterChip
+                label="Custom"
+                selected={mode === "custom"}
+                onPress={() => setMode("custom")}
+              />
+              <FilterChip
+                label="No limit"
+                selected={mode === "unlimited"}
+                onPress={() => setMode("unlimited")}
+              />
+            </ScrollView>
+            <Text className="text-zinc-500 text-xs">
+              {mode === "global"
+                ? "Uses the global ratio and seeding-time limits from qBittorrent's settings."
+                : mode === "unlimited"
+                  ? "Seeds indefinitely, ignoring the global limits."
+                  : "Set a custom ratio and/or seeding time. Leave a field blank for no limit on that one."}
+            </Text>
+          </Card>
+
+          {mode === "custom" ? (
+            <Card className="mb-4 gap-3">
+              <View className="flex-row items-center gap-2">
+                <Icon icon={Percent} size={16} color="#3b82f6" />
+                <Text className="text-zinc-300 text-sm font-semibold">
+                  Ratio limit
+                </Text>
+              </View>
+              <TextInput
+                label="Ratio"
+                placeholder="No limit"
+                value={ratio}
+                onChangeText={setRatio}
+                keyboardType="decimal-pad"
+              />
+
+              <View className="flex-row items-center gap-2 mt-1">
+                <Icon icon={Clock} size={16} color="#22c55e" />
+                <Text className="text-zinc-300 text-sm font-semibold">
+                  Seeding time
+                </Text>
+              </View>
+              <TextInput
+                label="Minutes"
+                placeholder="No limit"
+                value={minutes}
+                onChangeText={setMinutes}
+                keyboardType="numeric"
+              />
+            </Card>
+          ) : null}
+
+          {error ? (
+            <Text className="text-danger text-sm mb-3">{error}</Text>
+          ) : null}
+
+          <Button
+            label="Save Limits"
+            onPress={handleSave}
+            loading={setShare.isPending}
+          />
+        </KeyboardAwareScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/hooks/use-glances.ts
+++ b/hooks/use-glances.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCpu, getPerCpu, getLoad, getMem, getFs, getDiskIO, getGpu } from "@/services/glances-api";
+import { getCpu, getPerCpu, getLoad, getMem, getFs, getDiskIO, getGpu, getContainers } from "@/services/glances-api";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
 const FAST_POLL = 5000;
@@ -70,6 +70,16 @@ export function useGlancesGpu(instanceId?: string) {
   return useQuery({
     queryKey: ["glances", id, "gpu"],
     queryFn: () => getGpu(id ?? undefined),
+    refetchInterval: FAST_POLL,
+    enabled: enabled && !!id,
+  });
+}
+
+export function useGlancesContainers(instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("glances", instanceId);
+  return useQuery({
+    queryKey: ["glances", id, "containers"],
+    queryFn: () => getContainers(id ?? undefined),
     refetchInterval: FAST_POLL,
     enabled: enabled && !!id,
   });

--- a/hooks/use-qbittorrent.ts
+++ b/hooks/use-qbittorrent.ts
@@ -10,6 +10,7 @@ import {
   addTorrentMagnet,
   setDownloadLimit,
   setUploadLimit,
+  setShareLimits,
   getSpeedLimitsMode,
   toggleSpeedLimitsMode,
   getSpeedPreferences,
@@ -196,6 +197,27 @@ export function useAddTorrent(instanceId?: string) {
   const { instanceId: id } = useInstanceTarget("qbittorrent", instanceId);
   return useMutation({
     mutationFn: (magnetUri: string) => addTorrentMagnet(magnetUri, id ?? undefined),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] });
+    },
+  });
+}
+
+// --- Share Limits ---
+
+export function useSetShareLimits(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("qbittorrent", instanceId);
+  return useMutation({
+    mutationFn: ({
+      hashes,
+      ratioLimit,
+      seedingTimeLimit,
+    }: {
+      hashes: string[];
+      ratioLimit: number;
+      seedingTimeLimit: number;
+    }) => setShareLimits(hashes, ratioLimit, seedingTimeLimit, id ?? undefined),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] });
     },

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -15,6 +15,7 @@ import {
   updateSeries,
   searchForSeries,
   searchForEpisodes,
+  searchAllMissingEpisodes,
   getQualityProfiles,
   getRootFolders,
   getTags,
@@ -71,7 +72,8 @@ export function useSonarrCalendar(days = 7, instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "calendar", days],
-    queryFn: () => getCalendar(getDateOffset(0), getDateOffset(days), {}, id ?? undefined),
+    queryFn: () =>
+      getCalendar(getDateOffset(0), getDateOffset(days), {}, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.calendar,
     enabled: enabled && !!id,
   });
@@ -155,7 +157,8 @@ export function useToggleEpisodeMonitored(instanceId?: string) {
 export function useSearchForSeries(instanceId?: string) {
   const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
   return useMutation({
-    mutationFn: (seriesId: number) => searchForSeries(seriesId, id ?? undefined),
+    mutationFn: (seriesId: number) =>
+      searchForSeries(seriesId, id ?? undefined),
     onSuccess: () => toast("Search started"),
     onError: (err) => toastError("Search failed", err),
   });
@@ -164,8 +167,18 @@ export function useSearchForSeries(instanceId?: string) {
 export function useSearchForEpisodes(instanceId?: string) {
   const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
   return useMutation({
-    mutationFn: (episodeIds: number[]) => searchForEpisodes(episodeIds, id ?? undefined),
+    mutationFn: (episodeIds: number[]) =>
+      searchForEpisodes(episodeIds, id ?? undefined),
     onSuccess: () => toast("Search started"),
+    onError: (err) => toastError("Search failed", err),
+  });
+}
+
+export function useSearchAllMissingEpisodes(instanceId?: string) {
+  const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
+  return useMutation({
+    mutationFn: () => searchAllMissingEpisodes(id ?? undefined),
+    onSuccess: () => toast("Searching all missing episodes"),
     onError: (err) => toastError("Search failed", err),
   });
 }
@@ -183,9 +196,15 @@ export function useToggleSeriesMonitored(instanceId?: string) {
     }) => toggleSeriesMonitored(seriesId, monitored, id ?? undefined),
     onMutate: async ({ seriesId, monitored }) => {
       await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series"] });
-      await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      await queryClient.cancelQueries({
+        queryKey: ["sonarr", id, "series", seriesId],
+      });
 
-      const prevList = queryClient.getQueryData<SonarrSeries[]>(["sonarr", id, "series"]);
+      const prevList = queryClient.getQueryData<SonarrSeries[]>([
+        "sonarr",
+        id,
+        "series",
+      ]);
       const prevDetail = queryClient.getQueryData<SonarrSeries>([
         "sonarr",
         id,
@@ -213,13 +232,18 @@ export function useToggleSeriesMonitored(instanceId?: string) {
         queryClient.setQueryData(["sonarr", id, "series"], context.prevList);
       }
       if (context?.prevDetail) {
-        queryClient.setQueryData(["sonarr", id, "series", seriesId], context.prevDetail);
+        queryClient.setQueryData(
+          ["sonarr", id, "series", seriesId],
+          context.prevDetail,
+        );
       }
       toastError("Failed to update monitoring", err);
     },
     onSettled: (_data, _err, { seriesId }) => {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
-      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      queryClient.invalidateQueries({
+        queryKey: ["sonarr", id, "series", seriesId],
+      });
     },
   });
 }
@@ -242,13 +266,12 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
         seriesId,
       ]);
       if (!cached) throw new Error("Series not loaded");
-      return updateSeries(
-        { ...cached, qualityProfileId },
-        id ?? undefined,
-      );
+      return updateSeries({ ...cached, qualityProfileId }, id ?? undefined);
     },
     onMutate: async ({ seriesId, qualityProfileId }) => {
-      await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      await queryClient.cancelQueries({
+        queryKey: ["sonarr", id, "series", seriesId],
+      });
       await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series"] });
 
       const prevDetail = queryClient.getQueryData<SonarrSeries>([
@@ -293,7 +316,9 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
       toastError("Failed to update quality profile", err);
     },
     onSettled: (_data, _err, { seriesId }) => {
-      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      queryClient.invalidateQueries({
+        queryKey: ["sonarr", id, "series", seriesId],
+      });
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
     },
   });
@@ -319,14 +344,14 @@ export function useUpdateSeriesRootFolder(instanceId?: string) {
         seriesId,
       ]);
       if (!cached) throw new Error("Series not loaded");
-      return updateSeries(
-        { ...cached, rootFolderPath },
-        id ?? undefined,
-        { moveFiles },
-      );
+      return updateSeries({ ...cached, rootFolderPath }, id ?? undefined, {
+        moveFiles,
+      });
     },
     onMutate: async ({ seriesId, rootFolderPath }) => {
-      await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      await queryClient.cancelQueries({
+        queryKey: ["sonarr", id, "series", seriesId],
+      });
       await queryClient.cancelQueries({ queryKey: ["sonarr", id, "series"] });
 
       const prevDetail = queryClient.getQueryData<SonarrSeries>([
@@ -371,7 +396,9 @@ export function useUpdateSeriesRootFolder(instanceId?: string) {
       toastError("Failed to update root folder", err);
     },
     onSettled: (_data, _err, { seriesId }) => {
-      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series", seriesId] });
+      queryClient.invalidateQueries({
+        queryKey: ["sonarr", id, "series", seriesId],
+      });
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
     },
   });
@@ -407,7 +434,10 @@ export function useSonarrTags(instanceId?: string) {
   });
 }
 
-export function useSonarrReleasesForEpisode(episodeId: number, instanceId?: string) {
+export function useSonarrReleasesForEpisode(
+  episodeId: number,
+  instanceId?: string,
+) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "releases", "episode", episodeId],
@@ -428,7 +458,8 @@ export function useSonarrReleasesForSeason(
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "releases", "season", seriesId, seasonNumber],
-    queryFn: () => getReleasesForSeason(seriesId, seasonNumber, id ?? undefined),
+    queryFn: () =>
+      getReleasesForSeason(seriesId, seasonNumber, id ?? undefined),
     enabled: enabled && seriesId > 0 && seasonNumber >= 0 && !!id,
     staleTime: 60_000,
     gcTime: 5 * 60_000,

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -4,6 +4,7 @@ import {
   getSeriesById,
   getEpisodes,
   getEpisodeFiles,
+  deleteEpisodeFile,
   getCalendar,
   getQueue,
   getHistory,
@@ -151,6 +152,25 @@ export function useToggleEpisodeMonitored(instanceId?: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "episodes"] });
     },
+  });
+}
+
+export function useDeleteEpisodeFile(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
+  return useMutation({
+    mutationFn: (episodeFileId: number) =>
+      deleteEpisodeFile(episodeFileId, id ?? undefined),
+    onSuccess: () => {
+      // Refresh the episode list, file map, and series stats (file counts).
+      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "episodes"] });
+      queryClient.invalidateQueries({
+        queryKey: ["sonarr", id, "episodeFiles"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
+      toast("Episode file deleted");
+    },
+    onError: (err) => toastError("Delete failed", err),
   });
 }
 

--- a/lib/arr-poster-status.test.ts
+++ b/lib/arr-poster-status.test.ts
@@ -1,0 +1,142 @@
+import { radarrBarKind, sonarrBarKind, cornerColorFor } from "@/lib/arr-poster-status";
+import type { RadarrMovie, SonarrSeries } from "@/lib/types";
+
+function series(over: Partial<SonarrSeries>): SonarrSeries {
+  return {
+    status: "continuing",
+    monitored: true,
+    episodeCount: 0,
+    episodeFileCount: 0,
+    ...over,
+  } as SonarrSeries;
+}
+
+function movie(over: Partial<RadarrMovie>): RadarrMovie {
+  return {
+    status: "released",
+    monitored: true,
+    hasFile: false,
+    isAvailable: false,
+    ...over,
+  } as RadarrMovie;
+}
+
+describe("sonarrBarKind", () => {
+  it("downloading wins over everything", () => {
+    expect(
+      sonarrBarKind(series({ status: "ended", monitored: false }), true),
+    ).toBe("purple");
+  });
+
+  it("ended + complete → success", () => {
+    expect(
+      sonarrBarKind(series({ status: "ended", episodeCount: 10, episodeFileCount: 10 }), false),
+    ).toBe("success");
+  });
+
+  it("continuing + complete → primary", () => {
+    expect(
+      sonarrBarKind(
+        series({ status: "continuing", episodeCount: 10, episodeFileCount: 10 }),
+        false,
+      ),
+    ).toBe("primary");
+  });
+
+  it("missing + monitored → danger", () => {
+    expect(
+      sonarrBarKind(
+        series({ monitored: true, episodeCount: 10, episodeFileCount: 4 }),
+        false,
+      ),
+    ).toBe("danger");
+  });
+
+  it("missing + unmonitored → warning", () => {
+    expect(
+      sonarrBarKind(
+        series({ monitored: false, episodeCount: 10, episodeFileCount: 4 }),
+        false,
+      ),
+    ).toBe("warning");
+  });
+
+  it("zero episodes counts as complete", () => {
+    expect(
+      sonarrBarKind(series({ status: "continuing", episodeCount: 0, episodeFileCount: 0 }), false),
+    ).toBe("primary");
+    expect(
+      sonarrBarKind(series({ status: "ended", episodeCount: 0, episodeFileCount: 0 }), false),
+    ).toBe("success");
+  });
+
+  it("prefers statistics over top-level counts", () => {
+    const s = series({
+      status: "continuing",
+      monitored: true,
+      episodeCount: 0,
+      episodeFileCount: 0,
+      statistics: {
+        seasonCount: 1,
+        episodeCount: 10,
+        episodeFileCount: 3,
+        totalEpisodeCount: 10,
+        sizeOnDisk: 0,
+        percentOfEpisodes: 30,
+      },
+    });
+    expect(sonarrBarKind(s, false)).toBe("danger");
+  });
+});
+
+describe("radarrBarKind", () => {
+  it("downloading → purple", () => {
+    expect(radarrBarKind(movie({ hasFile: true, monitored: true }), true)).toBe("purple");
+  });
+
+  it("downloaded + monitored → success", () => {
+    expect(radarrBarKind(movie({ hasFile: true, monitored: true }), false)).toBe("success");
+  });
+
+  it("downloaded + unmonitored → default", () => {
+    expect(radarrBarKind(movie({ hasFile: true, monitored: false }), false)).toBe("default");
+  });
+
+  it("deleted (no file) → inverse", () => {
+    expect(
+      radarrBarKind(movie({ status: "deleted", hasFile: false, monitored: true }), false),
+    ).toBe("inverse");
+  });
+
+  it("available + monitored, no file → danger", () => {
+    expect(
+      radarrBarKind(movie({ isAvailable: true, monitored: true, hasFile: false }), false),
+    ).toBe("danger");
+  });
+
+  it("unmonitored, no file → warning", () => {
+    expect(
+      radarrBarKind(movie({ monitored: false, hasFile: false, isAvailable: false }), false),
+    ).toBe("warning");
+  });
+
+  it("monitored, unreleased, no file → primary", () => {
+    expect(
+      radarrBarKind(movie({ monitored: true, hasFile: false, isAvailable: false }), false),
+    ).toBe("primary");
+  });
+});
+
+describe("cornerColorFor", () => {
+  it("ended → red", () => {
+    expect(cornerColorFor("ended")).toBe("#ef4444");
+  });
+  it("deleted → gray", () => {
+    expect(cornerColorFor("deleted")).toBe("#71717a");
+  });
+  it("other statuses → null", () => {
+    expect(cornerColorFor("continuing")).toBeNull();
+    expect(cornerColorFor("released")).toBeNull();
+    expect(cornerColorFor("inCinemas")).toBeNull();
+  });
+});

--- a/lib/arr-poster-status.ts
+++ b/lib/arr-poster-status.ts
@@ -1,0 +1,79 @@
+import type { RadarrMovie, SonarrSeries } from "@/lib/types";
+
+/**
+ * Sonarr/Radarr-style poster status indicators (issue #47).
+ *
+ * The bar-color logic is a faithful port of the *arr frontends so the colors
+ * mean exactly what they mean in Sonarr/Radarr:
+ *   - Sonarr: frontend/src/Utilities/Series/getProgressBarKind.ts
+ *   - Radarr: frontend/src/Utilities/Movie/getProgressBarKind.ts
+ * The corner triangle mirrors SeriesIndexPoster/MovieIndexPoster (top-right
+ * ribbon): Sonarr shows red for `ended`, both show gray for `deleted`.
+ */
+
+export type PosterBarKind =
+  | "purple"
+  | "success"
+  | "primary"
+  | "danger"
+  | "warning"
+  | "default"
+  | "inverse";
+
+/** Bar-kind → hex. The 5 semantic kinds reuse the app theme (tailwind.config.ts). */
+export const BAR_KIND_COLOR: Record<PosterBarKind, string> = {
+  primary: "#3b82f6",
+  success: "#22c55e",
+  danger: "#ef4444",
+  warning: "#f59e0b",
+  purple: "#a855f7",
+  default: "#71717a",
+  inverse: "#52525b",
+};
+
+const CORNER_ENDED = "#ef4444"; // danger
+const CORNER_DELETED = "#71717a"; // gray
+
+/**
+ * Port of Sonarr's getProgressBarKind(status, monitored, progress, isDownloading).
+ * progress = episodeFileCount / episodeCount * 100 (no episodes ⇒ treated complete).
+ */
+export function sonarrBarKind(series: SonarrSeries, isDownloading: boolean): PosterBarKind {
+  if (isDownloading) return "purple";
+
+  const episodeCount = series.statistics?.episodeCount ?? series.episodeCount ?? 0;
+  const episodeFileCount =
+    series.statistics?.episodeFileCount ?? series.episodeFileCount ?? 0;
+  const progress = episodeCount ? (episodeFileCount / episodeCount) * 100 : 100;
+
+  if (progress === 100) {
+    return series.status === "ended" ? "success" : "primary";
+  }
+  if (series.monitored) return "danger";
+  return "warning";
+}
+
+/**
+ * Port of Radarr's getProgressBarKind(status, monitored, hasFile, isAvailable,
+ * isDownloading). Branches are evaluated in order; first match wins.
+ */
+export function radarrBarKind(movie: RadarrMovie, isDownloading: boolean): PosterBarKind {
+  if (isDownloading) return "purple";
+  if (movie.hasFile && movie.monitored) return "success";
+  if (movie.hasFile && !movie.monitored) return "default";
+  if (movie.status === "deleted") return "inverse";
+  if (movie.isAvailable && movie.monitored) return "danger";
+  if (!movie.monitored) return "warning";
+  return "primary";
+}
+
+/**
+ * Top-right corner triangle color, or null for no triangle.
+ * Sonarr: `ended` → red, `deleted` → gray. Radarr movie status is never
+ * `ended`, so only `deleted` produces a triangle there.
+ */
+export function cornerColorFor(status: string): string | null {
+  if (status === "ended") return CORNER_ENDED;
+  if (status === "deleted") return CORNER_DELETED;
+  return null;
+}

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -893,6 +893,14 @@ const DEMO_GLANCES_DISKIO = [
 const DEMO_GLANCES_GPU = [
   { key: "gpu_id", gpu_id: "0", name: "NVIDIA GeForce RTX 3060", mem: 42.5, proc: 28.0, temperature: 54, fan_speed: 38 },
 ];
+const DEMO_GLANCES_CONTAINERS = [
+  { id: "a1b2c3d4e5f6", name: "plex", status: "running", image: ["plexinc/pms-docker:latest"], cpu_percent: 18.4, memory_usage: 1503238553, memory_limit: 8589934592, uptime: "6 days", engine: "docker" },
+  { id: "b2c3d4e5f6a1", name: "qbittorrent", status: "running", image: ["lscr.io/linuxserver/qbittorrent:latest"], cpu_percent: 4.2, memory_usage: 524288000, memory_limit: 8589934592, uptime: "6 days", engine: "docker" },
+  { id: "c3d4e5f6a1b2", name: "sonarr", status: "running", image: ["lscr.io/linuxserver/sonarr:latest"], cpu_percent: 1.1, memory_usage: 312475648, memory_limit: 8589934592, uptime: "2 days", engine: "docker" },
+  { id: "d4e5f6a1b2c3", name: "radarr", status: "running", image: ["lscr.io/linuxserver/radarr:latest"], cpu_percent: 0.9, memory_usage: 298844160, memory_limit: 8589934592, uptime: "2 days", engine: "docker" },
+  { id: "e5f6a1b2c3d4", name: "prowlarr", status: "paused", image: ["lscr.io/linuxserver/prowlarr:latest"], cpu_percent: 0, memory_usage: 0, memory_limit: 8589934592, uptime: "", engine: "docker" },
+  { id: "f6a1b2c3d4e5", name: "bazarr", status: "exited", image: ["lscr.io/linuxserver/bazarr:latest"], cpu_percent: 0, memory_usage: 0, memory_limit: 8589934592, uptime: "", engine: "docker" },
+];
 
 // --- Bazarr ---
 
@@ -1004,6 +1012,7 @@ export function getDemoResponse(
       if (normalized === "/load") return DEMO_GLANCES_LOAD;
       if (normalized === "/diskio") return DEMO_GLANCES_DISKIO;
       if (normalized === "/gpu") return DEMO_GLANCES_GPU;
+      if (normalized === "/containers") return DEMO_GLANCES_CONTAINERS;
       return undefined;
     }
     case "qbittorrent": {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1192,6 +1192,22 @@ export interface GlancesGpuItem {
   fan_speed: number | null;
 }
 
+export interface GlancesContainerItem {
+  id: string;
+  name: string;
+  // One of: running, paused, created, restarting, removing, exited, dead, and
+  // (when a Docker healthcheck is configured) healthy/unhealthy/starting.
+  status: string;
+  // Docker reports image as a single-element list of comma-joined tags; Podman
+  // and some builds send a plain string. Normalize at render time.
+  image?: string | string[];
+  cpu_percent?: number | null;
+  memory_usage?: number | null;
+  memory_limit?: number | null;
+  uptime?: string;
+  engine?: string;
+}
+
 // --- Bazarr Types ---
 
 export interface BazarrMissingSubtitle {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -315,6 +315,7 @@ export interface RadarrMovie {
   rootFolderPath: string;
   movieFile?: RadarrMovieFile;
   genres?: string[];
+  tags?: number[];
   certification?: string;
   studio?: string;
 }
@@ -470,6 +471,7 @@ export interface SonarrSeries {
   rootFolderPath: string;
   ratings?: RatingsBundle;
   genres?: string[];
+  tags?: number[];
   certification?: string;
   firstAired?: string;
   nextAiring?: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,6 +73,11 @@ export interface QBTorrent {
   num_seeds: number;
   num_leechs: number;
   ratio: number;
+  // Per-torrent share limits from /torrents/info, sharing the setShareLimits
+  // sentinels: -2 = use global limit, -1 = no limit. seeding_time_limit is in
+  // minutes. (Elapsed seeding_time, by contrast, is reported in seconds.)
+  ratio_limit: number;
+  seeding_time_limit: number;
   eta: number;
   state: TorrentState;
   category: string;

--- a/services/glances-api.ts
+++ b/services/glances-api.ts
@@ -7,6 +7,7 @@ import type {
   GlancesLoad,
   GlancesDiskIOItem,
   GlancesGpuItem,
+  GlancesContainerItem,
 } from "@/lib/types";
 
 // Per-instance routing: every function takes an optional `instanceId`.
@@ -62,6 +63,17 @@ export async function getGpu(instanceId?: string): Promise<GlancesGpuItem[]> {
   // endpoint can 404, so swallow that into [] rather than surfacing as error.
   try {
     return await serviceRequest<GlancesGpuItem[]>("glances", "/gpu", { instanceId });
+  } catch (e) {
+    if (e instanceof HttpError && e.status === 404) return [];
+    throw e;
+  }
+}
+
+export async function getContainers(instanceId?: string): Promise<GlancesContainerItem[]> {
+  // The containers plugin 404s when no engine (Docker/Podman) is installed or
+  // the plugin is disabled — treat that as "no containers" rather than error.
+  try {
+    return await serviceRequest<GlancesContainerItem[]>("glances", "/containers", { instanceId });
   } catch (e) {
     if (e instanceof HttpError && e.status === 404) return [];
     throw e;

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -500,6 +500,35 @@ export function setUploadLimit(
   );
 }
 
+// --- Share Limits (per-torrent) ---
+
+// /torrents/setShareLimits. ratioLimit is a float; seedingTimeLimit and
+// inactiveSeedingTimeLimit are in minutes. For all three, -2 = use the global
+// limit and -1 = no limit. We don't surface the inactive-seeding limit in the
+// UI, so we always send -2 to leave the user's global setting untouched.
+export function setShareLimits(
+  hashes: string[],
+  ratioLimit: number,
+  seedingTimeLimit: number,
+  instanceId?: string,
+): Promise<void> {
+  const body = new URLSearchParams({
+    hashes: hashes.join("|"),
+    ratioLimit: String(ratioLimit),
+    seedingTimeLimit: String(seedingTimeLimit),
+    inactiveSeedingTimeLimit: "-2",
+  }).toString();
+  return qbRequest(
+    "/torrents/setShareLimits",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    },
+    instanceId,
+  );
+}
+
 // --- Alternative Speed Mode ---
 
 // /transfer/speedLimitsMode returns "0" (off) or "1" (on) as plain text.

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -84,6 +84,18 @@ export function getEpisodeFiles(
   });
 }
 
+// Deletes a single episode's downloaded file. The episode stays in the library
+// but flips back to missing (hasFile=false).
+export function deleteEpisodeFile(
+  episodeFileId: number,
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("sonarr", `/episodefile/${episodeFileId}`, {
+    method: "DELETE",
+    instanceId,
+  });
+}
+
 // --- Calendar ---
 
 export function getCalendar(

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -42,8 +42,13 @@ export function getSeries(instanceId?: string): Promise<SonarrSeries[]> {
   return serviceRequest<SonarrSeries[]>("sonarr", "/series", { instanceId });
 }
 
-export function getSeriesById(id: number, instanceId?: string): Promise<SonarrSeries> {
-  return serviceRequest<SonarrSeries>("sonarr", `/series/${id}`, { instanceId });
+export function getSeriesById(
+  id: number,
+  instanceId?: string,
+): Promise<SonarrSeries> {
+  return serviceRequest<SonarrSeries>("sonarr", `/series/${id}`, {
+    instanceId,
+  });
 }
 
 // --- Episodes ---
@@ -58,8 +63,13 @@ export function getEpisodes(
   });
 }
 
-export function getEpisode(id: number, instanceId?: string): Promise<SonarrEpisode> {
-  return serviceRequest<SonarrEpisode>("sonarr", `/episode/${id}`, { instanceId });
+export function getEpisode(
+  id: number,
+  instanceId?: string,
+): Promise<SonarrEpisode> {
+  return serviceRequest<SonarrEpisode>("sonarr", `/episode/${id}`, {
+    instanceId,
+  });
 }
 
 // --- Episode Files ---
@@ -244,16 +254,23 @@ export function updateSeries(
   options?: { moveFiles?: boolean },
 ): Promise<SonarrSeries> {
   const query = options?.moveFiles ? "?moveFiles=true" : "";
-  return serviceRequest<SonarrSeries>("sonarr", `/series/${series.id}${query}`, {
-    method: "PUT",
-    body: JSON.stringify(series),
-    instanceId,
-  });
+  return serviceRequest<SonarrSeries>(
+    "sonarr",
+    `/series/${series.id}${query}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(series),
+      instanceId,
+    },
+  );
 }
 
 // --- Search Commands ---
 
-export function searchForSeries(seriesId: number, instanceId?: string): Promise<void> {
+export function searchForSeries(
+  seriesId: number,
+  instanceId?: string,
+): Promise<void> {
   return serviceRequest<void>("sonarr", "/command", {
     method: "POST",
     body: JSON.stringify({ name: "SeriesSearch", seriesId }),
@@ -268,6 +285,17 @@ export function searchForEpisodes(
   return serviceRequest<void>("sonarr", "/command", {
     method: "POST",
     body: JSON.stringify({ name: "EpisodeSearch", episodeIds }),
+    instanceId,
+  });
+}
+
+// Searches every monitored missing episode in the library. With no params the
+// MissingEpisodeSearch command defaults to Monitored across all series — the
+// equivalent of Sonarr's Wanted › Missing › "Search All" button.
+export function searchAllMissingEpisodes(instanceId?: string): Promise<void> {
+  return serviceRequest<void>("sonarr", "/command", {
+    method: "POST",
+    body: JSON.stringify({ name: "MissingEpisodeSearch" }),
     instanceId,
   });
 }
@@ -332,8 +360,12 @@ export interface SonarrRootFolder {
   freeSpace: number;
 }
 
-export function getRootFolders(instanceId?: string): Promise<SonarrRootFolder[]> {
-  return serviceRequest<SonarrRootFolder[]>("sonarr", "/rootfolder", { instanceId });
+export function getRootFolders(
+  instanceId?: string,
+): Promise<SonarrRootFolder[]> {
+  return serviceRequest<SonarrRootFolder[]>("sonarr", "/rootfolder", {
+    instanceId,
+  });
 }
 
 // --- Tags ---

--- a/store/glances-ui-store.ts
+++ b/store/glances-ui-store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { getJSON, setJSON } from "@/store/storage";
+
+const STORAGE_KEY = "ui.glancesSections";
+
+// Remembered expand/collapse state for the long Glances sections. Per-core
+// defaults collapsed (the whole point on many-core servers — see issue #67);
+// the containers list defaults expanded so the new section is discoverable.
+interface GlancesSectionPrefs {
+  perCoreExpanded: boolean;
+  containersExpanded: boolean;
+}
+
+export const GLANCES_SECTION_DEFAULTS: GlancesSectionPrefs = {
+  perCoreExpanded: false,
+  containersExpanded: true,
+};
+
+interface GlancesUiStore extends GlancesSectionPrefs {
+  hydrate: () => void;
+  setPerCoreExpanded: (v: boolean) => void;
+  setContainersExpanded: (v: boolean) => void;
+}
+
+function snapshot(state: GlancesSectionPrefs): GlancesSectionPrefs {
+  return {
+    perCoreExpanded: state.perCoreExpanded,
+    containersExpanded: state.containersExpanded,
+  };
+}
+
+export const useGlancesUiStore = create<GlancesUiStore>((set, get) => ({
+  ...GLANCES_SECTION_DEFAULTS,
+
+  // Reads from the storage cache, populated by useConfigStore.hydrate(). Must
+  // be called after that; safe to call multiple times.
+  hydrate: () => {
+    const stored = getJSON<Partial<GlancesSectionPrefs>>(STORAGE_KEY);
+    if (stored) set({ ...GLANCES_SECTION_DEFAULTS, ...stored });
+  },
+
+  setPerCoreExpanded: (perCoreExpanded) => {
+    set({ perCoreExpanded });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), perCoreExpanded }));
+  },
+  setContainersExpanded: (containersExpanded) => {
+    set({ containersExpanded });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), containersExpanded }));
+  },
+}));


### PR DESCRIPTION
## Summary
A batch of self-contained enhancements (no new integrations):

- **Tags on shows/movies (#120)** — Sonarr/Radarr tags now render as a chip row under Genres on the series & movie detail screens.
- **qBittorrent share limits (#94)** — per-torrent ratio & seeding-time limits via a new Share Limits sheet on the torrent detail screen; current limits surfaced in the info card.
- **Search all missing (#118)** — a "Search Missing" button on the TV library fires Sonarr's `MissingEpisodeSearch`, behind a styled confirm.
- **Episode ordering & actions (#82)** — episodes list latest-first to match Sonarr; per-episode `⋯` menu with Automatic Search, Interactive Search, and Delete File (styled confirm); monitor toggle stays inline and enlarged.

Also adds a "Confirmations & Dialogs" rule to CLAUDE.md (no native `Alert` — use the styled `ConfirmModal` / `ActionSheet`).

Also brings earlier branch commits to `main`: poster status indicators (#47), shared calendar event row (#98).

Refs #120, #94, #118, #82