### PR TITLE
fix: Remote URL field blank until tapped on iOS (#149)

### DIFF
--- a/components/ui/text-input.tsx
+++ b/components/ui/text-input.tsx
@@ -1,4 +1,5 @@
-import { TextInput as RNTextInput, View, Text } from "react-native";
+import { useEffect, useRef } from "react";
+import { TextInput as RNTextInput, View, Text, Platform } from "react-native";
 import type { TextInputProps as RNTextInputProps } from "react-native";
 
 interface TextInputProps extends RNTextInputProps {
@@ -14,12 +15,36 @@ export function TextInput({
   className = "",
   ...props
 }: TextInputProps) {
+  const ref = useRef<RNTextInput>(null);
+  // Read the freshest value when the post-mount nudge fires.
+  const valueRef = useRef(props.value);
+  valueRef.current = props.value;
+
+  // iOS New Architecture (Fabric) intermittently fails to paint a controlled
+  // TextInput's initial non-empty `value` until the field is focused — the
+  // "Remote URL blank until you tap it" bug (#149). Re-assert the text once
+  // after the first frame so Fabric repaints it without requiring user focus.
+  // We write back the SAME value React already holds, so the input stays
+  // controlled and never desyncs from `value`/`onChangeText`. Empty fields are
+  // skipped so their placeholder still shows.
+  useEffect(() => {
+    if (Platform.OS !== "ios") return;
+    const id = requestAnimationFrame(() => {
+      const v = valueRef.current;
+      if (typeof v === "string" && v.length > 0) {
+        ref.current?.setNativeProps({ text: v });
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, []);
+
   return (
     <View className={containerClassName}>
       {label && (
         <Text className="text-zinc-400 text-sm mb-1.5">{label}</Text>
       )}
       <RNTextInput
+        ref={ref}
         className={`bg-surface-light border rounded-xl px-4 py-3 text-zinc-100 text-base ${
           error ? "border-danger" : "border-border"
         } ${className}`}


### PR DESCRIPTION
Fixes #149.

The Remote URL field (and other connection inputs) rendered blank even when a value was saved — the value only appeared after tapping the field.

On the New Architecture (Fabric), a controlled `TextInput` given a non-empty `value` at mount intermittently fails to paint its text until it receives a focus/layout event. Focusing the field forced the repaint, which is exactly the "blank until you tap it" behaviour.

The fix re-asserts the same value via `setNativeProps` one frame after mount, iOS-only, in the shared `TextInput` primitive — so every input is covered, the field stays fully controlled (no `value`/`onChangeText` change), and empty fields keep their placeholder.