### PR TITLE
Fix iOS modal-dismiss app hang (#83) and remove native Alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,21 @@ Notes:
 - `ConfirmModal` is a two-button (cancel + confirm) dialog. For **3+ choices** (e.g. "Delete" vs "Delete + Files"), use the styled **`ActionSheet`** (`components/ui/action-sheet.tsx`) instead — never a multi-button native `Alert`.
 - For transient success/error feedback, use the **`toast`** / **`toastError`** helpers from `components/ui/toast.tsx`, not `Alert`.
 
+### Modal sequencing on iOS — MUST follow (causes a frozen-app, force-quit hang)
+
+`ConfirmModal` and `ActionSheet` are React Native `<Modal>`s — on iOS each is a separate `UIViewController` presented over the screen. iOS will **not** present (or unmount the screen behind) a second view controller while another is mid-dismiss. On the New Architecture (Fabric, which this app uses) doing so **hangs the JS thread**: a transparent layer keeps eating touches, there is no crash log, and the user must force-quit. It is **intermittent and iOS-only** — it's a race between how fast your async work resolves and the ~300ms dismiss animation, so a fast LAN service triggers it while a slower one hides it, and Android (plain-view modals) never reproduces it. This was issue #83 (deleting a Radarr movie). Two forbidden shapes:
+
+1. **Opening a second modal from inside the first.** Never call `setPendingX(true)` / open a `ConfirmModal`/`ActionSheet` from an `ActionSheet` action's `onPress` — that presents while the sheet is still dismissing.
+2. **Navigating while a modal dismisses.** Never call `router.back()` / `router.push()` / `navigation.dispatch()` in a mutation's `onSuccess` (or a confirm's `onConfirm`) that also closed a modal in the same flow — the screen unmounts mid-dismiss.
+
+**The fix — sequence on the dismiss, never on the tap:**
+- Both `ConfirmModal` and `ActionSheet` expose an **`onClosed`** prop that fires once the modal is *fully* gone (backed by `hooks/use-modal-closed.ts`: iOS `onDismiss` fast-path + a timer backstop, since `onDismiss` is historically flaky on Fabric and absent on Android — so it is robust even if `onDismiss` never fires).
+- To **open another modal**, stash the choice in a `useRef` from the action's `onPress` and promote it to the next modal in the first sheet's `onClosed`.
+- To **navigate after a confirm**, use **`hooks/use-deferred-back.ts`** (`useDeferredBack`): call `arm()` before closing, `back()` in the mutation's `onSuccess`, and wire `onClosed={deferredBack.onClosed}` — it pops only after the modal is fully dismissed on iOS (immediate on Android).
+- Never paper over this with `setTimeout(() => router.back(), 250)` or similar fixed delays — that's the guess that keeps failing. Use the `onClosed` signal.
+
+Canonical reference: the delete flow in `app/movie/[id].tsx` and `app/series/[id].tsx` (actions sheet → confirm → pop). When adding any flow that chains a sheet into a dialog, or navigates right after a confirm, copy that wiring.
+
 ## UI Scale (Accessibility) — MUST follow when writing any new UI
 
 The app exposes a global UI scale preference (1.0 / 1.15 / 1.3) wired via NativeWind v4's reactive `rem` observable. `app/_layout.tsx` calls `rem.set(14 * uiScale)` whenever the setting changes, which scales every rem-based style across the running app with no remount. **Every new UI element must scale with this setting.** The rules:

