### PR TITLE
fix: bound pull-to-refresh spinner so it can't stick on iOS (Refs #147)

### DIFF
--- a/components/common/pull-to-refresh.tsx
+++ b/components/common/pull-to-refresh.tsx
@@ -1,46 +1,113 @@
-import { useState, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useFocusEffect } from "expo-router";
 import { lightHaptic } from "@/lib/haptics";
 
-/**
- * Hook that provides pull-to-refresh state tied to TanStack Query invalidation.
- * Pass optional query keys to only invalidate specific queries.
- */
-export function usePullToRefresh(queryKeys?: readonly unknown[][]) {
-  const [refreshing, setRefreshing] = useState(false);
-  const queryClient = useQueryClient();
+// The iOS UIRefreshControl (New Architecture / Fabric) retracts only when the
+// native side observes a clean `refreshing: true -> false` transition — see
+// RCTPullToRefreshViewComponentView.mm, which calls `endRefreshing` exactly on
+// that diff. Two guards keep that transition reliable and bounded (#147):
+//
+//   MIN_SPIN_MS — hold the spinner for at least this long before flipping to
+//     false, so the native `true` (begin animation) is guaranteed to land
+//     before we send `false` (end). A very fast refetch that flips false within
+//     the begin-animation window otherwise leaves the spinner visually pinned.
+//
+//   MAX_SPIN_MS — never let the spinner outlive a hung/unreachable service. A
+//     keyless `invalidateQueries()` (the dashboard) — or a scoped refetch —
+//     awaits every matching query's fetch to settle; with a 15s request abort +
+//     retry:2 + exponential backoff, a single dead service takes ~50s, which is
+//     exactly the "spinner never ends" the v1.8.1 fix never addressed (it only
+//     cleared the spinner on blur). We cap the wait and let the refetch finish
+//     in the background, so the cache still updates when the slow service lands.
+const MIN_SPIN_MS = 600;
+const MAX_SPIN_MS = 10000;
 
-  // iOS: react-native-screens detaches/freezes a blurred tab screen. If a
-  // pull-to-refresh is still in flight when the user switches tabs, the native
-  // UIRefreshControl is frozen mid-spin and never receives the later
-  // endRefreshing() once the invalidate resolves off-screen — it comes back
-  // visible-but-frozen (#147). Clearing `refreshing` on blur drives the
-  // control's prop to false while the screen is still attached, dismissing the
-  // spinner before detach. The in-flight invalidate keeps running regardless.
+/**
+ * Drives a pull-to-refresh spinner from an async refresh function with the
+ * timing guards above, re-entrancy protection, and iOS focus/blur resets so a
+ * spinner can never be stranded by a tab switch (react-native-screens detaches
+ * blurred tab screens, which froze the native control mid-spin — #147).
+ *
+ * Shared by `usePullToRefresh` (TanStack invalidation) and the hand-rolled
+ * torrent downloads view (custom refetch) so both get identical behavior.
+ */
+export function useRefreshSpinner(doRefresh: () => Promise<unknown>) {
+  const [refreshing, setRefreshing] = useState(false);
+  const mounted = useRef(true);
+  const running = useRef(false);
+  const endTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stop = useCallback(() => {
+    if (endTimer.current) {
+      clearTimeout(endTimer.current);
+      endTimer.current = null;
+    }
+    running.current = false;
+    if (mounted.current) setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      if (endTimer.current) clearTimeout(endTimer.current);
+    };
+  }, []);
+
+  // iOS: react-native-screens detaches a blurred tab screen. Clearing the
+  // spinner (and any pending end-timer) on blur dismisses the native control
+  // while the screen is still attached, so it can't come back frozen mid-spin.
   useFocusEffect(
     useCallback(() => {
-      return () => setRefreshing(false);
-    }, []),
+      return () => stop();
+    }, [stop]),
   );
 
   const onRefresh = useCallback(async () => {
+    if (running.current) return; // ignore re-pulls while one is already in flight
+    running.current = true;
     lightHaptic();
     setRefreshing(true);
+    const startedAt = Date.now();
+
+    let capTimer: ReturnType<typeof setTimeout> | null = null;
+    const cap = new Promise<void>((resolve) => {
+      capTimer = setTimeout(resolve, MAX_SPIN_MS);
+    });
+
     try {
-      if (queryKeys) {
-        await Promise.all(
-          queryKeys.map((key) =>
-            queryClient.invalidateQueries({ queryKey: key }),
-          ),
-        );
-      } else {
-        await queryClient.invalidateQueries();
-      }
+      // Bound the wait: whichever settles first wins. The refetch keeps running
+      // after the cap — it just no longer holds the spinner hostage.
+      await Promise.race([
+        Promise.resolve(doRefresh()).catch(() => {}),
+        cap,
+      ]);
     } finally {
-      setRefreshing(false);
+      if (capTimer) clearTimeout(capTimer);
+      const wait = Math.max(0, MIN_SPIN_MS - (Date.now() - startedAt));
+      endTimer.current = setTimeout(stop, wait);
     }
-  }, [queryClient, queryKeys]);
+  }, [doRefresh, stop]);
 
   return { refreshing, onRefresh };
