### PR TITLE
Add Glances network monitoring, Streaming Bandwidth widget, and Speed Stats sources (#53)

### DIFF
--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import Animated, { FadeIn } from "react-native-reanimated";
-import { HardDrive, Activity, Gpu, ChevronDown, ChevronUp, Container } from "lucide-react-native";
+import { HardDrive, Activity, Gpu, ChevronDown, ChevronUp, Container, Network } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -15,9 +15,11 @@ import {
   useGlancesMem,
   useGlancesFs,
   useGlancesDiskIO,
+  useGlancesNet,
   useGlancesGpu,
   useGlancesContainers,
 } from "@/hooks/use-glances";
+import { rankedInterfaces, type GlancesNetRate } from "@/services/glances-api";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useGlancesUiStore } from "@/store/glances-ui-store";
@@ -62,6 +64,7 @@ export default function GlancesScreen() {
         <GpuCard />
         <DisksCard />
         <DiskIOCard />
+        <NetworkCard />
         <ContainersCard />
       </View>
     </ScreenWrapper>
@@ -399,6 +402,72 @@ function DiskIORow({ drive }: { drive: GlancesDiskIOItem }) {
       <View className="flex-row gap-4">
         <Text className="text-zinc-400 text-xs">R {formatSpeed(readRate)}</Text>
         <Text className="text-zinc-400 text-xs">W {formatSpeed(writeRate)}</Text>
+      </View>
+    </View>
+  );
+}
+
+function NetworkCard() {
+  const { data: net, isLoading } = useGlancesNet();
+  const expanded = useGlancesUiStore((s) => s.networkExpanded);
+  const setExpanded = useGlancesUiStore((s) => s.setNetworkExpanded);
+
+  // Up, non-loopback interfaces sorted by throughput (real NIC on top).
+  const interfaces = net ? rankedInterfaces(net) : [];
+
+  // Hide entirely on hosts that expose no usable interface — same as DiskIO.
+  if (!isLoading && interfaces.length === 0) return null;
+
+  return (
+    <Card>
+      <Pressable
+        onPress={() => {
+          lightHaptic();
+          setExpanded(!expanded);
+        }}
+        className="flex-row items-center justify-between active:opacity-70"
+      >
+        <View className="flex-row items-center gap-2">
+          <Icon icon={Network} size={18} color="#a1a1aa" />
+          <CardTitle>Network</CardTitle>
+        </View>
+        <View className="flex-row items-center gap-2">
+          {!isLoading && (
+            <Text className="text-zinc-500 text-xs">
+              {interfaces.length} {interfaces.length === 1 ? "interface" : "interfaces"}
+            </Text>
+          )}
+          <Icon icon={expanded ? ChevronUp : ChevronDown} size={18} color="#71717a" />
+        </View>
+      </Pressable>
+
+      {isLoading ? (
+        <View className="mt-4">
+          <SkeletonCardContent rows={2} />
+        </View>
+      ) : expanded ? (
+        <Animated.View entering={FadeIn.duration(150)} className="gap-3 mt-4">
+          {interfaces.map((iface) => (
+            <NetworkRow key={iface.interface_name} iface={iface} />
+          ))}
+        </Animated.View>
+      ) : null}
+    </Card>
+  );
+}
+
+function NetworkRow({ iface }: { iface: GlancesNetRate }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <View className="flex-row items-center gap-2 flex-1 mr-2">
+        <Icon icon={Network} size={14} color="#a1a1aa" />
+        <Text className="text-zinc-300 text-sm" numberOfLines={1}>
+          {iface.alias || iface.interface_name}
+        </Text>
+      </View>
+      <View className="flex-row gap-4">
+        <Text className="text-zinc-400 text-xs">↓ {formatSpeed(iface.rx)}</Text>
+        <Text className="text-zinc-400 text-xs">↑ {formatSpeed(iface.tx)}</Text>
       </View>
     </View>
   );

--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -19,7 +19,7 @@ import {
   useGlancesGpu,
   useGlancesContainers,
 } from "@/hooks/use-glances";
-import { rankedInterfaces, type GlancesNetRate } from "@/services/glances-api";
+import { rankedInterfaces, isVirtualInterface, type GlancesNetRate } from "@/services/glances-api";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useGlancesUiStore } from "@/store/glances-ui-store";
@@ -412,8 +412,11 @@ function NetworkCard() {
   const expanded = useGlancesUiStore((s) => s.networkExpanded);
   const setExpanded = useGlancesUiStore((s) => s.setNetworkExpanded);
 
-  // Up, non-loopback interfaces sorted by throughput (real NIC on top).
+  // Up, non-loopback interfaces sorted by throughput (real NIC on top), split
+  // so Docker/veth noise sits under its own label like the widget's picker.
   const interfaces = net ? rankedInterfaces(net) : [];
+  const physical = interfaces.filter((i) => !isVirtualInterface(i.interface_name));
+  const virtual = interfaces.filter((i) => isVirtualInterface(i.interface_name));
 
   // Hide entirely on hosts that expose no usable interface — same as DiskIO.
   if (!isLoading && interfaces.length === 0) return null;
@@ -447,9 +450,23 @@ function NetworkCard() {
         </View>
       ) : expanded ? (
         <Animated.View entering={FadeIn.duration(150)} className="gap-3 mt-4">
-          {interfaces.map((iface) => (
+          {physical.map((iface) => (
             <NetworkRow key={iface.interface_name} iface={iface} />
           ))}
+          {virtual.length > 0 && (
+            <>
+              {/* Only label the group when real NICs sit above it; on a
+                  Docker-only host the virtual rows are the whole list. */}
+              {physical.length > 0 && (
+                <Text className="text-zinc-500 text-xs font-semibold uppercase tracking-wider mt-1">
+                  Virtual / Docker
+                </Text>
+              )}
+              {virtual.map((iface) => (
+                <NetworkRow key={iface.interface_name} iface={iface} />
+              ))}
+            </>
+          )}
         </Animated.View>
       ) : null}
     </Card>

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -5,6 +5,7 @@ import {
   MemoryStick,
   Gpu as GpuIconSvg,
   HardDrive,
+  Network,
   ServerCrash,
 } from "lucide-react-native";
 import type { LucideIcon } from "lucide-react-native";
@@ -12,7 +13,7 @@ import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
-import { getCpu, getMem, getFs, getGpu } from "@/services/glances-api";
+import { getCpu, getMem, getFs, getGpu, getNet, selectInterfaces, type GlancesNetRate } from "@/services/glances-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useUiScale } from "@/hooks/use-ui-scale";
@@ -22,7 +23,7 @@ import {
 } from "@/components/dashboard/widget-settings/server-stats-settings";
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
-import { formatBytes } from "@/lib/utils";
+import { formatBytes, formatSpeed } from "@/lib/utils";
 import type { GlancesFsItem, GlancesGpuItem } from "@/lib/types";
 import type { ServiceInstance } from "@/store/config-store";
 
@@ -198,27 +199,43 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
         refetchInterval: FAST_POLL,
         enabled: settings.showGpu,
       },
+      {
+        queryKey: ["glances", instance.id, "net"] as const,
+        queryFn: () => getNet(instance.id),
+        refetchInterval: FAST_POLL,
+        enabled: settings.showNetwork,
+      },
     ],
   });
-  const [cpuQuery, memQuery, fsQuery, gpuQuery] = queries;
+  const [cpuQuery, memQuery, fsQuery, gpuQuery, netQuery] = queries;
   const cpu = settings.showCpu ? cpuQuery.data : undefined;
   const mem = settings.showRam ? memQuery.data : undefined;
   const fs = settings.showDisks ? fsQuery.data : undefined;
   const gpus = settings.showGpu ? gpuQuery.data : undefined;
+  const netRows = settings.showNetwork
+    ? selectInterfaces(netQuery.data, settings.networkInterfaces, { activeOnly: true })
+    : [];
 
   const isLoading =
     (settings.showCpu && cpuQuery.isLoading) ||
     (settings.showRam && memQuery.isLoading) ||
     (settings.showDisks && fsQuery.isLoading) ||
-    (settings.showGpu && gpuQuery.isLoading);
-  const hasData = cpu || mem || (fs && fs.length > 0) || (gpus && gpus.length > 0);
+    (settings.showGpu && gpuQuery.isLoading) ||
+    (settings.showNetwork && netQuery.isLoading);
+  const hasData =
+    cpu ||
+    mem ||
+    (fs && fs.length > 0) ||
+    (gpus && gpus.length > 0) ||
+    netRows.length > 0;
   const showError =
     !isLoading &&
     !hasData &&
     ((settings.showCpu && cpuQuery.isError) ||
       (settings.showRam && memQuery.isError) ||
       (settings.showDisks && fsQuery.isError) ||
-      (settings.showGpu && gpuQuery.isError));
+      (settings.showGpu && gpuQuery.isError) ||
+      (settings.showNetwork && netQuery.isError));
 
   const gpuRings = buildGpuRings(gpus);
   const hasRings =
@@ -226,7 +243,9 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
     (settings.showRam && mem) ||
     gpuRings.length > 0;
   const hasDisks = settings.showDisks && fs && fs.length > 0;
-  const showDivider = hasRings && hasDisks;
+  const hasNetwork = settings.showNetwork && netRows.length > 0;
+  const showRingDisksDivider = hasRings && hasDisks;
+  const showNetworkDivider = (hasRings || hasDisks) && hasNetwork;
 
   return (
     <View className="gap-3">
@@ -278,7 +297,7 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
             </View>
           )}
 
-          {showDivider && <View className="h-px bg-border" />}
+          {showRingDisksDivider && <View className="h-px bg-border" />}
 
           {hasDisks && (
             <View className="gap-2">
@@ -287,8 +306,33 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
               ))}
             </View>
           )}
+
+          {showNetworkDivider && <View className="h-px bg-border" />}
+
+          {hasNetwork && (
+            <View className="gap-2">
+              {netRows.map((iface) => (
+                <NetRow key={iface.interface_name} iface={iface} />
+              ))}
+            </View>
+          )}
         </>
       )}
+    </View>
+  );
+}
+
+function NetRow({ iface }: { iface: GlancesNetRate }) {
+  return (
+    <View className="flex-row justify-between items-center gap-2">
+      <View className="flex-row items-center gap-1.5 flex-1 min-w-0">
+        <Icon icon={Network} size={11} color="#a1a1aa" />
+        <Text className="text-zinc-300 text-xs font-medium" numberOfLines={1}>
+          {iface.alias || iface.interface_name}
+        </Text>
+      </View>
+      <Text className="text-zinc-400 text-[0.7rem]">↓ {formatSpeed(iface.rx)}</Text>
+      <Text className="text-zinc-400 text-[0.7rem]">↑ {formatSpeed(iface.tx)}</Text>
     </View>
   );
 }

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -6,6 +6,8 @@ import {
   Gpu as GpuIconSvg,
   HardDrive,
   Network,
+  Gauge,
+  Activity,
   ServerCrash,
 } from "lucide-react-native";
 import type { LucideIcon } from "lucide-react-native";
@@ -13,7 +15,7 @@ import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
-import { getCpu, getMem, getFs, getGpu, getNet, selectInterfaces, type GlancesNetRate } from "@/services/glances-api";
+import { getCpu, getMem, getFs, getGpu, getNet, getLoad, selectInterfaces, type GlancesNetRate } from "@/services/glances-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useUiScale } from "@/hooks/use-ui-scale";
@@ -24,7 +26,7 @@ import {
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { formatBytes, formatSpeed } from "@/lib/utils";
-import type { GlancesFsItem, GlancesGpuItem } from "@/lib/types";
+import type { GlancesFsItem, GlancesGpuItem, GlancesLoad } from "@/lib/types";
 import type { ServiceInstance } from "@/store/config-store";
 
 const RING_BASE = 60;
@@ -179,7 +181,8 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
         queryKey: ["glances", instance.id, "cpu"] as const,
         queryFn: () => getCpu(instance.id),
         refetchInterval: FAST_POLL,
-        enabled: settings.showCpu,
+        // CPU also carries iowait, so fetch it when either is shown.
+        enabled: settings.showCpu || settings.showIoWait,
       },
       {
         queryKey: ["glances", instance.id, "mem"] as const,
@@ -205,9 +208,15 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
         refetchInterval: FAST_POLL,
         enabled: settings.showNetwork,
       },
+      {
+        queryKey: ["glances", instance.id, "load"] as const,
+        queryFn: () => getLoad(instance.id),
+        refetchInterval: FAST_POLL,
+        enabled: settings.showLoad,
+      },
     ],
   });
-  const [cpuQuery, memQuery, fsQuery, gpuQuery, netQuery] = queries;
+  const [cpuQuery, memQuery, fsQuery, gpuQuery, netQuery, loadQuery] = queries;
   const cpu = settings.showCpu ? cpuQuery.data : undefined;
   const mem = settings.showRam ? memQuery.data : undefined;
   const fs = settings.showDisks ? fsQuery.data : undefined;
@@ -215,37 +224,48 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
   const netRows = settings.showNetwork
     ? selectInterfaces(netQuery.data, settings.networkInterfaces, { activeOnly: true })
     : [];
