### PR TITLE
fix: #106 — health dots stuck red + second instance hidden on Services widget

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -288,7 +288,14 @@ export default function SettingsScreen() {
 
   if (editingInstance) {
     return (
+      // Key by instance id so the editor fully remounts when switching between
+      // instances. The form seeds its URL/credential fields from `inst` via
+      // useState initializers (which run once per mount); without a per-instance
+      // key those fields would keep a previous instance's values — the "remote
+      // URL shows blank until you tap it" symptom — and a Save could then
+      // persist the stale/empty value over a good stored URL (#106).
       <ServiceEditor
+        key={editingInstance.instanceId}
         serviceId={editingInstance.serviceId}
         instanceId={editingInstance.instanceId}
         isNew={editingInstance.isNew ?? false}

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -10,7 +10,10 @@ import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
 import { useConfigStore } from "@/store/config-store";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  resolveBoundInstances,
+  isExplicitInstanceBinding,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
   SERVICE_HEALTH_DEFAULT_SETTINGS,
   type ServiceHealthSettingsValue,
@@ -84,14 +87,23 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
     );
     if (allInstances.length === 0) continue;
     const binding = settings.instances[kindId];
-    // Workspace filter at per-instance granularity: the user attached
-    // specific instances to this dashboard (e.g. "Radarr Home" but not
-    // "Radarr Cabin"), so drop bound instances that aren't attached.
-    // This prevents the Cabin Radarr's offline status from showing up on
-    // the Home dashboard's health grid.
-    const bound = resolveBoundInstances(binding, allInstances).filter((inst) =>
-      attachedInstances.has(inst.id),
-    );
+    const resolved = resolveBoundInstances(binding, allInstances);
+    // Workspace filter at per-instance granularity, but ONLY for the default
+    // "all" aggregate: the user attached specific instances to this dashboard
+    // (e.g. "Radarr Home" but not "Radarr Cabin"), so a widget bound to "all"
+    // drops instances that aren't attached — that keeps the Cabin Radarr's
+    // offline status off the Home dashboard's health grid.
+    //
+    // When the user has *explicitly* picked instances in this widget's
+    // settings, honor that selection as-is. The picker lists every enabled
+    // instance of the kind, so the user can select one that isn't attached to
+    // the active workspace and expects it to show; the explicit per-widget
+    // pick is a deliberate choice that wins over the workspace default.
+    // Without this, an instance shown as selectable + selected in the widget
+    // settings was silently hidden — that was the second half of #106.
+    const bound = isExplicitInstanceBinding(binding)
+      ? resolved
+      : resolved.filter((inst) => attachedInstances.has(inst.id));
     if (bound.length === 0) continue;
     for (const inst of bound) {
       const health = healthByInstance.get(`${kindId}:${inst.id}`);

--- a/components/dashboard/widget-settings/instance-picker-row.test.ts
+++ b/components/dashboard/widget-settings/instance-picker-row.test.ts
@@ -1,0 +1,78 @@
+// Mock native storage before importing — instance-picker-row pulls in
+// use-instance-target → config-store → AsyncStorage/SecureStore at module
+// load. The functions under test are pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  resolveBoundInstances,
+  isExplicitInstanceBinding,
+  INSTANCE_BINDING_ALL,
+} from "./instance-picker-row";
+
+const A = { id: "a" };
+const B = { id: "b" };
+const C = { id: "c" };
+const ALL_INSTANCES = [A, B, C];
+
+describe("resolveBoundInstances", () => {
+  it("returns every instance for the 'all' sentinel", () => {
+    expect(resolveBoundInstances(INSTANCE_BINDING_ALL, ALL_INSTANCES)).toEqual(
+      ALL_INSTANCES,
+    );
+  });
+
+  it("returns every instance for null/undefined (legacy/unset)", () => {
+    expect(resolveBoundInstances(null, ALL_INSTANCES)).toEqual(ALL_INSTANCES);
+    expect(resolveBoundInstances(undefined, ALL_INSTANCES)).toEqual(ALL_INSTANCES);
+  });
+
+  it("returns every instance for an empty array", () => {
+    expect(resolveBoundInstances([], ALL_INSTANCES)).toEqual(ALL_INSTANCES);
+  });
+
+  it("matches a legacy scalar id like a single-element subset", () => {
+    expect(resolveBoundInstances("b", ALL_INSTANCES)).toEqual([B]);
+  });
+
+  it("narrows to the named subset, preserving instance order", () => {
+    expect(resolveBoundInstances(["c", "a"], ALL_INSTANCES)).toEqual([A, C]);
+  });
+
+  it("ignores ids not present in the instance list", () => {
+    expect(resolveBoundInstances(["a", "zzz"], ALL_INSTANCES)).toEqual([A]);
+  });
+});
+
+describe("isExplicitInstanceBinding (#106 — explicit picks bypass workspace filter)", () => {
+  it("is false for the aggregate/default bindings", () => {
+    expect(isExplicitInstanceBinding(INSTANCE_BINDING_ALL)).toBe(false);
+    expect(isExplicitInstanceBinding(null)).toBe(false);
+    expect(isExplicitInstanceBinding(undefined)).toBe(false);
+    expect(isExplicitInstanceBinding([])).toBe(false);
+  });
+
+  it("is true for a legacy scalar id", () => {
+    expect(isExplicitInstanceBinding("a")).toBe(true);
+  });
+
+  it("is true for a non-empty subset array", () => {
+    expect(isExplicitInstanceBinding(["a"])).toBe(true);
+    expect(isExplicitInstanceBinding(["a", "b"])).toBe(true);
+  });
+});

--- a/components/dashboard/widget-settings/instance-picker-row.tsx
+++ b/components/dashboard/widget-settings/instance-picker-row.tsx
@@ -34,6 +34,25 @@ export function resolveBoundInstances<T extends { id: string }>(
   return allInstances.filter((i) => allowed.has(i.id));
 }
 
+/**
+ * True when the binding names specific instances (a legacy scalar id or a
+ * non-empty subset array) rather than the "all"/aggregate default.
+ *
+ * An explicit pick is a deliberate per-widget choice that should win over the
+ * dashboard's workspace `attachedInstances` filter: the picker lists every
+ * enabled instance of the kind, so a user can select one that isn't attached
+ * to the current workspace and reasonably expect it to show. Surfaces that
+ * fan out across "all" attached instances still apply the workspace filter
+ * for the default case (see ServiceHealthCard). Without this distinction an
+ * instance shown as selectable + selected in the widget settings would be
+ * silently hidden — see #106.
+ */
+export function isExplicitInstanceBinding(value: StoredInstanceBinding): boolean {
+  if (value == null || value === INSTANCE_BINDING_ALL) return false;
+  if (typeof value === "string") return true;
+  return Array.isArray(value) && value.length > 0;
+}
+
 interface InstancePickerRowProps {
   serviceId: ServiceId;
   value: InstanceBindingValue;

--- a/hooks/use-service-health.test.ts
+++ b/hooks/use-service-health.test.ts
@@ -1,0 +1,153 @@
+// Mock the native storage layer before importing — use-service-health pulls in
+// http-client → config-store → AsyncStorage/SecureStore at module load. Same
+// shims as store/config-store.test.ts; the helper under test is pure.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  buildHealthProbeSignature,
+  type HealthProbeInputs,
+} from "./use-service-health";
+import { SERVICE_IDS, type ServiceId } from "@/lib/constants";
+import type { ServiceInstance, ServiceSecrets } from "@/store/config-store";
+
+// The health query's verdict is cached under a key derived from this
+// signature. The #106 regression was that the key was static, so a verdict
+// computed against the wrong URL (a remote probe fired before NetInfo had
+// corrected the away flag at cold start) stayed frozen. These tests pin the
+// signature to react to the inputs each probe actually uses.
+
+function emptyInstances(): Record<ServiceId, ServiceInstance[]> {
+  const out = {} as Record<ServiceId, ServiceInstance[]>;
+  for (const id of SERVICE_IDS) out[id] = [];
+  return out;
+}
+
+function makeInst(over: Partial<ServiceInstance> & { id: string }): ServiceInstance {
+  return {
+    enabled: true,
+    name: "Radarr",
+    localUrl: "http://10.0.0.2:7878",
+    remoteUrl: "http://radarr.example.com",
+    useRemote: false,
+    ignoreCertErrors: false,
+    ...over,
+  };
+}
+
+interface Opts {
+  instances: Record<ServiceId, ServiceInstance[]>;
+  secrets?: Record<string, ServiceSecrets>;
+  globalCustomHeaders?: Record<string, string>;
+  autoSwitchNetwork?: boolean;
+  networkAwayFromHome?: boolean;
+}
+
+// Compute the signature with a resolveUrl that mirrors getActiveUrl's
+// local/remote choice (useRemote OR away-while-auto-switching → remote).
+function sig(opts: Opts): string {
+  const autoSwitchNetwork = opts.autoSwitchNetwork ?? false;
+  const networkAwayFromHome = opts.networkAwayFromHome ?? false;
+  const inputs: HealthProbeInputs = {
+    serviceInstances: opts.instances,
+    instanceSecrets: opts.secrets ?? {},
+    globalCustomHeaders: opts.globalCustomHeaders ?? {},
+    autoSwitchNetwork,
+    networkAwayFromHome,
+    resolveUrl: (id, instanceId) => {
+      const inst = (opts.instances[id] ?? []).find((x) => x.id === instanceId);
+      if (!inst) return "";
+      const useRemote =
+        inst.useRemote || (autoSwitchNetwork && networkAwayFromHome);
+      return useRemote ? inst.remoteUrl : inst.localUrl;
+    },
+  };
+  return buildHealthProbeSignature(inputs);
+}
+
+describe("buildHealthProbeSignature — health query re-keys on its inputs (#106)", () => {
+  const oneRadarr = (): Record<ServiceId, ServiceInstance[]> => ({
+    ...emptyInstances(),
+    radarr: [makeInst({ id: "r1" })],
+  });
+
+  it("is stable for unchanged inputs", () => {
+    expect(sig({ instances: oneRadarr() })).toBe(sig({ instances: oneRadarr() }));
+  });
+
+  it("changes — and switches to the remote URL — when auto-switch flips to away", () => {
+    const home = sig({
+      instances: oneRadarr(),
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+    const away = sig({
+      instances: oneRadarr(),
+      autoSwitchNetwork: true,
+      networkAwayFromHome: true,
+    });
+    expect(away).not.toBe(home);
+    expect(home).toContain("http://10.0.0.2:7878");
+    expect(away).toContain("http://radarr.example.com");
+  });
+
+  it("changes when a stored URL is edited", () => {
+    const before = sig({ instances: oneRadarr() });
+    const after = sig({
+      instances: {
+        ...emptyInstances(),
+        radarr: [makeInst({ id: "r1", localUrl: "http://10.0.0.9:7878" })],
+      },
+    });
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when credentials appear (presence only — value isn't hashed)", () => {
+    const before = sig({ instances: oneRadarr() });
+    const withKey = sig({ instances: oneRadarr(), secrets: { r1: { apiKey: "abc" } } });
+    const withOtherKey = sig({
+      instances: oneRadarr(),
+      secrets: { r1: { apiKey: "different-but-still-present" } },
+    });
+    expect(withKey).not.toBe(before);
+    // Same presence, different value → same signature (so secrets never leak
+    // into the key); a value change is caught by the polling interval instead.
+    expect(withOtherKey).toBe(withKey);
+  });
+
+  it("changes when custom headers change", () => {
+    const before = sig({ instances: oneRadarr() });
+    const withHeader = sig({
+      instances: oneRadarr(),
+      globalCustomHeaders: { "CF-Access-Client-Id": "x" },
+    });
+    expect(withHeader).not.toBe(before);
+  });
+
+  it("ignores disabled instances", () => {
+    const enabled = sig({ instances: oneRadarr() });
+    const disabled = sig({
+      instances: {
+        ...emptyInstances(),
+        radarr: [makeInst({ id: "r1", enabled: false })],
+      },
+    });
+    expect(disabled).not.toBe(enabled);
+    expect(disabled).not.toContain("http://10.0.0.2:7878");
+  });
+});

--- a/hooks/use-service-health.ts
+++ b/hooks/use-service-health.ts
@@ -1,13 +1,73 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { checkInstanceHealth } from "@/lib/http-client";
 import { qbHealthCheck } from "@/services/qbittorrent-api";
 import { useConfigStore } from "@/store/config-store";
+import type { ServiceInstance, ServiceSecrets } from "@/store/config-store";
 import { SERVICE_IDS, POLLING_INTERVALS, SERVICE_DEFAULTS } from "@/lib/constants";
+import type { ServiceId } from "@/lib/constants";
 import type {
   HealthStatusKind,
   ServiceHealthStatus,
   ServiceInstanceHealthStatus,
 } from "@/lib/types";
+
+// The exact inputs each per-instance probe depends on. `resolveUrl` is
+// store.getActiveUrl, which already folds in useRemote + autoSwitchNetwork +
+// networkAwayFromHome, so the network flags are passed only to keep them in
+// the signature (and as honest deps).
+export interface HealthProbeInputs {
+  serviceInstances: Record<ServiceId, ServiceInstance[]>;
+  instanceSecrets: Record<string, ServiceSecrets>;
+  globalCustomHeaders: Record<string, string>;
+  autoSwitchNetwork: boolean;
+  networkAwayFromHome: boolean;
+  resolveUrl: (id: ServiceId, instanceId: string) => string;
+}
+
+/**
+ * A stable string fingerprint of everything the health probes actually send:
+ * each enabled instance's resolved URL, whether it carries credentials, its
+ * cert policy, and its merged custom-header names. Folding this into the
+ * `useServiceHealth` query key makes React Query refetch whenever any of it
+ * changes — most importantly when NetInfo flips the home/away flag (which
+ * flips `resolveUrl` from local to remote and back).
+ *
+ * Before this, the query used a static key with a 30s interval, so a verdict
+ * computed before the network settled — e.g. a remote-URL probe fired at cold
+ * start while the persisted away flag was still stale-true — stayed frozen
+ * until a reconnect event (toggling a VPN) or an app relaunch forced a
+ * refetch. That is the #106 report: services work on the LAN but the dot is
+ * stuck red, and only Tailscale on/off changes it.
+ *
+ * Credential *values* are intentionally reduced to presence so secrets never
+ * land in a query key; a same-presence key edit is picked up by the interval.
+ */
+export function buildHealthProbeSignature(inputs: HealthProbeInputs): string {
+  const globalHeaderKeys = Object.keys(inputs.globalCustomHeaders);
+  const parts: string[] = [
+    `net:${inputs.autoSwitchNetwork ? 1 : 0}:${inputs.networkAwayFromHome ? 1 : 0}`,
+  ];
+  for (const id of SERVICE_IDS) {
+    for (const inst of inputs.serviceInstances[id] ?? []) {
+      if (!inst.enabled) continue;
+      const url = inputs.resolveUrl(id, inst.id);
+      const s = inputs.instanceSecrets[inst.id] ?? {};
+      const hasCreds = s.apiKey || s.username || s.password ? 1 : 0;
+      // Mirror getMergedHeaders' merge (global + per-instance) by name only.
+      const headerKeys = [
+        ...globalHeaderKeys,
+        ...Object.keys(s.customHeaders ?? {}),
+      ]
+        .sort()
+        .join(",");
+      parts.push(
+        `${id}:${inst.id}:${url}:${hasCreds}:${inst.ignoreCertErrors ? 1 : 0}:${headerKeys}`,
+      );
+    }
+  }
+  return parts.join("|");
+}
 
 /**
  * Health check for every configured (kind, instance) pair. The result still
@@ -17,10 +77,39 @@ import type {
  * show "Radarr 4K is offline" instead of just "Radarr is offline".
  */
 export function useServiceHealth() {
+  // Subscribe to everything that feeds the per-instance probe so the verdict
+  // refreshes when any of it changes (see buildHealthProbeSignature for why).
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const instanceSecrets = useConfigStore((s) => s.instanceSecrets);
+  const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
+  const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
+  const globalCustomHeaders = useConfigStore((s) => s.globalCustomHeaders);
+
+  const probeSignature = useMemo(
+    () =>
+      buildHealthProbeSignature({
+        serviceInstances,
+        instanceSecrets,
+        globalCustomHeaders,
+        autoSwitchNetwork,
+        networkAwayFromHome,
+        resolveUrl: (id, instanceId) =>
+          useConfigStore.getState().getActiveUrl(id, instanceId),
+      }),
+    [
+      serviceInstances,
+      instanceSecrets,
+      globalCustomHeaders,
+      autoSwitchNetwork,
+      networkAwayFromHome,
+    ],
+  );
 
   return useQuery({
-    queryKey: ["serviceHealth"],
+    queryKey: ["serviceHealth", probeSignature],
+    // Keep showing the last verdict while a re-key refetch is in flight so the
+    // dots don't flash red for a probe cycle when the network or config changes.
+    placeholderData: keepPreviousData,
     queryFn: async (): Promise<ServiceHealthStatus[]> => {
       // Snapshot the instance map for stable iteration. Each kind contributes
       // one ServiceHealthStatus with an `instances` breakdown — kinds with no


### PR DESCRIPTION
Fixes #106. Two distinct bugs from that thread.

## 1. Health dots stuck red on working services
`useServiceHealth` used a static `["serviceHealth"]` key with a 30s interval, so a verdict computed before the network settled stayed frozen. With auto-switch on, `networkAwayFromHome` is restored from its persisted value at launch; if it's stale-`true`, the dashboard's first probe resolves the **remote** URL and fails on the LAN, then never re-runs until a reconnect event (VPN toggle) or relaunch. Service screens opened later (after NetInfo corrects the flag) resolve the **local** URL and work — exactly the report ("services work but the dot is stuck red; only Tailscale on/off changes it"; maintainer can't reproduce because their flag resolves before the first probe).

`getActiveUrl` is shared by both paths, so for one instance they can't diverge on URL — the only explanation is a stale cached verdict.

**Fix:** fold a signature of each enabled instance's resolved URL + credential presence + cert policy + custom-header names into the query key (`buildHealthProbeSignature`). React Query refetches the moment the home/away flag flips or config changes, so the dot self-heals. `keepPreviousData` prevents a red flash during the re-key. Secrets are reduced to presence, never hashed into a key. Also keyed the Settings instance editor by `instanceId` so its form re-seeds from the current instance — fixes "remote URL blank until you tap it" and stops a Save from overwriting a good URL with a stale empty value.

## 2. Newly-added instance hidden on the Services Health widget
The card filtered bound instances by the dashboard's `attachedInstances` on top of the per-slot binding. But the widget's instance picker lists **every enabled instance** (`useEnabledInstances`), so a user could select a newly-added instance that the card then silently dropped because it wasn't attached to the active workspace. (calendar.tsx avoids this — its picker only offers already-attached instances.)

**Fix:** honor an explicit per-widget selection (`isExplicitInstanceBinding`) over the workspace filter; keep the filter for the default `"all"` aggregate so workspace isolation still hides unattached instances in the common case. This matches the maintainer's own framing that selecting the instance in the widget settings should make it show.