### PR TITLE
feat: Recently Downloaded dashboard widget (#114)

### DIFF
--- a/components/dashboard/recently-downloaded-card.tsx
+++ b/components/dashboard/recently-downloaded-card.tsx
@@ -1,0 +1,269 @@
+import { ScrollView } from "react-native";
+import { useRouter } from "expo-router";
+import { useQueries } from "@tanstack/react-query";
+import { Card } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ServiceLogo } from "@/components/ui/service-logo";
+import { getHistory as getRadarrHistory, getRadarrPoster } from "@/services/radarr-api";
+import { getHistory as getSonarrHistory, getSonarrPoster } from "@/services/sonarr-api";
+import { useConfigStore } from "@/store/config-store";
+import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { POLLING_INTERVALS } from "@/lib/constants";
+import { formatEpisodeCode, relativeDate } from "@/lib/utils";
+import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import {
+  RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
+  type RecentlyDownloadedSettingsValue,
+} from "@/components/dashboard/widget-settings/recently-downloaded-settings";
+import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
+import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
+import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
+import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
+import { CardHeaderLink } from "@/components/dashboard/card-header-link";
+import type {
+  RadarrHistoryRecord,
+  SonarrHistoryRecord,
+} from "@/lib/types";
+
+// One imported entry from either Sonarr or Radarr, tagged with its source
+// instance so the per-tile router push targets the right id space (movie /
+// series ids aren't globally unique across instances of the same kind).
+type RecentItem =
+  | {
+      kind: "episode";
+      record: SonarrHistoryRecord;
+      instanceId: string;
+      // Pulled out for sorting — `date` is optional on the record type.
+      date: string;
+    }
+  | {
+      kind: "movie";
+      record: RadarrHistoryRecord;
+      instanceId: string;
+      date: string;
+    };
+
+// Radarr/Sonarr expose the import event under this name. Grab events fire too,
+// but the issue asks for "recently downloaded" — only completed imports count.
+const IMPORT_EVENT = "downloadFolderImported";
+
+export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
+  const router = useRouter();
+  const { settings } = useWidgetSettings<RecentlyDownloadedSettingsValue>(
+    slotId,
+    RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
+  );
+  const sonarrEnabled = useConfigStore((s) => s.services.sonarr.enabled);
+  const radarrEnabled = useConfigStore((s) => s.services.radarr.enabled);
+
+  const showSonarr = settings.includeSonarr && sonarrEnabled;
+  const showRadarr = settings.includeRadarr && radarrEnabled;
+
+  const allSonarrInstances = useEnabledInstances("sonarr");
+  const allRadarrInstances = useEnabledInstances("radarr");
+  const sonarrInstances = resolveBoundInstances(
+    settings.sonarrInstanceIds,
+    allSonarrInstances,
+  );
+  const radarrInstances = resolveBoundInstances(
+    settings.radarrInstanceIds,
+    allRadarrInstances,
+  );
+
+  // Fan history across each resolved instance. Query keys match the watchers
+  // in use-notification-watchers.tsx so we share the same cached page instead
+  // of issuing a second request per instance.
+  const sonarrQueries = useQueries({
+    queries: showSonarr
+      ? sonarrInstances.map((inst) => ({
+          queryKey: ["sonarr", inst.id, "history"] as const,
+          queryFn: () => getSonarrHistory(1, 50, inst.id),
+          refetchInterval: POLLING_INTERVALS.queue,
+        }))
+      : [],
+  });
+  const radarrQueries = useQueries({
+    queries: showRadarr
+      ? radarrInstances.map((inst) => ({
+          queryKey: ["radarr", inst.id, "history"] as const,
+          queryFn: () => getRadarrHistory(1, 50, inst.id),
+          refetchInterval: POLLING_INTERVALS.queue,
+        }))
+      : [],
+  });
+
+  // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton
+  // shows only while we're truly cold across both kinds; a single failing
+  // instance just contributes nothing to the merged list instead of flickering
+  // the card every refetch tick.
+  const sonarrState = aggregateMultiInstanceState(sonarrQueries);
+  const radarrState = aggregateMultiInstanceState(radarrQueries);
+  const isLoading =
+    (showSonarr && !sonarrState.hasAnyData && sonarrState.isInitialLoading) ||
+    (showRadarr && !radarrState.hasAnyData && radarrState.isInitialLoading);
+
+  const items: RecentItem[] = [];
+  if (showSonarr) {
+    sonarrQueries.forEach((q, i) => {
+      const instanceId = sonarrInstances[i]?.id;
+      if (!instanceId) return;
+      for (const r of q.data?.records ?? []) {
+        if (r.eventType !== IMPORT_EVENT || !r.date) continue;
+        items.push({ kind: "episode", record: r, instanceId, date: r.date });
+      }
+    });
+  }
+  if (showRadarr) {
+    radarrQueries.forEach((q, i) => {
+      const instanceId = radarrInstances[i]?.id;
+      if (!instanceId) return;
+      for (const r of q.data?.records ?? []) {
+        if (r.eventType !== IMPORT_EVENT || !r.date) continue;
+        items.push({ kind: "movie", record: r, instanceId, date: r.date });
+      }
+    });
+  }
+
+  // Sort descending by import timestamp so the freshest download is leftmost.
+  items.sort((a, b) => b.date.localeCompare(a.date));
+  const display = items.slice(0, settings.maxItems);
+
+  const noSources = !showSonarr && !showRadarr;
+  const noServicesEnabled = !sonarrEnabled && !radarrEnabled;
+  // The combined now-playing card uses a logo badge only when more than one
+  // kind is active — same here, so a single-source feed isn't cluttered.
+  const showSourceBadge = showSonarr && showRadarr;
+
+  return (
+    <Card>
+      <CardHeaderLink
+        title="Recently Downloaded"
+        // No single destination covers both — drop the user on the dashboard
+        // tab they're already on by leaving onPress undefined when both
+        // sources are active; otherwise route to the obvious one.
+        onPress={
+          showRadarr && !showSonarr
+            ? () => router.push("/(tabs)/movies")
+            : !showRadarr && showSonarr
+              ? () => router.push("/(tabs)/tv")
+              : undefined
+        }
+      />
+
+      {noSources ? (
+        <EmptyState
+          compact
+          title="No download sources"
+          message={
+            noServicesEnabled
+              ? "Configure Sonarr or Radarr in app settings."
+              : "Enable Sonarr or Radarr in the widget settings."
+          }
+        />
+      ) : isLoading ? (
+        <PosterSkeletonRow count={4} showSubtitle />
+      ) : display.length === 0 ? (
+        <EmptyState compact title="Nothing imported recently" />
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 12 }}
+        >
+          {display.map((item) =>
+            item.kind === "episode" ? (
+              <EpisodeTile
+                key={`ep-${item.instanceId}-${item.record.id}`}
+                item={item}
+                showSourceBadge={showSourceBadge}
+                onPress={() => {
+                  const seriesId =
+                    item.record.seriesId ?? item.record.series?.id;
+                  if (!seriesId) return;
+                  router.push(
+                    `/series/${seriesId}?instanceId=${item.instanceId}`,
+                  );
+                }}
+              />
+            ) : (
+              <MovieTile
+                key={`mv-${item.instanceId}-${item.record.id}`}
+                item={item}
+                showSourceBadge={showSourceBadge}
+                onPress={() => {
+                  const movieId = item.record.movieId ?? item.record.movie?.id;
+                  if (!movieId) return;
+                  router.push(
+                    `/movie/${movieId}?instanceId=${item.instanceId}`,
+                  );
+                }}
+              />
+            ),
+          )}
+        </ScrollView>
+      )}
+    </Card>
+  );
+}
+
+function EpisodeTile({
+  item,
+  showSourceBadge,
+  onPress,
+}: {
+  item: Extract<RecentItem, { kind: "episode" }>;
+  showSourceBadge: boolean;
+  onPress: () => void;
+}) {
+  const { record } = item;
+  const title = record.series?.title ?? record.sourceTitle ?? "Episode";
+  const code =
+    record.episode &&
+    formatEpisodeCode(
+      record.episode.seasonNumber ?? 0,
+      record.episode.episodeNumber ?? 0,
+    );
+  // "S02E04 · Today" — relativeDate keeps it human ("Today"/"Yesterday"/short
+  // weekday) and fits inside the single-line subtitle slot.
+  const subtitle = [code, relativeDate(item.date)].filter(Boolean).join(" · ");
+  return (
+    <MediaPosterTile
+      posterUrl={getSonarrPoster(record.series?.images)}
+      title={title}
+      subtitle={subtitle}
+      mediaType="tv"
+      topLeftBadge={
+        showSourceBadge ? <ServiceLogo id="sonarr" size={14} /> : undefined
+      }
+      onPress={onPress}
+    />
+  );
+}
+
+function MovieTile({
+  item,
+  showSourceBadge,
+  onPress,
+}: {
+  item: Extract<RecentItem, { kind: "movie" }>;
+  showSourceBadge: boolean;
+  onPress: () => void;
+}) {
+  const { record } = item;
+  const title = record.movie?.title ?? record.sourceTitle ?? "Movie";
+  const year = record.movie?.year ? String(record.movie.year) : null;
+  const subtitle = [year, relativeDate(item.date)].filter(Boolean).join(" · ");
+  return (
+    <MediaPosterTile
+      posterUrl={getRadarrPoster(record.movie?.images)}
+      title={title}
+      subtitle={subtitle}
+      mediaType="movie"
+      topLeftBadge={
+        showSourceBadge ? <ServiceLogo id="radarr" size={14} /> : undefined
+      }
+      onPress={onPress}
+    />
+  );
+}

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -11,6 +11,7 @@ import {
   Inbox,
   MonitorPlay,
   Newspaper,
+  PackageCheck,
   PlayCircle,
   Power,
   Radar,
@@ -23,6 +24,7 @@ import { DownloadCard } from "@/components/dashboard/download-card";
 import { SabnzbdQueueCard } from "@/components/dashboard/sabnzbd-queue-card";
 import { NzbgetQueueCard } from "@/components/dashboard/nzbget-queue-card";
 import { RadarrQueueCard } from "@/components/dashboard/radarr-queue-card";
+import { RecentlyDownloadedCard } from "@/components/dashboard/recently-downloaded-card";
 import { CalendarCard } from "@/components/dashboard/calendar-card";
 import { TautulliActivityCard } from "@/components/dashboard/tautulli-activity-card";
 import { OverseerrRequestsCard } from "@/components/dashboard/overseerr-requests-card";
@@ -103,6 +105,11 @@ import {
   RADARR_QUEUE_DEFAULT_SETTINGS,
   type RadarrQueueSettingsValue,
 } from "@/components/dashboard/widget-settings/radarr-queue-settings";
+import {
+  RecentlyDownloadedSettings,
+  RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
+  type RecentlyDownloadedSettingsValue,
+} from "@/components/dashboard/widget-settings/recently-downloaded-settings";
 import {
   ProwlarrStatsSettings,
   PROWLARR_STATS_DEFAULT_SETTINGS,
@@ -254,6 +261,16 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     settingsComponent: RadarrQueueSettings,
     defaultSettings: RADARR_QUEUE_DEFAULT_SETTINGS,
   },
+  "recently-downloaded": {
+    id: "recently-downloaded",
+    label: "Recently Downloaded",
+    description: "Latest imported movies and episodes from Radarr and Sonarr",
+    icon: PackageCheck,
+    service: ["sonarr", "radarr"],
+    component: RecentlyDownloadedCard,
+    settingsComponent: RecentlyDownloadedSettings,
+    defaultSettings: RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
+  },
   "calendar": {
     id: "calendar",
     label: "Calendar",
@@ -377,6 +394,7 @@ export type {
   OverseerrRequestsSettingsValue,
   SpeedStatsSettingsValue,
   RadarrQueueSettingsValue,
+  RecentlyDownloadedSettingsValue,
   ProwlarrStatsSettingsValue,
   BazarrWantedSettingsValue,
 };

--- a/components/dashboard/widget-settings/recently-downloaded-settings.tsx
+++ b/components/dashboard/widget-settings/recently-downloaded-settings.tsx
@@ -1,0 +1,97 @@
+import { View } from "react-native";
+import { Toggle } from "@/components/ui/toggle";
+import { useConfigStore } from "@/store/config-store";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+import {
+  InstancePickerRow,
+  INSTANCE_BINDING_ALL,
+  type InstanceBindingValue,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  MaxItemsSelector,
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
+
+export interface RecentlyDownloadedSettingsValue extends Record<string, unknown> {
+  // Per-service bindings so users can fan out across two Sonarrs while
+  // pinning to one Radarr (mirrors the Calendar widget). Each side accepts
+  // either the "all" sentinel or an array of instance UUIDs.
+  sonarrInstanceIds: InstanceBindingValue;
+  radarrInstanceIds: InstanceBindingValue;
+  includeSonarr: boolean;
+  includeRadarr: boolean;
+  maxItems: number;
+}
+
+export const RECENTLY_DOWNLOADED_DEFAULT_SETTINGS: RecentlyDownloadedSettingsValue = {
+  sonarrInstanceIds: INSTANCE_BINDING_ALL,
+  radarrInstanceIds: INSTANCE_BINDING_ALL,
+  includeSonarr: true,
+  includeRadarr: true,
+  maxItems: 10,
+};
+
+export function RecentlyDownloadedSettings({ slotId }: WidgetSettingsComponentProps) {
+  const sonarrEnabled = useConfigStore((s) => s.services.sonarr.enabled);
+  const radarrEnabled = useConfigStore((s) => s.services.radarr.enabled);
+  const { settings, update } = useWidgetSettings<RecentlyDownloadedSettingsValue>(
+    slotId,
+    RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
+  );
+
+  return (
+    <View className="px-4 py-2 gap-5">
+      <SettingsSection label="Sources">
+        <ToggleCard>
+          <Toggle
+            label="Sonarr (TV episodes)"
+            description={
+              sonarrEnabled
+                ? "Show recently imported episodes"
+                : "Enable Sonarr in Settings to use this source"
+            }
+            value={settings.includeSonarr && sonarrEnabled}
+            onValueChange={(includeSonarr) => update({ includeSonarr })}
+            disabled={!sonarrEnabled}
+          />
+          <Toggle
+            label="Radarr (movies)"
+            description={
+              radarrEnabled
+                ? "Show recently imported movies"
+                : "Enable Radarr in Settings to use this source"
+            }
+            value={settings.includeRadarr && radarrEnabled}
+            onValueChange={(includeRadarr) => update({ includeRadarr })}
+            disabled={!radarrEnabled}
+          />
+        </ToggleCard>
+      </SettingsSection>
+
+      {settings.includeSonarr && sonarrEnabled && (
+        <InstancePickerRow
+          serviceId="sonarr"
+          label="Sonarr instance"
+          value={settings.sonarrInstanceIds}
+          onChange={(sonarrInstanceIds) => update({ sonarrInstanceIds })}
+        />
+      )}
+
+      {settings.includeRadarr && radarrEnabled && (
+        <InstancePickerRow
+          serviceId="radarr"
+          label="Radarr instance"
+          value={settings.radarrInstanceIds}
+          onChange={(radarrInstanceIds) => update({ radarrInstanceIds })}
+        />
+      )}
+
+      <MaxItemsSelector
+        value={settings.maxItems}
+        onChange={(maxItems) => update({ maxItems })}
+      />
+    </View>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -64,6 +64,7 @@ export const DASHBOARD_WIDGET_IDS = [
   "sabnzbd-queue",
   "nzbget-queue",
   "radarr-queue",
+  "recently-downloaded",
   "calendar",
   "tautulli-activity",
   "overseerr-requests",


### PR DESCRIPTION
Closes #114.

New **Recently Downloaded** dashboard widget combining Radarr (movies) and Sonarr (TV episodes) into one horizontal poster row, ordered by most recent import.

- Filters history on `downloadFolderImported` and merges across all bound instances; sorts newest-first.
- Reuses the same history query keys as the notification watchers, so no extra requests.
- Tiles tap through to the movie/series detail on their source instance; a small source logo shows when both sources are active.
- Per-source toggles, per-service instance pickers, and a max-items selector in widget settings (mirrors the Calendar widget).