### PR TITLE
fix: clear orphaned pull-to-refresh spinner on blur (#147)

### DIFF
--- a/components/common/pull-to-refresh.tsx
+++ b/components/common/pull-to-refresh.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useFocusEffect } from "expo-router";
 import { lightHaptic } from "@/lib/haptics";
 
 /**
@@ -9,6 +10,19 @@ import { lightHaptic } from "@/lib/haptics";
 export function usePullToRefresh(queryKeys?: readonly unknown[][]) {
   const [refreshing, setRefreshing] = useState(false);
   const queryClient = useQueryClient();
+
+  // iOS: react-native-screens detaches/freezes a blurred tab screen. If a
+  // pull-to-refresh is still in flight when the user switches tabs, the native
+  // UIRefreshControl is frozen mid-spin and never receives the later
+  // endRefreshing() once the invalidate resolves off-screen — it comes back
+  // visible-but-frozen (#147). Clearing `refreshing` on blur drives the
+  // control's prop to false while the screen is still attached, dismissing the
+  // spinner before detach. The in-flight invalidate keeps running regardless.
+  useFocusEffect(
+    useCallback(() => {
+      return () => setRefreshing(false);
+    }, []),
+  );
 
   const onRefresh = useCallback(async () => {
     lightHaptic();

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -138,6 +138,16 @@ export function TorrentDownloadsView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refetch, statsResult.refetch]);
 
+  // iOS: clear the spinner on blur so a refresh still in flight when the user
+  // leaves the tab doesn't strand the native UIRefreshControl visible-but-
+  // frozen on return (#147). Mirrors the guard in usePullToRefresh for screens
+  // that hand-roll the refreshing boolean instead of using that hook.
+  useFocusEffect(
+    useCallback(() => {
+      return () => setRefreshing(false);
+    }, []),
+  );
+
   // Only the rows whose hashes are actually in-flight should disable —
   // mutating one torrent shouldn't gray out every other row's buttons.
   const busyHashes = new Set<string>([


### PR DESCRIPTION
Fixes #147.

Pulling to refresh the dashboard and switching tabs while the spinner was still spinning left the refresh indicator stuck (visible, not spinning) on return.

On iOS, react-native-screens detaches a blurred tab screen. When a refresh was still in flight at that moment, the native `UIRefreshControl` never received the later `endRefreshing()` (the prop flipped to `false` off-screen), so it came back frozen.

The fix resets `refreshing` to `false` on blur — while the screen is still attached — so the spinner is dismissed before detach. Done centrally in `usePullToRefresh` (covers every screen using it) and mirrored in the hand-rolled torrent downloads view. The in-flight invalidate/refetch keeps running, so data is still fresh on return.