+  const load = settings.showLoad ? loadQuery.data : undefined;
+  const iowait =
+    settings.showIoWait && typeof cpuQuery.data?.iowait === "number"
+      ? cpuQuery.data.iowait
+      : undefined;
 
   const isLoading =
-    (settings.showCpu && cpuQuery.isLoading) ||
+    ((settings.showCpu || settings.showIoWait) && cpuQuery.isLoading) ||
     (settings.showRam && memQuery.isLoading) ||
     (settings.showDisks && fsQuery.isLoading) ||
     (settings.showGpu && gpuQuery.isLoading) ||
-    (settings.showNetwork && netQuery.isLoading);
+    (settings.showNetwork && netQuery.isLoading) ||
+    (settings.showLoad && loadQuery.isLoading);
   const hasData =
     cpu ||
     mem ||
     (fs && fs.length > 0) ||
     (gpus && gpus.length > 0) ||
-    netRows.length > 0;
+    netRows.length > 0 ||
+    !!load ||
+    typeof iowait === "number";
   const showError =
     !isLoading &&
     !hasData &&
-    ((settings.showCpu && cpuQuery.isError) ||
+    (((settings.showCpu || settings.showIoWait) && cpuQuery.isError) ||
       (settings.showRam && memQuery.isError) ||
       (settings.showDisks && fsQuery.isError) ||
       (settings.showGpu && gpuQuery.isError) ||
-      (settings.showNetwork && netQuery.isError));
+      (settings.showNetwork && netQuery.isError) ||
+      (settings.showLoad && loadQuery.isError));
 
   const gpuRings = buildGpuRings(gpus);
   const hasRings =
     (settings.showCpu && cpu) ||
     (settings.showRam && mem) ||
     gpuRings.length > 0;
+  const hasStats = !!load || typeof iowait === "number";
   const hasDisks = settings.showDisks && fs && fs.length > 0;
   const hasNetwork = settings.showNetwork && netRows.length > 0;
-  const showRingDisksDivider = hasRings && hasDisks;
-  const showNetworkDivider = (hasRings || hasDisks) && hasNetwork;
+  const showStatsDivider = hasRings && hasStats;
+  const showDisksDivider = (hasRings || hasStats) && hasDisks;
+  const showNetworkDivider = (hasRings || hasStats || hasDisks) && hasNetwork;
 
   return (
     <View className="gap-3">
@@ -297,7 +317,11 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
             </View>
           )}
 
-          {showRingDisksDivider && <View className="h-px bg-border" />}
+          {showStatsDivider && <View className="h-px bg-border" />}
+
+          {hasStats && <StatsRow load={load} iowait={iowait} />}
+
+          {showDisksDivider && <View className="h-px bg-border" />}
 
           {hasDisks && (
             <View className="gap-2">
@@ -317,6 +341,42 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
             </View>
           )}
         </>
+      )}
+    </View>
+  );
+}
+
+// Glances returns different shapes per host OS (some omit load/iowait fields),
+// so guard each value to render a dash instead of crashing on undefined.toFixed
+// — mirrors the fmt() helper on the Glances screen.
+function loadVal(n: number | undefined): string {
+  return typeof n === "number" && Number.isFinite(n) ? n.toFixed(2) : "—";
+}
+
+function StatsRow({
+  load,
+  iowait,
+}: {
+  load: GlancesLoad | undefined;
+  iowait: number | undefined;
+}) {
+  return (
+    <View className="flex-row flex-wrap gap-x-4 gap-y-1">
+      {load && (
+        <View className="flex-row items-center gap-1.5">
+          <Icon icon={Gauge} size={11} color="#a1a1aa" />
+          <Text className="text-zinc-400 text-xs">
+            Load {loadVal(load.min1)} · {loadVal(load.min5)} · {loadVal(load.min15)}
+          </Text>
+        </View>
+      )}
+      {typeof iowait === "number" && (
+        <View className="flex-row items-center gap-1.5">
+          <Icon icon={Activity} size={11} color="#a1a1aa" />
+          <Text className="text-zinc-400 text-xs">
+            I/O Wait {iowait.toFixed(1)}%
+          </Text>
+        </View>
       )}
     </View>
   );

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
-import { ArrowDown, ArrowUp } from "lucide-react-native";
+import { ArrowDown, ArrowUp, ServerCrash } from "lucide-react-native";
 import { useQueries } from "@tanstack/react-query";
+import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ThroughputPill,
@@ -116,7 +117,7 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   // instance later goes offline. The sum gracefully drops to the live
   // instances' contributions instead of flickering back to skeleton on each
   // retry.
-  const { isInitialLoading } = aggregateMultiInstanceState([
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState([
     ...qbitQueries,
     ...sabQueries,
     ...rtQueries,
@@ -144,6 +145,22 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
         <Text className="text-zinc-500 text-sm">
           No sources selected. Enable download clients or server network in widget settings.
         </Text>
+      </Card>
+    );
+  }
+
+  // Every bound source errored without ever returning data — surface that
+  // instead of a misleading "0 B/s" that reads as "idle".
+  if (isAllErrored) {
+    return (
+      <Card>
+        {header}
+        <View className="flex-row items-center gap-2 py-1">
+          <Icon icon={ServerCrash} size={16} color="#71717a" />
+          <Text className="text-zinc-500 text-sm">
+            Could not reach {useNetwork ? "Glances" : "the download clients"}
+          </Text>
+        </View>
       </Card>
     );
   }

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -10,6 +10,7 @@ import {
 import { getServerState } from "@/services/qbittorrent-api";
 import { getRtorrentGlobalStats } from "@/services/rtorrent-api";
 import { getSabQueue } from "@/services/sabnzbd-api";
+import { getNzbgetStatus } from "@/services/nzbget-api";
 import { getNet, selectInterfaces } from "@/services/glances-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
@@ -31,6 +32,7 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   );
   const allQbitInstances = useEnabledInstances("qbittorrent");
   const allSabInstances = useEnabledInstances("sabnzbd");
+  const allNzbgetInstances = useEnabledInstances("nzbget");
   const allRtInstances = useEnabledInstances("rtorrent");
   const allGlancesInstances = useEnabledInstances("glances");
 
@@ -39,7 +41,11 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   // NIC Glances reports. The selection is forced when only one kind is
   // configured (see resolveSpeedStatsSource).
   const hasClients =
-    allQbitInstances.length + allSabInstances.length + allRtInstances.length > 0;
+    allQbitInstances.length +
+      allSabInstances.length +
+      allNzbgetInstances.length +
+      allRtInstances.length >
+    0;
   const source = resolveSpeedStatsSource(
     settings.source,
     hasClients,
@@ -54,13 +60,18 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     ? resolveBoundInstances(settings.instanceIds, allQbitInstances)
     : [];
   // When the user has no qBit configured at all, the toggle is moot — fold any
-  // enabled SAB instances in automatically so a SAB-only user sees real numbers
-  // instead of a perpetual skeleton. Once they enable qBit, the explicit toggle
-  // takes over again.
+  // enabled SAB/NZBGet instances in automatically so a usenet-only user sees
+  // real numbers instead of a perpetual skeleton. Once they enable qBit, the
+  // explicit toggles take over again.
   const effectiveIncludeSab =
     useClients && (settings.includeSab || allQbitInstances.length === 0);
   const sabInstances = effectiveIncludeSab
     ? resolveBoundInstances(settings.sabInstanceIds, allSabInstances)
+    : [];
+  const effectiveIncludeNzbget =
+    useClients && (settings.includeNzbget || allQbitInstances.length === 0);
+  const nzbgetInstances = effectiveIncludeNzbget
+    ? resolveBoundInstances(settings.nzbgetInstanceIds, allNzbgetInstances)
     : [];
   const rtInstances = useClients ? allRtInstances : [];
   // Glances interfaces: received bytes → down pill, sent bytes → up pill.
@@ -88,6 +99,16 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     queries: sabInstances.map((inst) => ({
       queryKey: ["sabnzbd", inst.id, "queue"] as const,
       queryFn: () => getSabQueue(inst.id),
+      refetchInterval: POLLING_INTERVALS.transferSpeed,
+    })),
+  });
+
+  // NZBGet mirrors SAB: instantaneous download rate only (bytes/sec, already in
+  // bytes so no normalization). The status RPC carries DownloadRate.
+  const nzbgetQueries = useQueries({
+    queries: nzbgetInstances.map((inst) => ({
+      queryKey: ["nzbget", inst.id, "status"] as const,
+      queryFn: () => getNzbgetStatus(inst.id),
       refetchInterval: POLLING_INTERVALS.transferSpeed,
     })),
   });
@@ -120,6 +141,7 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState([
     ...qbitQueries,
     ...sabQueries,
+    ...nzbgetQueries,
     ...rtQueries,
     ...glancesQueries,
   ]);
@@ -127,6 +149,7 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   const hasAnySource =
     qbitInstances.length +
       sabInstances.length +
+      nzbgetInstances.length +
       rtInstances.length +
       glancesInstances.length >
     0;
@@ -202,6 +225,11 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     const kbps = parseFloat(q.data.kbpersec);
     if (Number.isFinite(kbps)) dlSpeed += kbps * 1024;
   }
+  for (const q of nzbgetQueries) {
+    if (!q.data) continue;
+    // DownloadRate is already bytes/sec; download-only like SAB.
+    if (Number.isFinite(q.data.DownloadRate)) dlSpeed += q.data.DownloadRate;
+  }
   for (const q of rtQueries) {
     if (!q.data) continue;
     dlSpeed += q.data.dlSpeed;
@@ -222,12 +250,14 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   }
 
   // Lifetime totals are a client-only concept (qBit/rtorrent counters), so they
-  // only apply to a client-source widget. (SAB still suppresses the down total
-  // below — it adds live download speed with no matching counter.)
+  // only apply to a client-source widget. SAB and NZBGet suppress the down total
+  // — they add live download speed with no matching lifetime counter.
   const clientTotalsMeaningful = useClients;
   const scope = settings.totalsScope;
   const dlTotalLines =
-    clientTotalsMeaningful && sabInstances.length === 0
+    clientTotalsMeaningful &&
+    sabInstances.length === 0 &&
+    nzbgetInstances.length === 0
       ? buildTotalLines(scope, dlAlltime, dlSession)
       : [];
   const upTotalLines = clientTotalsMeaningful

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -1,18 +1,22 @@
 import { View, Text } from "react-native";
 import { ArrowDown, ArrowUp } from "lucide-react-native";
 import { useQueries } from "@tanstack/react-query";
-import { Icon } from "@/components/ui/icon";
-import { Card } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ThroughputPill,
+  ThroughputPillSkeleton,
+} from "@/components/dashboard/throughput-pill";
 import { getServerState } from "@/services/qbittorrent-api";
 import { getRtorrentGlobalStats } from "@/services/rtorrent-api";
 import { getSabQueue } from "@/services/sabnzbd-api";
+import { getNet, selectInterfaces } from "@/services/glances-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { formatSpeed, formatBytes } from "@/lib/utils";
 import {
   SPEED_STATS_DEFAULT_SETTINGS,
+  resolveSpeedStatsSource,
   type SpeedStatsSettingsValue,
 } from "@/components/dashboard/widget-settings/speed-stats-settings";
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
@@ -26,19 +30,41 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
   );
   const allQbitInstances = useEnabledInstances("qbittorrent");
   const allSabInstances = useEnabledInstances("sabnzbd");
-  // rtorrent has no per-widget instance binding yet (phase 2) — fold in every
-  // enabled rtorrent instance so its live speeds + lifetime totals show up. Like
-  // qBittorrent (and unlike SAB) it reports upload speed and lifetime counters.
-  const rtInstances = useEnabledInstances("rtorrent");
-  const qbitInstances = resolveBoundInstances(settings.instanceIds, allQbitInstances);
+  const allRtInstances = useEnabledInstances("rtorrent");
+  const allGlancesInstances = useEnabledInstances("glances");
+
+  // A widget shows exactly one source — download clients OR server network —
+  // so the pills never double-count traffic a client pushes through the same
+  // NIC Glances reports. The selection is forced when only one kind is
+  // configured (see resolveSpeedStatsSource).
+  const hasClients =
+    allQbitInstances.length + allSabInstances.length + allRtInstances.length > 0;
+  const source = resolveSpeedStatsSource(
+    settings.source,
+    hasClients,
+    allGlancesInstances.length > 0,
+  );
+  const useClients = source === "clients";
+  const useNetwork = source === "network";
+
+  // qBittorrent binds per-widget; rtorrent folds in every enabled instance (no
+  // per-widget binding yet, phase 2).
+  const qbitInstances = useClients
+    ? resolveBoundInstances(settings.instanceIds, allQbitInstances)
+    : [];
   // When the user has no qBit configured at all, the toggle is moot — fold any
   // enabled SAB instances in automatically so a SAB-only user sees real numbers
   // instead of a perpetual skeleton. Once they enable qBit, the explicit toggle
   // takes over again.
   const effectiveIncludeSab =
-    settings.includeSab || allQbitInstances.length === 0;
+    useClients && (settings.includeSab || allQbitInstances.length === 0);
   const sabInstances = effectiveIncludeSab
     ? resolveBoundInstances(settings.sabInstanceIds, allSabInstances)
