### PR TITLE
feat: implement Radarr Wanted (missing) movies list (#156)

### DIFF
--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -8,7 +8,7 @@ import {
   type RefreshControlProps,
 } from "react-native";
 import { useRouter } from "expo-router";
-import { Search, Film, Eye, EyeOff, Trash2, Info } from "lucide-react-native";
+import { Search, Film, Eye, EyeOff, Trash2, Info, ScanSearch } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -35,6 +35,7 @@ import {
   useRadarrQueue,
   useWantedMissing,
   useSearchForMovie,
+  useSearchAllMissingMovies,
   useToggleMovieMonitored,
   useDeleteMovie,
 } from "@/hooks/use-radarr";
@@ -119,8 +120,10 @@ export default function MoviesScreen() {
   const uiScale = useUiScale();
 
   const searchMutation = useSearchForMovie();
+  const searchMissing = useSearchAllMissingMovies();
   const toggleMonitor = useToggleMovieMonitored();
   const deleteMutation = useDeleteMovie();
+  const [missingConfirmOpen, setMissingConfirmOpen] = useState(false);
 
   const radarrHealth = healthData?.find((s) => s.id === "radarr");
 
@@ -209,6 +212,11 @@ export default function MoviesScreen() {
     setSheetTarget({ kind: "queue", item });
   };
 
+  const handleSearchMissing = () => {
+    mediumHaptic();
+    setMissingConfirmOpen(true);
+  };
+
   // Horizontal padding comes from ScreenWrapper's px-4; only vertical padding
   // here. pt = 0.5rem, matched at runtime so accessibility scale applies.
   const contentContainerStyle = {
@@ -230,12 +238,25 @@ export default function MoviesScreen() {
     <>
       <View className="flex-row items-center justify-between">
         <ServiceHeader name="Movies" online={radarrHealth?.online} serviceId="radarr" />
-        <Pressable
-          onPress={() => router.push("/movie/search")}
-          className="p-2 active:opacity-70"
-        >
-          <Icon icon={Search} size={ICON.LG} color="#a1a1aa" />
-        </Pressable>
+        <View className="flex-row items-center">
+          {tab === "wanted" && (
+            <Pressable
+              onPress={handleSearchMissing}
+              disabled={searchMissing.isPending}
+              className="p-2 active:opacity-70"
+              accessibilityLabel="Search all missing movies"
+            >
+              <Icon icon={ScanSearch} size={ICON.LG} color="#a1a1aa" />
+            </Pressable>
+          )}
+          <Pressable
+            onPress={() => router.push("/movie/search")}
+            className="p-2 active:opacity-70"
+            accessibilityLabel="Add movie"
+          >
+            <Icon icon={Search} size={ICON.LG} color="#a1a1aa" />
+          </Pressable>
+        </View>
       </View>
 
       <ScrollView
@@ -280,7 +301,15 @@ export default function MoviesScreen() {
           contentContainerStyle={contentContainerStyle}
         />
       )}
-      {tab !== "library" && (
+      {tab === "wanted" && (
+        <MovieWanted
+          onLongPress={openMovieSheet}
+          listHeader={header}
+          refreshControl={refreshCtl}
+          contentContainerStyle={contentContainerStyle}
+        />
+      )}
+      {tab === "queue" && (
         <ScrollView
           className="flex-1"
           contentContainerStyle={contentContainerStyle}
@@ -288,8 +317,7 @@ export default function MoviesScreen() {
           showsVerticalScrollIndicator={false}
         >
           {header}
-          {tab === "queue" && <MovieQueue onLongPress={openQueueSheet} />}
-          {tab === "wanted" && <MovieWanted />}
+          <MovieQueue onLongPress={openQueueSheet} />
         </ScrollView>
       )}
 
@@ -320,6 +348,19 @@ export default function MoviesScreen() {
         sortOptions={SORT_OPTIONS.map((o) => ({ key: o.key, label: o.label }))}
         sortValue={sort}
         onSortChange={setSort}
+      />
+
+      <ConfirmModal
+        visible={missingConfirmOpen}
+        title="Search Missing Movies"
+        message="Radarr will search every monitored missing movie in your library. This can queue a lot of grabs at once."
+        icon={ScanSearch}
+        confirmLabel="Search"
+        onConfirm={() => {
+          setMissingConfirmOpen(false);
+          searchMissing.mutate();
+        }}
+        onCancel={() => setMissingConfirmOpen(false)}
       />
 
       <ConfirmModal
@@ -435,20 +476,63 @@ function MovieQueue({ onLongPress }: { onLongPress: (item: RadarrQueueItem) => v
   );
 }
 
-function MovieWanted() {
-  const { data: wanted, isLoading } = useWantedMissing();
+function MovieWanted({
+  onLongPress,
+  listHeader,
+  refreshControl,
+  contentContainerStyle,
+}: {
+  onLongPress: (movie: RadarrMovie) => void;
+  listHeader: React.ReactElement;
+  refreshControl: React.ReactElement<RefreshControlProps>;
+  contentContainerStyle: React.ComponentProps<
+    typeof MonitoredLibraryGrid
+  >["contentContainerStyle"];
+}) {
+  const { data: wanted, isLoading, error } = useWantedMissing();
+  const { data: queue } = useRadarrQueue();
+  const router = useRouter();
 
-  if (isLoading) return <SkeletonCardContent rows={2} />;
+  const downloading = useMemo(
+    () => new Set((queue?.records ?? []).map((r) => r.movieId)),
+    [queue],
+  );
+
+  const count = wanted?.totalRecords ?? 0;
+  const header = (
+    <>
+      {listHeader}
+      {!isLoading && (
+        <View className="mb-4">
+          <Text className="text-zinc-400 text-sm">
+            {count} missing {count === 1 ? "movie" : "movies"}
+          </Text>
+        </View>
+      )}
+    </>
+  );
 
   return (
-    <View>
-      <Text className="text-zinc-400 text-sm mb-3">
-        {wanted?.totalRecords ?? 0} missing movies
-      </Text>
-      <EmptyState
-        title="Full wanted list"
-        message="View in Radarr for complete list"
-      />
-    </View>
+    <MonitoredLibraryGrid
+      data={wanted?.records}
+      isLoading={isLoading}
+      error={error}
+      monitorFilter="all"
+      sort="title-asc"
+      compare={compareMovies}
+      serviceId="radarr"
+      placeholderIcon={Film}
+      nounPlural="missing movies"
+      renderFooter={(m) => String(m.year)}
+      posterStatus={(m) => ({
+        barColor: BAR_KIND_COLOR[radarrBarKind(m, downloading.has(m.id))],
+        cornerColor: cornerColorFor(m.status),
+      })}
+      onItemPress={(m) => router.push(`/movie/${m.id}`)}
+      onItemLongPress={onLongPress}
+      ListHeaderComponent={header}
+      refreshControl={refreshControl}
+      contentContainerStyle={contentContainerStyle}
+    />
   );
 }

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -4,12 +4,13 @@ import {
   getMovie,
   getQueue,
   getHistory,
-  getWantedMissing,
+  getAllWantedMissing,
   getCalendar,
   searchMovies,
   addMovie,
   deleteMovie,
   searchForMovie,
+  searchAllMissingMovies,
   toggleMovieMonitored,
   updateMovie,
   changeMovieRootFolder,
@@ -79,11 +80,17 @@ export function useRadarrHistory(instanceId?: string) {
   });
 }
 
+// Fetches the complete wanted/missing list (all pages). Only mounted by the
+// Movies "Wanted" tab, so the full walk doesn't run while the user is elsewhere.
+// The key is namespaced with "all" so it never aliases the count-only
+// ["radarr", id, "wanted"] entry the dashboard's RadarrQueueCard owns — sharing
+// a key would let its 1-record badge fetch clobber the full list (and vice
+// versa), collapsing the grid to a single poster.
 export function useWantedMissing(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
-    queryKey: ["radarr", id, "wanted"],
-    queryFn: () => getWantedMissing(1, 1, id ?? undefined),
+    queryKey: ["radarr", id, "wanted", "all"],
+    queryFn: () => getAllWantedMissing(id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
   });
@@ -151,6 +158,15 @@ export function useSearchForMovie(instanceId?: string) {
   return useMutation({
     mutationFn: (movieId: number) => searchForMovie(movieId, id ?? undefined),
     onSuccess: () => toast("Search started"),
+    onError: (err) => toastError("Search failed", err),
+  });
+}
+
+export function useSearchAllMissingMovies(instanceId?: string) {
+  const { instanceId: id } = useInstanceTarget("radarr", instanceId);
+  return useMutation({
+    mutationFn: () => searchAllMissingMovies(id ?? undefined),
+    onSuccess: () => toast("Searching all missing movies"),
     onError: (err) => toastError("Search failed", err),
   });
 }

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -93,6 +93,29 @@ export function getWantedMissing(
   });
 }
 
+// Walks every page of the wanted/missing list. getWantedMissing above is the
+// cheap count-only call used for dashboard badges; this one fetches page 1 to
+// learn the total, then pulls the remaining pages in parallel and concatenates
+// them so the Wanted view shows the complete list, not a single page (issue #156).
+export async function getAllWantedMissing(
+  instanceId?: string,
+): Promise<RadarrWantedMissing> {
+  const pageSize = 100;
+  const first = await getWantedMissing(1, pageSize, instanceId);
+  const totalPages = Math.max(1, Math.ceil(first.totalRecords / pageSize));
+  if (totalPages <= 1) return first;
+  const rest = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, i) =>
+      getWantedMissing(i + 2, pageSize, instanceId),
+    ),
+  );
+  const records = rest.reduce(
+    (acc, page) => acc.concat(page.records),
+    [...first.records],
+  );
+  return { ...first, pageSize: records.length, records };
+}
+
 // --- Search ---
 
 export function searchMovies(
@@ -170,6 +193,18 @@ export function searchForMovie(movieId: number, instanceId?: string): Promise<vo
   return serviceRequest<void>("radarr", "/command", {
     method: "POST",
     body: JSON.stringify({ name: "MoviesSearch", movieIds: [movieId] }),
+    instanceId,
+  });
+}
+
+// Searches every monitored missing movie. With no FilterKey/FilterValue the
+// MissingMoviesSearch command defaults to all monitored missing movies — the
+// equivalent of Radarr's Wanted › Missing › "Search All" button (mirrors
+// Sonarr's searchAllMissingEpisodes).
+export function searchAllMissingMovies(instanceId?: string): Promise<void> {
+  return serviceRequest<void>("radarr", "/command", {
+    method: "POST",
+    body: JSON.stringify({ name: "MissingMoviesSearch" }),
     instanceId,
   });
 }


### PR DESCRIPTION
Closes #156.

The Movies "Wanted" tab was a placeholder: it fetched a single record to show a count, then told the user to open Radarr for the full list.

## Changes
- `getAllWantedMissing()` walks every page of `/wanted/missing` (page 1 gives the total, the rest fetched in parallel and concatenated). The cheap `getWantedMissing(1,1)` is kept for the dashboard badge.
- Wanted tab now renders the real virtualized `MonitoredLibraryGrid` (tap → details, long-press → search/monitor/delete, status overlays, UI-scale aware) as its own scroll container.
- Added a "Search All Missing" bulk action (`MissingMoviesSearch`) with a `ConfirmModal`, mirroring the TV screen.
- Header shows the missing count.
- Namespaced the full-list query key as `["radarr", id, "wanted", "all"]` so it no longer collides with the dashboard's count-only `["radarr", id, "wanted"]` fetch (which would otherwise clobber the list down to a single poster).