+}
+
+/**
+ * Pull-to-refresh tied to TanStack Query invalidation. Pass optional query keys
+ * to invalidate only specific queries; omit them to invalidate everything (the
+ * dashboard). Returns `{ refreshing, onRefresh }` for a RefreshControl.
+ */
+export function usePullToRefresh(queryKeys?: readonly unknown[][]) {
+  const queryClient = useQueryClient();
+  const doRefresh = useCallback(() => {
+    if (queryKeys) {
+      return Promise.all(
+        queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })),
+      );
+    }
+    return queryClient.invalidateQueries();
+  }, [queryClient, queryKeys]);
+
+  return useRefreshSpinner(doRefresh);
 }

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -24,6 +24,7 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { ServiceHeader } from "@/components/common/service-header";
 import { DemoBanner } from "@/components/common/demo-banner";
+import { useRefreshSpinner } from "@/components/common/pull-to-refresh";
 import { Card } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Badge } from "@/components/ui/badge";
@@ -34,7 +35,7 @@ import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import { ActionSheet } from "@/components/ui/action-sheet";
-import { errorHaptic, lightHaptic, mediumHaptic } from "@/lib/haptics";
+import { errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
 import {
   useSortStore,
@@ -99,7 +100,6 @@ export function TorrentDownloadsView({
   const [bulkDelete, setBulkDelete] = useState<{ count: number } | null>(null);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
-  const [refreshing, setRefreshing] = useState(false);
 
   // "all" sentinel → omit the param entirely (qBittorrent reads no param as
   // "all categories"); "" stays "" so it maps to uncategorized.
@@ -136,27 +136,16 @@ export function TorrentDownloadsView({
     : (["top", "left", "right", "bottom"] as const);
   const listBottomPadding = 24 + (usesFloatingTabBar ? tabBarHeight : 0);
 
-  const onRefresh = useCallback(async () => {
-    lightHaptic();
-    setRefreshing(true);
-    try {
-      await refetch();
-      await statsResult.refetch();
-    } finally {
-      setRefreshing(false);
-    }
+  // Hand-rolled refresh (custom qBittorrent refetch instead of a query-key
+  // invalidate) routed through the shared spinner primitive so it gets the
+  // same bounded-wait, minimum-spin, and iOS focus/blur reset as every other
+  // screen — that's what keeps the native control from sticking (#147).
+  const doRefresh = useCallback(async () => {
+    await refetch();
+    await statsResult.refetch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refetch, statsResult.refetch]);
-
-  // iOS: clear the spinner on blur so a refresh still in flight when the user
-  // leaves the tab doesn't strand the native UIRefreshControl visible-but-
-  // frozen on return (#147). Mirrors the guard in usePullToRefresh for screens
-  // that hand-roll the refreshing boolean instead of using that hook.
-  useFocusEffect(
-    useCallback(() => {
-      return () => setRefreshing(false);
-    }, []),
-  );
+  const { refreshing, onRefresh } = useRefreshSpinner(doRefresh);
 
   // Only the rows whose hashes are actually in-flight should disable —
   // mutating one torrent shouldn't gray out every other row's buttons.


### PR DESCRIPTION
## Summary
- The dashboard's keyless `invalidateQueries()` awaits every active query, so one unreachable service held the spinner ~50s (15s abort + retry:2 + backoff) — the "never ends" symptom. On the New Architecture a too-fast `true->false` flip also leaves the native `UIRefreshControl` pinned.
- Shared `useRefreshSpinner`: caps the wait (refetch keeps running in the background), enforces a minimum spin for a clean native retraction, adds a re-entrancy guard and focus/blur resets. `usePullToRefresh` wraps it so all screens benefit; `torrent-downloads-view` reuses it instead of hand-rolling the boolean.

## Test plan
- [x] `tsc --noEmit` clean; jest suite green (452 tests)
- [ ] iOS New-Arch device: pull-to-refresh dashboard with one service unreachable → spinner stops within ~10s
- [ ] Switch tabs mid-refresh → no orphaned spinner on return

Refs #147