### PR TITLE
fix: #83 — root folder change reverts (use bulk editor endpoint)

### DIFF
--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -12,6 +12,7 @@ import {
   searchForMovie,
   toggleMovieMonitored,
   updateMovie,
+  changeMovieRootFolder,
   getQualityProfiles,
   getRootFolders,
   getTags,
@@ -295,20 +296,7 @@ export function useUpdateMovieRootFolder(instanceId?: string) {
       movieId: number;
       rootFolderPath: string;
       moveFiles: boolean;
-    }) => {
-      const cached = queryClient.getQueryData<RadarrMovie>([
-        "radarr",
-        id,
-        "movie",
-        movieId,
-      ]);
-      if (!cached) throw new Error("Movie not loaded");
-      return updateMovie(
-        { ...cached, rootFolderPath },
-        id ?? undefined,
-        { moveFiles },
-      );
-    },
+    }) => changeMovieRootFolder(movieId, rootFolderPath, moveFiles, id ?? undefined),
     onMutate: async ({ movieId, rootFolderPath }) => {
       await queryClient.cancelQueries({ queryKey: ["radarr", id, "movie", movieId] });
       await queryClient.cancelQueries({ queryKey: ["radarr", id, "movies"] });

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -14,6 +14,7 @@ import {
   toggleEpisodeMonitored,
   toggleSeriesMonitored,
   updateSeries,
+  changeSeriesRootFolder,
   searchForSeries,
   searchForEpisodes,
   searchAllMissingEpisodes,
@@ -356,18 +357,7 @@ export function useUpdateSeriesRootFolder(instanceId?: string) {
       seriesId: number;
       rootFolderPath: string;
       moveFiles: boolean;
-    }) => {
-      const cached = queryClient.getQueryData<SonarrSeries>([
-        "sonarr",
-        id,
-        "series",
-        seriesId,
-      ]);
-      if (!cached) throw new Error("Series not loaded");
-      return updateSeries({ ...cached, rootFolderPath }, id ?? undefined, {
-        moveFiles,
-      });
-    },
+    }) => changeSeriesRootFolder(seriesId, rootFolderPath, moveFiles, id ?? undefined),
     onMutate: async ({ seriesId, rootFolderPath }) => {
       await queryClient.cancelQueries({
         queryKey: ["sonarr", id, "series", seriesId],

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -213,6 +213,30 @@ export function toggleMovieMonitored(
   });
 }
 
+// --- Change Root Folder (via bulk editor endpoint) ---
+//
+// The single PUT /movie/{id}?moveFiles=true does NOT work for a root-folder
+// change: it derives the move destination from the body's stale `path` (so
+// source == destination, no move) and the single-movie save overload never
+// recomputes `path` from the new `rootFolderPath` — leaving an inconsistent
+// record that "reverts" to the old location on the next GET (issue #83). The
+// editor endpoint derives the destination from `rootFolderPath` server-side and
+// rewrites `path` consistently. Send ONLY the id + rootFolderPath + moveFiles —
+// never echo back the old `path`. moveFiles:false still changes the root (Path
+// rebuilt under the new root, files left in place); moveFiles:true also moves.
+export function changeMovieRootFolder(
+  movieId: number,
+  rootFolderPath: string,
+  moveFiles: boolean,
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("radarr", "/movie/editor", {
+    method: "PUT",
+    body: JSON.stringify({ movieIds: [movieId], rootFolderPath, moveFiles }),
+    instanceId,
+  });
+}
+
 // --- Update Movie (full PUT) ---
 //
 // Radarr expects the entire movie resource on PUT. Our `RadarrMovie` type is a

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -255,6 +255,27 @@ export function toggleSeriesMonitored(
   });
 }
 
+// --- Change Root Folder (via bulk editor endpoint) ---
+//
+// See Radarr's changeMovieRootFolder for the full rationale. The single PUT
+// /series/{id}?moveFiles=true reverts the change: Sonarr derives the move
+// destination from the body's stale `path` (no move) and recomputes
+// `rootFolderPath` from that unchanged `path` on every GET, so the picked root
+// snaps back (issue #83). The editor rewrites `path` from `rootFolderPath`
+// server-side. Send ONLY the id + rootFolderPath + moveFiles.
+export function changeSeriesRootFolder(
+  seriesId: number,
+  rootFolderPath: string,
+  moveFiles: boolean,
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("sonarr", "/series/editor", {
+    method: "PUT",
+    body: JSON.stringify({ seriesIds: [seriesId], rootFolderPath, moveFiles }),
+    instanceId,
+  });
+}
+
 // --- Update Series (full PUT) ---
 //
 // Sonarr expects the entire series resource on PUT. As with Radarr, we forward


### PR DESCRIPTION
## Problem
Changing a Radarr movie / Sonarr series root folder reverted to the original (issue #83, remaining bug after the v1.7.1 hang fix).

## Cause
The mutation used the single-item PUT (`/movie/{id}`, `/series/{id}`) with the full cached body, overriding only `rootFolderPath` while leaving the stale `path`. Both servers derive the move destination from the body's `path` (so source == destination, no move) and never recompute `path` from the new `rootFolderPath`. Sonarr also recomputes `rootFolderPath` from the unchanged `path` on every GET, so the picked folder snaps back.

Verified against Radarr/Sonarr server source, the official web UI (`saveMovieEditor` → PUT `/movie/editor`), and the ArrAPI wrapper.

## Fix
Route the change through the bulk editor endpoint (`/movie/editor`, `/series/editor`) sending only `{ ids, rootFolderPath, moveFiles }` — the same call the official UI uses. The server derives the destination from `rootFolderPath` and rewrites `path` consistently. UI and modal-sequencing wiring unchanged; both 'Move files' and 'Keep files in place' now persist.

## Test plan
- Movie detail → change root folder → 'Move existing files' → pull-to-refresh: new root sticks.
- Same with 'Keep files in place'.
- Repeat for a Sonarr series.