+    : [];
+  const rtInstances = useClients ? allRtInstances : [];
+  // Glances interfaces: received bytes → down pill, sent bytes → up pill.
+  const glancesInstances = useNetwork
+    ? resolveBoundInstances(settings.glancesInstanceIds, allGlancesInstances)
     : [];
 
   // Fan out across the resolved instances and sum their counters so a single
@@ -75,6 +101,16 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     })),
   });
 
+  // Shares the ["glances", id, "net"] key with the Server Stats widget and the
+  // Glances screen, so the cache is reused across all three.
+  const glancesQueries = useQueries({
+    queries: glancesInstances.map((inst) => ({
+      queryKey: ["glances", inst.id, "net"] as const,
+      queryFn: () => getNet(inst.id),
+      refetchInterval: POLLING_INTERVALS.transferSpeed,
+    })),
+  });
+
   // Show the skeleton only on the very first cold load; once any instance has
   // returned a transfer snapshot, keep rendering the summed pill even if one
   // instance later goes offline. The sum gracefully drops to the live
@@ -84,27 +120,41 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     ...qbitQueries,
     ...sabQueries,
     ...rtQueries,
+    ...glancesQueries,
   ]);
 
-  const hasAnyInstance =
-    qbitInstances.length + sabInstances.length + rtInstances.length > 0;
+  const hasAnySource =
+    qbitInstances.length +
+      sabInstances.length +
+      rtInstances.length +
+      glancesInstances.length >
+    0;
 
-  if (isInitialLoading || !hasAnyInstance) {
+  const title = settings.title.trim();
+  const header = title ? (
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+    </CardHeader>
+  ) : null;
+
+  if (!hasAnySource) {
     return (
-      <Card className="flex-row gap-3">
-        <View className="flex-1 flex-row items-center gap-3 rounded-xl p-3 bg-blue-600/10">
-          <Skeleton width={18} height={18} borderRadius={4} />
-          <View className="gap-1.5">
-            <Skeleton width={80} height={20} />
-            <Skeleton width={60} height={12} />
-          </View>
-        </View>
-        <View className="flex-1 flex-row items-center gap-3 rounded-xl p-3 bg-green-600/10">
-          <Skeleton width={18} height={18} borderRadius={4} />
-          <View className="gap-1.5">
-            <Skeleton width={80} height={20} />
-            <Skeleton width={60} height={12} />
-          </View>
+      <Card>
+        {header}
+        <Text className="text-zinc-500 text-sm">
+          No sources selected. Enable download clients or server network in widget settings.
+        </Text>
+      </Card>
+    );
+  }
+
+  if (isInitialLoading) {
+    return (
+      <Card>
+        {header}
+        <View className="flex-row gap-3">
+          <ThroughputPillSkeleton tone="down" />
+          <ThroughputPillSkeleton tone="up" />
         </View>
       </Card>
     );
@@ -144,29 +194,50 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     dlAlltime += q.data.dlTotalLifetime;
     upAlltime += q.data.upTotalLifetime;
   }
+  for (const q of glancesQueries) {
+    if (!q.data) continue;
+    // Received → down, sent → up. Glances exposes no lifetime counter, so it
+    // contributes to live speed only (handled by the totals guard below).
+    for (const iface of selectInterfaces(q.data, settings.glancesInterfaces)) {
+      dlSpeed += iface.rx;
+      upSpeed += iface.tx;
+    }
+  }
 
-  // Hide the lifetime-total subtitle on the down pill when SAB is in the mix —
-  // SAB's queue endpoint exposes no equivalent counter, so the qBit-only sum
-  // would silently understate the stack and confuse the user. The settings
-  // toggle warns about this; the card just stops showing the misleading number.
-  const showDlTotal = sabInstances.length === 0;
+  // Lifetime totals are a client-only concept (qBit/rtorrent counters), so they
+  // only apply to a client-source widget. (SAB still suppresses the down total
+  // below — it adds live download speed with no matching counter.)
+  const clientTotalsMeaningful = useClients;
   const scope = settings.totalsScope;
-
-  const dlTotalLines = buildTotalLines(scope, dlAlltime, dlSession);
-  const upTotalLines = buildTotalLines(scope, upAlltime, upSession);
+  const dlTotalLines =
+    clientTotalsMeaningful && sabInstances.length === 0
+      ? buildTotalLines(scope, dlAlltime, dlSession)
+      : [];
+  const upTotalLines = clientTotalsMeaningful
+    ? buildTotalLines(scope, upAlltime, upSession)
+    : [];
 
   return (
-    <Card className="flex-row gap-3">
-      <SpeedPill
-        direction="down"
-        speed={formatSpeed(dlSpeed)}
-        totalLines={showDlTotal ? dlTotalLines : []}
-      />
-      <SpeedPill
-        direction="up"
-        speed={formatSpeed(upSpeed)}
-        totalLines={upTotalLines}
-      />
+    <Card>
+      {header}
+      <View className="flex-row gap-3">
+        <ThroughputPill
+          icon={ArrowDown}
+          iconColor="#3b82f6"
+          bgClass="bg-blue-600/10"
+          valueClass="text-download"
+          value={formatSpeed(dlSpeed)}
+          subtitles={dlTotalLines.map((l) => `${l.value} ${l.label}`)}
+        />
+        <ThroughputPill
+          icon={ArrowUp}
+          iconColor="#22c55e"
+          bgClass="bg-green-600/10"
+          valueClass="text-upload"
+          value={formatSpeed(upSpeed)}
+          subtitles={upTotalLines.map((l) => `${l.value} ${l.label}`)}
+        />
+      </View>
     </Card>
   );
 }
@@ -194,45 +265,3 @@ function buildTotalLines(
   }
 }
 
-function SpeedPill({
-  direction,
-  speed,
-  totalLines,
-}: {
-  direction: "down" | "up";
-  speed: string;
-  totalLines: { label: string; value: string }[];
-}) {
-  const isDown = direction === "down";
-  const ArrowIcon = isDown ? ArrowDown : ArrowUp;
-  const colorClass = isDown ? "text-download" : "text-upload";
-  const bgClass = isDown ? "bg-blue-600/10" : "bg-green-600/10";
-
-  return (
-    <View className={`flex-1 flex-row items-center gap-3 rounded-xl p-3 ${bgClass}`}>
-      <Icon icon={ArrowIcon} size={18} color={isDown ? "#3b82f6" : "#22c55e"} />
-      {/* `flex-1 min-w-0` is what lets the text column actually shrink inside
-          the flex row — without min-w-0 a long subtitle (e.g. "1.23 TB
-          session" at uiScale 1.3) keeps the intrinsic width and pushes the
-          pill past 50% of the card. numberOfLines={1} then ellipsizes the
-          worst-case string cleanly. */}
-      <View className="flex-1 min-w-0">
-        <Text
-          className={`text-lg font-bold ${colorClass}`}
-          numberOfLines={1}
-        >
-          {speed}
-        </Text>
-        {totalLines.map((line) => (
-          <Text
-            key={line.label}
-            className="text-zinc-500 text-xs"
-            numberOfLines={1}
-          >
-            {line.value} {line.label}
-          </Text>
-        ))}
-      </View>
-    </View>
-  );
-}

--- a/components/dashboard/streaming-bandwidth-card.tsx
+++ b/components/dashboard/streaming-bandwidth-card.tsx
@@ -1,0 +1,193 @@
+import { View, Text } from "react-native";
+import { Globe, Network } from "lucide-react-native";
+import { useQueries } from "@tanstack/react-query";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ThroughputPill,
+  ThroughputPillSkeleton,
+} from "@/components/dashboard/throughput-pill";
+import { getActivity as getTautulliActivity } from "@/services/tautulli-api";
+import { getSessions as getPlexSessions } from "@/services/plex-api";
+import { getSessions as getJellyfinSessions } from "@/services/jellyfin-api";
+import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
+  type StreamingBandwidthSettingsValue,
+} from "@/components/dashboard/widget-settings/streaming-bandwidth-settings";
+import {
+  resolveStreamingService,
+  tautulliActivityToWanLan,
+  plexSessionsToWanLan,
+  mediaServerSessionsToWanLan,
+  type StreamingServiceId,
+  type WanLanKbps,
+} from "@/lib/streaming-bandwidth";
+import { POLLING_INTERVALS } from "@/lib/constants";
+import { formatBitrate } from "@/lib/utils";
+import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
+import type {
+  TautulliActivity,
+  PlexSession,
+  JellyfinSession,
+} from "@/lib/types";
+import type { ServiceInstance } from "@/store/config-store";
+
+const STREAMING_SERVICES: readonly StreamingServiceId[] = [
+  "tautulli",
+  "plex",
+  "jellyfin",
+  "emby",
+];
+
+type StreamingPayload = TautulliActivity | PlexSession[] | JellyfinSession[];
+
+// Reuse the keys the now-playing / monitor surfaces already poll so the cache
+// is shared (no extra polling) for Plex/Jellyfin/Emby. Tautulli activity uses a
+// dedicated key (the monitor stores an adapter shape without WAN/LAN).
+function streamingQueryKey(kind: StreamingServiceId, id: string) {
+  switch (kind) {
+    case "tautulli":
+      return ["tautulli", id, "activity"] as const;
+    case "plex":
+      return ["plex", id, "sessions"] as const;
+    case "jellyfin":
+      return ["jellyfin", id, "sessions"] as const;
+    case "emby":
+      return ["emby", id, "sessions"] as const;
+  }
+}
+
+function fetchStreaming(
+  kind: StreamingServiceId,
+  id: string,
+): Promise<StreamingPayload> {
+  switch (kind) {
+    case "tautulli":
+      return getTautulliActivity(id);
+    case "plex":
+      return getPlexSessions(id);
+    case "jellyfin":
+      return getJellyfinSessions(id, "jellyfin");
+    case "emby":
+      return getJellyfinSessions(id, "emby");
+  }
+}
+
+function streamingWanLan(
+  kind: StreamingServiceId,
+  data: StreamingPayload,
+): WanLanKbps {
+  switch (kind) {
+    case "tautulli":
+      return tautulliActivityToWanLan(data as TautulliActivity);
+    case "plex":
+      return plexSessionsToWanLan(data as PlexSession[]);
+    default:
+      return mediaServerSessionsToWanLan(data as JellyfinSession[]);
+  }
+}
+
+export function StreamingBandwidthCard({ slotId }: WidgetComponentProps) {
+  const { settings } = useWidgetSettings<StreamingBandwidthSettingsValue>(
+    slotId,
+    STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
+  );
+
+  const tautulli = useEnabledInstances("tautulli");
+  const plex = useEnabledInstances("plex");
+  const jellyfin = useEnabledInstances("jellyfin");
+  const emby = useEnabledInstances("emby");
+  const instancesByService: Record<StreamingServiceId, ServiceInstance[]> = {
+    tautulli,
+    plex,
+    jellyfin,
+    emby,
+  };
+  const configured = STREAMING_SERVICES.filter(
+    (s) => instancesByService[s].length > 0,
+  );
+  const service = resolveStreamingService(settings.service, configured);
+
+  const instances = service
+    ? resolveBoundInstances(settings.instanceIds, instancesByService[service])
+    : [];
+
+  const queries = useQueries({
+    queries: instances.map((inst) => ({
+      queryKey: service
+        ? streamingQueryKey(service, inst.id)
+        : (["streaming-bandwidth", "idle"] as const),
+      queryFn: () => fetchStreaming(service!, inst.id),
+      refetchInterval: POLLING_INTERVALS.transferSpeed,
+    })),
+  });
+
+  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  const hasSource = !!service && instances.length > 0;
+
+  const title = settings.title.trim();
+  const header = title ? (
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+    </CardHeader>
+  ) : null;
+
+  if (!hasSource) {
+    return (
+      <Card>
+        {header}
+        <Text className="text-zinc-500 text-sm">
+          No streaming server selected. Pick one in widget settings.
+        </Text>
+      </Card>
+    );
+  }
+
+  if (isInitialLoading) {
+    return (
+      <Card>
+        {header}
+        <View className="flex-row gap-3">
+          <ThroughputPillSkeleton tone="up" />
+          <ThroughputPillSkeleton tone="down" />
+        </View>
+      </Card>
+    );
+  }
+
+  let wan = 0;
+  let lan = 0;
+  for (const q of queries) {
+    if (!q.data) continue;
+    const wl = streamingWanLan(service!, q.data);
+    wan += wl.wan;
+    lan += wl.lan;
+  }
+
+  return (
+    <Card>
+      {header}
+      <View className="flex-row gap-3">
+        <ThroughputPill
+          icon={Globe}
+          iconColor="#22c55e"
+          bgClass="bg-green-600/10"
+          valueClass="text-upload"
+          value={formatBitrate(wan)}
+          subtitles={["WAN"]}
+        />
+        <ThroughputPill
+          icon={Network}
+          iconColor="#3b82f6"
+          bgClass="bg-blue-600/10"
+          valueClass="text-download"
+          value={formatBitrate(lan)}
+          subtitles={["LAN"]}
+        />
+      </View>
+    </Card>
+  );
+}

