### PR TITLE
feat: Seerr Discover browse by network, studio & genre

### DIFF
--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { Image } from "expo-image";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   Search,
   Check,
@@ -32,6 +32,10 @@ import { ICON } from "@/lib/constants";
 import { successHaptic, errorHaptic } from "@/lib/haptics";
 import { MediaRow } from "@/components/overseerr/media-row";
 import { PosterCard } from "@/components/overseerr/poster-card";
+import {
+  DiscoverCollectionSlider,
+  type DiscoverSliderItem,
+} from "@/components/overseerr/discover-collection-slider";
 import { usePosterCellWidth } from "@/hooks/use-poster-cell";
 import { MediaDetailModal } from "@/components/overseerr/media-detail-modal";
 import {
@@ -43,13 +47,24 @@ import {
   useOverseerrPopularMovies,
   useOverseerrPopularTV,
   useOverseerrUpcomingMovies,
+  useOverseerrGenreSlider,
   useApproveRequest,
   useDeclineRequest,
 } from "@/hooks/use-overseerr";
-import { getPosterUrl } from "@/services/overseerr-api";
+import { getPosterUrl, getBackdropUrl } from "@/services/overseerr-api";
+import {
+  NETWORKS,
+  STUDIOS,
+  getDiscoverLogoUrl,
+  type DiscoverCollectionKind,
+} from "@/lib/overseerr-discover";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
-import type { OverseerrRequest, OverseerrMediaResult } from "@/lib/types";
+import type {
+  OverseerrRequest,
+  OverseerrMediaResult,
+  OverseerrMediaType,
+} from "@/lib/types";
 
 type Tab = "discover" | "search" | "requests";
 type RequestFilter =
@@ -78,6 +93,28 @@ function sortToParams(sort: RequestsSortKey): { sort: "added" | "modified" } {
 }
 
 const GRID_GAP = 12;
+
+// Static logo tiles for the network/studio sliders (computed once).
+const NETWORK_ITEMS: DiscoverSliderItem[] = NETWORKS.map((c) => ({
+  id: c.id,
+  name: c.name,
+  imageUrl: getDiscoverLogoUrl(c.logoPath),
+}));
+const STUDIO_ITEMS: DiscoverSliderItem[] = STUDIOS.map((c) => ({
+  id: c.id,
+  name: c.name,
+  imageUrl: getDiscoverLogoUrl(c.logoPath),
+}));
+
+function toGenreItems(
+  genres: { id: number; name: string; backdrops: string[] }[] | undefined,
+): DiscoverSliderItem[] {
+  return (genres ?? []).map((g) => ({
+    id: g.id,
+    name: g.name,
+    imageUrl: getBackdropUrl(g.backdrops?.[0]),
+  }));
+}
 
 const TAB_CONFIG: { key: Tab; label: string; icon: typeof Compass }[] = [
   { key: "discover", label: "Discover", icon: Compass },
@@ -176,10 +213,36 @@ function DiscoverTab({
 }: {
   onItemPress: (item: OverseerrMediaResult) => void;
 }) {
+  const router = useRouter();
   const trending = useOverseerrTrending();
   const popularMovies = useOverseerrPopularMovies();
   const popularTV = useOverseerrPopularTV();
   const upcoming = useOverseerrUpcomingMovies();
+  const movieGenres = useOverseerrGenreSlider("movie");
+  const tvGenres = useOverseerrGenreSlider("tv");
+
+  const movieGenreItems = useMemo(
+    () => toGenreItems(movieGenres.data),
+    [movieGenres.data],
+  );
+  const tvGenreItems = useMemo(() => toGenreItems(tvGenres.data), [tvGenres.data]);
+
+  const openCollection = useCallback(
+    (
+      kind: DiscoverCollectionKind,
+      item: DiscoverSliderItem,
+      mediaType?: OverseerrMediaType,
+    ) => {
+      const params = new URLSearchParams({
+        kind,
+        id: String(item.id),
+        title: item.name,
+      });
+      if (kind === "genre" && mediaType) params.set("mediaType", mediaType);
+      router.push(`/overseerr/discover-list?${params.toString()}`);
+    },
+    [router],
+  );
 
   return (
     <View>
@@ -200,6 +263,32 @@ function DiscoverTab({
         items={popularTV.data?.results}
         isLoading={popularTV.isLoading}
         onItemPress={onItemPress}
+      />
+      <DiscoverCollectionSlider
+        title="Networks"
+        variant="logo"
+        items={NETWORK_ITEMS}
+        onItemPress={(item) => openCollection("network", item)}
+      />
+      <DiscoverCollectionSlider
+        title="Studios"
+        variant="logo"
+        items={STUDIO_ITEMS}
+        onItemPress={(item) => openCollection("studio", item)}
+      />
+      <DiscoverCollectionSlider
+        title="Movie Genres"
+        variant="genre"
+        items={movieGenreItems}
+        isLoading={movieGenres.isLoading}
+        onItemPress={(item) => openCollection("genre", item, "movie")}
+      />
+      <DiscoverCollectionSlider
+        title="TV Genres"
+        variant="genre"
+        items={tvGenreItems}
+        isLoading={tvGenres.isLoading}
+        onItemPress={(item) => openCollection("genre", item, "tv")}
       />
       <MediaRow
         title="Upcoming Movies"

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -20,6 +20,7 @@ import {
   Bug,
   Heart,
   BookOpen,
+  Film,
 } from "lucide-react-native";
 import GithubLogo from "@/assets/services/github.svg";
 import { useUiScale } from "@/hooks/use-ui-scale";
@@ -594,6 +595,12 @@ export default function SettingsScreen() {
           label="Show workspace tour"
           subtitle="Replay the multi-dashboard intro"
           onPress={replayWorkspaceIntro}
+        />
+        <SettingsRow
+          icon={Film}
+          label="Movie & TV data by TMDB"
+          subtitle="This product uses the TMDB API but is not endorsed or certified by TMDB."
+          onPress={() => void Linking.openURL("https://www.themoviedb.org")}
         />
       </SettingsGroup>
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -20,7 +20,6 @@ import {
   Bug,
   Heart,
   BookOpen,
-  Film,
 } from "lucide-react-native";
 import GithubLogo from "@/assets/services/github.svg";
 import { useUiScale } from "@/hooks/use-ui-scale";
@@ -570,7 +569,29 @@ export default function SettingsScreen() {
 
       <SettingsGroup
         title="About"
-        footer="Dashboarr is open-source under GPL-3.0. Contributions and bug reports are welcome."
+        footer={
+          <>
+            Dashboarr is open-source under GPL-3.0. Contributions and bug reports
+            are welcome.
+            {"\n\n"}
+            Movie & TV metadata from{" "}
+            <Text
+              className="text-zinc-500"
+              onPress={() => void Linking.openURL("https://www.themoviedb.org")}
+            >
+              TMDB
+            </Text>{" "}
+            and{" "}
+            <Text
+              className="text-zinc-500"
+              onPress={() => void Linking.openURL("https://thetvdb.com")}
+            >
+              TheTVDB
+            </Text>
+            . This product uses the TMDB API but is not endorsed or certified by
+            TMDB.
+          </>
+        }
       >
         <SettingsRow
           leading={<GithubLogo width={githubLogoSize} height={githubLogoSize} />}
@@ -595,12 +616,6 @@ export default function SettingsScreen() {
           label="Show workspace tour"
           subtitle="Replay the multi-dashboard intro"
           onPress={replayWorkspaceIntro}
-        />
-        <SettingsRow
-          icon={Film}
-          label="Movie & TV data by TMDB"
-          subtitle="This product uses the TMDB API but is not endorsed or certified by TMDB."
-          onPress={() => void Linking.openURL("https://www.themoviedb.org")}
         />
       </SettingsGroup>
 

--- a/app/overseerr/discover-list.tsx
+++ b/app/overseerr/discover-list.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from "react";
+import { View, FlatList, ActivityIndicator } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import {
+  ScreenWrapper,
+  useScreenBottomPadding,
+} from "@/components/common/screen-wrapper";
+import { BackHeader } from "@/components/common/back-header";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBanner } from "@/components/common/error-banner";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PosterCard } from "@/components/overseerr/poster-card";
+import { MediaDetailModal } from "@/components/overseerr/media-detail-modal";
+import { usePosterCellLayout } from "@/hooks/use-poster-cell";
+import { useOverseerrDiscoverList } from "@/hooks/use-overseerr";
+import type { DiscoverCollectionKind } from "@/lib/overseerr-discover";
+import type { OverseerrMediaResult, OverseerrMediaType } from "@/lib/types";
+
+function isDiscoverKind(value: string | undefined): value is DiscoverCollectionKind {
+  return value === "network" || value === "studio" || value === "genre";
+}
+
+// Paginated grid of everything in a network / studio / genre, reached by
+// tapping a tile on the Seerr Discover tab. Hosts its own MediaDetailModal so
+// the existing request flow works here (the modal is screen-scoped). Opening
+// it only flips `selected` state and closing only clears it — no chained modal
+// at open time and no navigation on close — so the iOS modal-sequencing rules
+// (CLAUDE.md / issue #83) don't apply.
+export default function DiscoverListScreen() {
+  const params = useLocalSearchParams<{
+    kind?: string;
+    id?: string;
+    title?: string;
+    mediaType?: string;
+  }>();
+
+  const kind = params.kind;
+  const idNum = Number(params.id);
+  const mediaType: OverseerrMediaType = params.mediaType === "tv" ? "tv" : "movie";
+  const title = typeof params.title === "string" && params.title ? params.title : "Discover";
+  const valid = isDiscoverKind(kind) && Number.isFinite(idNum) && idNum > 0;
+
+  const { width: cellWidth, columns, gap } = usePosterCellLayout();
+  const paddingBottom = useScreenBottomPadding();
+  const [selected, setSelected] = useState<OverseerrMediaResult | null>(null);
+
+  const query = useOverseerrDiscoverList(
+    isDiscoverKind(kind) ? kind : "network",
+    valid ? idNum : 0,
+    mediaType,
+  );
+
+  const items = useMemo(
+    () => query.data?.pages.flatMap((page) => page.results) ?? [],
+    [query.data],
+  );
+
+  const emptyComponent = useMemo(() => {
+    if (query.isLoading) {
+      return (
+        <View className="flex-row flex-wrap" style={{ gap }}>
+          {Array.from({ length: 9 }).map((_, i) => (
+            <View key={i} style={{ width: cellWidth }}>
+              <Skeleton width="100%" height={Math.round(cellWidth * 1.5)} borderRadius={12} />
+              <Skeleton width="75%" height={10} borderRadius={4} className="mt-1.5" />
+            </View>
+          ))}
+        </View>
+      );
+    }
+    if (query.isError) {
+      return <ErrorBanner error={query.error} title="Failed to load titles" />;
+    }
+    return <EmptyState title="Nothing here" message="No titles to show." />;
+  }, [query.isLoading, query.isError, query.error, cellWidth, gap]);
+
+  if (!valid) {
+    return (
+      <ScreenWrapper scrollable={false}>
+        <BackHeader title={title} />
+        <EmptyState title="Invalid link" message="This discover collection couldn't be opened." />
+      </ScreenWrapper>
+    );
+  }
+
+  return (
+    <ScreenWrapper scrollable={false}>
+      {/* Fixed header — only the grid below scrolls. */}
+      <BackHeader title={title} />
+
+      <FlatList
+        // Fill the space under the fixed header so the list owns the scroll.
+        style={{ flex: 1 }}
+        // numColumns cannot change at runtime without a remount.
+        key={columns}
+        data={items}
+        keyExtractor={(item) => `${item.mediaType}-${item.id}`}
+        renderItem={({ item }) => (
+          <PosterCard item={item} onPress={setSelected} size="sm" widthOverride={cellWidth} />
+        )}
+        numColumns={columns}
+        columnWrapperStyle={{ gap, marginBottom: gap }}
+        ListEmptyComponent={emptyComponent}
+        ListFooterComponent={
+          query.isFetchingNextPage ? (
+            <View className="py-6 items-center">
+              <ActivityIndicator color="#3b82f6" />
+            </View>
+          ) : null
+        }
+        onEndReached={() => {
+          if (query.hasNextPage && !query.isFetchingNextPage) query.fetchNextPage();
+        }}
+        onEndReachedThreshold={0.5}
+        contentContainerStyle={{ paddingBottom }}
+        initialNumToRender={12}
+        maxToRenderPerBatch={12}
+        windowSize={5}
+        removeClippedSubviews
+        showsVerticalScrollIndicator={false}
+      />
+
+      <MediaDetailModal
+        item={selected}
+        visible={!!selected}
+        onClose={() => setSelected(null)}
+      />
+    </ScreenWrapper>
+  );
+}

--- a/components/overseerr/discover-collection-slider.tsx
+++ b/components/overseerr/discover-collection-slider.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { View, Text, ScrollView, Pressable, StyleSheet } from "react-native";
+import { Image } from "expo-image";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export interface DiscoverSliderItem {
+  id: number;
+  name: string;
+  imageUrl: string | null;
+}
+
+interface DiscoverCollectionSliderProps {
+  title: string;
+  // "logo" → duotone network/studio logo on a dark card (networks, studios).
+  // "genre" → backdrop image with the genre name overlaid.
+  variant: "logo" | "genre";
+  items: DiscoverSliderItem[];
+  isLoading?: boolean;
+  onItemPress: (item: DiscoverSliderItem) => void;
+}
+
+// Rem widths so tiles grow with uiScale; logos are landscape, genre tiles a
+// touch wider to fit the name overlay.
+const TILE_CLASS = {
+  logo: "w-[8rem] h-[4.5rem]",
+  genre: "w-[10rem] h-[5.5rem]",
+} as const;
+
+export function DiscoverCollectionSlider({
+  title,
+  variant,
+  items,
+  isLoading,
+  onItemPress,
+}: DiscoverCollectionSliderProps) {
+  if (!isLoading && items.length === 0) return null;
+
+  return (
+    <View className="mb-6">
+      <Text className="text-zinc-100 text-base font-semibold mb-3 px-1">
+        {title}
+      </Text>
+
+      {isLoading ? (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View className="flex-row gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                width={variant === "genre" ? 140 : 112}
+                height={variant === "genre" ? 77 : 63}
+                borderRadius={12}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 12 }}
+        >
+          {items.map((item) => (
+            <CollectionTile
+              key={item.id}
+              variant={variant}
+              item={item}
+              onPress={onItemPress}
+            />
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+function CollectionTile({
+  variant,
+  item,
+  onPress,
+}: {
+  variant: "logo" | "genre";
+  item: DiscoverSliderItem;
+  onPress: (item: DiscoverSliderItem) => void;
+}) {
+  const [errored, setErrored] = useState(false);
+  const showImage = !!item.imageUrl && !errored;
+
+  if (variant === "genre") {
+    return (
+      <Pressable
+        onPress={() => onPress(item)}
+        className={`active:opacity-80 rounded-xl overflow-hidden bg-surface-light justify-end ${TILE_CLASS.genre}`}
+      >
+        {showImage && (
+          <Image
+            source={{ uri: item.imageUrl! }}
+            style={StyleSheet.absoluteFillObject}
+            contentFit="cover"
+            cachePolicy="memory-disk"
+            transition={200}
+            recyclingKey={item.imageUrl}
+            onError={() => setErrored(true)}
+          />
+        )}
+        <View className="absolute inset-0 bg-black/40" />
+        <Text
+          className="text-white text-sm font-semibold px-2.5 py-2"
+          numberOfLines={2}
+        >
+          {item.name}
+        </Text>
+      </Pressable>
+    );
+  }
+
+  // logo variant
+  return (
+    <Pressable
+      onPress={() => onPress(item)}
+      className={`active:opacity-80 rounded-xl bg-surface-light items-center justify-center px-3 py-2 ${TILE_CLASS.logo}`}
+    >
+      {showImage ? (
+        <Image
+          source={{ uri: item.imageUrl! }}
+          style={{ width: "100%", height: "100%" }}
+          contentFit="contain"
+          cachePolicy="memory-disk"
+          transition={200}
+          recyclingKey={item.imageUrl}
+          onError={() => setErrored(true)}
+        />
+      ) : (
+        <Text
+          className="text-zinc-300 text-sm font-semibold text-center"
+          numberOfLines={2}
+        >
+          {item.name}
+        </Text>
+      )}
+    </Pressable>
+  );
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -314,6 +314,7 @@
       <a href="privacy-policy.html">Privacy Policy</a>
     </div>
     <p>Open source under GPL-3.0. Built by <a href="https://github.com/RenzoBeux">Renzo Beux</a>.</p>
+    <p style="margin-top: 0.75rem;">This product uses the <a href="https://www.themoviedb.org">TMDB</a> API but is not endorsed or certified by TMDB.</p>
   </footer>
 
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -314,7 +314,7 @@
       <a href="privacy-policy.html">Privacy Policy</a>
     </div>
     <p>Open source under GPL-3.0. Built by <a href="https://github.com/RenzoBeux">Renzo Beux</a>.</p>
-    <p style="margin-top: 0.75rem;">This product uses the <a href="https://www.themoviedb.org">TMDB</a> API but is not endorsed or certified by TMDB.</p>
+    <p style="margin-top: 0.5rem; font-size: 0.75rem; color: #52525b;">Movie &amp; TV metadata from <a href="https://www.themoviedb.org">TMDB</a> and <a href="https://thetvdb.com">TheTVDB</a>. This product uses the TMDB API but is not endorsed or certified by TMDB.</p>
   </footer>
 
 </body>

--- a/hooks/use-overseerr.ts
+++ b/hooks/use-overseerr.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  useInfiniteQuery,
+} from "@tanstack/react-query";
 import {
   getRequests,
   getRequestCount,
@@ -7,6 +12,10 @@ import {
   getPopularMovies,
   getPopularTV,
   getUpcomingMovies,
+  getNetworkContent,
+  getStudioContent,
+  getGenreContent,
+  getGenreSlider,
   requestMovie,
   requestTV,
   approveRequest,
@@ -24,6 +33,7 @@ import type {
   OverseerrMovieDetails,
   OverseerrTVDetails,
 } from "@/lib/types";
+import type { DiscoverCollectionKind } from "@/lib/overseerr-discover";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
@@ -115,6 +125,48 @@ export function useOverseerrUpcomingMovies(instanceId?: string) {
     queryFn: () => getUpcomingMovies(1, id ?? undefined),
     enabled: enabled && !!id,
     staleTime: 300000,
+  });
+}
+
+// --- Browse by network / studio / genre ---
+
+// Paginated discover list for a single network, studio, or genre. `kind`
+// selects the endpoint; `genreMediaType` is only consulted when kind ===
+// "genre" (network → tv, studio → movie are implied by the endpoint). The
+// endpoints are 1-based and report totalPages, so we page until page ===
+// totalPages.
+export function useOverseerrDiscoverList(
+  kind: DiscoverCollectionKind,
+  id: number,
+  genreMediaType: OverseerrMediaType = "movie",
+  instanceId?: string,
+) {
+  const { instanceId: target, enabled } = useInstanceTarget("overseerr", instanceId);
+  return useInfiniteQuery({
+    queryKey: ["overseerr", target, "discoverList", kind, id, genreMediaType],
+    queryFn: ({ pageParam }) => {
+      if (kind === "network") return getNetworkContent(id, pageParam, target ?? undefined);
+      if (kind === "studio") return getStudioContent(id, pageParam, target ?? undefined);
+      return getGenreContent(genreMediaType, id, pageParam, target ?? undefined);
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+    enabled: enabled && !!target && id > 0,
+    staleTime: 300000,
+  });
+}
+
+export function useOverseerrGenreSlider(
+  mediaType: OverseerrMediaType,
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled } = useInstanceTarget("overseerr", instanceId);
+  return useQuery({
+    queryKey: ["overseerr", id, "genreSlider", mediaType],
+    queryFn: () => getGenreSlider(mediaType, id ?? undefined),
+    enabled: enabled && !!id,
+    staleTime: 3600000, // 1 hour — genres rarely change
   });
 }
 

--- a/lib/overseerr-discover.ts
+++ b/lib/overseerr-discover.ts
@@ -1,0 +1,63 @@
+// Curated network/studio collections for Seerr's Discover tab, mirroring the
+// hardcoded lists in Overseerr's own NetworkSlider/StudioSlider. The ids are
+// TMDB network/company ids passed straight to /discover/tv/network/:id and
+// /discover/movies/studio/:id. Logos are TMDB images rendered through the same
+// duotone filter Overseerr uses so they read on a dark background.
+
+export type DiscoverCollectionKind = "network" | "studio" | "genre";
+
+export interface DiscoverCollection {
+  id: number;
+  name: string;
+  // TMDB image path (e.g. "/wwemzKWzjKYJFfCeiB57q3r4Bcm.png"). Build the full
+  // URL with getDiscoverLogoUrl().
+  logoPath: string;
+}
+
+const TMDB_LOGO_DUOTONE_BASE =
+  "https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)";
+
+export function getDiscoverLogoUrl(logoPath: string): string {
+  return `${TMDB_LOGO_DUOTONE_BASE}${logoPath}`;
+}
+
+// TV networks → /discover/tv/network/:id (results are mediaType "tv").
+export const NETWORKS: DiscoverCollection[] = [
+  { id: 213, name: "Netflix", logoPath: "/wwemzKWzjKYJFfCeiB57q3r4Bcm.png" },
+  { id: 2739, name: "Disney+", logoPath: "/gJ8VX6JSu3ciXHuC2dDGAo2lvwM.png" },
+  { id: 1024, name: "Prime Video", logoPath: "/ifhbNuuVnlwYy5oXA5VIb2YR8AZ.png" },
+  { id: 2552, name: "Apple TV+", logoPath: "/4KAy34EHvRM25Ih8wb82AuGU7zJ.png" },
+  { id: 453, name: "Hulu", logoPath: "/pqUTCleNUiTLAVlelGxUgWn1ELh.png" },
+  { id: 49, name: "HBO", logoPath: "/tuomPhY2UtuPTqqFnKMVHvSb724.png" },
+  { id: 4353, name: "Discovery+", logoPath: "/1D1bS3Dyw4ScYnFWTlBOvJXC3nb.png" },
+  { id: 2, name: "ABC", logoPath: "/ndAvF4JLsliGreX87jAc9GdjmJY.png" },
+  { id: 19, name: "FOX", logoPath: "/1DSpHrWyOORkL9N2QHX7Adt31mQ.png" },
+  { id: 359, name: "Cinemax", logoPath: "/6mSHSquNpfLgDdv6VnOOvC5Uz2h.png" },
+  { id: 174, name: "AMC", logoPath: "/pmvRmATOCaDykE6JrVoeYxlFHw3.png" },
+  { id: 67, name: "Showtime", logoPath: "/Allse9kbjiP6ExaQrnSpIhkurEi.png" },
+  { id: 318, name: "Starz", logoPath: "/8GJjw3HHsAJYwIWKIPBPfqMxlEa.png" },
+  { id: 71, name: "The CW", logoPath: "/ge9hzeaU7nMtQ4PjkFlc68dGAJ9.png" },
+  { id: 6, name: "NBC", logoPath: "/o3OedEP0f9mfZr33jz2BfXOUK5.png" },
+  { id: 16, name: "CBS", logoPath: "/nm8d7P7MJNiBLdgIzUK0gkuEA4r.png" },
+  { id: 4330, name: "Paramount+", logoPath: "/fi83B1oztoS47xxcemFdPMhIzK.png" },
+  { id: 4, name: "BBC One", logoPath: "/mVn7xESaTNmjBUyUtGNvDQd3CT1.png" },
+  { id: 56, name: "Cartoon Network", logoPath: "/c5OC6oVCg6QP4eqzW6XIq17CQjI.png" },
+  { id: 80, name: "Adult Swim", logoPath: "/9AKyspxVzywuaMuZ1Bvilu8sXly.png" },
+  { id: 13, name: "Nickelodeon", logoPath: "/ikZXxg6GnwpzqiZbRPhJGaZapqB.png" },
+  { id: 3353, name: "Peacock", logoPath: "/gIAcGTjKKr0KOHL5s4O36roJ8p7.png" },
+];
+
+// Movie studios → /discover/movies/studio/:id (results are mediaType "movie").
+export const STUDIOS: DiscoverCollection[] = [
+  { id: 2, name: "Disney", logoPath: "/wdrCwmRnLFJhEoH8GSfymY85KHT.png" },
+  { id: 127928, name: "20th Century Studios", logoPath: "/h0rjX5vjW5r8yEnUBStFarjcLT4.png" },
+  { id: 34, name: "Sony Pictures", logoPath: "/GagSvqWlyPdkFHMfQ3pNq6ix9P.png" },
+  { id: 174, name: "Warner Bros. Pictures", logoPath: "/ky0xOc5OrhzkZ1N6KyUxacfQsCk.png" },
+  { id: 33, name: "Universal", logoPath: "/8lvHyhjr8oUKOOy2dKXoALWKdp0.png" },
+  { id: 4, name: "Paramount", logoPath: "/fycMZt242LVjagMByZOLUGbCvv3.png" },
+  { id: 3, name: "Pixar", logoPath: "/1TjvGVDMYsj6JBxOAkUHpPEwLf7.png" },
+  { id: 521, name: "Dreamworks", logoPath: "/kP7t6RwGz2AvvTkvnI1uteEwHet.png" },
+  { id: 420, name: "Marvel Studios", logoPath: "/hUzeosd33nzE5MCNsZxCGEKTXaQ.png" },
+  { id: 9993, name: "DC", logoPath: "/2Tc1P3Ac8M479naPp1kYT3izLS5.png" },
+  { id: 41077, name: "A24", logoPath: "/1ZXsGaFPgrgS6ZZGS37AqD5uU12.png" },
+];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -680,6 +680,14 @@ export interface OverseerrSearchResponse {
   results: OverseerrMediaResult[];
 }
 
+// One entry from /discover/genreslider/{movie,tv}: a genre plus a few backdrop
+// paths used to illustrate the genre tile.
+export interface OverseerrGenreSliderItem {
+  id: number;
+  name: string;
+  backdrops: string[];
+}
+
 export interface OverseerrMovieDetails {
   id: number;
   title: string;

--- a/services/overseerr-api.ts
+++ b/services/overseerr-api.ts
@@ -1,7 +1,9 @@
 import { serviceRequest } from "@/lib/http-client";
 import type {
+  OverseerrMediaType,
   OverseerrRequestsResponse,
   OverseerrSearchResponse,
+  OverseerrGenreSliderItem,
   OverseerrRequest,
   OverseerrRequestCount,
   OverseerrTrendingResult,
@@ -112,6 +114,61 @@ export function getRecentlyAdded(
   instanceId?: string,
 ): Promise<OverseerrSearchResponse> {
   return serviceRequest<OverseerrSearchResponse>("overseerr", "/discover/recently-added", {
+    instanceId,
+  });
+}
+
+// --- Browse by network / studio / genre ---
+// Path-param discover endpoints. Only `page` is sent — Overseerr's
+// express-openapi-validator 500s on undeclared query params, so `language` is
+// intentionally omitted. Responses carry an extra network/studio/genre object
+// alongside `results`, which we ignore (OverseerrSearchResponse reads results).
+
+export function getNetworkContent(
+  networkId: number,
+  page = 1,
+  instanceId?: string,
+): Promise<OverseerrSearchResponse> {
+  return serviceRequest<OverseerrSearchResponse>("overseerr", `/discover/tv/network/${networkId}`, {
+    params: { page },
+    instanceId,
+  });
+}
+
+export function getStudioContent(
+  studioId: number,
+  page = 1,
+  instanceId?: string,
+): Promise<OverseerrSearchResponse> {
+  return serviceRequest<OverseerrSearchResponse>("overseerr", `/discover/movies/studio/${studioId}`, {
+    params: { page },
+    instanceId,
+  });
+}
+
+// Genre ids differ between movie and tv, so the caller picks the media type
+// (which also selects the endpoint).
+export function getGenreContent(
+  mediaType: OverseerrMediaType,
+  genreId: number,
+  page = 1,
+  instanceId?: string,
+): Promise<OverseerrSearchResponse> {
+  const path =
+    mediaType === "movie"
+      ? `/discover/movies/genre/${genreId}`
+      : `/discover/tv/genre/${genreId}`;
+  return serviceRequest<OverseerrSearchResponse>("overseerr", path, {
+    params: { page },
+    instanceId,
+  });
+}
+
+export function getGenreSlider(
+  mediaType: OverseerrMediaType,
+  instanceId?: string,
+): Promise<OverseerrGenreSliderItem[]> {
+  return serviceRequest<OverseerrGenreSliderItem[]>("overseerr", `/discover/genreslider/${mediaType}`, {
     instanceId,
   });
 }


### PR DESCRIPTION
Adds network/studio/genre browse to the Seerr Discover tab (issue #116), matching Seerr's own Discover. Tapping a tile opens a paginated grid that reuses the existing poster, detail, and request flow. Networks/studios mirror Seerr's curated lists (no enumeration API exists); genres are fetched live via the genreslider endpoints. Also adds TMDB and TheTVDB attribution in Settings and on the landing page.

## Test plan
- Seerr tab → Discover: Networks, Studios, Movie Genres, TV Genres sliders render and scroll
- Tap a tile → paginated grid loads, scroll paginates, tap a title → request flow works
- Settings → About shows the TMDB/TheTVDB attribution
- `tsc --noEmit` clean; 405 jest tests pass

Closes #116