--- a/app/(tabs)/downloads.tsx
+++ b/app/(tabs)/downloads.tsx
@@ -3,7 +3,6 @@ import {
   View,
   Text,
   Pressable,
-  Alert,
   BackHandler,
   FlatList,
   RefreshControl,
@@ -32,6 +31,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
+import { ActionSheet } from "@/components/ui/action-sheet";
 import { errorHaptic, lightHaptic, mediumHaptic } from "@/lib/haptics";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
 import {
@@ -272,6 +272,7 @@ function QbittorrentDownloadsScreen({
   const setSort = useSortStore((s) => s.setDownloads);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [speedLimitsOpen, setSpeedLimitsOpen] = useState(false);
+  const [bulkDelete, setBulkDelete] = useState<{ count: number } | null>(null);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
   const [refreshing, setRefreshing] = useState(false);
@@ -382,27 +383,15 @@ function QbittorrentDownloadsScreen({
   const handleBulkDelete = () => {
     const hashes = selectedHashes();
     if (hashes.length === 0) return;
-    Alert.alert("Delete Torrents", `Delete ${hashes.length} torrent(s)?`, [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          deleteMutation.mutate({ hashes });
-          multiSelect.clear();
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          deleteMutation.mutate({ hashes, deleteFiles: true });
-          multiSelect.clear();
-        },
-      },
-    ]);
+    setBulkDelete({ count: hashes.length });
+  };
+
+  const runBulkDelete = (deleteFiles: boolean) => {
+    const hashes = selectedHashes();
+    if (hashes.length === 0) return;
+    errorHaptic();
+    deleteMutation.mutate({ hashes, deleteFiles });
+    multiSelect.clear();
   };
 
   const handleTorrentPress = (torrent: QBTorrent) => {
@@ -624,6 +613,27 @@ function QbittorrentDownloadsScreen({
         visible={speedLimitsOpen}
         onClose={() => setSpeedLimitsOpen(false)}
       />
+
+      <ActionSheet
+        visible={bulkDelete !== null}
+        onClose={() => setBulkDelete(null)}
+        title="Delete torrents"
+        subtitle={bulkDelete ? `${bulkDelete.count} selected` : ""}
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runBulkDelete(false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runBulkDelete(true),
+          },
+        ]}
+      />
     </SafeAreaView>
   );
 }
@@ -709,21 +719,7 @@ function TorrentListItem({
   const isPaused = isTorrentPaused(torrent.state);
   const badgeVariant = getTorrentBadgeVariant(torrent.state);
 
-  const handleDelete = () => {
-    Alert.alert("Delete Torrent", `Delete "${truncateText(torrent.name, 30)}"?`, [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => onDelete(torrent, false),
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => onDelete(torrent, true),
-      },
-    ]);
-  };
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   return (
     <Card
@@ -781,7 +777,7 @@ function TorrentListItem({
               )}
             </Pressable>
             <Pressable
-              onPress={handleDelete}
+              onPress={() => setDeleteOpen(true)}
               disabled={busy}
               className={`p-1.5 active:opacity-70 ${busy ? "opacity-50" : ""}`}
               hitSlop={6}
@@ -791,6 +787,27 @@ function TorrentListItem({
           </View>
         )}
       </View>
+
+      <ActionSheet
+        visible={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        title="Delete torrent"
+        subtitle={truncateText(torrent.name, 40)}
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => onDelete(torrent, false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => onDelete(torrent, true),
+          },
+        ]}
+      />
     </Card>
   );
 }

--- a/app/(tabs)/indexers.tsx
+++ b/app/(tabs)/indexers.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { View, Text, Pressable, Alert, Platform, ScrollView } from "react-native";
+import { View, Text, Pressable, Platform, ScrollView } from "react-native";
 import { toast, toastError } from "@/components/ui/toast";
 import { Search, Power, AlertTriangle, CheckCircle, XCircle } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { ServiceHeader } from "@/components/common/service-header";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -143,24 +144,22 @@ function IndexerList() {
 
 function IndexerSearch() {
   const [query, setQuery] = useState("");
+  const [pendingGrab, setPendingGrab] = useState<ProwlarrSearchResult | null>(
+    null,
+  );
   const { data: results, isLoading } = useProwlarrSearch(query);
   const grabRelease = useGrabRelease();
 
-  const handleGrab = (result: ProwlarrSearchResult) => {
-    Alert.alert("Grab Release", `Send "${result.title}" to download client?`, [
-      { text: "Cancel", style: "cancel" },
+  const confirmGrab = () => {
+    if (!pendingGrab) return;
+    grabRelease.mutate(
+      { guid: pendingGrab.guid, indexerId: pendingGrab.indexerId },
       {
-        text: "Grab",
-        onPress: () =>
-          grabRelease.mutate(
-            { guid: result.guid, indexerId: result.indexerId },
-            {
-              onSuccess: () => toast("Sent to download client"),
-              onError: (err) => toastError("Failed to grab release", err),
-            },
-          ),
+        onSuccess: () => toast("Sent to download client"),
+        onError: (err) => toastError("Failed to grab release", err),
       },
-    ]);
+    );
+    setPendingGrab(null);
   };
 
   return (
@@ -183,7 +182,7 @@ function IndexerSearch() {
         <View className="gap-2">
           {results.slice(0, 50).map((result) => (
             <Card key={result.guid}>
-              <Pressable onPress={() => handleGrab(result)} className="active:opacity-80">
+              <Pressable onPress={() => setPendingGrab(result)} className="active:opacity-80">
                 <Text className="text-zinc-200 text-sm" numberOfLines={2}>
                   {result.title}
                 </Text>
@@ -209,6 +208,19 @@ function IndexerSearch() {
           ))}
         </View>
       )}
+
+      <ConfirmModal
+        visible={pendingGrab !== null}
+        title="Grab Release"
+        message={
+          pendingGrab
+            ? `Send "${pendingGrab.title}" to download client?`
+            : ""
+        }
+        confirmLabel="Grab"
+        onConfirm={confirmGrab}
+        onCancel={() => setPendingGrab(null)}
+      />
     </View>
   );
 }

--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -1,9 +1,8 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import {
   View,
   Text,
   Pressable,
-  Alert,
   ScrollView,
   RefreshControl,
   type RefreshControlProps,
@@ -21,6 +20,7 @@ import { FilterChip } from "@/components/ui/filter-chip";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import {
   MonitoredLibraryGrid,
   MONITOR_FILTER_OPTIONS,
@@ -124,6 +124,21 @@ export default function MoviesScreen() {
 
   const radarrHealth = healthData?.find((s) => s.id === "radarr");
 
+  const [pendingDelete, setPendingDelete] = useState<{
+    id: number;
+    title: string;
+    tmdbId?: number;
+    withFiles: boolean;
+  } | null>(null);
+  // Set from the actions sheet, promoted to the confirm modal only after the
+  // sheet has fully closed — never stack two native modals on iOS.
+  const deleteIntent = useRef<{
+    id: number;
+    title: string;
+    tmdbId?: number;
+    withFiles: boolean;
+  } | null>(null);
+
   const sheetMovie: RadarrMovie | undefined =
     sheetTarget?.kind === "movie"
       ? sheetTarget.item
@@ -160,25 +175,25 @@ export default function MoviesScreen() {
         icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
         variant: "danger",
         onPress: () => {
-          Alert.alert("Delete Movie", `Delete "${movie.title}"?`, [
-            { text: "Cancel", style: "cancel" },
-            {
-              text: "Delete",
-              style: "destructive",
-              onPress: () =>
-                deleteMutation.mutate({ id: movie.id, tmdbId: movie.tmdbId }),
-            },
-            {
-              text: "Delete + Files",
-              style: "destructive",
-              onPress: () =>
-                deleteMutation.mutate({
-                  id: movie.id,
-                  deleteFiles: true,
-                  tmdbId: movie.tmdbId,
-                }),
-            },
-          ]);
+          deleteIntent.current = {
+            id: movie.id,
+            title: movie.title,
+            tmdbId: movie.tmdbId,
+            withFiles: false,
+          };
+        },
+      },
+      {
+        label: "Delete + Files",
+        icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+        variant: "danger",
+        onPress: () => {
+          deleteIntent.current = {
+            id: movie.id,
+            title: movie.title,
+            tmdbId: movie.tmdbId,
+            withFiles: true,
+          };
         },
       },
     ];
@@ -281,6 +296,12 @@ export default function MoviesScreen() {
       <ActionSheet
         visible={sheetTarget !== null}
         onClose={() => setSheetTarget(null)}
+        onClosed={() => {
+          if (deleteIntent.current) {
+            setPendingDelete(deleteIntent.current);
+            deleteIntent.current = null;
+          }
+        }}
         title={sheetMovie?.title}
         subtitle={sheetMovie ? String(sheetMovie.year) : undefined}
         actions={actions}
@@ -299,6 +320,32 @@ export default function MoviesScreen() {
         sortOptions={SORT_OPTIONS.map((o) => ({ key: o.key, label: o.label }))}
         sortValue={sort}
         onSortChange={setSort}
+      />
+
+      <ConfirmModal
+        visible={pendingDelete !== null}
+        title={pendingDelete?.withFiles ? "Delete movie + files?" : "Delete movie?"}
+        message={
+          pendingDelete
+            ? pendingDelete.withFiles
+              ? `Remove "${pendingDelete.title}" from Radarr and delete files from disk. This can't be undone.`
+              : `Remove "${pendingDelete.title}" from Radarr. Files on disk will be kept.`
+            : ""
+        }
+        icon={Trash2}
+        tone="danger"
+        confirmLabel={pendingDelete?.withFiles ? "Delete + Files" : "Delete"}
+        onConfirm={() => {
+          if (pendingDelete) {
+            deleteMutation.mutate({
+              id: pendingDelete.id,
+              deleteFiles: pendingDelete.withFiles,
+              tmdbId: pendingDelete.tmdbId,
+            });
+          }
+          setPendingDelete(null);
+        }}
+        onCancel={() => setPendingDelete(null)}
       />
     </ScreenWrapper>
   );

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from "react";
-import { View, Text, Alert, BackHandler, Pressable, Linking, Platform } from "react-native";
+import { useCallback, useRef, useState } from "react";
+import { View, Text, BackHandler, Pressable, Linking, Platform } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import { router, useFocusEffect } from "expo-router";
 import { Image } from "expo-image";
@@ -71,6 +71,7 @@ import {
 import { PassphrasePrompt } from "@/components/common/passphrase-prompt";
 import type { PassphraseMode, PassphraseResult } from "@/components/common/passphrase-prompt";
 import { ConfirmModal } from "@/components/common/confirm-modal";
+import { ActionSheet } from "@/components/ui/action-sheet";
 import { SettingsGroup } from "@/components/settings/settings-group";
 import { SettingsRow } from "@/components/settings/settings-row";
 import { SettingsToggleRow } from "@/components/settings/settings-toggle-row";
@@ -942,6 +943,14 @@ function ServiceEditor({
   );
   const [testing, setTesting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [unsavedOpen, setUnsavedOpen] = useState(false);
+  // Chosen in the unsaved-changes sheet, run only after it has fully closed —
+  // "Save" can open the HTTP-warning modal, and stacking modals hangs iOS.
+  const unsavedIntent = useRef<"save" | "discard" | null>(null);
+  const [httpWarning, setHttpWarning] = useState<{
+    message: string;
+    resolve: (ok: boolean) => void;
+  } | null>(null);
 
   const usesBasicAuth =
     serviceId === "qbittorrent" ||
@@ -985,15 +994,7 @@ function ServiceEditor({
       onBack();
       return;
     }
-    Alert.alert(
-      "Unsaved changes",
-      "Your URL or credentials haven't been saved. What would you like to do?",
-      [
-        { text: "Keep editing", style: "cancel" },
-        { text: "Discard", style: "destructive", onPress: onBack },
-        { text: "Save", onPress: () => void handleSave() },
-      ],
-    );
+    setUnsavedOpen(true);
   };
 
   // Intercept Android hardware back / swipe-back so it closes the editor
@@ -1010,10 +1011,7 @@ function ServiceEditor({
 
   const confirmHttpWarning = (message: string) =>
     new Promise<boolean>((resolve) => {
-      Alert.alert("Remote URL uses HTTP", message, [
-        { text: "Cancel", style: "cancel", onPress: () => resolve(false) },
-        { text: "Save anyway", style: "destructive", onPress: () => resolve(true) },
-      ]);
+      setHttpWarning({ message, resolve });
     });
 
   const handleSave = async () => {
@@ -1300,6 +1298,51 @@ function ServiceEditor({
         onClose={() => {
           setShowAddToDashboards(false);
           onBack();
+        }}
+      />
+
+      <ActionSheet
+        visible={unsavedOpen}
+        onClose={() => setUnsavedOpen(false)}
+        onClosed={() => {
+          const intent = unsavedIntent.current;
+          unsavedIntent.current = null;
+          if (intent === "discard") onBack();
+          else if (intent === "save") void handleSave();
+        }}
+        title="Unsaved changes"
+        subtitle="Your URL or credentials haven't been saved."
+        actions={[
+          {
+            label: "Save",
+            onPress: () => {
+              unsavedIntent.current = "save";
+            },
+          },
+          {
+            label: "Discard",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => {
+              unsavedIntent.current = "discard";
+            },
+          },
+        ]}
+      />
+
+      <ConfirmModal
+        visible={httpWarning !== null}
+        title="Remote URL uses HTTP"
+        message={httpWarning?.message ?? ""}
+        tone="danger"
+        confirmLabel="Save anyway"
+        onConfirm={() => {
+          httpWarning?.resolve(true);
+          setHttpWarning(null);
+        }}
+        onCancel={() => {
+          httpWarning?.resolve(false);
+          setHttpWarning(null);
         }}
       />
     </ScreenWrapper>

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -1,9 +1,8 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import {
   View,
   Text,
   Pressable,
-  Alert,
   ScrollView,
   RefreshControl,
   type RefreshControlProps,
@@ -128,6 +127,18 @@ export default function TVScreen() {
   const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [sheetTarget, setSheetTarget] = useState<SeriesSheetTarget>(null);
   const [missingConfirmOpen, setMissingConfirmOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<{
+    id: number;
+    title: string;
+    withFiles: boolean;
+  } | null>(null);
+  // Set from the actions sheet, promoted to the confirm modal only after the
+  // sheet has fully closed — never stack two native modals on iOS.
+  const deleteIntent = useRef<{
+    id: number;
+    title: string;
+    withFiles: boolean;
+  } | null>(null);
   const router = useRouter();
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["sonarr"]]);
@@ -176,20 +187,23 @@ export default function TVScreen() {
           icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
           variant: "danger",
           onPress: () => {
-            Alert.alert("Delete Series", `Delete "${series.title}"?`, [
-              { text: "Cancel", style: "cancel" },
-              {
-                text: "Delete",
-                style: "destructive",
-                onPress: () => deleteMutation.mutate({ id: series.id }),
-              },
-              {
-                text: "Delete + Files",
-                style: "destructive",
-                onPress: () =>
-                  deleteMutation.mutate({ id: series.id, deleteFiles: true }),
-              },
-            ]);
+            deleteIntent.current = {
+              id: series.id,
+              title: series.title,
+              withFiles: false,
+            };
+          },
+        },
+        {
+          label: "Delete + Files",
+          icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+          variant: "danger",
+          onPress: () => {
+            deleteIntent.current = {
+              id: series.id,
+              title: series.title,
+              withFiles: true,
+            };
           },
         },
       ];
@@ -348,6 +362,12 @@ export default function TVScreen() {
       <ActionSheet
         visible={sheetTarget !== null}
         onClose={() => setSheetTarget(null)}
+        onClosed={() => {
+          if (deleteIntent.current) {
+            setPendingDelete(deleteIntent.current);
+            deleteIntent.current = null;
+          }
+        }}
         title={sheetTitle}
         subtitle={sheetSubtitle}
         actions={actions}
@@ -379,6 +399,31 @@ export default function TVScreen() {
           searchMissing.mutate();
         }}
         onCancel={() => setMissingConfirmOpen(false)}
+      />
+
+      <ConfirmModal
+        visible={pendingDelete !== null}
+        title={pendingDelete?.withFiles ? "Delete show + files?" : "Delete show?"}
+        message={
+          pendingDelete
+            ? pendingDelete.withFiles
+              ? `Remove "${pendingDelete.title}" from Sonarr and delete all episode files from disk. This can't be undone.`
+              : `Remove "${pendingDelete.title}" from Sonarr. Files on disk will be kept.`
+            : ""
+        }
+        icon={Trash2}
+        tone="danger"
+        confirmLabel={pendingDelete?.withFiles ? "Delete + Files" : "Delete"}
+        onConfirm={() => {
+          if (pendingDelete) {
+            deleteMutation.mutate({
+              id: pendingDelete.id,
+              deleteFiles: pendingDelete.withFiles,
+            });
+          }
+          setPendingDelete(null);
+        }}
+        onCancel={() => setPendingDelete(null)}
       />
     </ScreenWrapper>
   );

--- a/app/backend.tsx
+++ b/app/backend.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { View, Text, Pressable, Alert, ActivityIndicator, Platform } from "react-native";
+import { View, Text, Pressable, ActivityIndicator, Platform } from "react-native";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import { Bell, QrCode, Unlink, Cloud, CloudOff, RefreshCw } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { BackendStatusPill } from "@/components/ui/backend-status-pill";
 import { toast, toastError } from "@/components/ui/toast";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useBackendStore } from "@/store/backend-store";
 import {
   getBackendHealth,
@@ -51,6 +52,8 @@ export default function BackendScreen() {
 
   const [mode, setMode] = useState<Mode>("summary");
   const [busy, setBusy] = useState(false);
+  const [confirmUnpair, setConfirmUnpair] = useState(false);
+  const [confirmRotate, setConfirmRotate] = useState(false);
   const [backendUrl, setBackendUrl] = useState("");
   const [manualToken, setManualToken] = useState("");
   const [permission, requestPermission] = useCameraPermissions();
@@ -144,57 +147,41 @@ export default function BackendScreen() {
     }
   }, []);
 
-  const handleUnpair = useCallback(() => {
-    Alert.alert("Unpair backend", "This will stop push notifications from this backend. Continue?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Unpair",
-        style: "destructive",
-        onPress: async () => {
-          setBusy(true);
-          try {
-            try {
-              await unregisterDevice();
-            } catch {
-              /* ignore — unpair locally even if server is unreachable */
-            }
-            await unpair();
-            toast("Backend unpaired", "success");
-          } finally {
-            setBusy(false);
-          }
-        },
-      },
-    ]);
+  const handleUnpair = useCallback(() => setConfirmUnpair(true), []);
+
+  const performUnpair = useCallback(async () => {
+    setConfirmUnpair(false);
+    setBusy(true);
+    try {
+      try {
+        await unregisterDevice();
+      } catch {
+        /* ignore — unpair locally even if server is unreachable */
+      }
+      await unpair();
+      toast("Backend unpaired", "success");
+    } finally {
+      setBusy(false);
+    }
   }, [unpair]);
 
-  const handleRotate = useCallback(() => {
-    Alert.alert(
-      "Rotate backend secret",
-      "This unpairs the current shared secret. Scan a fresh pairing QR from your backend to get a new one. Push notifications will stop until you re-pair.",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Rotate",
-          style: "destructive",
-          onPress: async () => {
-            setBusy(true);
-            try {
-              try {
-                await unregisterDevice();
-              } catch {
-                /* ignore — rotate locally even if server is unreachable */
-              }
-              await unpair();
-              // Drops us into the un-paired summary state; user scans a new QR.
-              toast("Secret rotated — scan a new pairing QR", "success");
-            } finally {
-              setBusy(false);
-            }
-          },
-        },
-      ],
-    );
+  const handleRotate = useCallback(() => setConfirmRotate(true), []);
+
+  const performRotate = useCallback(async () => {
+    setConfirmRotate(false);
+    setBusy(true);
+    try {
+      try {
+        await unregisterDevice();
+      } catch {
+        /* ignore — rotate locally even if server is unreachable */
+      }
+      await unpair();
+      // Drops us into the un-paired summary state; user scans a new QR.
+      toast("Secret rotated — scan a new pairing QR", "success");
+    } finally {
+      setBusy(false);
+    }
   }, [unpair]);
 
   useEffect(() => {
@@ -373,6 +360,28 @@ export default function BackendScreen() {
           </View>
         </>
       )}
+
+      <ConfirmModal
+        visible={confirmUnpair}
+        title="Unpair backend"
+        message="This will stop push notifications from this backend. Continue?"
+        icon={Unlink}
+        tone="danger"
+        confirmLabel="Unpair"
+        onConfirm={performUnpair}
+        onCancel={() => setConfirmUnpair(false)}
+      />
+
+      <ConfirmModal
+        visible={confirmRotate}
+        title="Rotate backend secret"
+        message="This unpairs the current shared secret. Scan a fresh pairing QR from your backend to get a new one. Push notifications will stop until you re-pair."
+        icon={RefreshCw}
+        tone="danger"
+        confirmLabel="Rotate"
+        onConfirm={performRotate}
+        onCancel={() => setConfirmRotate(false)}
+      />
     </ScreenWrapper>
   );
 }

--- a/app/dashboard-edit/[id].tsx
+++ b/app/dashboard-edit/[id].tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { usePreventRemove } from "@react-navigation/native";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { Platform, Pressable, ScrollView, Text, View } from "react-native";
 import Animated, {
   FadeIn,
   FadeOut,
@@ -141,6 +141,9 @@ export default function DashboardEditScreen() {
   const navigation = useNavigation();
   const allowRemoveRef = useRef(false);
   const pendingActionRef = useRef<Parameters<typeof navigation.dispatch>[0] | null>(null);
+  // On iOS the actual navigation is deferred to the modal's onClosed; this marks
+  // that the user confirmed (vs cancelled) so onClosed knows to proceed.
+  const discardConfirmedRef = useRef(false);
   const [discardOpen, setDiscardOpen] = useState(false);
 
   usePreventRemove(
@@ -157,8 +160,7 @@ export default function DashboardEditScreen() {
     }, [navigation]),
   );
 
-  function confirmDiscard() {
-    setDiscardOpen(false);
+  function performDiscard() {
     const action = pendingActionRef.current;
     pendingActionRef.current = null;
     allowRemoveRef.current = true;
@@ -166,6 +168,18 @@ export default function DashboardEditScreen() {
       navigation.dispatch(action);
     } else {
       router.back();
+    }
+  }
+
+  function confirmDiscard() {
+    setDiscardOpen(false);
+    // iOS: navigate only after the modal has fully dismissed — popping or
+    // dispatching mid-dismiss hangs the JS thread on Fabric (see useModalClosed
+    // / useDeferredBack). Android has no such constraint, so go immediately.
+    if (Platform.OS === "ios") {
+      discardConfirmedRef.current = true;
+    } else {
+      performDiscard();
     }
   }
 
@@ -608,6 +622,12 @@ export default function DashboardEditScreen() {
           pendingActionRef.current = null;
         }}
         onConfirm={confirmDiscard}
+        onClosed={() => {
+          if (discardConfirmedRef.current) {
+            discardConfirmedRef.current = false;
+            performDiscard();
+          }
+        }}
       />
 
       <DashboardIconPickerSheet

--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { View, Text, Pressable, Alert, ActivityIndicator } from "react-native";
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
 import { Wifi, Plus, Pencil, Trash2 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { toast } from "@/components/ui/toast";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useConfigStore } from "@/store/config-store";
 import { detectWifi, normalizeBssid } from "@/lib/wifi";
 import type { HomeNetwork } from "@/store/config-store";
@@ -28,6 +29,7 @@ export default function HomeNetworksScreen() {
   const [ssid, setSsid] = useState("");
   const [bssid, setBssid] = useState("");
   const [detecting, setDetecting] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<HomeNetwork | null>(null);
 
   const resetForm = () => {
     setSsid("");
@@ -129,22 +131,11 @@ export default function HomeNetworksScreen() {
     setMode("list");
   };
 
-  const handleDelete = (network: HomeNetwork) => {
-    Alert.alert(
-      "Remove network",
-      `Stop treating "${network.ssid}" as a home network?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Remove",
-          style: "destructive",
-          onPress: () => {
-            removeHomeNetwork(network.id);
-            toast(`${network.ssid} removed`, "success");
-          },
-        },
-      ],
-    );
+  const confirmDelete = () => {
+    if (!pendingDelete) return;
+    removeHomeNetwork(pendingDelete.id);
+    toast(`${pendingDelete.ssid} removed`, "success");
+    setPendingDelete(null);
   };
 
   if (mode === "add" || mode === "edit") {
@@ -275,7 +266,7 @@ export default function HomeNetworksScreen() {
                     <Icon icon={Pencil} size={16} color="#71717a" />
                   </Pressable>
                   <Pressable
-                    onPress={() => handleDelete(network)}
+                    onPress={() => setPendingDelete(network)}
                     className="p-2 active:opacity-70"
                   >
                     <Icon icon={Trash2} size={16} color="#71717a" />
@@ -305,6 +296,21 @@ export default function HomeNetworksScreen() {
           </View>
         </View>
       )}
+
+      <ConfirmModal
+        visible={pendingDelete !== null}
+        title="Remove network"
+        message={
+          pendingDelete
+            ? `Stop treating "${pendingDelete.ssid}" as a home network?`
+            : ""
+        }
+        icon={Trash2}
+        tone="danger"
+        confirmLabel="Remove"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </ScreenWrapper>
   );
 }

--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { View, Text, ScrollView, Linking, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
@@ -40,6 +40,7 @@ import {
   useRadarrTags,
 } from "@/hooks/use-radarr";
 import { useServiceImage } from "@/hooks/use-service-image";
+import { useDeferredBack } from "@/hooks/use-deferred-back";
 import {
   formatBytes,
   formatAudioChannels,
@@ -55,6 +56,7 @@ export default function MovieDetailScreen() {
     instanceId?: string;
   }>();
   const router = useRouter();
+  const deferredBack = useDeferredBack();
   const { data: movie, isLoading, error } = useRadarrMovie(Number(id), instanceId);
   const deleteMutation = useDeleteMovie(instanceId);
   const toggleMonitored = useToggleMovieMonitored(instanceId);
@@ -69,6 +71,12 @@ export default function MovieDetailScreen() {
   const [rootFolderVisible, setRootFolderVisible] = useState(false);
   const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<DeleteMode>(null);
+  // Chosen in the actions sheet, promoted to the confirm modal only once that
+  // sheet has fully closed — never stack two native modals on iOS.
+  const deleteIntent = useRef<DeleteMode>(null);
+  // Same deal: a picked root folder, opened into the "move files?" sheet only
+  // after the root-folder sheet is fully gone.
+  const rootFolderIntent = useRef<string | null>(null);
 
   const poster = movie?.images.find((i) => i.coverType === "poster");
   const fanart = movie?.images.find((i) => i.coverType === "fanart");
@@ -123,18 +131,22 @@ export default function MovieDetailScreen() {
 
   const confirmDelete = () => {
     if (!pendingDelete) return;
+    const withFiles = pendingDelete === "withFiles";
+    // Close the confirm modal first, then pop the screen only after it has
+    // fully dismissed — popping mid-dismiss hangs the JS thread on iOS/Fabric.
+    deferredBack.arm();
+    setPendingDelete(null);
     deleteMutation.mutate(
       {
         id: movie.id,
-        deleteFiles: pendingDelete === "withFiles",
+        deleteFiles: withFiles,
         tmdbId: movie.tmdbId,
       },
       {
-        onSuccess: () => router.back(),
+        onSuccess: () => deferredBack.back(),
         onError: (err) => toastError("Failed to delete movie", err),
       },
     );
-    setPendingDelete(null);
   };
 
   const actions: MediaActionItem[] = [
@@ -270,6 +282,12 @@ export default function MovieDetailScreen() {
       <ActionSheet
         visible={actionsVisible}
         onClose={() => setActionsVisible(false)}
+        onClosed={() => {
+          if (deleteIntent.current) {
+            setPendingDelete(deleteIntent.current);
+            deleteIntent.current = null;
+          }
+        }}
         title={movie.title}
         actions={[
           {
@@ -277,8 +295,7 @@ export default function MovieDetailScreen() {
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
             variant: "danger",
             onPress: () => {
-              setActionsVisible(false);
-              setPendingDelete("keep");
+              deleteIntent.current = "keep";
             },
           },
           {
@@ -286,8 +303,7 @@ export default function MovieDetailScreen() {
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
             variant: "danger",
             onPress: () => {
-              setActionsVisible(false);
-              setPendingDelete("withFiles");
+              deleteIntent.current = "withFiles";
             },
           },
         ]}
@@ -320,6 +336,12 @@ export default function MovieDetailScreen() {
       <ActionSheet
         visible={rootFolderVisible}
         onClose={() => setRootFolderVisible(false)}
+        onClosed={() => {
+          if (rootFolderIntent.current) {
+            setPendingRootFolder(rootFolderIntent.current);
+            rootFolderIntent.current = null;
+          }
+        }}
         title="Root Folder"
         subtitle={movie.title}
         actions={(rootFolders ?? []).map((f) => ({
@@ -333,8 +355,7 @@ export default function MovieDetailScreen() {
           ),
           onPress: () => {
             if (f.path === movie.rootFolderPath) return;
-            setRootFolderVisible(false);
-            setPendingRootFolder(f.path);
+            rootFolderIntent.current = f.path;
           },
         }))}
       />
@@ -393,6 +414,7 @@ export default function MovieDetailScreen() {
         }
         onConfirm={confirmDelete}
         onCancel={() => setPendingDelete(null)}
+        onClosed={deferredBack.onClosed}
       />
     </>
   );

--- a/app/nzb/[nzbId].tsx
+++ b/app/nzb/[nzbId].tsx
@@ -1,5 +1,6 @@
-import { View, Text, Alert, ActivityIndicator } from "react-native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
+import { View, Text, ActivityIndicator } from "react-native";
+import { useLocalSearchParams } from "expo-router";
 import { Pause, Play, Trash2, ArrowDown, Clock } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -8,6 +9,8 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Button } from "@/components/ui/button";
+import { ActionSheet } from "@/components/ui/action-sheet";
+import { useDeferredBack } from "@/hooks/use-deferred-back";
 import {
   useDeleteNzbgetGroup,
   useDeleteNzbgetHistorySlot,
@@ -60,7 +63,6 @@ export default function NzbgetSlotDetailScreen() {
     nzbId: string;
     instanceId?: string;
   }>();
-  const router = useRouter();
   const numericId = Number(nzbId);
 
   const {
@@ -78,6 +80,8 @@ export default function NzbgetSlotDetailScreen() {
   const resumeSlot = useResumeNzbgetGroup(instanceId);
   const deleteSlot = useDeleteNzbgetGroup(instanceId);
   const deleteHistory = useDeleteNzbgetHistorySlot(instanceId);
+  const [deleteSheetOpen, setDeleteSheetOpen] = useState(false);
+  const deferredBack = useDeferredBack();
 
   const queueGroup = groups?.find((g) => g.NZBID === numericId);
   const historyItem = historyItems?.find((h) => h.NZBID === numericId);
@@ -133,34 +137,16 @@ export default function NzbgetSlotDetailScreen() {
       ? formatEta(Math.round(remainingBytes / overallSpeed))
       : undefined;
 
-  const handleDelete = () => {
-    Alert.alert("Delete Download", "Are you sure?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          if (inQueue) {
-            deleteSlot.mutate({ nzbId: numericId });
-          } else {
-            deleteHistory.mutate({ nzbId: numericId });
-          }
-          router.back();
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          if (inQueue) {
-            deleteSlot.mutate({ nzbId: numericId, deleteFiles: true });
-          } else {
-            deleteHistory.mutate({ nzbId: numericId, deleteFiles: true });
-          }
-          router.back();
-        },
-      },
-    ]);
+  const runDelete = (deleteFiles: boolean) => {
+    if (inQueue) {
+      deleteSlot.mutate({ nzbId: numericId, deleteFiles });
+    } else {
+      deleteHistory.mutate({ nzbId: numericId, deleteFiles });
+    }
+    // Pop back, but only once the sheet is fully dismissed — navigating mid-
+    // dismiss hangs the JS thread on iOS/Fabric. See useDeferredBack.
+    deferredBack.arm();
+    deferredBack.back();
   };
 
   return (
@@ -237,12 +223,34 @@ export default function NzbgetSlotDetailScreen() {
         <Button
           label="Delete"
           variant="danger"
-          onPress={handleDelete}
+          onPress={() => setDeleteSheetOpen(true)}
           loading={deleteSlot.isPending || deleteHistory.isPending}
           icon={<Icon icon={Trash2} size={16} color="white" />}
           className="flex-1"
         />
       </View>
+
+      <ActionSheet
+        visible={deleteSheetOpen}
+        onClose={() => setDeleteSheetOpen(false)}
+        onClosed={deferredBack.onClosed}
+        title={name}
+        subtitle="Delete this download?"
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(true),
+          },
+        ]}
+      />
     </ScreenWrapper>
   );
 }

--- a/app/sab/[nzo_id].tsx
+++ b/app/sab/[nzo_id].tsx
@@ -1,5 +1,6 @@
-import { View, Text, Alert, ActivityIndicator } from "react-native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
+import { View, Text, ActivityIndicator } from "react-native";
+import { useLocalSearchParams } from "expo-router";
 import { Pause, Play, Trash2, ArrowDown, Clock } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -8,6 +9,8 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Button } from "@/components/ui/button";
+import { ActionSheet } from "@/components/ui/action-sheet";
+import { useDeferredBack } from "@/hooks/use-deferred-back";
 import {
   useSabQueue,
   useSabHistory,
@@ -36,7 +39,6 @@ export default function SabSlotDetailScreen() {
     nzo_id: string;
     instanceId?: string;
   }>();
-  const router = useRouter();
   const {
     data: queue,
     isLoading: queueLoading,
@@ -51,6 +53,8 @@ export default function SabSlotDetailScreen() {
   const resumeSlot = useResumeSabSlot(instanceId);
   const deleteSlot = useDeleteSabSlot(instanceId);
   const deleteHistory = useDeleteSabHistorySlot(instanceId);
+  const [deleteSheetOpen, setDeleteSheetOpen] = useState(false);
+  const deferredBack = useDeferredBack();
 
   const queueSlot = queue?.slots.find((s) => s.nzo_id === nzo_id);
   const historySlot = history?.slots.find((s) => s.nzo_id === nzo_id);
@@ -93,34 +97,16 @@ export default function SabSlotDetailScreen() {
     : 0;
   const isPaused = status === "Paused";
 
-  const handleDelete = () => {
-    Alert.alert("Delete Download", "Are you sure?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          if (inQueue) {
-            deleteSlot.mutate({ nzoId: nzo_id });
-          } else {
-            deleteHistory.mutate({ nzoId: nzo_id });
-          }
-          router.back();
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          if (inQueue) {
-            deleteSlot.mutate({ nzoId: nzo_id, deleteFiles: true });
-          } else {
-            deleteHistory.mutate({ nzoId: nzo_id, deleteFiles: true });
-          }
-          router.back();
-        },
-      },
-    ]);
+  const runDelete = (deleteFiles: boolean) => {
+    if (inQueue) {
+      deleteSlot.mutate({ nzoId: nzo_id, deleteFiles });
+    } else {
+      deleteHistory.mutate({ nzoId: nzo_id, deleteFiles });
+    }
+    // Pop back, but only once the sheet is fully dismissed — navigating mid-
+    // dismiss hangs the JS thread on iOS/Fabric. See useDeferredBack.
+    deferredBack.arm();
+    deferredBack.back();
   };
 
   return (
@@ -199,12 +185,34 @@ export default function SabSlotDetailScreen() {
         <Button
           label="Delete"
           variant="danger"
-          onPress={handleDelete}
+          onPress={() => setDeleteSheetOpen(true)}
           loading={deleteSlot.isPending || deleteHistory.isPending}
           icon={<Icon icon={Trash2} size={16} color="white" />}
           className="flex-1"
         />
       </View>
+
+      <ActionSheet
+        visible={deleteSheetOpen}
+        onClose={() => setDeleteSheetOpen(false)}
+        onClosed={deferredBack.onClosed}
+        title={name}
+        subtitle="Delete this download?"
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(true),
+          },
+        ]}
+      />
     </ScreenWrapper>
   );
 }

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useRef, useState, useMemo } from "react";
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
@@ -58,6 +58,7 @@ import {
   formatResolution,
 } from "@/lib/utils";
 import { useServiceImage } from "@/hooks/use-service-image";
+import { useDeferredBack } from "@/hooks/use-deferred-back";
 import type {
   SonarrEpisode,
   SonarrEpisodeFile,
@@ -73,6 +74,7 @@ export default function SeriesDetailScreen() {
     instanceId?: string;
   }>();
   const router = useRouter();
+  const deferredBack = useDeferredBack();
   const {
     data: series,
     isLoading,
@@ -95,6 +97,12 @@ export default function SeriesDetailScreen() {
     null,
   );
   const [pendingDelete, setPendingDelete] = useState<DeleteMode>(null);
+  // Chosen in the actions sheet, promoted to the confirm modal only once that
+  // sheet has fully closed — never stack two native modals on iOS.
+  const deleteIntent = useRef<DeleteMode>(null);
+  // Same deal: a picked root folder, opened into the "move files?" sheet only
+  // after the root-folder sheet is fully gone.
+  const rootFolderIntent = useRef<string | null>(null);
 
   const episodeFileMap = useMemo(() => {
     const map = new Map<number, SonarrEpisodeFile>();
@@ -159,17 +167,21 @@ export default function SeriesDetailScreen() {
 
   const confirmDelete = () => {
     if (!pendingDelete) return;
+    const withFiles = pendingDelete === "withFiles";
+    // Close the confirm modal first, then pop the screen only after it has
+    // fully dismissed — popping mid-dismiss hangs the JS thread on iOS/Fabric.
+    deferredBack.arm();
+    setPendingDelete(null);
     deleteSeries.mutate(
       {
         id: series.id,
-        deleteFiles: pendingDelete === "withFiles",
+        deleteFiles: withFiles,
       },
       {
-        onSuccess: () => router.back(),
+        onSuccess: () => deferredBack.back(),
         onError: (err) => toastError("Failed to delete show", err),
       },
     );
-    setPendingDelete(null);
   };
 
   const actions: MediaActionItem[] = [
@@ -313,6 +325,12 @@ export default function SeriesDetailScreen() {
       <ActionSheet
         visible={actionsVisible}
         onClose={() => setActionsVisible(false)}
+        onClosed={() => {
+          if (deleteIntent.current) {
+            setPendingDelete(deleteIntent.current);
+            deleteIntent.current = null;
+          }
+        }}
         title={series.title}
         actions={[
           {
@@ -320,8 +338,7 @@ export default function SeriesDetailScreen() {
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
             variant: "danger",
             onPress: () => {
-              setActionsVisible(false);
-              setPendingDelete("keep");
+              deleteIntent.current = "keep";
             },
           },
           {
@@ -329,8 +346,7 @@ export default function SeriesDetailScreen() {
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
             variant: "danger",
             onPress: () => {
-              setActionsVisible(false);
-              setPendingDelete("withFiles");
+              deleteIntent.current = "withFiles";
             },
           },
         ]}
@@ -363,6 +379,12 @@ export default function SeriesDetailScreen() {
       <ActionSheet
         visible={rootFolderVisible}
         onClose={() => setRootFolderVisible(false)}
+        onClosed={() => {
+          if (rootFolderIntent.current) {
+            setPendingRootFolder(rootFolderIntent.current);
+            rootFolderIntent.current = null;
+          }
+        }}
         title="Root Folder"
         subtitle={series.title}
         actions={(rootFolders ?? []).map((f) => ({
@@ -376,8 +398,7 @@ export default function SeriesDetailScreen() {
           ),
           onPress: () => {
             if (f.path === series.rootFolderPath) return;
-            setRootFolderVisible(false);
-            setPendingRootFolder(f.path);
+            rootFolderIntent.current = f.path;
           },
         }))}
       />
@@ -436,6 +457,7 @@ export default function SeriesDetailScreen() {
         }
         onConfirm={confirmDelete}
         onCancel={() => setPendingDelete(null)}
+        onClosed={deferredBack.onClosed}
       />
     </>
   );
@@ -707,6 +729,9 @@ function EpisodeRow({
   const deleteFile = useDeleteEpisodeFile(instanceId);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  // Open the confirm only after the actions sheet has fully closed (iOS can't
+  // present a second modal while the first is dismissing).
+  const wantDeleteFile = useRef(false);
   const mediaInfo = episodeFile?.mediaInfo;
 
   // Search/delete live in the "⋯" sheet so the row stays uncluttered and the
@@ -733,7 +758,9 @@ function EpisodeRow({
             label: "Delete File",
             icon: <Icon icon={Trash2} size={20} color="#ef4444" />,
             variant: "danger" as const,
-            onPress: () => setConfirmDelete(true),
+            onPress: () => {
+              wantDeleteFile.current = true;
+            },
           },
         ]
       : []),
@@ -805,6 +832,12 @@ function EpisodeRow({
       <ActionSheet
         visible={sheetOpen}
         onClose={() => setSheetOpen(false)}
+        onClosed={() => {
+          if (wantDeleteFile.current) {
+            wantDeleteFile.current = false;
+            setConfirmDelete(true);
+          }
+        }}
         title={formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)}
         subtitle={episode.title}
         actions={episodeActions}

--- a/app/torrent/[hash].tsx
+++ b/app/torrent/[hash].tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { View, Text, Alert, ActivityIndicator } from "react-native";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { View, Text, ActivityIndicator } from "react-native";
+import { useLocalSearchParams } from "expo-router";
 import {
   Pause,
   Play,
@@ -17,7 +17,9 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Button } from "@/components/ui/button";
+import { ActionSheet } from "@/components/ui/action-sheet";
 import { ShareLimitsSheet } from "@/components/qbittorrent/share-limits-sheet";
+import { useDeferredBack } from "@/hooks/use-deferred-back";
 import {
   useTorrent,
   useTorrentFiles,
@@ -31,7 +33,6 @@ import { isTorrentPaused } from "@/lib/types";
 
 export default function TorrentDetailScreen() {
   const { hash } = useLocalSearchParams<{ hash: string }>();
-  const router = useRouter();
   const { data: torrent, isLoading, error } = useTorrent(hash);
   const { data: files } = useTorrentFiles(hash);
   const { data: trackers } = useTorrentTrackers(hash);
@@ -39,6 +40,8 @@ export default function TorrentDetailScreen() {
   const resumeMutation = useResumeTorrent();
   const deleteMutation = useDeleteTorrent();
   const [shareLimitsOpen, setShareLimitsOpen] = useState(false);
+  const [deleteSheetOpen, setDeleteSheetOpen] = useState(false);
+  const deferredBack = useDeferredBack();
 
   if (!torrent) {
     return (
@@ -65,26 +68,12 @@ export default function TorrentDetailScreen() {
 
   const isPaused = isTorrentPaused(torrent.state);
 
-  const handleDelete = () => {
-    Alert.alert("Delete Torrent", "Are you sure?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          deleteMutation.mutate({ hashes: [hash] });
-          router.back();
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          deleteMutation.mutate({ hashes: [hash], deleteFiles: true });
-          router.back();
-        },
-      },
-    ]);
+  const runDelete = (deleteFiles: boolean) => {
+    deleteMutation.mutate({ hashes: [hash], deleteFiles });
+    // Pop back, but only once the sheet is fully dismissed — navigating mid-
+    // dismiss hangs the JS thread on iOS/Fabric. See useDeferredBack.
+    deferredBack.arm();
+    deferredBack.back();
   };
 
   return (
@@ -194,7 +183,7 @@ export default function TorrentDetailScreen() {
           <Button
             label="Delete"
             variant="danger"
-            onPress={handleDelete}
+            onPress={() => setDeleteSheetOpen(true)}
             loading={deleteMutation.isPending}
             icon={<Icon icon={Trash2} size={16} color="white" />}
             className="flex-1"
@@ -216,6 +205,28 @@ export default function TorrentDetailScreen() {
         hash={hash}
         ratioLimit={torrent.ratio_limit ?? -2}
         seedingTimeLimit={torrent.seeding_time_limit ?? -2}
+      />
+
+      <ActionSheet
+        visible={deleteSheetOpen}
+        onClose={() => setDeleteSheetOpen(false)}
+        onClosed={deferredBack.onClosed}
+        title={torrent.name}
+        subtitle="Remove this torrent from qBittorrent?"
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(true),
+          },
+        ]}
       />
     </>
   );

--- a/app/wake-on-lan.tsx
+++ b/app/wake-on-lan.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { View, Text, Pressable, Alert } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { Zap, Plus, Pencil, Trash2, X } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -8,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { toast, toastError } from "@/components/ui/toast";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useConfigStore } from "@/store/config-store";
 import { sendWakeOnLan } from "@/lib/wake-on-lan";
 import type { WakeOnLanDevice } from "@/store/config-store";
@@ -29,6 +30,9 @@ export default function WakeOnLanScreen() {
   const [broadcastAddress, setBroadcastAddress] = useState("");
   const [port, setPort] = useState("");
   const [sendingId, setSendingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<WakeOnLanDevice | null>(
+    null,
+  );
 
   const resetForm = () => {
     setName("");
@@ -78,22 +82,11 @@ export default function WakeOnLanScreen() {
     setMode("list");
   };
 
-  const handleDelete = (device: WakeOnLanDevice) => {
-    Alert.alert(
-      "Delete Device",
-      `Remove "${device.name}" from Wake-on-LAN?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: () => {
-            setWolDevices(wolDevices.filter((d) => d.id !== device.id));
-            toast(`${device.name} removed`, "success");
-          },
-        },
-      ],
-    );
+  const confirmDelete = () => {
+    if (!pendingDelete) return;
+    setWolDevices(wolDevices.filter((d) => d.id !== pendingDelete.id));
+    toast(`${pendingDelete.name} removed`, "success");
+    setPendingDelete(null);
   };
 
   const handleWake = async (device: WakeOnLanDevice) => {
@@ -210,7 +203,7 @@ export default function WakeOnLanScreen() {
                   <Pressable onPress={() => startEdit(device)} className="p-2 active:opacity-70">
                     <Icon icon={Pencil} size={16} color="#71717a" />
                   </Pressable>
-                  <Pressable onPress={() => handleDelete(device)} className="p-2 active:opacity-70">
+                  <Pressable onPress={() => setPendingDelete(device)} className="p-2 active:opacity-70">
                     <Icon icon={Trash2} size={16} color="#71717a" />
                   </Pressable>
                 </View>
@@ -227,6 +220,21 @@ export default function WakeOnLanScreen() {
           ))}
         </View>
       )}
+
+      <ConfirmModal
+        visible={pendingDelete !== null}
+        title="Delete Device"
+        message={
+          pendingDelete
+            ? `Remove "${pendingDelete.name}" from Wake-on-LAN?`
+            : ""
+        }
+        icon={Trash2}
+        tone="danger"
+        confirmLabel="Delete"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </ScreenWrapper>
   );
 }

--- a/components/common/app-version-card.tsx
+++ b/components/common/app-version-card.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { View, Text, Alert, Linking } from "react-native";
+import { View, Text, Linking } from "react-native";
 import { Sparkles } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { toast, toastError } from "@/components/ui/toast";
 import {
   NATIVE_VERSION,
@@ -17,6 +18,12 @@ import {
 
 export function AppVersionCard() {
   const [checking, setChecking] = useState(false);
+  const [storeUpdate, setStoreUpdate] = useState<{
+    message: string;
+    confirmLabel: string;
+    url: string;
+  } | null>(null);
+  const [otaUpdate, setOtaUpdate] = useState(false);
   const updateId = getCurrentUpdateId();
   const updateIdLabel = updateId ? updateId.slice(0, 8) : "embedded";
 
@@ -52,40 +59,16 @@ export function AppVersionCard() {
         storeResult.source === "github" ? "Open release" : "Open store";
 
       if (storeResult.hasUpdate && storeResult.storeVersion) {
-        Alert.alert(
-          "Update available",
-          `A newer version (${storeResult.storeVersion}) is available on ${sourceLabel}. You're on ${NATIVE_VERSION}.`,
-          [
-            { text: "Later", style: "cancel" },
-            {
-              text: openButtonLabel,
-              onPress: () => {
-                if (storeResult.storeUrl) Linking.openURL(storeResult.storeUrl);
-              },
-            },
-          ],
-        );
+        setStoreUpdate({
+          message: `A newer version (${storeResult.storeVersion}) is available on ${sourceLabel}. You're on ${NATIVE_VERSION}.`,
+          confirmLabel: openButtonLabel,
+          url: storeResult.storeUrl ?? "",
+        });
         return;
       }
 
       if (otaResult.available) {
-        Alert.alert(
-          "Update available",
-          "A new over-the-air update is available. Install and restart now?",
-          [
-            { text: "Later", style: "cancel" },
-            {
-              text: "Install",
-              onPress: async () => {
-                try {
-                  await downloadAndApplyOtaUpdate();
-                } catch (err) {
-                  toastError("Failed to install update", err);
-                }
-              },
-            },
-          ],
-        );
+        setOtaUpdate(true);
         return;
       }
 
@@ -94,7 +77,7 @@ export function AppVersionCard() {
           otaSettled.error instanceof Error
             ? otaSettled.error.message
             : String(otaSettled.error);
-        Alert.alert("OTA check failed", msg || "Unknown error checking for updates.");
+        toast(msg || "Unknown error checking for updates.", "error");
         return;
       }
 
@@ -129,6 +112,38 @@ export function AppVersionCard() {
         onPress={handleCheck}
         variant="outline"
         loading={checking}
+      />
+
+      <ConfirmModal
+        visible={storeUpdate !== null}
+        title="Update available"
+        message={storeUpdate?.message ?? ""}
+        icon={Sparkles}
+        confirmLabel={storeUpdate?.confirmLabel ?? "Open"}
+        cancelLabel="Later"
+        onConfirm={() => {
+          if (storeUpdate?.url) Linking.openURL(storeUpdate.url);
+          setStoreUpdate(null);
+        }}
+        onCancel={() => setStoreUpdate(null)}
+      />
+
+      <ConfirmModal
+        visible={otaUpdate}
+        title="Update available"
+        message="A new over-the-air update is available. Install and restart now?"
+        icon={Sparkles}
+        confirmLabel="Install"
+        cancelLabel="Later"
+        onConfirm={async () => {
+          setOtaUpdate(false);
+          try {
+            await downloadAndApplyOtaUpdate();
+          } catch (err) {
+            toastError("Failed to install update", err);
+          }
+        }}
+        onCancel={() => setOtaUpdate(false)}
       />
     </Card>
   );

--- a/components/common/confirm-modal.tsx
+++ b/components/common/confirm-modal.tsx
@@ -3,6 +3,7 @@ import { Modal, View, Text, KeyboardAvoidingView, Platform } from "react-native"
 import { Icon } from "@/components/ui/icon";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useModalClosed } from "@/hooks/use-modal-closed";
 
 export type ConfirmTone = "default" | "danger";
 
@@ -16,6 +17,13 @@ interface ConfirmModalProps {
   cancelLabel?: string;
   onConfirm: () => void;
   onCancel: () => void;
+  /**
+   * Fired once the modal is fully dismissed (see `useModalClosed`). Use this to
+   * sequence anything that must not run while the modal is still tearing down —
+   * e.g. `router.back()`, which hangs the JS thread on iOS/Fabric if it races
+   * the dismiss. See `useDeferredBack`.
+   */
+  onClosed?: () => void;
 }
 
 export function ConfirmModal({
@@ -28,12 +36,17 @@ export function ConfirmModal({
   cancelLabel = "Cancel",
   onConfirm,
   onCancel,
+  onClosed,
 }: ConfirmModalProps) {
   const isDanger = tone === "danger";
   const resolvedConfirmLabel =
     confirmLabel ?? (isDanger ? "Delete" : "Confirm");
   const iconColor = isDanger ? "#ef4444" : "#60a5fa";
   const iconBg = isDanger ? "bg-danger/15" : "bg-primary/15";
+
+  // Fire onClosed once the modal is fully dismissed — the safe point to pop the
+  // screen / open another modal on iOS. See useModalClosed.
+  const handleDismiss = useModalClosed(visible, onClosed);
 
   return (
     <Modal
@@ -42,6 +55,7 @@ export function ConfirmModal({
       animationType="fade"
       statusBarTranslucent
       onRequestClose={onCancel}
+      onDismiss={handleDismiss}
     >
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/components/common/release-detail-sheet.tsx
+++ b/components/common/release-detail-sheet.tsx
@@ -31,6 +31,7 @@ import { formatBytes, formatReleaseAge } from "@/lib/utils";
 import { getQualityColor } from "@/lib/quality-colors";
 import { useGrabRadarrRelease } from "@/hooks/use-radarr";
 import { useGrabSonarrRelease } from "@/hooks/use-sonarr";
+import { useModalClosed } from "@/hooks/use-modal-closed";
 import type { ArrRelease, SonarrRelease } from "@/lib/types";
 
 const { height: SCREEN_H } = Dimensions.get("window");
@@ -43,6 +44,11 @@ interface ReleaseDetailSheetProps {
   instanceId?: string;
   onClose: () => void;
   onGrabbed?: () => void;
+  /**
+   * Fired once the sheet's native `<Modal>` is fully gone — the safe point to
+   * navigate on iOS (see `useModalClosed`).
+   */
+  onClosed?: () => void;
 }
 
 export function ReleaseDetailSheet({
@@ -51,9 +57,11 @@ export function ReleaseDetailSheet({
   instanceId,
   onClose,
   onGrabbed,
+  onClosed,
 }: ReleaseDetailSheetProps) {
   const insets = useSafeAreaInsets();
   const [mounted, setMounted] = useState(false);
+  const handleDismiss = useModalClosed(mounted, onClosed);
   const translateY = useSharedValue(OFFSCREEN);
   const backdrop = useSharedValue(0);
 
@@ -118,7 +126,13 @@ export function ReleaseDetailSheet({
 
   if (!release) {
     return (
-      <Modal visible={mounted} transparent animationType="none" statusBarTranslucent>
+      <Modal
+        visible={mounted}
+        transparent
+        animationType="none"
+        statusBarTranslucent
+        onDismiss={handleDismiss}
+      >
         <View />
       </Modal>
     );
@@ -144,6 +158,7 @@ export function ReleaseDetailSheet({
       animationType="none"
       statusBarTranslucent
       onRequestClose={onClose}
+      onDismiss={handleDismiss}
     >
       <GestureHandlerRootView style={{ flex: 1 }}>
         <View className="flex-1 justify-end">

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator,
   Pressable,
 } from "react-native";
-import { useRouter } from "expo-router";
 import { Search, AlertTriangle, X, Check } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -26,6 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { lightHaptic } from "@/lib/haptics";
 import { getHttpErrorMessage } from "@/lib/http-client";
+import { useDeferredBack } from "@/hooks/use-deferred-back";
 import { useSortStore, type ReleasesSortKey } from "@/store/sort-store";
 
 type Release = ArrRelease | SonarrRelease;
@@ -166,7 +166,7 @@ export function ReleasesPicker({
   query,
   instanceId,
 }: ReleasesPickerProps) {
-  const router = useRouter();
+  const deferredBack = useDeferredBack();
   const sortKey = useSortStore((s) => s.releases);
   const setSortKey = useSortStore((s) => s.setReleases);
 
@@ -449,9 +449,13 @@ export function ReleasesPicker({
         onClose={() => setSelected(null)}
         onGrabbed={() => {
           // After a grab succeeds, pop back to the detail screen so the user
-          // sees their queue update in context.
-          setTimeout(() => router.back(), 250);
+          // sees their queue update in context — but only once the sheet has
+          // fully dismissed (navigating mid-dismiss hangs iOS/Fabric). Replaces
+          // a fixed setTimeout guess with the sheet's real onClosed signal.
+          deferredBack.arm();
+          deferredBack.back();
         }}
+        onClosed={deferredBack.onClosed}
       />
     </View>
   );

--- a/components/dashboard/dashboard-picker-sheet.tsx
+++ b/components/dashboard/dashboard-picker-sheet.tsx
@@ -8,7 +8,6 @@ import {
   Dimensions,
   StyleSheet,
   TextInput,
-  Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
 import {
@@ -64,6 +63,7 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
   const insets = useSafeAreaInsets();
 
   const [mounted, setMounted] = useState(false);
+  const [pendingRemove, setPendingRemove] = useState<Dashboard | null>(null);
   const [creating, setCreating] = useState(false);
   const [createDraft, setCreateDraft] = useState("");
   // Submit-only commit (via the keyboard return key or the inline check
@@ -136,21 +136,7 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
 
   function handleRemove(d: Dashboard) {
     if (dashboards.length <= 1) return;
-    Alert.alert(
-      "Delete dashboard?",
-      `"${d.name}" and its widget settings will be removed. This cannot be undone.`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: () => {
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-            removeDashboard(d.id);
-          },
-        },
-      ],
-    );
+    setPendingRemove(d);
   }
 
   function handleOpenEditor(d: Dashboard) {
@@ -428,6 +414,57 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
               </View>
             </ScrollView>
           </Animated.View>
+
+          {/* In-sheet confirm — a nested native Modal can't reliably present
+              over this one on iOS, so we overlay the confirm inside the sheet's
+              own Modal instead of stacking a ConfirmModal. */}
+          {pendingRemove && (
+            <View
+              style={StyleSheet.absoluteFill}
+              className="items-center justify-center px-8"
+            >
+              <Pressable
+                style={StyleSheet.absoluteFill}
+                className="bg-black/70"
+                onPress={() => setPendingRemove(null)}
+              />
+              <View className="w-full max-w-md rounded-2xl bg-surface border border-border p-5 gap-4">
+                <View className="flex-row items-center gap-3">
+                  <View className="bg-danger/15 rounded-xl p-2.5">
+                    <Icon icon={Trash2} size={20} color="#ef4444" />
+                  </View>
+                  <Text className="text-zinc-100 text-lg font-semibold flex-1">
+                    Delete dashboard?
+                  </Text>
+                </View>
+                <Text className="text-zinc-400 text-sm leading-5">
+                  {`"${pendingRemove.name}" and its widget settings will be removed. This cannot be undone.`}
+                </Text>
+                <View className="flex-row gap-3 mt-1">
+                  <Pressable
+                    onPress={() => setPendingRemove(null)}
+                    className="flex-1 rounded-xl border border-border py-2.5 items-center active:opacity-70"
+                  >
+                    <Text className="text-zinc-300 text-sm font-semibold">
+                      Cancel
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+                      removeDashboard(pendingRemove.id);
+                      setPendingRemove(null);
+                    }}
+                    className="flex-1 rounded-xl bg-danger py-2.5 items-center active:opacity-70"
+                  >
+                    <Text className="text-white text-sm font-semibold">
+                      Delete
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            </View>
+          )}
         </View>
       </GestureHandlerRootView>
     </Modal>

--- a/components/downloads/usenet-downloads-view.tsx
+++ b/components/downloads/usenet-downloads-view.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import { View, Text, Pressable, Alert, BackHandler } from "react-native";
+import { View, Text, Pressable, BackHandler } from "react-native";
 import { toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect } from "expo-router";
 import {
@@ -21,6 +21,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
+import { ActionSheet } from "@/components/ui/action-sheet";
 import { errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { useMultiSelect } from "@/hooks/use-multi-select";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -83,6 +84,7 @@ export function UsenetDownloadsView({
   const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [nzbUrl, setNzbUrl] = useState("");
+  const [bulkDelete, setBulkDelete] = useState<{ count: number } | null>(null);
 
   const { data: queue, error: queueError } = adapter.useQueue();
   const { data: history, error: historyError } = adapter.useHistory(50);
@@ -163,39 +165,21 @@ export function UsenetDownloadsView({
   const handleBulkDelete = () => {
     const sel = selectedItems();
     if (sel.length === 0) return;
-    Alert.alert("Delete Downloads", `Delete ${sel.length} item(s)?`, [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          sel.forEach((s) => {
-            if (s.source === "history") {
-              deleteHistorySlot.mutate({ id: s.id });
-            } else {
-              deleteSlot.mutate({ id: s.id });
-            }
-          });
-          multiSelect.clear();
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          sel.forEach((s) => {
-            if (s.source === "history") {
-              deleteHistorySlot.mutate({ id: s.id, deleteFiles: true });
-            } else {
-              deleteSlot.mutate({ id: s.id, deleteFiles: true });
-            }
-          });
-          multiSelect.clear();
-        },
-      },
-    ]);
+    setBulkDelete({ count: sel.length });
+  };
+
+  const runBulkDelete = (deleteFiles: boolean) => {
+    const sel = selectedItems();
+    if (sel.length === 0) return;
+    errorHaptic();
+    sel.forEach((s) => {
+      if (s.source === "history") {
+        deleteHistorySlot.mutate({ id: s.id, deleteFiles });
+      } else {
+        deleteSlot.mutate({ id: s.id, deleteFiles });
+      }
+    });
+    multiSelect.clear();
   };
 
   const handleItemPress = (item: UnifiedItem) => {
@@ -355,6 +339,27 @@ export function UsenetDownloadsView({
         sortValue={sort}
         onSortChange={setSort}
       />
+
+      <ActionSheet
+        visible={bulkDelete !== null}
+        onClose={() => setBulkDelete(null)}
+        title="Delete downloads"
+        subtitle={bulkDelete ? `${bulkDelete.count} selected` : ""}
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runBulkDelete(false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runBulkDelete(true),
+          },
+        ]}
+      />
     </>
   );
 }
@@ -452,34 +457,15 @@ function SlotListItem({
   const badgeVariant = usenetBadgeVariant(item.status);
   const showProgress = inQueue || item.status === "completed";
 
-  const handleDelete = () => {
-    Alert.alert("Delete Download", `Delete "${truncateText(item.name, 30)}"?`, [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          if (item.source === "history") {
-            deleteHistory.mutate({ id: item.id });
-          } else {
-            deleteSlot.mutate({ id: item.id });
-          }
-        },
-      },
-      {
-        text: "Delete + Files",
-        style: "destructive",
-        onPress: () => {
-          errorHaptic();
-          if (item.source === "history") {
-            deleteHistory.mutate({ id: item.id, deleteFiles: true });
-          } else {
-            deleteSlot.mutate({ id: item.id, deleteFiles: true });
-          }
-        },
-      },
-    ]);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const runDelete = (deleteFiles: boolean) => {
+    errorHaptic();
+    if (item.source === "history") {
+      deleteHistory.mutate({ id: item.id, deleteFiles });
+    } else {
+      deleteSlot.mutate({ id: item.id, deleteFiles });
+    }
   };
 
   const togglePending = pauseSlot.isPending || resumeSlot.isPending;
@@ -543,7 +529,7 @@ function SlotListItem({
               </Pressable>
             )}
             <Pressable
-              onPress={handleDelete}
+              onPress={() => setDeleteOpen(true)}
               disabled={deletePending}
               className={`p-1.5 active:opacity-70 ${deletePending ? "opacity-50" : ""}`}
               hitSlop={6}
@@ -553,6 +539,27 @@ function SlotListItem({
           </View>
         )}
       </View>
+
+      <ActionSheet
+        visible={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        title="Delete download"
+        subtitle={truncateText(item.name, 40)}
+        actions={[
+          {
+            label: "Delete",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(false),
+          },
+          {
+            label: "Delete + Files",
+            icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
+            variant: "danger",
+            onPress: () => runDelete(true),
+          },
+        ]}
+      />
     </Card>
   );
 }

--- a/components/ui/action-sheet.tsx
+++ b/components/ui/action-sheet.tsx
@@ -28,6 +28,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { lightHaptic, errorHaptic } from "@/lib/haptics";
 import { ICON } from "@/lib/constants";
 import { GlassSurface } from "@/components/ui/glass-surface";
+import { useModalClosed } from "@/hooks/use-modal-closed";
 
 const { height: SCREEN_H } = Dimensions.get("window");
 const SHEET_MAX = Math.round(SCREEN_H * 0.85);
@@ -49,6 +50,13 @@ interface ActionSheetProps {
   title?: string;
   subtitle?: string;
   actions: ActionSheetAction[];
+  /**
+   * Fired once the sheet is fully dismissed (its native `<Modal>` is gone).
+   * Use this — not the action's `onPress` — to open another modal or navigate,
+   * so iOS never presents/unmounts a second view controller while this one is
+   * still tearing down (which hangs the JS thread on Fabric).
+   */
+  onClosed?: () => void;
 }
 
 export function ActionSheet({
@@ -57,9 +65,13 @@ export function ActionSheet({
   title,
   subtitle,
   actions,
+  onClosed,
 }: ActionSheetProps) {
   const insets = useSafeAreaInsets();
   const [mounted, setMounted] = useState(false);
+  // Fire onClosed once the sheet's native <Modal> is fully gone — the safe
+  // point to open another modal / navigate on iOS. See useModalClosed.
+  const handleDismiss = useModalClosed(mounted, onClosed);
   const translateY = useSharedValue(OFFSCREEN);
   const backdrop = useSharedValue(0);
 
@@ -118,6 +130,7 @@ export function ActionSheet({
       animationType="none"
       statusBarTranslucent
       onRequestClose={onClose}
+      onDismiss={handleDismiss}
     >
       <GestureHandlerRootView style={{ flex: 1 }}>
         <View className="flex-1 justify-end">

--- a/hooks/use-deferred-back.ts
+++ b/hooks/use-deferred-back.ts
@@ -1,0 +1,64 @@
+import { useCallback, useRef } from "react";
+import { Platform } from "react-native";
+import { useRouter } from "expo-router";
+
+/**
+ * Safely navigate back after a confirm dialog (a `<Modal>`) closes.
+ *
+ * On iOS, calling `router.back()` — which unmounts the current native screen —
+ * while a `<Modal>` is still running its dismiss animation hangs the JS thread
+ * on the New Architecture (Fabric). iOS will not present/dismiss one
+ * UIViewController while another is mid-transition, so the only reliable moment
+ * to pop the screen is *after* the modal reports it is fully dismissed (its
+ * `onDismiss`). See react-native#10727, react-native#48611 and
+ * react-native-screens#3648.
+ *
+ * Usage:
+ *   const back = useDeferredBack();
+ *   // on confirm:
+ *   back.arm();                 // mark that a pop is coming once the modal closes
+ *   setPendingDelete(null);     // start closing the confirm modal
+ *   mutation.mutate(args, { onSuccess: () => back.back() });
+ *   // on the modal:
+ *   <ConfirmModal ... onClosed={back.onClosed} />
+ *
+ * Android has no such constraint, so `back()` pops immediately there and the
+ * modal/screen teardown overlap is harmless.
+ */
+export function useDeferredBack() {
+  const router = useRouter();
+  const modalClosed = useRef(true);
+  const wantBack = useRef(false);
+
+  // Call right before starting to close the modal that a back() will follow.
+  const arm = useCallback(() => {
+    if (Platform.OS !== "ios") return;
+    modalClosed.current = false;
+    wantBack.current = false;
+  }, []);
+
+  // Wire to the modal's onClosed. Pops now if a back() was already requested.
+  const onClosed = useCallback(() => {
+    modalClosed.current = true;
+    if (wantBack.current) {
+      wantBack.current = false;
+      router.back();
+    }
+  }, [router]);
+
+  // Request the pop (e.g. from a mutation's onSuccess). Defers until the modal
+  // is fully dismissed on iOS; immediate on Android.
+  const back = useCallback(() => {
+    if (Platform.OS !== "ios") {
+      router.back();
+      return;
+    }
+    if (modalClosed.current) {
+      router.back();
+    } else {
+      wantBack.current = true;
+    }
+  }, [router]);
+
+  return { arm, onClosed, back };
+}

--- a/hooks/use-modal-closed.ts
+++ b/hooks/use-modal-closed.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef } from "react";
+import { Platform } from "react-native";
+
+/**
+ * Fire `onClosed` exactly once after a `<Modal>` is fully gone — robustly across
+ * platforms and React Native versions.
+ *
+ * Why this exists: on iOS you must not present (or unmount the screen behind) a
+ * second view controller while a modal is still dismissing — it hangs the JS
+ * thread on the New Architecture. See react-native#10727 and #50152 ("invisible
+ * layer blocks UI when rapidly opening and closing modals"). The safe signal is
+ * the modal's `onDismiss`, but that callback has a long history of not firing on
+ * some iOS versions (react-native#29455, #47694) and Android never fires it.
+ *
+ * So we treat `onDismiss` as the fast path on iOS and back it with a timer armed
+ * on the open→closed transition (this also drives Android). Whichever lands
+ * first wins; a once-guard makes the other a no-op. The backstop delay sits
+ * safely past the dismiss animation, so `onClosed` never fires while the modal
+ * is still on screen.
+ *
+ * @param isOpen      whether the native modal is currently presented
+ * @param onClosed    called once after it is fully dismissed
+ * @param fallbackMs  backstop delay after `isOpen`→false (default 500ms)
+ * @returns the `onDismiss` handler to attach to the `<Modal>` (undefined on Android)
+ */
+export function useModalClosed(
+  isOpen: boolean,
+  onClosed?: () => void,
+  fallbackMs = 500,
+) {
+  const cbRef = useRef(onClosed);
+  cbRef.current = onClosed;
+  const fired = useRef(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wasOpen = useRef(isOpen);
+
+  const clear = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+
+  const fire = useCallback(() => {
+    if (fired.current) return;
+    fired.current = true;
+    clear();
+    cbRef.current?.();
+  }, []);
+
+  useEffect(() => {
+    if (isOpen && !wasOpen.current) {
+      // Reopened — reset for the next close cycle.
+      fired.current = false;
+      clear();
+    } else if (!isOpen && wasOpen.current) {
+      // Started closing — arm the backstop in case onDismiss never lands.
+      clear();
+      timer.current = setTimeout(fire, fallbackMs);
+    }
+    wasOpen.current = isOpen;
+  }, [isOpen, fire, fallbackMs]);
+
+  // Clean up any pending timer on unmount.
+  useEffect(() => clear, []);
+
+  return Platform.OS === "ios" ? fire : undefined;
+}


### PR DESCRIPTION
## Summary
Fixes the iOS app hang when deleting a movie or series (#83), and the same hang class elsewhere in the app.

On the New Architecture, presenting a modal while another is dismissing (or popping a screen while a dialog is mid-dismiss) freezes the JS thread: frozen UI, force-quit, no crash log. It is iOS-only and timing-dependent, which is why it was not reproducible locally.

## Changes
- Add `useModalClosed` (iOS `onDismiss` plus a timer backstop) and `useDeferredBack` hooks.
- Route every modal-to-modal and confirm-to-navigate transition through `onClosed` instead of firing mid-dismiss: movie/series delete and root folder, torrent/SAB/NZBGet delete, dashboard discard, and the releases-picker grab (dropping a `setTimeout` band-aid).
- Replace the remaining native `Alert.alert` confirmations with the styled `ConfirmModal`, `ActionSheet`, or `toast` per CLAUDE.md. Delete behavior is unchanged.
- Document the modal-sequencing rule in CLAUDE.md.