--- a/components/dashboard/streaming-bandwidth-card.tsx
+++ b/components/dashboard/streaming-bandwidth-card.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
-import { Globe, Network } from "lucide-react-native";
+import { Globe, Network, ServerCrash } from "lucide-react-native";
 import { useQueries } from "@tanstack/react-query";
+import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ThroughputPill,
@@ -25,7 +26,7 @@ import {
   type StreamingServiceId,
   type WanLanKbps,
 } from "@/lib/streaming-bandwidth";
-import { POLLING_INTERVALS } from "@/lib/constants";
+import { POLLING_INTERVALS, SERVICE_DEFAULTS } from "@/lib/constants";
 import { formatBitrate } from "@/lib/utils";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import type {
@@ -125,8 +126,9 @@ export function StreamingBandwidthCard({ slotId }: WidgetComponentProps) {
     })),
   });
 
-  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState(queries);
   const hasSource = !!service && instances.length > 0;
+  const serviceLabel = service ? SERVICE_DEFAULTS[service].name : "";
 
   const title = settings.title.trim();
   const header = title ? (
@@ -142,6 +144,22 @@ export function StreamingBandwidthCard({ slotId }: WidgetComponentProps) {
         <Text className="text-zinc-500 text-sm">
           No streaming server selected. Pick one in widget settings.
         </Text>
+      </Card>
+    );
+  }
+
+  // Every bound instance errored without ever returning data — surface that
+  // instead of a misleading "0 Mbps" that reads as "nothing streaming".
+  if (isAllErrored) {
+    return (
+      <Card>
+        {header}
+        <View className="flex-row items-center gap-2 py-1">
+          <Icon icon={ServerCrash} size={16} color="#71717a" />
+          <Text className="text-zinc-500 text-sm">
+            Could not reach {serviceLabel}
+          </Text>
+        </View>
       </Card>
     );
   }
@@ -188,6 +206,13 @@ export function StreamingBandwidthCard({ slotId }: WidgetComponentProps) {
           subtitles={["LAN"]}
         />
       </View>
+      {/* Jellyfin/Emby only expose a bitrate while transcoding, so direct-play
+          streams read as 0 — say so rather than look broken. */}
+      {(service === "jellyfin" || service === "emby") && (
+        <Text className="text-zinc-600 text-[0.7rem] mt-2">
+          Transcoded streams only — direct play isn&apos;t counted
+        </Text>
+      )}
     </Card>
   );
 }

