### PR TITLE
fix: match TV calendar poster art to Releasing Soon widget (#140)

### DIFF
--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -23,7 +23,6 @@ import {
   useScreenBottomPadding,
 } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
-import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterChip } from "@/components/ui/filter-chip";
@@ -63,6 +62,7 @@ import {
 } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
+import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { formatEpisodeCode, relativeDate, localDateKey } from "@/lib/utils";
 import { mediumHaptic } from "@/lib/haptics";
@@ -530,28 +530,16 @@ function CalendarView({
             </Text>
             <View className="gap-2">
               {entries.map((ep) => (
-                <Card
+                <CalendarEventRow
                   key={ep.id}
+                  images={ep.series.images}
+                  service="sonarr"
+                  title={ep.series.title}
+                  subtitle={`${formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} — ${ep.title}`}
+                  hasFile={ep.hasFile}
                   onPress={() => router.push(`/series/${ep.seriesId}`)}
                   onLongPress={() => onLongPress(ep)}
-                >
-                  <View className="flex-row items-center gap-2">
-                    <View
-                      className={`w-1 h-10 rounded-full ${
-                        ep.hasFile ? "bg-success" : "bg-zinc-600"
-                      }`}
-                    />
-                    <View className="flex-1">
-                      <Text className="text-zinc-200 text-sm" numberOfLines={1}>
-                        {ep.series.title}
-                      </Text>
-                      <Text className="text-zinc-500 text-xs">
-                        {formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} —{" "}
-                        {ep.title}
-                      </Text>
-                    </View>
-                  </View>
-                </Card>
+                />
               ))}
             </View>
           </View>

--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -36,6 +36,8 @@ export interface CalendarEventRowProps {
   /** Drives the status indicators: green when downloaded, gray when missing. */
   hasFile: boolean;
   onPress: () => void;
+  /** Optional long-press (e.g. the TV calendar opens an episode action sheet). */
+  onLongPress?: () => void;
 }
 
 /**
@@ -53,6 +55,7 @@ export function CalendarEventRow({
   subtitle,
   hasFile,
   onPress,
+  onLongPress,
 }: CalendarEventRowProps) {
   const scale = useUiScale();
   const rowHeight = Math.round(ROW_HEIGHT * scale);
@@ -70,6 +73,7 @@ export function CalendarEventRow({
   return (
     <Pressable
       onPress={onPress}
+      onLongPress={onLongPress}
       className="active:opacity-80 overflow-hidden rounded-xl bg-surface-light"
       style={{ height: rowHeight }}
     >


### PR DESCRIPTION
Fixes #140.

The TV Shows screen's **Calendar** tab rendered plain text rows (a thin colored spine + title + subtitle), while the dashboard's **Releasing Soon** widget showed rich poster/backdrop tiles. They diverged because the TV calendar used a bespoke `Card` layout instead of the shared `CalendarEventRow` that the widget (and the standalone Calendar tab) already use.

This renders the TV calendar through the same `CalendarEventRow`, so the two surfaces are visually identical (poster thumbnail, fanart backdrop, status badge). A small optional `onLongPress` prop was added to `CalendarEventRow` to keep the existing episode action sheet.