--- a/components/dashboard/throughput-pill.tsx
+++ b/components/dashboard/throughput-pill.tsx
@@ -1,0 +1,58 @@
+import { View, Text } from "react-native";
+import type { LucideIcon } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export interface ThroughputPillProps {
+  icon: LucideIcon;
+  iconColor: string; // hex — react-native-svg props are numeric/string, not rem
+  bgClass: string; // tint, e.g. "bg-blue-600/10"
+  valueClass: string; // value text color, e.g. "text-download"
+  value: string; // formatted figure, e.g. "8.2 MB/s" or "18.4 Mbps"
+  subtitles?: string[]; // muted lines under the value (totals, "WAN"/"LAN", …)
+}
+
+/**
+ * One half of a two-pill throughput card: an icon + a big value + optional muted
+ * subtitles. Shared by Speed Stats (down/up in MB/s) and Streaming Bandwidth
+ * (WAN/LAN in Mbps) so both read identically.
+ */
+export function ThroughputPill({
+  icon,
+  iconColor,
+  bgClass,
+  valueClass,
+  value,
+  subtitles,
+}: ThroughputPillProps) {
+  return (
+    <View className={`flex-1 flex-row items-center gap-3 rounded-xl p-3 ${bgClass}`}>
+      <Icon icon={icon} size={18} color={iconColor} />
+      {/* `flex-1 min-w-0` lets the text column shrink so a long subtitle
+          ellipsizes instead of pushing the pill past 50% of the card. */}
+      <View className="flex-1 min-w-0">
+        <Text className={`text-lg font-bold ${valueClass}`} numberOfLines={1}>
+          {value}
+        </Text>
+        {subtitles?.map((line) => (
+          <Text key={line} className="text-zinc-500 text-xs" numberOfLines={1}>
+            {line}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+export function ThroughputPillSkeleton({ tone }: { tone: "down" | "up" }) {
+  const bgClass = tone === "down" ? "bg-blue-600/10" : "bg-green-600/10";
+  return (
+    <View className={`flex-1 flex-row items-center gap-3 rounded-xl p-3 ${bgClass}`}>
+      <Skeleton width={18} height={18} borderRadius={4} />
+      <View className="gap-1.5">
+        <Skeleton width={80} height={20} />
+        <Skeleton width={60} height={12} />
+      </View>
+    </View>
+  );
+}

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -204,7 +204,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
   "server-stats": {
     id: "server-stats",
     label: "Server Stats",
-    description: "CPU, RAM and disk usage from Glances",
+    description: "CPU, RAM, disk and network from Glances",
     icon: Cpu,
     service: "glances",
     component: ServerStatsCard,

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -223,7 +223,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     label: "Speed Stats",
     description: "Live download/upload speeds from clients or server network",
     icon: Gauge,
-    service: ["qbittorrent", "sabnzbd", "glances"],
+    service: ["qbittorrent", "sabnzbd", "nzbget", "rtorrent", "glances"],
     component: SpeedStatsCard,
     settingsComponent: SpeedStatsSettings,
     defaultSettings: SPEED_STATS_DEFAULT_SETTINGS,

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -214,9 +214,9 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
   "speed-stats": {
     id: "speed-stats",
     label: "Speed Stats",
-    description: "Live download and upload speeds",
+    description: "Live download/upload speeds from clients or server network",
     icon: Gauge,
-    service: ["qbittorrent", "sabnzbd"],
+    service: ["qbittorrent", "sabnzbd", "glances"],
     component: SpeedStatsCard,
     settingsComponent: SpeedStatsSettings,
     defaultSettings: SPEED_STATS_DEFAULT_SETTINGS,

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   CalendarDays,
   Captions,
+  Cast,
   Clapperboard,
   Cpu,
   Download,
@@ -27,6 +28,7 @@ import { RadarrQueueCard } from "@/components/dashboard/radarr-queue-card";
 import { RecentlyDownloadedCard } from "@/components/dashboard/recently-downloaded-card";
 import { CalendarCard } from "@/components/dashboard/calendar-card";
 import { StreamMonitorCard } from "@/components/dashboard/stream-monitor-card";
+import { StreamingBandwidthCard } from "@/components/dashboard/streaming-bandwidth-card";
 import { OverseerrRequestsCard } from "@/components/dashboard/overseerr-requests-card";
 import { PlexNowPlayingCard } from "@/components/dashboard/plex-now-playing-card";
 import { JellyfinNowPlayingCard } from "@/components/dashboard/jellyfin-now-playing-card";
@@ -90,6 +92,11 @@ import {
   STREAM_MONITOR_DEFAULT_SETTINGS,
   type StreamMonitorSettingsValue,
 } from "@/components/dashboard/widget-settings/stream-monitor-settings";
+import {
+  StreamingBandwidthSettings,
+  STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
+  type StreamingBandwidthSettingsValue,
+} from "@/components/dashboard/widget-settings/streaming-bandwidth-settings";
 import {
   OverseerrRequestsSettings,
   OVERSEERR_REQUESTS_DEFAULT_SETTINGS,
@@ -291,6 +298,16 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     settingsComponent: StreamMonitorSettings,
     defaultSettings: STREAM_MONITOR_DEFAULT_SETTINGS,
   },
+  "streaming-bandwidth": {
+    id: "streaming-bandwidth",
+    label: "Streaming Bandwidth",
+    description: "Live WAN/LAN streaming bandwidth from Plex, Tautulli, Jellyfin or Emby",
+    icon: Cast,
+    service: ["tautulli", "plex", "jellyfin", "emby"],
+    component: StreamingBandwidthCard,
+    settingsComponent: StreamingBandwidthSettings,
+    defaultSettings: STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
+  },
   "overseerr-requests": {
     id: "overseerr-requests",
     label: "Seerr Requests",
@@ -391,6 +408,7 @@ export type {
   EmbyNowPlayingSettingsValue,
   CombinedNowPlayingSettingsValue,
   StreamMonitorSettingsValue,
+  StreamingBandwidthSettingsValue,
   OverseerrRequestsSettingsValue,
   SpeedStatsSettingsValue,
   RadarrQueueSettingsValue,

--- a/components/dashboard/widget-settings/network-interface-picker-row.tsx
+++ b/components/dashboard/widget-settings/network-interface-picker-row.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { Check, ChevronDown, ChevronUp } from "lucide-react-native";
+import { useQueries } from "@tanstack/react-query";
+import { Icon } from "@/components/ui/icon";
+import {
+  getNet,
+  rankedInterfaces,
+  isVirtualInterface,
+  NETWORK_INTERFACES_ALL,
+  type NetworkInterfacesValue,
+  type GlancesNetRate,
+} from "@/services/glances-api";
+import { useEnabledInstances } from "@/hooks/use-instance-target";
+import {
+  resolveBoundInstances,
+  type InstanceBindingValue,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+import { formatSpeed } from "@/lib/utils";
+
+// Re-exported so settings panels can keep importing the value contract from the
+// picker they render. Source of truth lives in services/glances-api.
+export { NETWORK_INTERFACES_ALL, type NetworkInterfacesValue };
+
+const FAST_POLL = 5000;
+
+interface NetworkInterfacePickerRowProps {
+  // Which Glances instances the widget is bound to — the candidate interface
+  // names are gathered from these hosts.
+  instanceIds: InstanceBindingValue;
+  value: NetworkInterfacesValue;
+  onChange: (value: NetworkInterfacesValue) => void;
+}
+
+/**
+ * Lets a widget restrict its network section to specific interfaces, or track
+ * every active real one. Candidate interfaces are fetched live from the bound
+ * Glances host(s) and rendered as a grouped checklist: an "All active" default,
+ * then physical NICs (with their live ↓/↑ rate to make the busy one obvious),
+ * then a collapsed "Virtual / Docker" group so container hosts aren't a wall of
+ * veth chips. Selections are stored by interface name and applied per-instance.
+ */
+export function NetworkInterfacePickerRow({
+  instanceIds,
+  value,
+  onChange,
+}: NetworkInterfacePickerRowProps) {
+  const allInstances = useEnabledInstances("glances");
+  const instances = resolveBoundInstances(instanceIds, allInstances);
+
+  // Reuse the same query key the widgets/screen poll on, so candidates appear
+  // instantly when data is already cached.
+  const queries = useQueries({
+    queries: instances.map((inst) => ({
+      queryKey: ["glances", inst.id, "net"] as const,
+      queryFn: () => getNet(inst.id),
+      refetchInterval: FAST_POLL,
+    })),
+  });
+
+  // Merge interfaces across bound hosts by name (summing rates on collisions),
+  // then sort by name for a STABLE order — sorting by live throughput would
+  // reorder rows under the user's finger as rates update.
+  const byName = new Map<string, GlancesNetRate>();
+  for (const q of queries) {
+    if (!q.data) continue;
+    for (const iface of rankedInterfaces(q.data)) {
+      const existing = byName.get(iface.interface_name);
+      if (existing) {
+        existing.rx += iface.rx;
+        existing.tx += iface.tx;
+      } else {
+        byName.set(iface.interface_name, { ...iface });
+      }
+    }
+  }
+  const merged = Array.from(byName.values()).sort((a, b) =>
+    a.interface_name.localeCompare(b.interface_name),
+  );
+  const physical = merged.filter((i) => !isVirtualInterface(i.interface_name));
+  const virtual = merged.filter((i) => isVirtualInterface(i.interface_name));
+
+  const isAll = value === NETWORK_INTERFACES_ALL;
+  const selectedSet = new Set<string>(isAll ? [] : value);
+
+  // Auto-expand the virtual group when one of its interfaces is already picked,
+  // so a saved selection is never hidden.
+  const hasVirtualSelected = virtual.some((i) => selectedSet.has(i.interface_name));
+  const [showVirtual, setShowVirtual] = useState(false);
+  const virtualExpanded = showVirtual || hasVirtualSelected;
+
+  const toggle = (name: string) => {
+    if (isAll) {
+      // From "all" → start a fresh explicit subset with just this interface.
+      onChange([name]);
+      return;
+    }
+    if (selectedSet.has(name)) {
+      const next = (value as string[]).filter((v) => v !== name);
+      onChange(next.length === 0 ? NETWORK_INTERFACES_ALL : next);
+    } else {
+      onChange([...(value as string[]), name]);
+    }
+  };
+
+  return (
+    <View>
+      <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
+        Interfaces
+      </Text>
+      <View className="bg-surface-light rounded-2xl border border-border divide-y divide-border/60 overflow-hidden">
+        <SelectRow
+          label="All active interfaces"
+          caption="Real NICs only — Docker/virtual excluded"
+          selected={isAll}
+          onPress={() => onChange(NETWORK_INTERFACES_ALL)}
+        />
+        {physical.map((iface) => (
+          <SelectRow
+            key={iface.interface_name}
+            label={iface.alias || iface.interface_name}
+            caption={rateCaption(iface)}
+            selected={!isAll && selectedSet.has(iface.interface_name)}
+            onPress={() => toggle(iface.interface_name)}
+          />
+        ))}
+
+        {virtual.length > 0 && (
+          <>
+            <Pressable
+              onPress={() => setShowVirtual((v) => !v)}
+              className="flex-row items-center justify-between px-3 py-2.5 active:opacity-70"
+            >
+              <Text className="text-zinc-400 text-xs uppercase tracking-wider">
+                Virtual / Docker ({virtual.length})
+              </Text>
+              <Icon
+                icon={virtualExpanded ? ChevronUp : ChevronDown}
+                size={16}
+                color="#71717a"
+              />
+            </Pressable>
+            {virtualExpanded &&
+              virtual.map((iface) => (
+                <SelectRow
+                  key={iface.interface_name}
+                  label={iface.alias || iface.interface_name}
+                  caption={rateCaption(iface)}
+                  selected={!isAll && selectedSet.has(iface.interface_name)}
+                  onPress={() => toggle(iface.interface_name)}
+                />
+              ))}
+          </>
+        )}
+      </View>
+      {merged.length === 0 ? (
+        <Text className="text-zinc-600 text-xs mt-2">
+          No active interfaces detected yet.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function rateCaption(iface: GlancesNetRate): string {
+  if (iface.rx + iface.tx <= 0) return "idle";
+  return `↓ ${formatSpeed(iface.rx)}   ↑ ${formatSpeed(iface.tx)}`;
+}
+
+function SelectRow({
+  label,
+  caption,
+  selected,
+  onPress,
+}: {
+  label: string;
+  caption?: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`flex-row items-center gap-3 px-3 py-2.5 active:opacity-70 ${
+        selected ? "bg-primary/10" : ""
+      }`}
+    >
+      <View
+        className={`w-5 h-5 rounded-md items-center justify-center border ${
+          selected ? "bg-primary border-primary" : "border-zinc-600"
+        }`}
+      >
+        {selected ? <Icon icon={Check} size={14} color="#fff" /> : null}
+      </View>
+      <View className="flex-1 min-w-0">
+        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
+          {label}
+        </Text>
+        {caption ? (
+          <Text className="text-zinc-500 text-[0.7rem]" numberOfLines={1}>
+            {caption}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}

--- a/components/dashboard/widget-settings/server-stats-settings.tsx
+++ b/components/dashboard/widget-settings/server-stats-settings.tsx
@@ -26,6 +26,10 @@ export interface ServerStatsSettingsValue extends Record<string, unknown> {
   showGpu: boolean;
   showDisks: boolean;
   showNetwork: boolean;
+  // Load average (1/5/15 min) and CPU I/O wait — off by default to keep the
+  // widget compact; the Glances screen always shows them.
+  showLoad: boolean;
+  showIoWait: boolean;
   // Which interfaces the network section shows. "all" = every active,
   // non-loopback interface; an array restricts to those names.
   networkInterfaces: NetworkInterfacesValue;
@@ -40,6 +44,8 @@ export const SERVER_STATS_DEFAULT_SETTINGS: ServerStatsSettingsValue = {
   // Off by default: hosts with many Docker containers expose a lot of
   // interfaces, so "all interfaces" is noisy. Opt in and pick the NIC(s).
   showNetwork: false,
+  showLoad: false,
+  showIoWait: false,
   networkInterfaces: NETWORK_INTERFACES_ALL,
 };
 
@@ -87,6 +93,18 @@ export function ServerStatsSettings({ slotId }: WidgetSettingsComponentProps) {
             description="Live send/receive rate per interface"
             value={settings.showNetwork}
             onValueChange={(showNetwork) => update({ showNetwork })}
+          />
+          <Toggle
+            label="Load average"
+            description="System load over 1, 5 and 15 minutes"
+            value={settings.showLoad}
+            onValueChange={(showLoad) => update({ showLoad })}
+          />
+          <Toggle
+            label="I/O wait"
+            description="Share of CPU time waiting on disk/network I/O"
+            value={settings.showIoWait}
+            onValueChange={(showIoWait) => update({ showIoWait })}
           />
         </ToggleCard>
       </SettingsSection>

--- a/components/dashboard/widget-settings/server-stats-settings.tsx
+++ b/components/dashboard/widget-settings/server-stats-settings.tsx
@@ -8,6 +8,11 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
+  NetworkInterfacePickerRow,
+  NETWORK_INTERFACES_ALL,
+  type NetworkInterfacesValue,
+} from "@/components/dashboard/widget-settings/network-interface-picker-row";
+import {
   SettingsSection,
   ToggleCard,
 } from "@/components/dashboard/widget-settings/widget-settings-blocks";
@@ -20,6 +25,10 @@ export interface ServerStatsSettingsValue extends Record<string, unknown> {
   showRam: boolean;
   showGpu: boolean;
   showDisks: boolean;
+  showNetwork: boolean;
+  // Which interfaces the network section shows. "all" = every active,
+  // non-loopback interface; an array restricts to those names.
+  networkInterfaces: NetworkInterfacesValue;
 }
 
 export const SERVER_STATS_DEFAULT_SETTINGS: ServerStatsSettingsValue = {
@@ -28,6 +37,10 @@ export const SERVER_STATS_DEFAULT_SETTINGS: ServerStatsSettingsValue = {
   showRam: true,
   showGpu: true,
   showDisks: true,
+  // Off by default: hosts with many Docker containers expose a lot of
+  // interfaces, so "all interfaces" is noisy. Opt in and pick the NIC(s).
+  showNetwork: false,
+  networkInterfaces: NETWORK_INTERFACES_ALL,
 };
 
 export function ServerStatsSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -69,8 +82,23 @@ export function ServerStatsSettings({ slotId }: WidgetSettingsComponentProps) {
             value={settings.showDisks}
             onValueChange={(showDisks) => update({ showDisks })}
           />
+          <Toggle
+            label="Network throughput"
+            description="Live send/receive rate per interface"
+            value={settings.showNetwork}
+            onValueChange={(showNetwork) => update({ showNetwork })}
+          />
         </ToggleCard>
       </SettingsSection>
+      {settings.showNetwork ? (
+        <SettingsSection label="Network">
+          <NetworkInterfacePickerRow
+            instanceIds={settings.instanceIds}
+            value={settings.networkInterfaces}
+            onChange={(networkInterfaces) => update({ networkInterfaces })}
+          />
+        </SettingsSection>
+      ) : null}
     </View>
   );
 }

--- a/components/dashboard/widget-settings/speed-stats-settings.tsx
+++ b/components/dashboard/widget-settings/speed-stats-settings.tsx
@@ -67,6 +67,9 @@ export interface SpeedStatsSettingsValue extends Record<string, unknown> {
   // Which SAB instances to fold in when `includeSab` is on. Same shape as
   // `instanceIds`; "all" auto-includes newly-added SAB instances.
   sabInstanceIds: InstanceBindingValue;
+  // NZBGet mirror of the SAB pair — download-only, no upload or lifetime total.
+  includeNzbget: boolean;
+  nzbgetInstanceIds: InstanceBindingValue;
   // Which transfer-counter the subtitle reflects. See SpeedStatsTotalsScope.
   totalsScope: SpeedStatsTotalsScope;
   // Which Glances instances to read interfaces from (when source = network).
@@ -81,6 +84,8 @@ export const SPEED_STATS_DEFAULT_SETTINGS: SpeedStatsSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
   includeSab: false,
   sabInstanceIds: INSTANCE_BINDING_ALL,
+  includeNzbget: false,
+  nzbgetInstanceIds: INSTANCE_BINDING_ALL,
   totalsScope: "alltime",
   glancesInstanceIds: INSTANCE_BINDING_ALL,
   glancesInterfaces: NETWORK_INTERFACES_ALL,
@@ -109,39 +114,55 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
   );
   const qbitInstances = useEnabledInstances("qbittorrent");
   const sabInstances = useEnabledInstances("sabnzbd");
+  const nzbgetInstances = useEnabledInstances("nzbget");
   const rtInstances = useEnabledInstances("rtorrent");
   const glancesInstances = useEnabledInstances("glances");
   const hasClients =
-    qbitInstances.length + sabInstances.length + rtInstances.length > 0;
+    qbitInstances.length +
+      sabInstances.length +
+      nzbgetInstances.length +
+      rtInstances.length >
+    0;
   const hasGlances = glancesInstances.length > 0;
   const source = resolveSpeedStatsSource(settings.source, hasClients, hasGlances);
-  const [showSabWarning, setShowSabWarning] = useState(false);
 
-  // SAB exposes neither a session nor lifetime data counter the way qBit does
-  // (the `queue` envelope only carries instantaneous `kbpersec`), so the moment
-  // a user folds SAB into a card that already has a qBit binding, the "X total"
-  // subtitle becomes incomplete. Surface that explicitly the first time they
-  // flip the toggle on so they don't read the qBit number as a stack total.
+  // SAB/NZBGet expose only an instantaneous download speed (no upload, no
+  // lifetime counter), so folding either into a card that already has a qBit
+  // binding makes the "X total" subtitle incomplete. Warn the first time the
+  // user flips a toggle on. One modal, parameterized by which client.
+  const [pendingUsenet, setPendingUsenet] = useState<null | "sab" | "nzbget">(null);
+  const usenetLabel = pendingUsenet === "nzbget" ? "NZBGet" : "SABnzbd";
   const hasBoundQbit =
     resolveBoundInstances(settings.instanceIds, qbitInstances).length > 0;
 
   const handleIncludeSabChange = (next: boolean) => {
     if (next && hasBoundQbit && !settings.includeSab) {
-      setShowSabWarning(true);
+      setPendingUsenet("sab");
       return;
     }
     update({ includeSab: next });
   };
 
-  const confirmSabWarning = () => {
-    setShowSabWarning(false);
-    update({ includeSab: true });
+  const handleIncludeNzbgetChange = (next: boolean) => {
+    if (next && hasBoundQbit && !settings.includeNzbget) {
+      setPendingUsenet("nzbget");
+      return;
+    }
+    update({ includeNzbget: next });
   };
 
-  // When no qBit is configured, the "Include SABnzbd" toggle is moot — the
-  // card auto-includes SAB anyway since it's the only source. Show the SAB
+  const confirmUsenetWarning = () => {
+    if (pendingUsenet === "sab") update({ includeSab: true });
+    else if (pendingUsenet === "nzbget") update({ includeNzbget: true });
+    setPendingUsenet(null);
+  };
+
+  // When no qBit is configured, the include toggles are moot — the card
+  // auto-includes the usenet client anyway since it's the only source. Show the
   // picker directly in that case so the setting matches what the card does.
   const sabIsOnlySource = qbitInstances.length === 0 && sabInstances.length > 0;
+  const nzbgetIsOnlySource =
+    qbitInstances.length === 0 && nzbgetInstances.length > 0;
 
   return (
     <View className="px-4 py-2 gap-5">
@@ -209,6 +230,33 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
               onChange={(sabInstanceIds) => update({ sabInstanceIds })}
             />
           )}
+
+          {nzbgetInstances.length > 0 && !nzbgetIsOnlySource && (
+            <>
+              <Toggle
+                label="Include NZBGet"
+                description="Adds Usenet download speed to the down pill. NZBGet has no uploads and no lifetime total."
+                value={settings.includeNzbget}
+                onValueChange={handleIncludeNzbgetChange}
+              />
+
+              {settings.includeNzbget && (
+                <InstancePickerRow
+                  serviceId="nzbget"
+                  value={settings.nzbgetInstanceIds}
+                  onChange={(nzbgetInstanceIds) => update({ nzbgetInstanceIds })}
+                />
+              )}
+            </>
+          )}
+
+          {nzbgetIsOnlySource && (
+            <InstancePickerRow
+              serviceId="nzbget"
+              value={settings.nzbgetInstanceIds}
+              onChange={(nzbgetInstanceIds) => update({ nzbgetInstanceIds })}
+            />
+          )}
         </>
       )}
 
@@ -228,13 +276,13 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
       )}
 
       <ConfirmModal
-        visible={showSabWarning}
-        title="Lifetime total won't include SAB"
-        message="SABnzbd's API doesn't expose a lifetime data counter, so the 'total' shown under the download speed will only reflect your qBittorrent instances. Live speed will still be the combined total."
+        visible={pendingUsenet !== null}
+        title={`Lifetime total won't include ${usenetLabel}`}
+        message={`${usenetLabel}'s API doesn't expose a lifetime data counter, so the 'total' shown under the download speed will only reflect your qBittorrent instances. Live speed will still be the combined total.`}
         icon={TriangleAlert}
-        confirmLabel="Add SABnzbd"
-        onConfirm={confirmSabWarning}
-        onCancel={() => setShowSabWarning(false)}
+        confirmLabel={`Add ${usenetLabel}`}
+        onConfirm={confirmUsenetWarning}
+        onCancel={() => setPendingUsenet(null)}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/speed-stats-settings.tsx
+++ b/components/dashboard/widget-settings/speed-stats-settings.tsx
@@ -3,6 +3,7 @@ import { View } from "react-native";
 import { TriangleAlert } from "lucide-react-native";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { Toggle } from "@/components/ui/toggle";
+import { TextInput } from "@/components/ui/text-input";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
@@ -12,7 +13,15 @@ import {
   resolveBoundInstances,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
-import { ChipGroup } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import {
+  NetworkInterfacePickerRow,
+  NETWORK_INTERFACES_ALL,
+  type NetworkInterfacesValue,
+} from "@/components/dashboard/widget-settings/network-interface-picker-row";
+import {
+  ChipGroup,
+  SettingsSection,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 // Which counter the "X GB total" subtitle reflects on the pill.
 //   alltime — qBittorrent's lifetime totals (alltime_dl/alltime_ul). Survives
@@ -28,7 +37,26 @@ const TOTALS_SCOPE_OPTIONS: readonly { value: SpeedStatsTotalsScope; label: stri
   { value: "both", label: "Both" },
 ];
 
+// A widget shows ONE source at a time, so its purpose is unambiguous and the
+// pills never double-count (download-client traffic flows through the same NIC
+// Glances reports, so summing them would count it twice). Place several widgets
+// with different titles for different purposes.
+//   clients — qBittorrent / SABnzbd / rTorrent transfer speeds.
+//   network — Glances interface throughput (received → down, sent → up).
+export type SpeedStatsSource = "clients" | "network";
+
+const SOURCE_OPTIONS: readonly { value: SpeedStatsSource; label: string }[] = [
+  { value: "clients", label: "Download clients" },
+  { value: "network", label: "Server network" },
+];
+
 export interface SpeedStatsSettingsValue extends Record<string, unknown> {
+  // Optional label shown above the pills (like the service widgets' titles).
+  // Empty = no header. Lets a user place several Speed Stats widgets for
+  // different purposes ("Torrents", "Internet", …).
+  title: string;
+  // Which single data source the widget shows. See SpeedStatsSource.
+  source: SpeedStatsSource;
   // Which qBittorrent instances to graph. "all" sums every enabled instance's
   // speeds into one card; an array of UUIDs sums just those servers.
   instanceIds: InstanceBindingValue;
@@ -41,14 +69,38 @@ export interface SpeedStatsSettingsValue extends Record<string, unknown> {
   sabInstanceIds: InstanceBindingValue;
   // Which transfer-counter the subtitle reflects. See SpeedStatsTotalsScope.
   totalsScope: SpeedStatsTotalsScope;
+  // Which Glances instances to read interfaces from (when source = network).
+  glancesInstanceIds: InstanceBindingValue;
+  // Which interfaces to sum. "all" = every active, non-loopback, real interface.
+  glancesInterfaces: NetworkInterfacesValue;
 }
 
 export const SPEED_STATS_DEFAULT_SETTINGS: SpeedStatsSettingsValue = {
+  title: "",
+  source: "clients",
   instanceIds: INSTANCE_BINDING_ALL,
   includeSab: false,
   sabInstanceIds: INSTANCE_BINDING_ALL,
   totalsScope: "alltime",
+  glancesInstanceIds: INSTANCE_BINDING_ALL,
+  glancesInterfaces: NETWORK_INTERFACES_ALL,
 };
+
+/**
+ * The source actually used, given what's configured. When only one kind is
+ * available the choice is forced (so a Glances-only setup shows network without
+ * the user touching the selector); when both are configured the stored choice
+ * wins. Shared by the card and the settings panel so they never disagree.
+ */
+export function resolveSpeedStatsSource(
+  source: SpeedStatsSource,
+  hasClients: boolean,
+  hasGlances: boolean,
+): SpeedStatsSource {
+  if (hasClients && hasGlances) return source;
+  if (hasGlances) return "network";
+  return "clients";
+}
 
 export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
   const { settings, update } = useWidgetSettings<SpeedStatsSettingsValue>(
@@ -57,6 +109,12 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
   );
   const qbitInstances = useEnabledInstances("qbittorrent");
   const sabInstances = useEnabledInstances("sabnzbd");
+  const rtInstances = useEnabledInstances("rtorrent");
+  const glancesInstances = useEnabledInstances("glances");
+  const hasClients =
+    qbitInstances.length + sabInstances.length + rtInstances.length > 0;
+  const hasGlances = glancesInstances.length > 0;
+  const source = resolveSpeedStatsSource(settings.source, hasClients, hasGlances);
   const [showSabWarning, setShowSabWarning] = useState(false);
 
   // SAB exposes neither a session nor lifetime data counter the way qBit does
@@ -87,33 +145,64 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
 
   return (
     <View className="px-4 py-2 gap-5">
-      {qbitInstances.length > 0 && (
-        <InstancePickerRow
-          serviceId="qbittorrent"
-          value={settings.instanceIds}
-          onChange={(instanceIds) => update({ instanceIds })}
+      <SettingsSection label="Title">
+        <TextInput
+          placeholder="e.g. Torrents, Internet"
+          value={settings.title}
+          onChangeText={(title) => update({ title })}
+          maxLength={24}
+          returnKeyType="done"
         />
-      )}
+      </SettingsSection>
 
-      {qbitInstances.length > 0 && (
+      {hasClients && hasGlances && (
         <ChipGroup
-          label="Totals shown"
-          options={TOTALS_SCOPE_OPTIONS}
-          value={settings.totalsScope}
-          onChange={(totalsScope) => update({ totalsScope })}
+          label="Source"
+          options={SOURCE_OPTIONS}
+          value={source}
+          onChange={(next) => update({ source: next })}
         />
       )}
 
-      {sabInstances.length > 0 && !sabIsOnlySource && (
+      {source === "clients" && (
         <>
-          <Toggle
-            label="Include SABnzbd"
-            description="Adds Usenet download speed to the down pill. SAB has no uploads and no lifetime total."
-            value={settings.includeSab}
-            onValueChange={handleIncludeSabChange}
-          />
+          {qbitInstances.length > 0 && (
+            <InstancePickerRow
+              serviceId="qbittorrent"
+              value={settings.instanceIds}
+              onChange={(instanceIds) => update({ instanceIds })}
+            />
+          )}
 
-          {settings.includeSab && (
+          {qbitInstances.length > 0 && (
+            <ChipGroup
+              label="Totals shown"
+              options={TOTALS_SCOPE_OPTIONS}
+              value={settings.totalsScope}
+              onChange={(totalsScope) => update({ totalsScope })}
+            />
+          )}
+
+          {sabInstances.length > 0 && !sabIsOnlySource && (
+            <>
+              <Toggle
+                label="Include SABnzbd"
+                description="Adds Usenet download speed to the down pill. SAB has no uploads and no lifetime total."
+                value={settings.includeSab}
+                onValueChange={handleIncludeSabChange}
+              />
+
+              {settings.includeSab && (
+                <InstancePickerRow
+                  serviceId="sabnzbd"
+                  value={settings.sabInstanceIds}
+                  onChange={(sabInstanceIds) => update({ sabInstanceIds })}
+                />
+              )}
+            </>
+          )}
+
+          {sabIsOnlySource && (
             <InstancePickerRow
               serviceId="sabnzbd"
               value={settings.sabInstanceIds}
@@ -123,12 +212,19 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
         </>
       )}
 
-      {sabIsOnlySource && (
-        <InstancePickerRow
-          serviceId="sabnzbd"
-          value={settings.sabInstanceIds}
-          onChange={(sabInstanceIds) => update({ sabInstanceIds })}
-        />
+      {source === "network" && hasGlances && (
+        <>
+          <InstancePickerRow
+            serviceId="glances"
+            value={settings.glancesInstanceIds}
+            onChange={(glancesInstanceIds) => update({ glancesInstanceIds })}
+          />
+          <NetworkInterfacePickerRow
+            instanceIds={settings.glancesInstanceIds}
+            value={settings.glancesInterfaces}
+            onChange={(glancesInterfaces) => update({ glancesInterfaces })}
+          />
+        </>
       )}
 
       <ConfirmModal

--- a/components/dashboard/widget-settings/streaming-bandwidth-settings.tsx
+++ b/components/dashboard/widget-settings/streaming-bandwidth-settings.tsx
@@ -1,0 +1,99 @@
+import { View } from "react-native";
+import { TextInput } from "@/components/ui/text-input";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { SERVICE_DEFAULTS } from "@/lib/constants";
+import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+import {
+  InstancePickerRow,
+  INSTANCE_BINDING_ALL,
+  type InstanceBindingValue,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  ChipGroup,
+  SettingsSection,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import {
+  resolveStreamingService,
+  type StreamingServiceId,
+} from "@/lib/streaming-bandwidth";
+
+const STREAMING_SERVICES: readonly StreamingServiceId[] = [
+  "tautulli",
+  "plex",
+  "jellyfin",
+  "emby",
+];
+
+export interface StreamingBandwidthSettingsValue extends Record<string, unknown> {
+  // Optional header above the pills — lets a user place several widgets for
+  // different servers ("Plex", "Jellyfin", …).
+  title: string;
+  // Which media server to read streaming bandwidth from.
+  service: StreamingServiceId;
+  // Which instances of that service to sum.
+  instanceIds: InstanceBindingValue;
+}
+
+export const STREAMING_BANDWIDTH_DEFAULT_SETTINGS: StreamingBandwidthSettingsValue = {
+  title: "",
+  service: "tautulli",
+  instanceIds: INSTANCE_BINDING_ALL,
+};
+
+export function StreamingBandwidthSettings({ slotId }: WidgetSettingsComponentProps) {
+  const { settings, update } = useWidgetSettings<StreamingBandwidthSettingsValue>(
+    slotId,
+    STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
+  );
+
+  // Called unconditionally (stable hook order); cheap selectors.
+  const tautulli = useEnabledInstances("tautulli");
+  const plex = useEnabledInstances("plex");
+  const jellyfin = useEnabledInstances("jellyfin");
+  const emby = useEnabledInstances("emby");
+  const countByService: Record<StreamingServiceId, number> = {
+    tautulli: tautulli.length,
+    plex: plex.length,
+    jellyfin: jellyfin.length,
+    emby: emby.length,
+  };
+  const configured = STREAMING_SERVICES.filter((s) => countByService[s] > 0);
+  const service = resolveStreamingService(settings.service, configured);
+
+  const serviceOptions = configured.map((s) => ({
+    value: s,
+    label: SERVICE_DEFAULTS[s].name,
+  }));
+
+  return (
+    <View className="px-4 py-2 gap-5">
+      <SettingsSection label="Title">
+        <TextInput
+          placeholder="e.g. Plex, Streaming"
+          value={settings.title}
+          onChangeText={(title) => update({ title })}
+          maxLength={24}
+          returnKeyType="done"
+        />
+      </SettingsSection>
+
+      {configured.length > 1 && service && (
+        <ChipGroup
+          label="Source"
+          options={serviceOptions}
+          value={service}
+          onChange={(next) => update({ service: next })}
+        />
+      )}
+
+      {service && (
+        <InstancePickerRow
+          serviceId={service}
+          value={settings.instanceIds}
+          onChange={(instanceIds) => update({ instanceIds })}
+        />
+      )}
+    </View>
+  );
+}

--- a/hooks/use-glances.ts
+++ b/hooks/use-glances.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCpu, getPerCpu, getLoad, getMem, getFs, getDiskIO, getGpu, getContainers } from "@/services/glances-api";
+import { getCpu, getPerCpu, getLoad, getMem, getFs, getDiskIO, getNet, getGpu, getContainers } from "@/services/glances-api";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
 const FAST_POLL = 5000;
@@ -60,6 +60,16 @@ export function useGlancesDiskIO(instanceId?: string) {
   return useQuery({
     queryKey: ["glances", id, "diskio"],
     queryFn: () => getDiskIO(id ?? undefined),
+    refetchInterval: FAST_POLL,
+    enabled: enabled && !!id,
+  });
+}
+
+export function useGlancesNet(instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("glances", instanceId);
+  return useQuery({
+    queryKey: ["glances", id, "net"],
+    queryFn: () => getNet(id ?? undefined),
     refetchInterval: FAST_POLL,
     enabled: enabled && !!id,
   });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -91,6 +91,7 @@ export const DASHBOARD_WIDGET_IDS = [
   "recently-downloaded",
   "calendar",
   "stream-monitor",
+  "streaming-bandwidth",
   "overseerr-requests",
   "combined-now-playing",
   "plex-now-playing",

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -652,9 +652,10 @@ const DEMO_TAUTULLI_ACTIVITY = {
   stream_count_direct_play: 1,
   stream_count_direct_stream: 0,
   stream_count_transcode: 1,
-  total_bandwidth: 14680064,
-  wan_bandwidth: 8388608,
-  lan_bandwidth: 6291456,
+  // kbps — consistent with the two demo sessions below (8000 + 6000).
+  total_bandwidth: 14000,
+  wan_bandwidth: 8000,
+  lan_bandwidth: 6000,
   sessions: [
     {
       session_key: "abc123",
@@ -993,7 +994,31 @@ const DEMO_JELLYFIN_SESSIONS = [
       RunTimeTicks: 9960000 * 10000,
       ImageTags: { Primary: "tag-1" },
     },
-    PlayState: { PositionTicks: 4681200 * 10000, IsPaused: false, PlayMethod: "DirectPlay" },
+    PlayState: { PositionTicks: 4681200 * 10000, IsPaused: false, PlayMethod: "Transcode" },
+    // Local transcode → LAN bucket (4 Mbps).
+    TranscodingInfo: { VideoCodec: "h264", Bitrate: 4000000, CompletionPercentage: 0 },
+  },
+  {
+    Id: "session-demo-2",
+    UserId: DEMO_JELLYFIN_USER_ID,
+    UserName: "alex",
+    Client: "Jellyfin Android",
+    DeviceName: "Pixel 8",
+    DeviceId: "device-2",
+    ApplicationVersion: "2.6.1",
+    RemoteEndPoint: "203.0.113.45",
+    IsActive: true,
+    NowPlayingItem: {
+      Id: "jf-2",
+      Name: "Severance",
+      Type: "Episode",
+      ProductionYear: 2024,
+      RunTimeTicks: 3120000 * 10000,
+      ImageTags: { Primary: "tag-1" },
+    },
+    PlayState: { PositionTicks: 1200000 * 10000, IsPaused: false, PlayMethod: "Transcode" },
+    // Remote transcode → WAN bucket (8 Mbps).
+    TranscodingInfo: { VideoCodec: "h264", Bitrate: 8000000, CompletionPercentage: 0 },
   },
 ];
 

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1016,6 +1016,14 @@ const DEMO_GLANCES_DISKIO = [
   { disk_name: "sda", read_bytes: 4096000, write_bytes: 1048576, read_count: 128, write_count: 32, time_since_update: 1 },
   { disk_name: "sdb", read_bytes: 20971520, write_bytes: 8388608, read_count: 512, write_count: 256, time_since_update: 1 },
 ];
+const DEMO_GLANCES_NET = [
+  { interface_name: "eth0", is_up: true, bytes_recv: 8650752, bytes_sent: 1153024, bytes_recv_rate_per_sec: 8650752, bytes_sent_rate_per_sec: 1153024, speed: 1000000000, time_since_update: 1 },
+  { interface_name: "wg0", is_up: true, bytes_recv: 245760, bytes_sent: 92160, bytes_recv_rate_per_sec: 245760, bytes_sent_rate_per_sec: 92160, speed: 0, time_since_update: 1 },
+  // Virtual (Docker) interfaces — grouped/hidden in the picker, excluded from "all".
+  { interface_name: "docker0", is_up: true, bytes_recv: 131072, bytes_sent: 196608, bytes_recv_rate_per_sec: 131072, bytes_sent_rate_per_sec: 196608, speed: 0, time_since_update: 1 },
+  { interface_name: "veth9a1b2c", is_up: true, bytes_recv: 40960, bytes_sent: 20480, bytes_recv_rate_per_sec: 40960, bytes_sent_rate_per_sec: 20480, speed: 10000000000, time_since_update: 1 },
+  { interface_name: "lo", is_up: true, bytes_recv: 524288, bytes_sent: 524288, bytes_recv_rate_per_sec: 524288, bytes_sent_rate_per_sec: 524288, speed: 0, time_since_update: 1 },
+];
 const DEMO_GLANCES_GPU = [
   { key: "gpu_id", gpu_id: "0", name: "NVIDIA GeForce RTX 3060", mem: 42.5, proc: 28.0, temperature: 54, fan_speed: 38 },
 ];
@@ -1211,6 +1219,7 @@ export function getDemoResponse(
       if (normalized === "/percpu") return DEMO_GLANCES_PERCPU;
       if (normalized === "/load") return DEMO_GLANCES_LOAD;
       if (normalized === "/diskio") return DEMO_GLANCES_DISKIO;
+      if (normalized === "/network") return DEMO_GLANCES_NET;
       if (normalized === "/gpu") return DEMO_GLANCES_GPU;
       if (normalized === "/containers") return DEMO_GLANCES_CONTAINERS;
       return undefined;

--- a/lib/streaming-bandwidth.test.ts
+++ b/lib/streaming-bandwidth.test.ts
@@ -1,0 +1,126 @@
+// Mock native storage before importing — streaming-bandwidth pulls in
+// now-playing-stream → plex-api → config-store → AsyncStorage/SecureStore at
+// module load. The functions under test are pure. Same shims as the other tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  tautulliActivityToWanLan,
+  plexSessionsToWanLan,
+  mediaServerSessionsToWanLan,
+  resolveStreamingService,
+} from "@/lib/streaming-bandwidth";
+import type {
+  TautulliActivity,
+  PlexSession,
+  JellyfinSession,
+} from "@/lib/types";
+
+describe("tautulliActivityToWanLan", () => {
+  it("reads the server-aggregated wan/lan fields (kbps)", () => {
+    const activity = {
+      wan_bandwidth: 8000,
+      lan_bandwidth: 6000,
+    } as TautulliActivity;
+    expect(tautulliActivityToWanLan(activity)).toEqual({ wan: 8000, lan: 6000 });
+  });
+
+  it("is zero for missing data or missing fields", () => {
+    expect(tautulliActivityToWanLan(undefined)).toEqual({ wan: 0, lan: 0 });
+    expect(tautulliActivityToWanLan({} as TautulliActivity)).toEqual({
+      wan: 0,
+      lan: 0,
+    });
+  });
+});
+
+describe("plexSessionsToWanLan", () => {
+  const session = (bandwidth: number, location: "lan" | "wan"): PlexSession =>
+    ({ Session: { id: "s", bandwidth, location } } as PlexSession);
+
+  it("sums per-session bandwidth into wan/lan buckets", () => {
+    const out = plexSessionsToWanLan([
+      session(8000, "wan"),
+      session(2000, "wan"),
+      session(6000, "lan"),
+    ]);
+    expect(out).toEqual({ wan: 10000, lan: 6000 });
+  });
+
+  it("treats a missing/unknown location as lan (local)", () => {
+    const out = plexSessionsToWanLan([
+      { Session: { id: "s", bandwidth: 1500 } } as PlexSession,
+    ]);
+    expect(out).toEqual({ wan: 0, lan: 1500 });
+  });
+
+  it("is zero for no sessions", () => {
+    expect(plexSessionsToWanLan([])).toEqual({ wan: 0, lan: 0 });
+    expect(plexSessionsToWanLan(undefined)).toEqual({ wan: 0, lan: 0 });
+  });
+});
+
+describe("mediaServerSessionsToWanLan (Jellyfin/Emby)", () => {
+  const session = (
+    remote: string | undefined,
+    bitrateBps?: number,
+  ): JellyfinSession =>
+    ({
+      Id: "s",
+      Client: "web",
+      DeviceName: "tv",
+      RemoteEndPoint: remote,
+      ...(bitrateBps !== undefined
+        ? { TranscodingInfo: { Bitrate: bitrateBps } }
+        : {}),
+    } as JellyfinSession);
+
+  it("converts transcode bitrate (bps) to kbps and splits by endpoint", () => {
+    const out = mediaServerSessionsToWanLan([
+      session("203.0.113.7", 8_000_000), // remote → WAN, 8000 kbps
+      session("192.168.1.20", 4_000_000), // local → LAN, 4000 kbps
+    ]);
+    expect(out).toEqual({ wan: 8000, lan: 4000 });
+  });
+
+  it("ignores direct-play sessions (no TranscodingInfo bitrate)", () => {
+    const out = mediaServerSessionsToWanLan([
+      session("192.168.1.20"), // direct play, no bitrate → contributes 0
+      session("203.0.113.7", 5_000_000),
+    ]);
+    expect(out).toEqual({ wan: 5000, lan: 0 });
+  });
+
+  it("is zero for no sessions", () => {
+    expect(mediaServerSessionsToWanLan(undefined)).toEqual({ wan: 0, lan: 0 });
+  });
+});
+
+describe("resolveStreamingService", () => {
+  it("keeps the stored preference when it is still configured", () => {
+    expect(resolveStreamingService("plex", ["tautulli", "plex"])).toBe("plex");
+  });
+
+  it("falls back to the first configured service when the preference is gone", () => {
+    expect(resolveStreamingService("plex", ["jellyfin", "emby"])).toBe("jellyfin");
+  });
+
+  it("returns null when nothing is configured", () => {
+    expect(resolveStreamingService("plex", [])).toBeNull();
+  });
+});

--- a/lib/streaming-bandwidth.ts
+++ b/lib/streaming-bandwidth.ts
@@ -1,0 +1,75 @@
+import { isLocalEndpoint } from "@/lib/now-playing-stream";
+import type {
+  TautulliActivity,
+  PlexSession,
+  JellyfinSession,
+} from "@/lib/types";
+
+// Media servers that can report live streaming bandwidth. Tautulli and Plex
+// expose measured bandwidth; Jellyfin/Emby only expose the transcode target
+// bitrate (and only while a stream is transcoding) — see the converter below.
+export type StreamingServiceId = "tautulli" | "plex" | "jellyfin" | "emby";
+
+// Streaming is outbound-only (server → viewers). We split it by client
+// location: WAN = remote/internet, LAN = local. Both values are in kbit/s.
+export interface WanLanKbps {
+  wan: number;
+  lan: number;
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+// Tautulli aggregates WAN/LAN bandwidth server-side (kbps) — the cleanest source.
+export function tautulliActivityToWanLan(
+  activity: TautulliActivity | undefined,
+): WanLanKbps {
+  if (!activity) return { wan: 0, lan: 0 };
+  return { wan: num(activity.wan_bandwidth), lan: num(activity.lan_bandwidth) };
+}
+
+// Plex tags each session with its bandwidth (kbps) and lan/wan location; sum
+// the active sessions per bucket.
+export function plexSessionsToWanLan(
+  sessions: PlexSession[] | undefined,
+): WanLanKbps {
+  let wan = 0;
+  let lan = 0;
+  for (const s of sessions ?? []) {
+    const bw = num(s.Session?.bandwidth);
+    if (s.Session?.location === "wan") wan += bw;
+    else lan += bw;
+  }
+  return { wan, lan };
+}
+
+// Jellyfin/Emby expose no measured bandwidth — only TranscodingInfo.Bitrate
+// (bits/sec, the transcode target), and only while a session is transcoding.
+// Direct-play streams contribute nothing, so this is an approximation. LAN vs
+// WAN is inferred from the session's RemoteEndPoint.
+export function mediaServerSessionsToWanLan(
+  sessions: JellyfinSession[] | undefined,
+): WanLanKbps {
+  let wan = 0;
+  let lan = 0;
+  for (const s of sessions ?? []) {
+    const bitrateBps = num(s.TranscodingInfo?.Bitrate);
+    if (bitrateBps <= 0) continue;
+    const kbps = bitrateBps / 1000; // bits/s → kbit/s
+    if (isLocalEndpoint(s.RemoteEndPoint)) lan += kbps;
+    else wan += kbps;
+  }
+  return { wan, lan };
+}
+
+// Pick the streaming service the widget should read: the stored preference when
+// it's still configured, otherwise the first configured one (so a widget keeps
+// working if its service is removed), or null when none are configured.
+export function resolveStreamingService(
+  pref: StreamingServiceId,
+  configured: readonly StreamingServiceId[],
+): StreamingServiceId | null {
+  if (configured.includes(pref)) return pref;
+  return configured[0] ?? null;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1293,6 +1293,24 @@ export interface GlancesDiskIOItem {
   time_since_update: number;
 }
 
+export interface GlancesNetItem {
+  interface_name: string;
+  // Optional human alias configured in Glances; prefer it for display.
+  alias?: string | null;
+  is_up?: boolean;
+  // bytes_recv/bytes_sent are the deltas since the last sample (same as the
+  // diskio plugin), so rate = bytes / time_since_update. Glances v4 also ships
+  // the pre-computed *_rate_per_sec fields; prefer those when present.
+  bytes_recv: number;
+  bytes_sent: number;
+  bytes_all?: number;
+  bytes_recv_rate_per_sec?: number | null;
+  bytes_sent_rate_per_sec?: number | null;
+  // Max link speed in bits/sec (0 when the OS can't report it).
+  speed?: number;
+  time_since_update: number;
+}
+
 export interface GlancesGpuItem {
   key: string;
   gpu_id: string;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,6 +28,19 @@ export function formatSpeed(bytesPerSecond: number): string {
 }
 
 /**
+ * Format a kilobit/second value as a streaming bitrate (e.g., 18.4 Mbps,
+ * 1.20 Gbps). Streaming bandwidth is conventionally read in bits, not bytes —
+ * use this (not formatSpeed) for Plex/Tautulli/Jellyfin/Emby throughput.
+ */
+export function formatBitrate(kbps: number): string {
+  if (!Number.isFinite(kbps) || kbps <= 0) return "0 Mbps";
+  const mbps = kbps / 1000;
+  if (mbps >= 1000) return `${(mbps / 1000).toFixed(2)} Gbps`;
+  if (mbps >= 100) return `${Math.round(mbps)} Mbps`;
+  return `${mbps.toFixed(1)} Mbps`;
+}
+
+/**
  * Format seconds to ETA string (e.g., 2h 15m, 45m, 30s)
  */
 export function formatEta(seconds: number): string {

--- a/services/glances-api.test.ts
+++ b/services/glances-api.test.ts
@@ -1,0 +1,171 @@
+// Mock native storage before importing — glances-api pulls in http-client →
+// config-store → AsyncStorage/SecureStore at module load. The functions under
+// test are pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  isVirtualInterface,
+  rankedInterfaces,
+  selectInterfaces,
+  NETWORK_INTERFACES_ALL,
+} from "@/services/glances-api";
+import type { GlancesNetItem } from "@/lib/types";
+
+function iface(
+  interface_name: string,
+  rx: number,
+  tx: number,
+  is_up = true,
+): GlancesNetItem {
+  return {
+    interface_name,
+    is_up,
+    bytes_recv: rx,
+    bytes_sent: tx,
+    bytes_recv_rate_per_sec: rx,
+    bytes_sent_rate_per_sec: tx,
+    time_since_update: 1,
+  };
+}
+
+describe("isVirtualInterface", () => {
+  it.each([
+    "docker0",
+    "docker_gwbridge",
+    "br-1a2b3c4d5e6f",
+    "veth9a1b2c",
+    "virbr0",
+    "vnet0",
+    "vmnet1",
+    "cni0",
+    "flannel.1",
+    "cali1234567",
+    "cilium_host",
+    "weave",
+    "kube-bridge",
+    "nerdctl0",
+  ])("treats %s as virtual", (name) => {
+    expect(isVirtualInterface(name)).toBe(true);
+  });
+
+  it.each([
+    "eth0",
+    "eno1",
+    "enp3s0",
+    "ens18",
+    "wlan0",
+    "wlp2s0",
+    "wg0", // WireGuard VPN — a real connection, not virtual
+    "tailscale0",
+    "tun0",
+    "ppp0",
+    "br0", // a plain bridge (no Docker hash) is a real interface
+    "bond0",
+    "team0",
+  ])("treats %s as real", (name) => {
+    expect(isVirtualInterface(name)).toBe(false);
+  });
+});
+
+describe("rankedInterfaces", () => {
+  it("excludes loopback, puts physical before virtual, sorts by throughput within group", () => {
+    const ranked = rankedInterfaces([
+      iface("lo", 9_000_000, 9_000_000),
+      iface("docker0", 500_000, 500_000),
+      iface("veth9a1b", 10, 10),
+      iface("eth0", 1_000_000, 100_000),
+      iface("wg0", 2_000_000, 2_000_000),
+    ]);
+    expect(ranked.map((i) => i.interface_name)).toEqual([
+      "wg0", // physical, busiest
+      "eth0", // physical
+      "docker0", // virtual, busiest
+      "veth9a1b", // virtual
+    ]);
+  });
+
+  it("drops interfaces that are explicitly down", () => {
+    const ranked = rankedInterfaces([
+      iface("eth0", 100, 100, false),
+      iface("eth1", 100, 100, true),
+    ]);
+    expect(ranked.map((i) => i.interface_name)).toEqual(["eth1"]);
+  });
+
+  it("computes rx/tx, preferring the server-supplied rate", () => {
+    const [eth0] = rankedInterfaces([iface("eth0", 4096, 2048)]);
+    expect(eth0.rx).toBe(4096);
+    expect(eth0.tx).toBe(2048);
+  });
+
+  it("falls back to delta / time_since_update when no rate field is present", () => {
+    const [eth0] = rankedInterfaces([
+      {
+        interface_name: "eth0",
+        is_up: true,
+        bytes_recv: 8000,
+        bytes_sent: 4000,
+        time_since_update: 2,
+      },
+    ]);
+    expect(eth0.rx).toBe(4000);
+    expect(eth0.tx).toBe(2000);
+  });
+});
+
+describe("selectInterfaces", () => {
+  const net = [
+    iface("eth0", 1_000_000, 100_000),
+    iface("wg0", 0, 0), // idle physical
+    iface("docker0", 500_000, 500_000),
+    iface("lo", 9_000_000, 9_000_000),
+  ];
+
+  it("returns [] for missing data", () => {
+    expect(selectInterfaces(undefined, NETWORK_INTERFACES_ALL)).toEqual([]);
+  });
+
+  it("'all' excludes virtual and loopback", () => {
+    const names = selectInterfaces(net, NETWORK_INTERFACES_ALL).map(
+      (i) => i.interface_name,
+    );
+    expect(names).toEqual(["eth0", "wg0"]);
+    expect(names).not.toContain("docker0");
+    expect(names).not.toContain("lo");
+  });
+
+  it("'all' with activeOnly also drops idle interfaces", () => {
+    const names = selectInterfaces(net, NETWORK_INTERFACES_ALL, {
+      activeOnly: true,
+    }).map((i) => i.interface_name);
+    expect(names).toEqual(["eth0"]); // wg0 is idle
+  });
+
+  it("an explicit list returns exactly those, including virtual ones", () => {
+    const names = selectInterfaces(net, ["docker0", "eth0"]).map(
+      (i) => i.interface_name,
+    );
+    expect(names.sort()).toEqual(["docker0", "eth0"]);
+  });
+
+  it("an explicit list never matches loopback even if named", () => {
+    // rankedInterfaces already strips loopback, so it can't be selected.
+    expect(selectInterfaces(net, ["lo"])).toEqual([]);
+  });
+});

--- a/services/glances-api.ts
+++ b/services/glances-api.ts
@@ -8,6 +8,7 @@ import type {
   GlancesDiskIOItem,
   GlancesGpuItem,
   GlancesContainerItem,
+  GlancesNetItem,
 } from "@/lib/types";
 
 // Per-instance routing: every function takes an optional `instanceId`.
@@ -56,6 +57,95 @@ export async function getFs(instanceId?: string): Promise<GlancesFsItem[]> {
 
 export function getDiskIO(instanceId?: string): Promise<GlancesDiskIOItem[]> {
   return serviceRequest<GlancesDiskIOItem[]>("glances", "/diskio", { instanceId });
+}
+
+export function getNet(instanceId?: string): Promise<GlancesNetItem[]> {
+  return serviceRequest<GlancesNetItem[]>("glances", "/network", { instanceId });
+}
+
+// Loopback carries local inter-service traffic, not the server's actual
+// connection — hide it from network views (the analog of isRealDisk).
+export function isLoopbackInterface(name: string): boolean {
+  const n = name.toLowerCase();
+  return n === "lo" || n === "lo0" || n.startsWith("loopback");
+}
+
+// Container/virtualization interfaces that are noise when monitoring the
+// server's real connection: Docker bridges + veth pairs, libvirt/VMware/KVM
+// taps, Kubernetes CNIs. VPN tunnels (wg*, tailscale*, tun*, ppp*) are
+// deliberately NOT virtual — users monitor those as genuine connections. A
+// plain `br0`/`bond0` is a real bridge/aggregate, so only `br-<id>` (Docker's
+// user-network pattern) is matched, not every `br*`.
+const VIRTUAL_IFACE_PATTERNS: readonly RegExp[] = [
+  /^docker/i, /^br-/i, /^veth/i, /^virbr/i, /^vnet/i, /^vmnet/i,
+  /^cni/i, /^flannel/i, /^cali/i, /^cilium/i, /^weave/i, /^kube/i,
+  /^nerdctl/i, /^ifb/i, /^dummy/i,
+];
+
+export function isVirtualInterface(name: string): boolean {
+  return VIRTUAL_IFACE_PATTERNS.some((re) => re.test(name));
+}
+
+export interface GlancesNetRate extends GlancesNetItem {
+  rx: number; // bytes/sec received
+  tx: number; // bytes/sec sent
+}
+
+// Prefer Glances' server-computed per-second rate; fall back to the
+// delta-over-interval formula the diskio view uses.
+function netRxTx(item: GlancesNetItem): { rx: number; tx: number } {
+  const rate = (precomputed: number | null | undefined, delta: number): number => {
+    if (typeof precomputed === "number" && Number.isFinite(precomputed)) return precomputed;
+    return item.time_since_update > 0 ? delta / item.time_since_update : 0;
+  };
+  return {
+    rx: rate(item.bytes_recv_rate_per_sec, item.bytes_recv),
+    tx: rate(item.bytes_sent_rate_per_sec, item.bytes_sent),
+  };
+}
+
+// Up, non-loopback interfaces with computed rx/tx. Physical NICs first, then
+// virtual (Docker/veth/…), each group sorted by total throughput descending —
+// so the real connection floats to the top above container noise. Shared by the
+// Glances screen (shows all) and the widgets (filter/sum by name).
+export function rankedInterfaces(items: GlancesNetItem[]): GlancesNetRate[] {
+  return items
+    .filter((i) => i.is_up !== false && !isLoopbackInterface(i.interface_name))
+    .map((i) => ({ ...i, ...netRxTx(i) }))
+    .sort((a, b) => {
+      const av = isVirtualInterface(a.interface_name) ? 1 : 0;
+      const bv = isVirtualInterface(b.interface_name) ? 1 : 0;
+      return av - bv || b.rx + b.tx - (a.rx + a.tx);
+    });
+}
+
+// Widget-side selection of which interfaces to show. The sentinel "all" tracks
+// every active, non-loopback interface; an array restricts to those names.
+// Stored as a string (not null) so it survives JSON export and auto-includes
+// interfaces that appear later. Owned here (the Glances data contract) so both
+// the picker UI and the consuming widgets share one source of truth.
+export const NETWORK_INTERFACES_ALL = "all" as const;
+export type NetworkInterfacesValue = string[] | typeof NETWORK_INTERFACES_ALL;
+
+// Resolve a selection against a live /network payload. The "all" sentinel means
+// every real (non-virtual) interface — Docker/veth/bridge interfaces are
+// excluded so the common case isn't drowned in container noise; with
+// `activeOnly` it further drops idle NICs. An explicit name list is always shown
+// verbatim, including virtual ones (the user picked them on purpose) and even
+// when momentarily idle.
+export function selectInterfaces(
+  net: GlancesNetItem[] | undefined,
+  selection: NetworkInterfacesValue,
+  opts: { activeOnly?: boolean } = {},
+): GlancesNetRate[] {
+  if (!net) return [];
+  const ranked = rankedInterfaces(net);
+  if (selection === NETWORK_INTERFACES_ALL) {
+    const real = ranked.filter((i) => !isVirtualInterface(i.interface_name));
+    return opts.activeOnly ? real.filter((i) => i.rx + i.tx > 0) : real;
+  }
+  const allowed = new Set(selection);
+  return ranked.filter((i) => allowed.has(i.interface_name));
 }
 
 export async function getGpu(instanceId?: string): Promise<GlancesGpuItem[]> {

--- a/store/glances-ui-store.ts
+++ b/store/glances-ui-store.ts
@@ -9,23 +9,29 @@ const STORAGE_KEY = "ui.glancesSections";
 interface GlancesSectionPrefs {
   perCoreExpanded: boolean;
   containersExpanded: boolean;
+  networkExpanded: boolean;
 }
 
 export const GLANCES_SECTION_DEFAULTS: GlancesSectionPrefs = {
   perCoreExpanded: false,
   containersExpanded: true,
+  // Collapsed by default — Docker-heavy hosts expose many interfaces and the
+  // section is just-in-case detail, not a primary metric.
+  networkExpanded: false,
 };
 
 interface GlancesUiStore extends GlancesSectionPrefs {
   hydrate: () => void;
   setPerCoreExpanded: (v: boolean) => void;
   setContainersExpanded: (v: boolean) => void;
+  setNetworkExpanded: (v: boolean) => void;
 }
 
 function snapshot(state: GlancesSectionPrefs): GlancesSectionPrefs {
   return {
     perCoreExpanded: state.perCoreExpanded,
     containersExpanded: state.containersExpanded,
+    networkExpanded: state.networkExpanded,
   };
 }
 
@@ -46,5 +52,9 @@ export const useGlancesUiStore = create<GlancesUiStore>((set, get) => ({
   setContainersExpanded: (containersExpanded) => {
     set({ containersExpanded });
     setJSON(STORAGE_KEY, snapshot({ ...get(), containersExpanded }));
+  },
+  setNetworkExpanded: (networkExpanded) => {
+    set({ networkExpanded });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), networkExpanded }));
   },
 }));


### PR DESCRIPTION
Refs #53.

## What
- Glances server network monitoring: per-interface Rx/Tx on the Glances screen, plus a Network section in the Server Stats widget with a physical-first interface picker that groups Docker/virtual NICs.
- Speed Stats widget: optional title, one-source-per-widget model (download clients OR Glances network), and NZBGet + rtorrent folded into the clients source (rtorrent-only and nzbget-only users can now use it).
- New Streaming Bandwidth widget: live WAN/LAN streaming bandwidth (Mbps) from Tautulli, Plex, Jellyfin, or Emby.
- Server Stats widget: added Load Average and I/O Wait toggles.
- Both throughput widgets show an offline state instead of a misleading 0 when a source is unreachable.

## Test plan
- `tsc --noEmit` clean; 452 jest tests pass (47 new, covering WAN/LAN math and interface classification).
- Demo mode exercises every new surface (Glances network, Speed Stats sources, Streaming Bandwidth for all four services).
- Reviewed with a multi-agent adversarial pass; the one real finding (load.toFixed crash on partial-data hosts) is fixed.

## Known limitations
- "All active" network selection sums every real NIC, so a bonded setup (bond0 plus members) double-counts. Niche.
- Jellyfin and Emby expose only transcode target bitrate, so direct-play streams read as 0 (surfaced via an in-card caveat).
