### PR TITLE
feat: per-dashboard home networks + workspace-scoped instances

### DIFF
--- a/app/(tabs)/activity.tsx
+++ b/app/(tabs)/activity.tsx
@@ -22,6 +22,7 @@ import { ErrorBanner } from "@/components/common/error-banner";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { ServiceLogo } from "@/components/ui/service-logo";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
@@ -45,21 +46,27 @@ interface MonitorSource {
 // Tracearr + JellyStat) and the media servers with live sessions (Jellyfin +
 // Emby) into a flat source list. The per-kind hook calls keep a stable order.
 function useMonitorSources(): MonitorSource[] {
+  const attached = useAttachedInstances();
   const tautulli = useEnabledInstances("tautulli");
   const tracearr = useEnabledInstances("tracearr");
   const jellystat = useEnabledInstances("jellystat");
   const jellyfin = useEnabledInstances("jellyfin");
   const emby = useEnabledInstances("emby");
-  return useMemo<MonitorSource[]>(
-    () => [
-      ...tautulli.map((i) => ({ kind: "tautulli" as MonitorKind, instanceId: i.id })),
-      ...tracearr.map((i) => ({ kind: "tracearr" as MonitorKind, instanceId: i.id })),
-      ...jellystat.map((i) => ({ kind: "jellystat" as MonitorKind, instanceId: i.id })),
-      ...jellyfin.map((i) => ({ kind: "jellyfin" as MonitorKind, instanceId: i.id })),
-      ...emby.map((i) => ({ kind: "emby" as MonitorKind, instanceId: i.id })),
-    ],
-    [tautulli, tracearr, jellystat, jellyfin, emby],
-  );
+  return useMemo<MonitorSource[]>(() => {
+    // Only monitors attached to the active workspace — otherwise a curated
+    // dashboard's Activity tab would surface (and poll every 5s) another
+    // workspace's live sessions and history (#148 review Rec #2). This is a
+    // full-screen tab with no per-widget binding, so the filter is purely the
+    // workspace attachment set.
+    const inWs = (i: { id: string }) => attached.has(i.id);
+    return [
+      ...tautulli.filter(inWs).map((i) => ({ kind: "tautulli" as MonitorKind, instanceId: i.id })),
+      ...tracearr.filter(inWs).map((i) => ({ kind: "tracearr" as MonitorKind, instanceId: i.id })),
+      ...jellystat.filter(inWs).map((i) => ({ kind: "jellystat" as MonitorKind, instanceId: i.id })),
+      ...jellyfin.filter(inWs).map((i) => ({ kind: "jellyfin" as MonitorKind, instanceId: i.id })),
+      ...emby.filter(inWs).map((i) => ({ kind: "emby" as MonitorKind, instanceId: i.id })),
+    ];
+  }, [tautulli, tracearr, jellystat, jellyfin, emby, attached]);
 }
 
 // Stream monitors with a dedicated stats screen (charts + most active users).

--- a/app/(tabs)/bazarr.tsx
+++ b/app/(tabs)/bazarr.tsx
@@ -4,6 +4,7 @@ import { Captions, Search as SearchIcon, Film, Tv } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { FilterChip } from "@/components/ui/filter-chip";
@@ -26,6 +27,14 @@ import { truncateText } from "@/lib/utils";
 type Tab = "movies" | "episodes" | "history";
 
 export default function BazarrScreen() {
+  return (
+    <WorkspaceServiceGuard kinds={["bazarr"]}>
+      <BazarrScreenInner />
+    </WorkspaceServiceGuard>
+  );
+}
+
+function BazarrScreenInner() {
   const [tab, setTab] = useState<Tab>("movies");
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["bazarr"]]);

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { View, Text, TouchableOpacity, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import {
@@ -16,12 +16,12 @@ import {
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import * as Haptics from "expo-haptics";
-import Animated, { FadeIn, FadeInDown, FadeOut } from "react-native-reanimated";
+import Animated, { FadeInDown } from "react-native-reanimated";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useConfigStore } from "@/store/config-store";
 import { CardErrorBoundary } from "@/components/common/error-boundary";
-import { ICON } from "@/lib/constants";
+import { ICON, type WidgetId } from "@/lib/constants";
 import {
   WIDGET_REGISTRY,
   isWidgetServiceAttached,
@@ -33,6 +33,29 @@ import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sh
 import { useAttachedKinds } from "@/hooks/use-active-dashboard";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 
+// Memoized so toggling editMode (which re-renders DashboardScreen) doesn't
+// re-render the heavy, data-fetching widget bodies. editMode only drives the
+// surrounding chrome (the per-slot control row + dashed border), so each
+// widget's props (widgetId/slotId) stay stable and React.memo skips the
+// expensive subtree — that's what makes entering edit mode feel instant on a
+// full dashboard instead of stalling while every widget re-runs its hooks.
+const WidgetSlotBody = memo(function WidgetSlotBody({
+  widgetId,
+  slotId,
+}: {
+  widgetId: WidgetId;
+  slotId: string;
+}) {
+  const widget = WIDGET_REGISTRY[widgetId];
+  if (!widget) return null;
+  const WidgetComponent = widget.component;
+  return (
+    <CardErrorBoundary>
+      <WidgetComponent slotId={slotId} />
+    </CardErrorBoundary>
+  );
+});
+
 export default function DashboardScreen() {
   const { refreshing, onRefresh } = usePullToRefresh();
   const services = useConfigStore((s) => s.services);
@@ -42,9 +65,24 @@ export default function DashboardScreen() {
   const moveSlot = useConfigStore((s) => s.moveSlot);
   const router = useRouter();
   const [editMode, setEditMode] = useState(false);
+  const [showEditControls, setShowEditControls] = useState(false);
   const [pickerVisible, setPickerVisible] = useState(false);
   const [dashboardPickerVisible, setDashboardPickerVisible] = useState(false);
   const [settingsForSlot, setSettingsForSlot] = useState<string | null>(null);
+
+  // Entering edit mode mounts a per-widget control row (several SVG icons each)
+  // for every visible widget at once — heavy enough to stall the tap. So show
+  // the cheap edit affordance (dashed border + banner) immediately on toggle,
+  // then mount the control rows on the next frame. The pencil tap feels instant
+  // and the controls pop in a frame later instead of freezing on the tap.
+  useEffect(() => {
+    if (!editMode) {
+      setShowEditControls(false);
+      return;
+    }
+    const handle = requestAnimationFrame(() => setShowEditControls(true));
+    return () => cancelAnimationFrame(handle);
+  }, [editMode]);
 
   const activeDashboard =
     dashboards.find((d) => d.id === activeDashboardId) ?? dashboards[0];
@@ -186,20 +224,16 @@ export default function DashboardScreen() {
       ) : (
         <View className="gap-4">
           {editMode && (
-            <Animated.View
-              entering={FadeIn}
-              exiting={FadeOut}
-              className="bg-primary/10 border border-primary/30 rounded-xl px-4 py-2"
-            >
+            <View className="bg-primary/10 border border-primary/30 rounded-xl px-4 py-2">
               <Text className="text-primary text-sm font-medium text-center">
                 Reorder, remove, or add widgets
               </Text>
-            </Animated.View>
+            </View>
           )}
           {visibleSlots.map((slot, visibleIndex) => {
             const widget = WIDGET_REGISTRY[slot.widgetId];
             if (!widget) return null;
-            const { component: WidgetComponent, label, settingsComponent } = widget;
+            const { label, settingsComponent } = widget;
             const isFirst = visibleIndex === 0;
             const isLast = visibleIndex === visibleSlots.length - 1;
 
@@ -208,12 +242,8 @@ export default function DashboardScreen() {
                 key={slot.id}
                 entering={FadeInDown.delay(visibleIndex * 80).springify()}
               >
-                {editMode && (
-                  <Animated.View
-                    entering={FadeIn}
-                    exiting={FadeOut}
-                    className="flex-row items-center justify-between mb-1 px-1"
-                  >
+                {showEditControls && (
+                  <View className="flex-row items-center justify-between mb-1 px-1">
                     <View className="flex-row items-center gap-1.5 flex-1">
                       <Icon icon={GripVertical} size={ICON.SM} color="#52525b" />
                       <Text className="text-zinc-500 text-xs font-medium" numberOfLines={1}>
@@ -254,7 +284,7 @@ export default function DashboardScreen() {
                         <Icon icon={X} size={ICON.MD} color="#ef4444" />
                       </TouchableOpacity>
                     </View>
-                  </Animated.View>
+                  </View>
                 )}
                 <View
                   style={editMode ? {
@@ -265,24 +295,20 @@ export default function DashboardScreen() {
                     opacity: 0.85,
                   } : undefined}
                 >
-                  <CardErrorBoundary>
-                    <WidgetComponent slotId={slot.id} />
-                  </CardErrorBoundary>
+                  <WidgetSlotBody widgetId={slot.widgetId} slotId={slot.id} />
                 </View>
               </Animated.View>
             );
           })}
 
           {editMode && (
-            <Animated.View entering={FadeIn} exiting={FadeOut}>
-              <TouchableOpacity
-                onPress={openPicker}
-                className="flex-row items-center justify-center gap-2 border border-dashed border-zinc-700 rounded-2xl py-4"
-              >
-                <Icon icon={Plus} size={ICON.MD} color="#a1a1aa" />
-                <Text className="text-zinc-300 text-sm font-medium">Add widget</Text>
-              </TouchableOpacity>
-            </Animated.View>
+            <TouchableOpacity
+              onPress={openPicker}
+              className="flex-row items-center justify-center gap-2 border border-dashed border-zinc-700 rounded-2xl py-4"
+            >
+              <Icon icon={Plus} size={ICON.MD} color="#a1a1aa" />
+              <Text className="text-zinc-300 text-sm font-medium">Add widget</Text>
+            </TouchableOpacity>
           )}
         </View>
       )}

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -33,6 +33,15 @@ import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sh
 import { useAttachedKinds } from "@/hooks/use-active-dashboard";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 
+// Progressive mount: how many widgets render in the first paint, and how many
+// more reveal per frame after that. Opening the dashboard otherwise mounts every
+// data-fetching widget (and fires every first poll) in a single commit, which
+// froze the JS thread for ~700ms. Rendering a screenful immediately and
+// streaming the rest a couple per frame keeps the open responsive while the
+// below-the-fold widgets fill in. REVEAL_INITIAL ≈ a phone screenful of cards.
+const REVEAL_INITIAL = 3;
+const REVEAL_BATCH = 2;
+
 // Memoized so toggling editMode (which re-renders DashboardScreen) doesn't
 // re-render the heavy, data-fetching widget bodies. editMode only drives the
 // surrounding chrome (the per-slot control row + dashed border), so each
@@ -69,6 +78,7 @@ export default function DashboardScreen() {
   const [pickerVisible, setPickerVisible] = useState(false);
   const [dashboardPickerVisible, setDashboardPickerVisible] = useState(false);
   const [settingsForSlot, setSettingsForSlot] = useState<string | null>(null);
+  const [revealCount, setRevealCount] = useState(REVEAL_INITIAL);
 
   // Entering edit mode mounts a per-widget control row (several SVG icons each)
   // for every visible widget at once — heavy enough to stall the tap. So show
@@ -83,6 +93,13 @@ export default function DashboardScreen() {
     const handle = requestAnimationFrame(() => setShowEditControls(true));
     return () => cancelAnimationFrame(handle);
   }, [editMode]);
+
+  // Restart the progressive reveal when switching dashboards — a different
+  // dashboard remounts a different widget set (keyed by slot id), so without
+  // this the new set would mount all at once after the first reveal completed.
+  useEffect(() => {
+    setRevealCount(REVEAL_INITIAL);
+  }, [activeDashboardId]);
 
   const activeDashboard =
     dashboards.find((d) => d.id === activeDashboardId) ?? dashboards[0];
@@ -107,6 +124,20 @@ export default function DashboardScreen() {
     if (!isWidgetServiceEnabled(widget, services)) return false;
     return isWidgetServiceAttached(widget, attachedKinds);
   });
+
+  // Grow the reveal one batch per frame until every visible widget is mounted.
+  // Already-mounted widgets are memoized (WidgetSlotBody), so each step only
+  // pays for the newly-revealed slots — spreading the first-mount cost across
+  // frames instead of one ~700ms block. Settles within a few frames.
+  useEffect(() => {
+    if (revealCount >= visibleSlots.length) return;
+    const handle = requestAnimationFrame(() =>
+      setRevealCount((c) => c + REVEAL_BATCH),
+    );
+    return () => cancelAnimationFrame(handle);
+  }, [revealCount, visibleSlots.length]);
+
+  const revealedSlots = visibleSlots.slice(0, revealCount);
 
   function handleMove(slotId: string, direction: "up" | "down") {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -230,7 +261,7 @@ export default function DashboardScreen() {
               </Text>
             </View>
           )}
-          {visibleSlots.map((slot, visibleIndex) => {
+          {revealedSlots.map((slot, visibleIndex) => {
             const widget = WIDGET_REGISTRY[slot.widgetId];
             if (!widget) return null;
             const { label, settingsComponent } = widget;
@@ -238,10 +269,10 @@ export default function DashboardScreen() {
             const isLast = visibleIndex === visibleSlots.length - 1;
 
             return (
-              <Animated.View
-                key={slot.id}
-                entering={FadeInDown.delay(visibleIndex * 80).springify()}
-              >
+              // No per-index delay: progressive mounting already staggers the
+              // reveal (each widget springs in as its batch mounts), so an
+              // index-based delay would make late widgets wait ~1s to appear.
+              <Animated.View key={slot.id} entering={FadeInDown.springify()}>
                 {showEditControls && (
                   <View className="flex-row items-center justify-between mb-1 px-1">
                     <View className="flex-row items-center gap-1.5 flex-1">

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -5,6 +5,7 @@ import {
   GripVertical,
   ChevronUp,
   ChevronDown,
+  Copy,
   Pencil,
   Check,
   Settings,
@@ -32,6 +33,9 @@ import { WidgetSettingsSheet } from "@/components/dashboard/widget-settings-shee
 import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sheet";
 import { useAttachedKinds } from "@/hooks/use-active-dashboard";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
+import { resolveDashboardIcon } from "@/lib/dashboard-icons";
+import { ActionSheet } from "@/components/ui/action-sheet";
+import { toast } from "@/components/ui/toast";
 
 // Progressive mount: how many widgets render in the first paint, and how many
 // more reveal per frame after that. Opening the dashboard otherwise mounts every
@@ -68,16 +72,21 @@ const WidgetSlotBody = memo(function WidgetSlotBody({
 export default function DashboardScreen() {
   const { refreshing, onRefresh } = usePullToRefresh();
   const services = useConfigStore((s) => s.services);
+  const serviceInstances = useConfigStore((s) => s.serviceInstances);
   const dashboards = useConfigStore((s) => s.dashboards);
   const activeDashboardId = useConfigStore((s) => s.activeDashboardId);
   const removeSlot = useConfigStore((s) => s.removeSlot);
   const moveSlot = useConfigStore((s) => s.moveSlot);
+  const copySlotToDashboard = useConfigStore((s) => s.copySlotToDashboard);
   const router = useRouter();
   const [editMode, setEditMode] = useState(false);
   const [showEditControls, setShowEditControls] = useState(false);
   const [pickerVisible, setPickerVisible] = useState(false);
   const [dashboardPickerVisible, setDashboardPickerVisible] = useState(false);
   const [settingsForSlot, setSettingsForSlot] = useState<string | null>(null);
+  // Slot the user is copying to another dashboard (#6). Drives the destination
+  // ActionSheet below; null when closed.
+  const [copySlotId, setCopySlotId] = useState<string | null>(null);
   const [revealCount, setRevealCount] = useState(REVEAL_INITIAL);
 
   // Entering edit mode mounts a per-widget control row (several SVG icons each)
@@ -111,7 +120,16 @@ export default function DashboardScreen() {
   const dashboardColor = resolveDashboardColor(activeDashboard?.color);
 
   const attachedKinds = useAttachedKinds();
-  const hasAnyEnabled = Object.values(services).some((s) => s.enabled);
+  // Whether ANY instance is enabled anywhere (not just resolved on this
+  // workspace). The misleading "No services configured" copy must only show when
+  // the user truly has nothing set up: a curated workspace with zero attached
+  // instances still has services globally — it just needs them attached, which
+  // is what the empty-state CTA below offers (#5). The active-dashboard-derived
+  // `services` view would read all-disabled for such a workspace and wrongly
+  // send the user to Settings.
+  const hasAnyEnabledGlobally = Object.values(serviceInstances).some((list) =>
+    list.some((i) => i.enabled),
+  );
 
   // Slots whose required service is disabled OR has no attached instance on
   // this dashboard get filtered out so users don't see broken/irrelevant
@@ -196,7 +214,7 @@ export default function DashboardScreen() {
               <Icon icon={SlidersHorizontal} size={ICON.MD} color="#71717a" />
             </TouchableOpacity>
           )}
-          {hasAnyEnabled && (
+          {hasAnyEnabledGlobally && (
             <TouchableOpacity
               onPress={() => setEditMode((e) => !e)}
               className="p-2"
@@ -213,7 +231,7 @@ export default function DashboardScreen() {
         </View>
       </View>
 
-      {isAutoAttach && hasAnyEnabled && activeDashboard && (
+      {isAutoAttach && hasAnyEnabledGlobally && activeDashboard && (
         <Pressable
           onPress={() => {
             Haptics.selectionAsync();
@@ -243,7 +261,7 @@ export default function DashboardScreen() {
         </Pressable>
       )}
 
-      {!hasAnyEnabled ? (
+      {!hasAnyEnabledGlobally ? (
         <View className="flex-1 items-center justify-center py-20">
           <Text className="text-zinc-400 text-base text-center">
             No services configured yet.
@@ -251,6 +269,68 @@ export default function DashboardScreen() {
           <Text className="text-zinc-500 text-sm text-center mt-1">
             Go to Settings to add your first service.
           </Text>
+        </View>
+      ) : visibleSlots.length === 0 && !editMode && activeDashboard ? (
+        // A fresh/curated workspace with nothing to show yet. Without this, the
+        // screen was blank or fell through to the misleading "No services
+        // configured" copy even though services exist globally — the user just
+        // hasn't attached any here or added widgets (#5). Two cases: no attached
+        // services (send them to the editor to attach) vs attached-but-no-widgets
+        // (open the Add Widget sheet).
+        <View className="flex-1 items-center justify-center py-16 px-6">
+          <View
+            className="w-16 h-16 rounded-2xl items-center justify-center mb-4"
+            style={{ backgroundColor: `${dashboardColor}26` }}
+          >
+            <Icon
+              icon={attachedKinds.size === 0 ? SlidersHorizontal : Sparkles}
+              size={28}
+              color={dashboardColor}
+            />
+          </View>
+          {attachedKinds.size === 0 ? (
+            <>
+              <Text className="text-zinc-200 text-base font-semibold text-center">
+                No services attached
+              </Text>
+              <Text className="text-zinc-500 text-sm text-center mt-1 leading-5">
+                Attach the services that belong on this workspace to start
+                building it.
+              </Text>
+              <Pressable
+                onPress={() => {
+                  Haptics.selectionAsync();
+                  router.push(`/dashboard-edit/${activeDashboard.id}` as any);
+                }}
+                className="flex-row items-center gap-2 rounded-xl px-4 py-2.5 mt-5 active:opacity-80"
+                style={{ backgroundColor: `${dashboardColor}26` }}
+              >
+                <Icon icon={SlidersHorizontal} size={ICON.SM} color={dashboardColor} />
+                <Text className="text-sm font-semibold" style={{ color: dashboardColor }}>
+                  Attach services
+                </Text>
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <Text className="text-zinc-200 text-base font-semibold text-center">
+                No widgets yet
+              </Text>
+              <Text className="text-zinc-500 text-sm text-center mt-1 leading-5">
+                Add widgets to see your services at a glance on this workspace.
+              </Text>
+              <Pressable
+                onPress={openPicker}
+                className="flex-row items-center gap-2 rounded-xl px-4 py-2.5 mt-5 active:opacity-80"
+                style={{ backgroundColor: `${dashboardColor}26` }}
+              >
+                <Icon icon={Plus} size={ICON.SM} color={dashboardColor} />
+                <Text className="text-sm font-semibold" style={{ color: dashboardColor }}>
+                  Add widget
+                </Text>
+              </Pressable>
+            </>
+          )}
         </View>
       ) : (
         <View className="gap-4">
@@ -298,6 +378,19 @@ export default function DashboardScreen() {
                       >
                         <Icon icon={ChevronDown} size={ICON.MD} color={isLast ? "#3f3f46" : "#a1a1aa"} />
                       </TouchableOpacity>
+                      {dashboards.length > 1 && (
+                        <TouchableOpacity
+                          onPress={() => {
+                            Haptics.selectionAsync();
+                            setCopySlotId(slot.id);
+                          }}
+                          className="p-1 ml-1"
+                          hitSlop={6}
+                          accessibilityLabel="Copy widget to another dashboard"
+                        >
+                          <Icon icon={Copy} size={ICON.MD} color="#a1a1aa" />
+                        </TouchableOpacity>
+                      )}
                       {settingsComponent && (
                         <TouchableOpacity
                           onPress={() => openSettings(slot.id)}
@@ -352,6 +445,32 @@ export default function DashboardScreen() {
       <DashboardPickerSheet
         visible={dashboardPickerVisible}
         onClose={() => setDashboardPickerVisible(false)}
+      />
+      <ActionSheet
+        visible={copySlotId !== null}
+        onClose={() => setCopySlotId(null)}
+        title="Copy widget to…"
+        subtitle="Adds a copy, with its settings, to the chosen dashboard."
+        actions={dashboards
+          .filter((d) => d.id !== activeDashboardId)
+          .map((d) => ({
+            label: d.name,
+            icon: (
+              <Icon
+                icon={resolveDashboardIcon(d.icon)}
+                size={ICON.MD}
+                color={resolveDashboardColor(d.color)}
+              />
+            ),
+            onPress: () => {
+              if (copySlotId) {
+                copySlotToDashboard(copySlotId, d.id);
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                toast(`Copied to ${d.name}`, "success");
+              }
+              setCopySlotId(null);
+            },
+          }))}
       />
     </ScreenWrapper>
   );

--- a/app/(tabs)/emby.tsx
+++ b/app/(tabs)/emby.tsx
@@ -1,7 +1,12 @@
 import { MediaServerScreen } from "@/components/media-server/media-server-screen";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 
 // Emby shares the Jellyfin screen (MediaServerScreen) — same API surface,
 // parameterized by serviceId. See lib/media-server-config.ts.
 export default function EmbyScreen() {
-  return <MediaServerScreen serviceId="emby" />;
+  return (
+    <WorkspaceServiceGuard kinds={["emby"]}>
+      <MediaServerScreen serviceId="emby" />
+    </WorkspaceServiceGuard>
+  );
 }

--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -4,6 +4,7 @@ import { HardDrive, Activity, Gpu, ChevronDown, ChevronUp, Container, Network } 
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
@@ -51,6 +52,14 @@ function pct(n: number | null | undefined): number {
 }
 
 export default function GlancesScreen() {
+  return (
+    <WorkspaceServiceGuard kinds={["glances"]}>
+      <GlancesScreenInner />
+    </WorkspaceServiceGuard>
+  );
+}
+
+function GlancesScreenInner() {
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["glances"]]);
   const glancesHealth = healthData?.find((s) => s.id === "glances");

--- a/app/(tabs)/indexers.tsx
+++ b/app/(tabs)/indexers.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { ServiceHeader } from "@/components/common/service-header";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { FilterChip } from "@/components/ui/filter-chip";
@@ -30,6 +31,14 @@ import type { ProwlarrIndexer, ProwlarrSearchResult } from "@/lib/types";
 type Tab = "indexers" | "search" | "stats";
 
 export default function IndexersScreen() {
+  return (
+    <WorkspaceServiceGuard kinds={["prowlarr"]}>
+      <IndexersScreenInner />
+    </WorkspaceServiceGuard>
+  );
+}
+
+function IndexersScreenInner() {
   const [tab, setTab] = useState<Tab>("indexers");
   const { data: healthData } = useServiceHealth();
   const { refreshing, onRefresh } = usePullToRefresh([["prowlarr"]]);

--- a/app/(tabs)/jellyfin.tsx
+++ b/app/(tabs)/jellyfin.tsx
@@ -1,7 +1,12 @@
 import { MediaServerScreen } from "@/components/media-server/media-server-screen";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 
 // Jellyfin and Emby share one screen (MediaServerScreen), parameterized by
 // serviceId — they expose the same API. See lib/media-server-config.ts.
 export default function JellyfinScreen() {
-  return <MediaServerScreen serviceId="jellyfin" />;
+  return (
+    <WorkspaceServiceGuard kinds={["jellyfin"]}>
+      <MediaServerScreen serviceId="jellyfin" />
+    </WorkspaceServiceGuard>
+  );
 }

--- a/app/(tabs)/movies.tsx
+++ b/app/(tabs)/movies.tsx
@@ -1,7 +1,12 @@
 import { MoviesView } from "@/components/radarr/movies-view";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 
 // Standalone Movies tab. The screen body lives in MoviesView so the combined
 // Library tab can reuse it behind a Movies/TV switcher.
 export default function MoviesScreen() {
-  return <MoviesView />;
+  return (
+    <WorkspaceServiceGuard kinds={["radarr"]}>
+      <MoviesView />
+    </WorkspaceServiceGuard>
+  );
 }

--- a/app/(tabs)/music.tsx
+++ b/app/(tabs)/music.tsx
@@ -1,7 +1,12 @@
 import { MusicView } from "@/components/lidarr/music-view";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 
 // Standalone Music tab (Lidarr). The screen body lives in MusicView so it can
 // be reused embedded elsewhere, mirroring MoviesView / TvView.
 export default function MusicScreen() {
-  return <MusicView />;
+  return (
+    <WorkspaceServiceGuard kinds={["lidarr"]}>
+      <MusicView />
+    </WorkspaceServiceGuard>
+  );
 }

--- a/app/(tabs)/plex.tsx
+++ b/app/(tabs)/plex.tsx
@@ -24,6 +24,7 @@ import {
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { FilterChip } from "@/components/ui/filter-chip";
@@ -86,6 +87,14 @@ function compareRecent(
 }
 
 export default function PlexScreen() {
+  return (
+    <WorkspaceServiceGuard kinds={["plex"]}>
+      <PlexScreenInner />
+    </WorkspaceServiceGuard>
+  );
+}
+
+function PlexScreenInner() {
   const [tab, setTab] = useState<Tab>("playing");
   const recentSort = useSortStore((s) => s.plexRecent);
   const setRecentSort = useSortStore((s) => s.setPlexRecent);

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -8,7 +8,7 @@ import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
-import { useAttachedKinds } from "@/hooks/use-active-dashboard";
+import { useAttachedKinds, useActiveDashboard } from "@/hooks/use-active-dashboard";
 import { lightHaptic } from "@/lib/haptics";
 import type { ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
@@ -32,13 +32,23 @@ export default function ServicesScreen() {
   const router = useRouter();
   const services = useConfigStore((s) => s.services);
   const wolDevices = useConfigStore((s) => s.wolDevices);
-  const servicesOrder = useConfigStore((s) => s.servicesOrder);
-  const setServicesOrder = useConfigStore((s) => s.setServicesOrder);
+  const globalServicesOrder = useConfigStore((s) => s.servicesOrder);
+  const setDashboardServicesOrder = useConfigStore(
+    (s) => s.setDashboardServicesOrder,
+  );
+  const activeDashboard = useActiveDashboard();
   const attachedKinds = useAttachedKinds();
   const { data: health } = useServiceHealth();
   const [editing, setEditing] = useState(false);
 
-  const fullOrder = useMemo(() => applyServicesOrder(servicesOrder), [servicesOrder]);
+  // v30: tile order is per-workspace — each dashboard can arrange its Services
+  // grid independently. Falls back to the global order when this dashboard has
+  // no custom one, so existing setups are unchanged until the user reorders.
+  const effectiveOrder = activeDashboard?.servicesOrder ?? globalServicesOrder;
+  const fullOrder = useMemo(
+    () => applyServicesOrder(effectiveOrder),
+    [effectiveOrder],
+  );
   // Workspace filter: only show enabled services with at least one attached
   // instance on the active dashboard. The full canonical order still drives
   // reorder neighbor lookups (so swapping with a hidden tile doesn't
@@ -71,7 +81,9 @@ export default function ServicesScreen() {
     const next = [...fullOrder];
     [next[a], next[b]] = [next[b], next[a]];
     lightHaptic();
-    setServicesOrder(next);
+    // Persist onto the active dashboard so the rearrangement stays scoped to
+    // this workspace and doesn't reshuffle the others.
+    if (activeDashboard) setDashboardServicesOrder(activeDashboard.id, next);
   };
 
   if (!enabledServices.length) {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -698,6 +698,12 @@ function InstanceList({
   const moveInstance = useConfigStore((s) => s.moveInstance);
   const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
   const dashboards = useConfigStore((s) => s.dashboards);
+  const activeDashboardId = useConfigStore((s) => s.activeDashboardId);
+  // The "active instance" pin is per-workspace and written onto whichever
+  // dashboard is currently active. Name it so the user knows which workspace
+  // this chip row is editing — Settings is otherwise workspace-agnostic (#11).
+  const activeDashboardName =
+    dashboards.find((d) => d.id === activeDashboardId)?.name ?? "this workspace";
   const kindLabel = SERVICE_DEFAULTS_KIND_LABEL[serviceId];
   // Per-instance tri-state health for the row dot. The shared hook is already
   // polling, so this is a pure index by instance UUID.
@@ -867,7 +873,10 @@ function InstanceList({
         {instances.length > 1 ? (
           <View className="px-4 py-3 border-t border-surface-light">
             <Text className="text-zinc-500 text-xs mb-2">
-              Active in this workspace
+              Active in{" "}
+              <Text className="text-zinc-300 font-medium">
+                {activeDashboardName}
+              </Text>
             </Text>
             <View className="flex-row flex-wrap gap-2">
               {instances

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -692,18 +692,10 @@ function InstanceList({
   const instances = useConfigStore(
     (s) => s.serviceInstances[serviceId] ?? EMPTY_INSTANCES,
   );
-  const activeId = useConfigStore((s) => s.activeInstance[serviceId]);
   const addInstance = useConfigStore((s) => s.addInstance);
   const removeInstance = useConfigStore((s) => s.removeInstance);
   const moveInstance = useConfigStore((s) => s.moveInstance);
-  const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
   const dashboards = useConfigStore((s) => s.dashboards);
-  const activeDashboardId = useConfigStore((s) => s.activeDashboardId);
-  // The "active instance" pin is per-workspace and written onto whichever
-  // dashboard is currently active. Name it so the user knows which workspace
-  // this chip row is editing — Settings is otherwise workspace-agnostic (#11).
-  const activeDashboardName =
-    dashboards.find((d) => d.id === activeDashboardId)?.name ?? "this workspace";
   const kindLabel = SERVICE_DEFAULTS_KIND_LABEL[serviceId];
   // Per-instance tri-state health for the row dot. The shared hook is already
   // polling, so this is a pure index by instance UUID.
@@ -781,7 +773,6 @@ function InstanceList({
               ? inst.remoteUrl || "No remote URL"
               : inst.localUrl || "No local URL"
             : "Disabled";
-          const isActive = inst.id === activeId;
           // Only enabled instances are actively probed; for disabled ones
           // we want NO dot (not red) — there's nothing wrong, the user has
           // just turned it off.
@@ -798,12 +789,7 @@ function InstanceList({
                 className="flex-1 flex-row items-center px-4 py-3 active:opacity-70"
               >
                 <View className="flex-1">
-                  <View className="flex-row items-center gap-2">
-                    <Text className="text-zinc-100 text-base">{inst.name}</Text>
-                    {isActive && instances.length > 1 ? (
-                      <Text className="text-primary text-xs">• active</Text>
-                    ) : null}
-                  </View>
+                  <Text className="text-zinc-100 text-base">{inst.name}</Text>
                   <Text className="text-zinc-500 text-xs">{subtitle}</Text>
                   {totalDashboards > 1
                     ? (() => {
@@ -870,37 +856,6 @@ function InstanceList({
           }
           onPress={handleAdd}
         />
-        {instances.length > 1 ? (
-          <View className="px-4 py-3 border-t border-surface-light">
-            <Text className="text-zinc-500 text-xs mb-2">
-              Active in{" "}
-              <Text className="text-zinc-300 font-medium">
-                {activeDashboardName}
-              </Text>
-            </Text>
-            <View className="flex-row flex-wrap gap-2">
-              {instances
-                .filter((i) => i.enabled)
-                .map((inst) => (
-                  <Pressable
-                    key={inst.id}
-                    onPress={() => setActiveInstance(serviceId, inst.id)}
-                    className={`px-3 py-1.5 rounded-full ${
-                      inst.id === activeId ? "bg-primary" : "bg-surface-light"
-                    }`}
-                  >
-                    <Text
-                      className={`text-sm font-medium ${
-                        inst.id === activeId ? "text-white" : "text-zinc-400"
-                      }`}
-                    >
-                      {inst.name}
-                    </Text>
-                  </Pressable>
-                ))}
-            </View>
-          </View>
-        ) : null}
       </SettingsGroup>
 
       <ConfirmModal

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -402,7 +402,7 @@ export default function SettingsScreen() {
           label="Home Networks"
           subtitle={
             autoSwitchNetwork && homeNetworksCount === 0
-              ? "Add at least one to enable auto-switching"
+              ? "Add at least one — without it the app stays on remote URLs"
               : homeNetworksCount > 0
                 ? `${homeNetworksCount} network${homeNetworksCount > 1 ? "s" : ""} configured`
                 : "Configure your home WiFi networks"
@@ -1132,13 +1132,11 @@ function ServiceEditor({
 
   const handleTest = async () => {
     setTesting(true);
-    // Resolve which URL the app will actually use, mirroring getActiveUrl:
-    // the per-instance "always remote" override OR auto-switch deciding we're
-    // currently away from home. Testing only `useRemote ? remote : local`
-    // (ignoring auto-switch) was misleading — it could report a green local
-    // probe while the dashboard silently resolved the empty remote URL and
-    // every service failed. We still test the in-progress form values, not the
-    // saved ones, so Test validates what the user typed before they Save.
+    // Resolve which URL the app will actually use right now, mirroring
+    // getActiveUrl: the per-instance "always remote" override OR auto-switch
+    // deciding we're away from home (in which case the app uses remote only and
+    // never the local URL). We test the in-progress form values, not the saved
+    // ones, so Test validates what the user typed before they Save.
     const { autoSwitchNetwork, networkAwayFromHome } = useConfigStore.getState();
     const useRemote =
       config.useRemote || (autoSwitchNetwork && networkAwayFromHome);

--- a/app/(tabs)/tv.tsx
+++ b/app/(tabs)/tv.tsx
@@ -1,7 +1,12 @@
 import { TvView } from "@/components/sonarr/tv-view";
+import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 
 // Standalone TV tab. The screen body lives in TvView so the combined Library
 // tab can reuse it behind a Movies/TV switcher.
 export default function TVScreen() {
-  return <TvView />;
+  return (
+    <WorkspaceServiceGuard kinds={["sonarr"]}>
+      <TvView />
+    </WorkspaceServiceGuard>
+  );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ import { NotificationWatchers } from "@/hooks/use-notification-watchers";
 import { useBackendHealth } from "@/hooks/use-backend-health";
 import { useAppUpdateCheck } from "@/hooks/use-app-update-check";
 import { useNetworkAutoSwitch } from "@/hooks/use-network";
+import { evaluateHomeNetwork } from "@/lib/network";
 import { pushConfigSnapshot } from "@/services/backend-api";
 import { syncInsecureHosts } from "@/lib/insecure-tls";
 import { ErrorBoundary, SilentErrorBoundary } from "@/components/common/error-boundary";
@@ -32,6 +33,14 @@ import "../global.css";
 // Pause/resume polling based on app state
 function onAppStateChange(status: AppStateStatus) {
   focusManager.setFocused(status === "active");
+  if (status === "active") {
+    // The network may have changed while we were backgrounded — walked out the
+    // door, or toggled a VPN like Tailscale (whose interface changes don't
+    // deliver NetInfo events to a suspended JS runtime). Re-evaluate the home
+    // network so URLs and health dots reflect reality on resume (#161). Shares
+    // the evaluator's in-flight gate and no-ops when auto-switch is off.
+    void evaluateHomeNetwork();
+  }
 }
 
 // Notification payloads come from a paired backend. The backend is trusted,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -83,6 +83,17 @@ function NotificationRouter() {
     function handleNotificationData(data: Record<string, unknown> | undefined) {
       if (!data?.type) return;
 
+      // Notifications are global (you're alerted about every instance, on any
+      // workspace). So before routing, switch to the first workspace that has
+      // this alert's instance attached — otherwise the destination screen would
+      // resolve to "not attached here" and look empty. No-op when the active
+      // workspace already includes it (or none does).
+      const instanceId =
+        typeof data.instanceId === "string" ? data.instanceId : null;
+      if (instanceId) {
+        useConfigStore.getState().activateDashboardForInstance(instanceId);
+      }
+
       switch (data.type) {
         case "radarr": {
           const id = asPositiveIntId(data.movieId);

--- a/app/dashboard-edit/[id].tsx
+++ b/app/dashboard-edit/[id].tsx
@@ -236,9 +236,25 @@ export default function DashboardEditScreen() {
     return out;
   }, [attachedSet, serviceInstances]);
 
+  // Tabs that may be pinned. For an auto-attach dashboard the user hasn't
+  // curated yet, the draft `attached` is intentionally empty — but the live
+  // workspace includes every instance, so deriving pickability from the empty
+  // draft would offer only "Services" while the real bottom bar is full (#9).
+  // Use all enabled kinds in that case; once the user touches attachment, the
+  // draft becomes the source of truth.
+  const pickableKinds = useMemo(() => {
+    if (!wasAutoAttach || touchedAttached) return attachedKinds;
+    const out = new Set<ServiceId>();
+    for (const kind of SERVICE_IDS) {
+      const list = serviceInstances[kind] ?? [];
+      if (list.some((inst) => inst.enabled)) out.add(kind);
+    }
+    return out;
+  }, [wasAutoAttach, touchedAttached, attachedKinds, serviceInstances]);
+
   const pickable = useMemo(
-    () => pickableTabIdsFor(attachedKinds),
-    [attachedKinds],
+    () => pickableTabIdsFor(pickableKinds),
+    [pickableKinds],
   );
 
   // Recompute the still-pickable tab set from a hypothetical attachment list

--- a/app/dashboard-edit/[id].tsx
+++ b/app/dashboard-edit/[id].tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   ChevronUp,
   Plus,
+  Wifi,
   X,
 } from "lucide-react-native";
 import * as Haptics from "expo-haptics";
@@ -82,6 +83,10 @@ export default function DashboardEditScreen() {
   const setDashboardPinnedTabs = useConfigStore(
     (s) => s.setDashboardPinnedTabs,
   );
+  const globalHomeNetworks = useConfigStore((s) => s.homeNetworks);
+  const setDashboardHomeNetworkIds = useConfigStore(
+    (s) => s.setDashboardHomeNetworkIds,
+  );
 
   // Snapshot the dashboard into editable draft state when the screen mounts.
   // If the dashboard is later removed (e.g. via another device through a
@@ -102,6 +107,18 @@ export default function DashboardEditScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dashboard?.id]);
 
+  // Home-network selection draft (#148). undefined = use ALL home networks
+  // (and future ones); an array selects a subset of the global list by id.
+  // Snapshot on mount, same lifecycle as initialAttached above.
+  const initialHomeNetworkIds = useMemo<string[] | undefined>(
+    () =>
+      dashboard?.homeNetworkIds === undefined
+        ? undefined
+        : [...dashboard.homeNetworkIds],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dashboard?.id],
+  );
+
   const [name, setName] = useState(dashboard?.name ?? "");
   const [icon, setIcon] = useState<string>(() =>
     resolveIconName(dashboard?.icon),
@@ -116,6 +133,15 @@ export default function DashboardEditScreen() {
   );
   const [iconSheetOpen, setIconSheetOpen] = useState(false);
 
+  // Home-network selection editing state. `homeNetworkIdsDraft === undefined`
+  // means "All" (use every home network); an array is a custom subset of the
+  // global list. Switching to Custom seeds from all current ids so it starts
+  // equivalent to All and the user unticks from there.
+  const [homeNetworkIdsDraft, setHomeNetworkIdsDraft] = useState<
+    string[] | undefined
+  >(initialHomeNetworkIds);
+  const customHomeNetworks = homeNetworkIdsDraft !== undefined;
+
   // Track whether the draft diverges from the persisted dashboard so we can
   // (1) skip silent writes on save and (2) prompt before discarding on back.
   const initialName = dashboard?.name ?? "";
@@ -128,12 +154,17 @@ export default function DashboardEditScreen() {
     [dashboard?.id],
   );
   const trimmedName = name.trim();
+  const homeNetworksDirty = !idSelectionsEqual(
+    homeNetworkIdsDraft,
+    initialHomeNetworkIds,
+  );
   const dirty =
     (trimmedName.length > 0 && trimmedName !== initialName) ||
     icon !== initialIcon ||
     color !== initialColor ||
     touchedAttached ||
-    !arraysEqual(pinned, initialPinned);
+    !arraysEqual(pinned, initialPinned) ||
+    homeNetworksDirty;
 
   // Intercept back/swipe-dismiss while the draft is dirty so the user gets a
   // chance to keep editing or explicitly discard. Bypass is held in a ref —
@@ -309,6 +340,34 @@ export default function DashboardEditScreen() {
     });
   }
 
+  function setHomeNetworksMode(custom: boolean) {
+    Haptics.selectionAsync();
+    // Custom seeds from all current ids so it starts equivalent to All; the
+    // user then unticks. All clears the selection so future networks are
+    // included automatically again.
+    setHomeNetworkIdsDraft(
+      custom ? globalHomeNetworks.map((n) => n.id) : undefined,
+    );
+  }
+
+  function toggleHomeNetwork(id: string) {
+    Haptics.selectionAsync();
+    setHomeNetworkIdsDraft((prev) => {
+      const cur = prev ?? globalHomeNetworks.map((n) => n.id);
+      return cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id];
+    });
+  }
+
+  function selectAllHomeNetworks() {
+    Haptics.selectionAsync();
+    setHomeNetworkIdsDraft(globalHomeNetworks.map((n) => n.id));
+  }
+
+  function selectNoHomeNetworks() {
+    Haptics.selectionAsync();
+    setHomeNetworkIdsDraft([]);
+  }
+
   function handleSave() {
     if (!dashboard) {
       router.back();
@@ -330,6 +389,10 @@ export default function DashboardEditScreen() {
     }
     if (!arraysEqual(pinned, initialPinned)) {
       setDashboardPinnedTabs(dashboard.id, pinned);
+    }
+    if (homeNetworksDirty) {
+      // undefined → use all home networks; an array → custom subset by id.
+      setDashboardHomeNetworkIds(dashboard.id, homeNetworkIdsDraft);
     }
     toast("Dashboard updated", "success");
     allowRemoveRef.current = true;
@@ -612,6 +675,106 @@ export default function DashboardEditScreen() {
         )}
       </Section>
 
+      <Section
+        label="Home networks"
+        hint="Local URLs are used only on a confirmed home WiFi. This workspace uses all your home networks by default — switch to Custom to use only some. Add or edit networks in Settings → Home Networks."
+      >
+        {globalHomeNetworks.length === 0 ? (
+          <Text className="text-zinc-500 text-xs leading-4">
+            No home networks yet. Add them in Settings → Home Networks, then
+            choose which apply to this workspace here.
+          </Text>
+        ) : (
+          <>
+            <View className="flex-row gap-2 mb-3">
+              <SegmentButton
+                label="All"
+                active={!customHomeNetworks}
+                color={color}
+                onPress={() => setHomeNetworksMode(false)}
+              />
+              <SegmentButton
+                label="Custom"
+                active={customHomeNetworks}
+                color={color}
+                onPress={() => setHomeNetworksMode(true)}
+              />
+            </View>
+
+            {!customHomeNetworks ? (
+              <View className="rounded-2xl bg-surface-light border border-border/70 px-3 py-3 gap-2">
+                <Text className="text-zinc-500 text-xs">
+                  Using all {globalHomeNetworks.length} home network
+                  {globalHomeNetworks.length === 1 ? "" : "s"} (including any you
+                  add later).
+                </Text>
+                {globalHomeNetworks.map((n) => (
+                  <View key={n.id} className="flex-row items-center gap-2">
+                    <Icon icon={Wifi} size={14} color="#71717a" />
+                    <Text
+                      className="text-zinc-300 text-sm flex-1"
+                      numberOfLines={1}
+                    >
+                      {n.ssid}
+                    </Text>
+                    <Text className="text-zinc-600 text-xs">
+                      {n.bssid ? "pinned" : "SSID"}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <View className="gap-2">
+                <View className="flex-row items-center gap-1 mb-0.5">
+                  <MiniButton
+                    label="All"
+                    disabled={
+                      (homeNetworkIdsDraft ?? []).length ===
+                      globalHomeNetworks.length
+                    }
+                    onPress={selectAllHomeNetworks}
+                  />
+                  <MiniButton
+                    label="None"
+                    disabled={(homeNetworkIdsDraft ?? []).length === 0}
+                    onPress={selectNoHomeNetworks}
+                  />
+                </View>
+                {globalHomeNetworks.map((n) => {
+                  const on = (homeNetworkIdsDraft ?? []).includes(n.id);
+                  return (
+                    <Pressable
+                      key={n.id}
+                      onPress={() => toggleHomeNetwork(n.id)}
+                      className="flex-row items-center gap-3 rounded-2xl bg-surface-light border border-border/70 px-3 py-3 active:bg-surface"
+                    >
+                      <Checkbox on={on} color={color} />
+                      <View className="flex-1">
+                        <Text
+                          className={`text-sm ${on ? "text-zinc-100 font-medium" : "text-zinc-400"}`}
+                          numberOfLines={1}
+                        >
+                          {n.ssid}
+                        </Text>
+                        <Text className="text-zinc-500 text-xs">
+                          {n.bssid ? `Pinned to ${n.bssid}` : "SSID-only match"}
+                        </Text>
+                      </View>
+                    </Pressable>
+                  );
+                })}
+                {(homeNetworkIdsDraft ?? []).length === 0 && (
+                  <Text className="text-amber-500/80 text-xs leading-4">
+                    No networks selected — this workspace will use remote URLs
+                    everywhere.
+                  </Text>
+                )}
+              </View>
+            )}
+          </>
+        )}
+      </Section>
+
       <ConfirmModal
         visible={discardOpen}
         title="Discard changes?"
@@ -679,6 +842,38 @@ const MiniButton = memo(function MiniButton({ label, disabled, onPress }: MiniBu
       style={{ opacity: disabled ? 0.4 : 1 }}
     >
       <Text className="text-zinc-300 text-[0.7rem] font-medium">{label}</Text>
+    </Pressable>
+  );
+});
+
+interface SegmentButtonProps {
+  label: string;
+  active: boolean;
+  color: string;
+  onPress: () => void;
+}
+
+const SegmentButton = memo(function SegmentButton({
+  label,
+  active,
+  color,
+  onPress,
+}: SegmentButtonProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-1 rounded-xl py-2.5 items-center border active:opacity-80"
+      style={{
+        backgroundColor: active ? `${color}1A` : "transparent",
+        borderColor: active ? color : "#3f3f46",
+      }}
+    >
+      <Text
+        className="text-sm font-semibold"
+        style={{ color: active ? color : "#a1a1aa" }}
+      >
+        {label}
+      </Text>
     </Pressable>
   );
 });
@@ -909,6 +1104,21 @@ function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
   for (let i = 0; i < a.length; i++) {
     if (a[i] !== b[i]) return false;
   }
+  return true;
+}
+
+// Compare two home-network selections. `undefined` (All) is distinct from `[]`
+// (Custom with nothing selected) — toggling between them is a real change — so a
+// strict undefined check comes before the order-independent set compare.
+function idSelectionsEqual(
+  a: string[] | undefined,
+  b: string[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  for (const id of a) if (!setB.has(id)) return false;
   return true;
 }
 

--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -222,8 +222,9 @@ export default function HomeNetworksScreen() {
             No home networks configured
           </Text>
           <Text className="text-zinc-500 text-sm text-center px-6">
-            Add at least one network to enable automatic local/remote URL
-            switching.
+            Add the WiFi networks you trust as "home". Local URLs are used only
+            on these networks; everywhere else the app uses your remote URLs, so
+            your API keys are never sent to an untrusted LAN.
           </Text>
           <View className="flex-row gap-2 mt-2">
             <Button

--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { View, Text, Pressable, ActivityIndicator } from "react-native";
 import { Wifi, Plus, Pencil, Trash2 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -10,11 +10,10 @@ import { TextInput } from "@/components/ui/text-input";
 import { toast } from "@/components/ui/toast";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useConfigStore } from "@/store/config-store";
-import { detectWifi, normalizeBssid } from "@/lib/wifi";
+import { detectWifi, validateHomeNetworkInput } from "@/lib/wifi";
 import type { HomeNetwork } from "@/store/config-store";
-
-const MAX_HOME_NETWORKS = 20;
-const MAC_RE = /^[0-9a-f:.\-]+$/i;
+import { MAX_HOME_NETWORKS } from "@/lib/constants";
+import { resolveDashboardColor } from "@/lib/dashboard-colors";
 
 type Mode = "list" | "add" | "edit";
 
@@ -23,6 +22,26 @@ export default function HomeNetworksScreen() {
   const addHomeNetwork = useConfigStore((s) => s.addHomeNetwork);
   const updateHomeNetwork = useConfigStore((s) => s.updateHomeNetwork);
   const removeHomeNetwork = useConfigStore((s) => s.removeHomeNetwork);
+  const dashboards = useConfigStore((s) => s.dashboards);
+
+  // Read-only cross-reference: which workspaces use each network (#148). A
+  // dashboard with `homeNetworkIds === undefined` uses ALL networks; one with a
+  // selection uses only the ids it lists. Surfaced as color pills so the user
+  // can see a network's reach without leaving this screen.
+  const usageByNetworkId = useMemo(() => {
+    const map = new Map<string, { id: string; name: string; color: string }[]>();
+    for (const net of homeNetworks) map.set(net.id, []);
+    for (const d of dashboards) {
+      const usesAll = d.homeNetworkIds === undefined;
+      const selected = usesAll ? null : new Set(d.homeNetworkIds);
+      const info = { id: d.id, name: d.name, color: resolveDashboardColor(d.color) };
+      for (const net of homeNetworks) {
+        if (usesAll || selected!.has(net.id)) map.get(net.id)!.push(info);
+      }
+    }
+    return map;
+  }, [dashboards, homeNetworks]);
+  const dashboardCount = dashboards.length;
 
   const [mode, setMode] = useState<Mode>("list");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -80,38 +99,11 @@ export default function HomeNetworksScreen() {
   };
 
   const handleSave = () => {
-    const trimmedSsid = ssid.trim();
-    if (!trimmedSsid) {
-      toast("WiFi name (SSID) is required", "error");
-      return;
-    }
-    if (trimmedSsid.length > 64) {
-      toast("WiFi name is too long", "error");
-      return;
-    }
-
-    const trimmedBssid = bssid.trim();
-    if (trimmedBssid && !MAC_RE.test(trimmedBssid)) {
-      toast("BSSID looks invalid — use a MAC like aa:bb:cc:dd:ee:ff", "error");
-      return;
-    }
-    if (trimmedBssid.length > 64) {
-      toast("BSSID is too long", "error");
-      return;
-    }
-
-    const normalizedBssid = normalizeBssid(trimmedBssid);
-
-    // Block exact (ssid, bssid) duplicates so a single AP can't appear twice.
-    // In edit mode the entry being edited is excluded from the check.
-    const duplicate = homeNetworks.some(
-      (n) =>
-        n.id !== editingId &&
-        n.ssid === trimmedSsid &&
-        n.bssid === normalizedBssid,
-    );
-    if (duplicate) {
-      toast("This network is already saved", "error");
+    // Shared with the per-dashboard override editor so both apply identical
+    // SSID/BSSID/duplicate rules (#148).
+    const result = validateHomeNetworkInput(ssid, bssid, homeNetworks, editingId);
+    if (!result.ok) {
+      toast(result.error, "error");
       return;
     }
 
@@ -120,11 +112,11 @@ export default function HomeNetworksScreen() {
         toast(`Maximum of ${MAX_HOME_NETWORKS} networks reached`, "error");
         return;
       }
-      addHomeNetwork({ ssid: trimmedSsid, bssid: normalizedBssid });
-      toast(`${trimmedSsid} added`, "success");
+      addHomeNetwork({ ssid: result.ssid, bssid: result.bssid });
+      toast(`${result.ssid} added`, "success");
     } else if (editingId) {
-      updateHomeNetwork(editingId, { ssid: trimmedSsid, bssid: normalizedBssid });
-      toast(`${trimmedSsid} updated`, "success");
+      updateHomeNetwork(editingId, { ssid: result.ssid, bssid: result.bssid });
+      toast(`${result.ssid} updated`, "success");
     }
 
     resetForm();
@@ -188,6 +180,22 @@ export default function HomeNetworksScreen() {
           </View>
         </Card>
 
+        {mode === "edit" && editingId && (
+          <View className="mb-4 gap-2">
+            <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+              Used by
+            </Text>
+            <UsedByPills
+              users={usageByNetworkId.get(editingId) ?? []}
+              dashboardCount={dashboardCount}
+            />
+            <Text className="text-zinc-600 text-xs leading-4">
+              Choose which workspaces use this network from each dashboard's
+              settings. Workspaces using all networks are included automatically.
+            </Text>
+          </View>
+        )}
+
         <View className="flex-row gap-3">
           <Button
             label="Cancel"
@@ -245,7 +253,13 @@ export default function HomeNetworksScreen() {
         </View>
       ) : (
         <View className="gap-3">
-          {homeNetworks.map((network) => (
+          <Text className="text-zinc-500 text-xs px-1 -mt-1">
+            Every workspace uses all of these by default. Open a dashboard's
+            settings to use only some — the pills show which workspaces use each.
+          </Text>
+          {homeNetworks.map((network) => {
+            const users = usageByNetworkId.get(network.id) ?? [];
+            return (
             <Card key={network.id} className="gap-2">
               <View className="flex-row items-center">
                 <View className="bg-surface-light rounded-xl p-2.5 mr-3">
@@ -274,8 +288,10 @@ export default function HomeNetworksScreen() {
                   </Pressable>
                 </View>
               </View>
+              <UsedByPills users={users} dashboardCount={dashboardCount} />
             </Card>
-          ))}
+            );
+          })}
           <View className="flex-row gap-2 mt-1">
             <Button
               label="Add current WiFi"
@@ -313,5 +329,61 @@ export default function HomeNetworksScreen() {
         onCancel={() => setPendingDelete(null)}
       />
     </ScreenWrapper>
+  );
+}
+
+interface UsedByPillsProps {
+  users: { id: string; name: string; color: string }[];
+  dashboardCount: number;
+}
+
+// Read-only summary of which workspaces use a network (#148). Collapses to a
+// single "all dashboards" chip when every workspace includes it, and warns when
+// no workspace does (it would never switch to local anywhere).
+function UsedByPills({ users, dashboardCount }: UsedByPillsProps) {
+  if (dashboardCount > 0 && users.length === dashboardCount) {
+    return (
+      <View className="flex-row flex-wrap gap-1.5">
+        <View className="rounded-full px-2 py-0.5 border border-border/70 bg-surface-light">
+          <Text className="text-[0.65rem] font-medium text-zinc-400">
+            Used by all dashboards
+          </Text>
+        </View>
+      </View>
+    );
+  }
+  if (users.length === 0) {
+    return (
+      <View className="flex-row flex-wrap gap-1.5">
+        <View className="rounded-full px-2 py-0.5 border border-amber-500/40 bg-amber-500/10">
+          <Text className="text-[0.65rem] font-medium text-amber-500/90">
+            Not used by any dashboard
+          </Text>
+        </View>
+      </View>
+    );
+  }
+  return (
+    <View className="flex-row flex-wrap gap-1.5">
+      {users.map((d) => (
+        <View
+          key={d.id}
+          className="flex-row items-center gap-1 rounded-full px-2 py-0.5 border"
+          style={{ borderColor: `${d.color}55`, backgroundColor: `${d.color}1A` }}
+        >
+          <View
+            className="w-1.5 h-1.5 rounded-full"
+            style={{ backgroundColor: d.color }}
+          />
+          <Text
+            className="text-[0.65rem] font-medium"
+            style={{ color: d.color }}
+            numberOfLines={1}
+          >
+            {d.name}
+          </Text>
+        </View>
+      ))}
+    </View>
   );
 }

--- a/components/common/workspace-service-guard.tsx
+++ b/components/common/workspace-service-guard.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+import { View, Text, Pressable } from "react-native";
+import { useRouter } from "expo-router";
+import { Layers } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import {
+  useAttachedKinds,
+  useActiveDashboard,
+} from "@/hooks/use-active-dashboard";
+import type { ServiceId } from "@/lib/constants";
+
+/**
+ * Gates a per-service tab to the active workspace. When NONE of `kinds` has an
+ * attached instance on the active dashboard, the screen would otherwise resolve
+ * to `instanceId = null` and render generic "No data" / empty content — which
+ * reads as "the service is down" rather than "this service isn't part of this
+ * workspace" (#8). This shows an explicit not-attached state with a path to the
+ * dashboard's settings instead.
+ *
+ * The guarded screen lives in `children`, so its data hooks only mount when the
+ * kind is actually attached — keeping the early-return free of rules-of-hooks
+ * issues and avoiding needless work on a workspace that excludes the service.
+ */
+export function WorkspaceServiceGuard({
+  kinds,
+  children,
+}: {
+  kinds: ServiceId[];
+  children: ReactNode;
+}) {
+  const attachedKinds = useAttachedKinds();
+  const attached = kinds.some((k) => attachedKinds.has(k));
+  if (attached) return <>{children}</>;
+  return <NotAttachedState />;
+}
+
+function NotAttachedState() {
+  const router = useRouter();
+  const active = useActiveDashboard();
+  return (
+    <ScreenWrapper scrollable={false}>
+      <View className="flex-1 items-center justify-center px-8 gap-2">
+        <View className="w-16 h-16 rounded-2xl bg-surface-light items-center justify-center mb-2">
+          <Icon icon={Layers} size={28} color="#71717a" />
+        </View>
+        <Text className="text-zinc-100 text-lg font-semibold text-center">
+          Not attached to this workspace
+        </Text>
+        <Text className="text-zinc-500 text-sm text-center leading-5">
+          This service isn&apos;t part of the current dashboard. Attach it in the
+          dashboard&apos;s settings, or switch to a workspace that includes it.
+        </Text>
+        {active && (
+          <Pressable
+            onPress={() => router.push(`/dashboard-edit/${active.id}` as any)}
+            className="mt-4 rounded-xl bg-surface-light border border-border px-4 py-2.5 active:opacity-70"
+          >
+            <Text className="text-zinc-200 text-sm font-semibold">
+              Dashboard settings
+            </Text>
+          </Pressable>
+        )}
+      </View>
+    </ScreenWrapper>
+  );
+}

--- a/components/dashboard/bazarr-wanted-card.tsx
+++ b/components/dashboard/bazarr-wanted-card.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getWantedMovies, getWantedEpisodes } from "@/services/bazarr-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useBazarrPosters } from "@/hooks/use-bazarr-posters";
 import { POLLING_INTERVALS } from "@/lib/constants";
@@ -14,7 +14,6 @@ import {
   BAZARR_WANTED_DEFAULT_SETTINGS,
   type BazarrWantedSettingsValue,
 } from "@/components/dashboard/widget-settings/bazarr-wanted-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
@@ -37,8 +36,7 @@ export function BazarrWantedCard({ slotId }: WidgetComponentProps) {
     slotId,
     BAZARR_WANTED_DEFAULT_SETTINGS,
   );
-  const allInstances = useEnabledInstances("bazarr");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("bazarr", settings.instanceIds);
   const router = useRouter();
 
   const movieQueries = useQueries({

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -7,14 +7,13 @@ import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useConfigStore } from "@/store/config-store";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   CALENDAR_DEFAULT_SETTINGS,
   type CalendarSettingsValue,
 } from "@/components/dashboard/widget-settings/calendar-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import {
@@ -82,15 +81,13 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   const showSonarr = settings.includeSonarr && sonarrEnabled;
   const showRadarr = settings.includeRadarr && radarrEnabled;
 
-  const allSonarrInstances = useEnabledInstances("sonarr");
-  const allRadarrInstances = useEnabledInstances("radarr");
-  const sonarrInstances = resolveBoundInstances(
+  const sonarrInstances = useWorkspaceScopedInstances(
+    "sonarr",
     settings.sonarrInstanceIds,
-    allSonarrInstances,
   );
-  const radarrInstances = resolveBoundInstances(
+  const radarrInstances = useWorkspaceScopedInstances(
+    "radarr",
     settings.radarrInstanceIds,
-    allRadarrInstances,
   );
 
   // Fan out the calendar fetch across each resolved instance per kind. The

--- a/components/dashboard/combined-now-playing-card.tsx
+++ b/components/dashboard/combined-now-playing-card.tsx
@@ -6,10 +6,9 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getSessions as getPlexSessions } from "@/services/plex-api";
 import { getSessions as getMediaServerSessions } from "@/services/jellyfin-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
@@ -38,17 +37,17 @@ export function CombinedNowPlayingCard({ slotId }: WidgetComponentProps) {
   );
   const router = useRouter();
 
-  const plexInstances = resolveBoundInstances(
+  const plexInstances = useWorkspaceScopedInstances(
+    "plex",
     settings.plexInstanceIds,
-    useEnabledInstances("plex"),
   );
-  const jellyfinInstances = resolveBoundInstances(
+  const jellyfinInstances = useWorkspaceScopedInstances(
+    "jellyfin",
     settings.jellyfinInstanceIds,
-    useEnabledInstances("jellyfin"),
   );
-  const embyInstances = resolveBoundInstances(
+  const embyInstances = useWorkspaceScopedInstances(
+    "emby",
     settings.embyInstanceIds,
-    useEnabledInstances("emby"),
   );
 
   // Flat list of (kind, instance) describing each session query, in display

--- a/components/dashboard/dashboard-picker-sheet.tsx
+++ b/components/dashboard/dashboard-picker-sheet.tsx
@@ -14,6 +14,7 @@ import {
   Check,
   ChevronUp,
   ChevronDown,
+  Copy,
   Plus,
   Settings as SettingsIcon,
   Trash2,
@@ -56,6 +57,7 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
   const dashboards = useConfigStore((s) => s.dashboards);
   const activeDashboardId = useConfigStore((s) => s.activeDashboardId);
   const addDashboard = useConfigStore((s) => s.addDashboard);
+  const duplicateDashboard = useConfigStore((s) => s.duplicateDashboard);
   const removeDashboard = useConfigStore((s) => s.removeDashboard);
   const setActiveDashboard = useConfigStore((s) => s.setActiveDashboard);
   const moveDashboard = useConfigStore((s) => s.moveDashboard);
@@ -64,6 +66,7 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
 
   const [mounted, setMounted] = useState(false);
   const [pendingRemove, setPendingRemove] = useState<Dashboard | null>(null);
+  const [pendingDuplicate, setPendingDuplicate] = useState<Dashboard | null>(null);
   const [creating, setCreating] = useState(false);
   const [createDraft, setCreateDraft] = useState("");
   // Submit-only commit (via the keyboard return key or the inline check
@@ -154,6 +157,25 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
     setMounted(false);
     onClose();
     router.push(`/dashboard-edit/${d.id}` as any);
+  }
+
+  function handleDuplicate(d: Dashboard) {
+    const clone = duplicateDashboard(d.id);
+    if (!clone) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    // Switch to the clone and open its editor so the user can tweak the copy
+    // (point it at a different instance, recolor, etc.) right away — same snap-
+    // close-then-push flow as create, which avoids the picker's slide-out
+    // animation sitting on top of the route transition.
+    setActiveDashboard(clone.id);
+    setCreating(false);
+    setCreateDraft("");
+    creatingCommittedRef.current = false;
+    translateY.value = OFFSCREEN;
+    backdrop.value = 0;
+    setMounted(false);
+    onClose();
+    router.push(`/dashboard-edit/${clone.id}` as any);
   }
 
   function commitCreate() {
@@ -337,6 +359,17 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
                             />
                           </Pressable>
                           <Pressable
+                            onPress={() => {
+                              Haptics.selectionAsync();
+                              setPendingDuplicate(d);
+                            }}
+                            hitSlop={6}
+                            className="p-1 ml-1"
+                            accessibilityLabel="Duplicate dashboard"
+                          >
+                            <Icon icon={Copy} size={ICON.MD} color="#a1a1aa" />
+                          </Pressable>
+                          <Pressable
                             onPress={() => handleOpenEditor(d)}
                             hitSlop={6}
                             className="p-1 ml-1"
@@ -459,6 +492,56 @@ export function DashboardPickerSheet({ visible, onClose }: DashboardPickerSheetP
                   >
                     <Text className="text-white text-sm font-semibold">
                       Delete
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            </View>
+          )}
+
+          {/* Duplicate confirm — same in-sheet overlay pattern as delete (a
+              nested ConfirmModal would hit the iOS Fabric modal-stacking hang). */}
+          {pendingDuplicate && (
+            <View
+              style={StyleSheet.absoluteFill}
+              className="items-center justify-center px-8"
+            >
+              <Pressable
+                style={StyleSheet.absoluteFill}
+                className="bg-black/70"
+                onPress={() => setPendingDuplicate(null)}
+              />
+              <View className="w-full max-w-md rounded-2xl bg-surface border border-border p-5 gap-4">
+                <View className="flex-row items-center gap-3">
+                  <View className="bg-primary/15 rounded-xl p-2.5">
+                    <Icon icon={Copy} size={20} color="#60a5fa" />
+                  </View>
+                  <Text className="text-zinc-100 text-lg font-semibold flex-1">
+                    Duplicate dashboard?
+                  </Text>
+                </View>
+                <Text className="text-zinc-400 text-sm leading-5">
+                  {`A copy of "${pendingDuplicate.name}" will be created with its widgets and settings. You'll be taken to the new dashboard to customize it.`}
+                </Text>
+                <View className="flex-row gap-3 mt-1">
+                  <Pressable
+                    onPress={() => setPendingDuplicate(null)}
+                    className="flex-1 rounded-xl border border-border py-2.5 items-center active:opacity-70"
+                  >
+                    <Text className="text-zinc-300 text-sm font-semibold">
+                      Cancel
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      const target = pendingDuplicate;
+                      setPendingDuplicate(null);
+                      handleDuplicate(target);
+                    }}
+                    className="flex-1 rounded-xl bg-primary py-2.5 items-center active:opacity-70"
+                  >
+                    <Text className="text-white text-sm font-semibold">
+                      Duplicate
                     </Text>
                   </Pressable>
                 </View>

--- a/components/dashboard/download-card.tsx
+++ b/components/dashboard/download-card.tsx
@@ -13,7 +13,7 @@ import { Icon } from "@/components/ui/icon";
 import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useTorrentPosterMap } from "@/hooks/use-torrent-poster-map";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { lightHaptic } from "@/lib/haptics";
 import { formatSpeed, formatEta } from "@/lib/utils";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
@@ -23,7 +23,6 @@ import {
   type DownloadsSettingsValue,
   type DownloadsSortBy,
 } from "@/components/dashboard/widget-settings/downloads-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { isTorrentPaused, type QBTorrent, type TorrentState } from "@/lib/types";
@@ -214,12 +213,14 @@ export function DownloadCard({ slotId }: WidgetComponentProps) {
   // Aggregate across all enabled qBittorrent instances when bound to "all";
   // narrow to the bound subset otherwise. Each instance keeps its own cache
   // slot via the [serviceId, instanceId, …] queryKey shape.
-  const allQbInstances = useEnabledInstances("qbittorrent");
-  const qbInstances = resolveBoundInstances(settings.instanceIds, allQbInstances);
+  const qbInstances = useWorkspaceScopedInstances(
+    "qbittorrent",
+    settings.instanceIds,
+  );
   // rtorrent has no per-widget instance binding yet (phase 2) — include every
-  // enabled rtorrent instance, fetched in full (rtorrent returns the whole
-  // library in one call) and classified/sorted/capped client-side below.
-  const rtInstances = useEnabledInstances("rtorrent");
+  // attached enabled rtorrent instance, fetched in full (rtorrent returns the
+  // whole library in one call) and classified/sorted/capped client-side below.
+  const rtInstances = useWorkspaceScopedInstances("rtorrent", undefined);
 
   const qbQueries = useQueries({
     queries: qbInstances.map((inst) => ({

--- a/components/dashboard/lidarr-queue-card.tsx
+++ b/components/dashboard/lidarr-queue-card.tsx
@@ -6,14 +6,13 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getQueue, getWantedMissing, getLidarrAlbumCover } from "@/services/lidarr-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   LIDARR_QUEUE_DEFAULT_SETTINGS,
   type LidarrQueueSettingsValue,
 } from "@/components/dashboard/widget-settings/lidarr-queue-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
@@ -30,8 +29,7 @@ export function LidarrQueueCard({ slotId }: WidgetComponentProps) {
   );
   // Aggregate queue + wanted counts across every enabled Lidarr instance, or
   // narrow to the bound subset based on the slot's instance binding.
-  const allInstances = useEnabledInstances("lidarr");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("lidarr", settings.instanceIds);
 
   const queueQueries = useQueries({
     queries: instances.map((inst) => ({

--- a/components/dashboard/overseerr-requests-card.tsx
+++ b/components/dashboard/overseerr-requests-card.tsx
@@ -12,8 +12,8 @@ import {
   getTVDetails,
   getPosterUrl,
 } from "@/services/overseerr-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import type {
   OverseerrRequest,
@@ -26,7 +26,6 @@ import {
   type OverseerrRequestsSettingsValue,
   type OverseerrStatusFilter,
 } from "@/components/dashboard/widget-settings/overseerr-requests-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
@@ -66,8 +65,7 @@ export function OverseerrRequestsCard({ slotId }: WidgetComponentProps) {
     slotId,
     OVERSEERR_REQUESTS_DEFAULT_SETTINGS,
   );
-  const allInstances = useEnabledInstances("overseerr");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("overseerr", settings.instanceIds);
   const router = useRouter();
 
   // Fan out requests + counts across the resolved instances. Each request is

--- a/components/dashboard/plex-now-playing-card.tsx
+++ b/components/dashboard/plex-now-playing-card.tsx
@@ -5,14 +5,13 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getSessions } from "@/services/plex-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   PLEX_NOW_PLAYING_DEFAULT_SETTINGS,
   type PlexNowPlayingSettingsValue,
 } from "@/components/dashboard/widget-settings/plex-now-playing-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
@@ -26,8 +25,7 @@ export function PlexNowPlayingCard({ slotId }: WidgetComponentProps) {
     slotId,
     PLEX_NOW_PLAYING_DEFAULT_SETTINGS,
   );
-  const allInstances = useEnabledInstances("plex");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("plex", settings.instanceIds);
   const router = useRouter();
 
   const queries = useQueries({

--- a/components/dashboard/prowlarr-stats-card.tsx
+++ b/components/dashboard/prowlarr-stats-card.tsx
@@ -8,14 +8,13 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { getIndexers, getIndexerStatuses } from "@/services/prowlarr-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   PROWLARR_STATS_DEFAULT_SETTINGS,
   type ProwlarrStatsSettingsValue,
 } from "@/components/dashboard/widget-settings/prowlarr-stats-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 
@@ -24,8 +23,7 @@ export function ProwlarrStatsCard({ slotId }: WidgetComponentProps) {
     slotId,
     PROWLARR_STATS_DEFAULT_SETTINGS,
   );
-  const allInstances = useEnabledInstances("prowlarr");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("prowlarr", settings.instanceIds);
   const router = useRouter();
 
   const indexerQueries = useQueries({

--- a/components/dashboard/radarr-queue-card.tsx
+++ b/components/dashboard/radarr-queue-card.tsx
@@ -9,14 +9,13 @@ import {
   getWantedMissing,
   getRadarrPoster,
 } from "@/services/radarr-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   RADARR_QUEUE_DEFAULT_SETTINGS,
   type RadarrQueueSettingsValue,
 } from "@/components/dashboard/widget-settings/radarr-queue-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
@@ -33,8 +32,7 @@ export function RadarrQueueCard({ slotId }: WidgetComponentProps) {
   );
   // Aggregate queue + wanted counts across every enabled Radarr instance, or
   // narrow to the bound subset based on the slot's instance binding.
-  const allInstances = useEnabledInstances("radarr");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("radarr", settings.instanceIds);
 
   const queueQueries = useQueries({
     queries: instances.map((inst) => ({

--- a/components/dashboard/recently-downloaded-card.tsx
+++ b/components/dashboard/recently-downloaded-card.tsx
@@ -7,8 +7,8 @@ import { ServiceLogo } from "@/components/ui/service-logo";
 import { getHistory as getRadarrHistory, getRadarrPoster } from "@/services/radarr-api";
 import { getHistory as getSonarrHistory, getSonarrPoster } from "@/services/sonarr-api";
 import { useConfigStore } from "@/store/config-store";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { formatEpisodeCode, relativeDate } from "@/lib/utils";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
@@ -16,7 +16,6 @@ import {
   RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
   type RecentlyDownloadedSettingsValue,
 } from "@/components/dashboard/widget-settings/recently-downloaded-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
 import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
@@ -60,15 +59,13 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
   const showSonarr = settings.includeSonarr && sonarrEnabled;
   const showRadarr = settings.includeRadarr && radarrEnabled;
 
-  const allSonarrInstances = useEnabledInstances("sonarr");
-  const allRadarrInstances = useEnabledInstances("radarr");
-  const sonarrInstances = resolveBoundInstances(
+  const sonarrInstances = useWorkspaceScopedInstances(
+    "sonarr",
     settings.sonarrInstanceIds,
-    allSonarrInstances,
   );
-  const radarrInstances = resolveBoundInstances(
+  const radarrInstances = useWorkspaceScopedInstances(
+    "radarr",
     settings.radarrInstanceIds,
-    allRadarrInstances,
   );
 
   // Fan history across each resolved instance. Query keys match the watchers

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -17,14 +17,13 @@ import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { getCpu, getMem, getFs, getGpu, getNet, getLoad, selectInterfaces, type GlancesNetRate } from "@/services/glances-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import {
   SERVER_STATS_DEFAULT_SETTINGS,
   type ServerStatsSettingsValue,
 } from "@/components/dashboard/widget-settings/server-stats-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { formatBytes, formatSpeed } from "@/lib/utils";
 import type { GlancesFsItem, GlancesGpuItem, GlancesLoad } from "@/lib/types";
@@ -137,8 +136,7 @@ export function ServerStatsCard({ slotId }: WidgetComponentProps) {
     SERVER_STATS_DEFAULT_SETTINGS,
   );
 
-  const allInstances = useEnabledInstances("glances");
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances("glances", settings.instanceIds);
 
   const allHidden =
     !settings.showCpu && !settings.showRam && !settings.showGpu && !settings.showDisks;

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { View, Text } from "react-native";
 import Svg, { Circle } from "react-native-svg";
 import {
@@ -58,7 +59,13 @@ interface MetricRingProps {
   icon: LucideIcon;
 }
 
-function MetricRing({ percent, label, sublabel, icon }: MetricRingProps) {
+// Memoized: each Glances section has its own query, so when (say) the `net`
+// query lands every poll, InstanceBlock re-renders — but the CPU/RAM/GPU rings'
+// props are unchanged, so memo skips re-drawing their SVGs. Only the ring whose
+// metric actually changed re-renders. This is the main fix for server-stats
+// being the dashboard's heaviest re-render (6 queries × N instances, each
+// resolution previously redrawing every ring).
+const MetricRing = memo(function MetricRing({ percent, label, sublabel, icon }: MetricRingProps) {
   // Use numeric pixel size scaled by uiScale so the ring resizes with
   // accessibility scaling — react-native-svg props are numeric, not rem.
   const scale = useUiScale();
@@ -122,7 +129,7 @@ function MetricRing({ percent, label, sublabel, icon }: MetricRingProps) {
       ) : null}
     </View>
   );
-}
+});
 
 export function ServerStatsCard({ slotId }: WidgetComponentProps) {
   const { settings } = useWidgetSettings<ServerStatsSettingsValue>(
@@ -221,9 +228,15 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
   const mem = settings.showRam ? memQuery.data : undefined;
   const fs = settings.showDisks ? fsQuery.data : undefined;
   const gpus = settings.showGpu ? gpuQuery.data : undefined;
-  const netRows = settings.showNetwork
-    ? selectInterfaces(netQuery.data, settings.networkInterfaces, { activeOnly: true })
-    : [];
+  // Memoized so an unchanged `net` payload keeps the same row refs across polls,
+  // letting the memoized NetRow children skip re-rendering.
+  const netRows = useMemo(
+    () =>
+      settings.showNetwork
+        ? selectInterfaces(netQuery.data, settings.networkInterfaces, { activeOnly: true })
+        : [],
+    [settings.showNetwork, netQuery.data, settings.networkInterfaces],
+  );
   const load = settings.showLoad ? loadQuery.data : undefined;
   const iowait =
     settings.showIoWait && typeof cpuQuery.data?.iowait === "number"
@@ -255,7 +268,7 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
       (settings.showNetwork && netQuery.isError) ||
       (settings.showLoad && loadQuery.isError));
 
-  const gpuRings = buildGpuRings(gpus);
+  const gpuRings = useMemo(() => buildGpuRings(gpus), [gpus]);
   const hasRings =
     (settings.showCpu && cpu) ||
     (settings.showRam && mem) ||
@@ -353,7 +366,7 @@ function loadVal(n: number | undefined): string {
   return typeof n === "number" && Number.isFinite(n) ? n.toFixed(2) : "—";
 }
 
-function StatsRow({
+const StatsRow = memo(function StatsRow({
   load,
   iowait,
 }: {
@@ -380,9 +393,9 @@ function StatsRow({
       )}
     </View>
   );
-}
+});
 
-function NetRow({ iface }: { iface: GlancesNetRate }) {
+const NetRow = memo(function NetRow({ iface }: { iface: GlancesNetRate }) {
   return (
     <View className="flex-row justify-between items-center gap-2">
       <View className="flex-row items-center gap-1.5 flex-1 min-w-0">
@@ -395,7 +408,7 @@ function NetRow({ iface }: { iface: GlancesNetRate }) {
       <Text className="text-zinc-400 text-[0.7rem]">↑ {formatSpeed(iface.tx)}</Text>
     </View>
   );
-}
+});
 
 interface GpuRingEntry {
   key: string;
@@ -441,7 +454,7 @@ function shortenGpuName(name: string): string {
     .trim();
 }
 
-function DiskRow({ disk }: { disk: GlancesFsItem }) {
+const DiskRow = memo(function DiskRow({ disk }: { disk: GlancesFsItem }) {
   const mount = disk.mnt_point.replace(/^\/host/, "") || "/";
   const pct = Math.min(Math.max(disk.percent, 0), 100);
   return (
@@ -471,4 +484,4 @@ function DiskRow({ disk }: { disk: GlancesFsItem }) {
       </View>
     </View>
   );
-}
+});

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -8,6 +8,7 @@ import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { ICON, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
+import { resolveActiveUrlKind } from "@/lib/url-validation";
 import { useConfigStore } from "@/store/config-store";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import {
@@ -36,6 +37,9 @@ interface RenderEntry {
   instanceId: string;
   label: string;
   status: HealthStatusKind;
+  // Which URL this instance is actively using ("local"/"remote"), or null when
+  // neither is configured. Drives the L/R corner badge (#148).
+  urlKind: "local" | "remote" | null;
 }
 
 // Tailwind class + iOS shadow color for the small corner dot, by tri-state.
@@ -52,6 +56,13 @@ const DOT_SHADOW: Record<HealthStatusKind, string> = {
   offline: "#ef4444",
 };
 
+// L/R corner badge palette — deliberately hues NOT used by the status dot
+// (green/amber/red) so the two corners read as different signals at a glance.
+const URL_KIND_BG: Record<"local" | "remote", string> = {
+  local: "bg-sky-500",
+  remote: "bg-violet-500",
+};
+
 export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   const { settings } = useWidgetSettings<ServiceHealthSettingsValue>(
     slotId,
@@ -61,6 +72,10 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
   const servicesOrder = useConfigStore((s) => s.servicesOrder);
   const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
+  // Subscribed so the L/R badge flips live when the user walks home/away or
+  // toggles auto-switch — both feed resolveActiveUrlKind below.
+  const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
+  const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
   const attachedInstances = useAttachedInstances();
   const router = useRouter();
 
@@ -115,6 +130,11 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
         // glance instead of seeing two identical "qBittorrent" tiles.
         label: inst.name,
         status: health?.status ?? "offline",
+        urlKind: resolveActiveUrlKind(
+          inst,
+          autoSwitchNetwork,
+          networkAwayFromHome,
+        ),
       });
     }
   }
@@ -155,6 +175,15 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
                     online={entry.status !== "offline"}
                   />
                 </View>
+                {settings.showUrlBadge && entry.urlKind && (
+                  <View
+                    className={`absolute -top-0.5 -left-0.5 w-4 h-4 rounded-full border-2 border-surface items-center justify-center ${URL_KIND_BG[entry.urlKind]}`}
+                  >
+                    <Text className="text-white text-[0.6rem] font-bold leading-none">
+                      {entry.urlKind === "local" ? "L" : "R"}
+                    </Text>
+                  </View>
+                )}
                 <View
                   className={`absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-surface ${DOT_BG[entry.status]}`}
                   style={Platform.OS === "ios" ? {

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -10,7 +10,7 @@ import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
 import { resolveActiveUrlKind } from "@/lib/url-validation";
 import { useConfigStore } from "@/store/config-store";
-import { useAttachedInstances } from "@/hooks/use-active-dashboard";
+import { useAttachedInstances, useActiveDashboard } from "@/hooks/use-active-dashboard";
 import {
   resolveBoundInstances,
   isExplicitInstanceBinding,
@@ -76,8 +76,19 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   // toggles auto-switch — both feed resolveActiveUrlKind below.
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
   const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
+  const homeNetworks = useConfigStore((s) => s.homeNetworks);
   const attachedInstances = useAttachedInstances();
+  const activeDashboard = useActiveDashboard();
   const router = useRouter();
+
+  // A workspace that explicitly selected no live home networks (homeNetworkIds:
+  // [] or only stale ids) is "always remote" — mirror getActiveUrl step 2 so the
+  // L/R badge reads "remote" even when global auto-switch is off (#148).
+  const workspaceForcesRemote = (() => {
+    const ids = activeDashboard?.homeNetworkIds;
+    if (!Array.isArray(ids)) return false;
+    return !ids.some((id) => homeNetworks.some((n) => n.id === id));
+  })();
 
   const hiddenSet = new Set(settings.hiddenKinds);
   // Index health by (kind, instanceId) so we can pair each bound instance with
@@ -134,6 +145,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
           inst,
           autoSwitchNetwork,
           networkAwayFromHome,
+          workspaceForcesRemote,
         ),
       });
     }

--- a/components/dashboard/speed-stats-card.tsx
+++ b/components/dashboard/speed-stats-card.tsx
@@ -22,6 +22,8 @@ import {
   type SpeedStatsSettingsValue,
 } from "@/components/dashboard/widget-settings/speed-stats-settings";
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { scopeInstancesToWorkspace } from "@/hooks/use-workspace-instances";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 
@@ -30,53 +32,76 @@ export function SpeedStatsCard({ slotId }: WidgetComponentProps) {
     slotId,
     SPEED_STATS_DEFAULT_SETTINGS,
   );
+  const attached = useAttachedInstances();
   const allQbitInstances = useEnabledInstances("qbittorrent");
   const allSabInstances = useEnabledInstances("sabnzbd");
   const allNzbgetInstances = useEnabledInstances("nzbget");
   const allRtInstances = useEnabledInstances("rtorrent");
   const allGlancesInstances = useEnabledInstances("glances");
 
+  // Scope each kind to the active workspace up front so the source / "is
+  // configured here?" decisions below — and the rendered lists — only ever
+  // consider instances attached to this dashboard (#148 review Rec #1).
+  const wsQbit = scopeInstancesToWorkspace(allQbitInstances, undefined, attached);
+  const wsSab = scopeInstancesToWorkspace(allSabInstances, undefined, attached);
+  const wsNzbget = scopeInstancesToWorkspace(allNzbgetInstances, undefined, attached);
+  const wsRt = scopeInstancesToWorkspace(allRtInstances, undefined, attached);
+  const wsGlances = scopeInstancesToWorkspace(allGlancesInstances, undefined, attached);
+
   // A widget shows exactly one source — download clients OR server network —
   // so the pills never double-count traffic a client pushes through the same
   // NIC Glances reports. The selection is forced when only one kind is
   // configured (see resolveSpeedStatsSource).
   const hasClients =
-    allQbitInstances.length +
-      allSabInstances.length +
-      allNzbgetInstances.length +
-      allRtInstances.length >
-    0;
+    wsQbit.length + wsSab.length + wsNzbget.length + wsRt.length > 0;
   const source = resolveSpeedStatsSource(
     settings.source,
     hasClients,
-    allGlancesInstances.length > 0,
+    wsGlances.length > 0,
   );
   const useClients = source === "clients";
   const useNetwork = source === "network";
 
-  // qBittorrent binds per-widget; rtorrent folds in every enabled instance (no
-  // per-widget binding yet, phase 2).
+  // qBittorrent binds per-widget; rtorrent folds in every attached enabled
+  // instance (no per-widget binding yet, phase 2). An explicit per-widget pick
+  // still wins over the workspace filter (see scopeInstancesToWorkspace).
   const qbitInstances = useClients
-    ? resolveBoundInstances(settings.instanceIds, allQbitInstances)
+    ? scopeInstancesToWorkspace(
+        resolveBoundInstances(settings.instanceIds, allQbitInstances),
+        settings.instanceIds,
+        attached,
+      )
     : [];
-  // When the user has no qBit configured at all, the toggle is moot — fold any
-  // enabled SAB/NZBGet instances in automatically so a usenet-only user sees
-  // real numbers instead of a perpetual skeleton. Once they enable qBit, the
-  // explicit toggles take over again.
+  // When the user has no qBit attached here, the toggle is moot — fold any
+  // attached SAB/NZBGet instances in automatically so a usenet-only workspace
+  // sees real numbers instead of a perpetual skeleton. Once they attach qBit,
+  // the explicit toggles take over again.
   const effectiveIncludeSab =
-    useClients && (settings.includeSab || allQbitInstances.length === 0);
+    useClients && (settings.includeSab || wsQbit.length === 0);
   const sabInstances = effectiveIncludeSab
-    ? resolveBoundInstances(settings.sabInstanceIds, allSabInstances)
+    ? scopeInstancesToWorkspace(
+        resolveBoundInstances(settings.sabInstanceIds, allSabInstances),
+        settings.sabInstanceIds,
+        attached,
+      )
     : [];
   const effectiveIncludeNzbget =
-    useClients && (settings.includeNzbget || allQbitInstances.length === 0);
+    useClients && (settings.includeNzbget || wsQbit.length === 0);
   const nzbgetInstances = effectiveIncludeNzbget
-    ? resolveBoundInstances(settings.nzbgetInstanceIds, allNzbgetInstances)
+    ? scopeInstancesToWorkspace(
+        resolveBoundInstances(settings.nzbgetInstanceIds, allNzbgetInstances),
+        settings.nzbgetInstanceIds,
+        attached,
+      )
     : [];
-  const rtInstances = useClients ? allRtInstances : [];
+  const rtInstances = useClients ? wsRt : [];
   // Glances interfaces: received bytes → down pill, sent bytes → up pill.
   const glancesInstances = useNetwork
-    ? resolveBoundInstances(settings.glancesInstanceIds, allGlancesInstances)
+    ? scopeInstancesToWorkspace(
+        resolveBoundInstances(settings.glancesInstanceIds, allGlancesInstances),
+        settings.glancesInstanceIds,
+        attached,
+      )
     : [];
 
   // Fan out across the resolved instances and sum their counters so a single

--- a/components/dashboard/stream-monitor-card.tsx
+++ b/components/dashboard/stream-monitor-card.tsx
@@ -4,12 +4,11 @@ import { useQueries } from "@tanstack/react-query";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { getMonitorAdapter, type MonitorKind } from "@/lib/monitor-adapter";
 import { parseHiddenUsers } from "@/lib/now-playing-stream";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
@@ -32,13 +31,13 @@ export function StreamMonitorCard({ slotId }: WidgetComponentProps) {
   );
   const router = useRouter();
 
-  const tautulliInstances = resolveBoundInstances(
+  const tautulliInstances = useWorkspaceScopedInstances(
+    "tautulli",
     settings.tautulliInstanceIds,
-    useEnabledInstances("tautulli"),
   );
-  const tracearrInstances = resolveBoundInstances(
+  const tracearrInstances = useWorkspaceScopedInstances(
+    "tracearr",
     settings.tracearrInstanceIds,
-    useEnabledInstances("tracearr"),
   );
 
   const sources = [

--- a/components/dashboard/streaming-bandwidth-card.tsx
+++ b/components/dashboard/streaming-bandwidth-card.tsx
@@ -12,8 +12,10 @@ import { getSessions as getPlexSessions } from "@/services/plex-api";
 import { getSessions as getJellyfinSessions } from "@/services/jellyfin-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { scopeInstancesToWorkspace } from "@/hooks/use-workspace-instances";
 import {
   STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
   type StreamingBandwidthSettingsValue,
@@ -97,6 +99,7 @@ export function StreamingBandwidthCard({ slotId }: WidgetComponentProps) {
     STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
   );
 
+  const attached = useAttachedInstances();
   const tautulli = useEnabledInstances("tautulli");
   const plex = useEnabledInstances("plex");
   const jellyfin = useEnabledInstances("jellyfin");
@@ -107,13 +110,21 @@ export function StreamingBandwidthCard({ slotId }: WidgetComponentProps) {
     jellyfin,
     emby,
   };
+  // Only services with an instance ATTACHED to the active workspace count as
+  // "configured here" (#148 review Rec #1).
   const configured = STREAMING_SERVICES.filter(
-    (s) => instancesByService[s].length > 0,
+    (s) =>
+      scopeInstancesToWorkspace(instancesByService[s], undefined, attached)
+        .length > 0,
   );
   const service = resolveStreamingService(settings.service, configured);
 
   const instances = service
-    ? resolveBoundInstances(settings.instanceIds, instancesByService[service])
+    ? scopeInstancesToWorkspace(
+        resolveBoundInstances(settings.instanceIds, instancesByService[service]),
+        settings.instanceIds,
+        attached,
+      )
     : [];
 
   const queries = useQueries({

--- a/components/dashboard/usenet-queue-card.tsx
+++ b/components/dashboard/usenet-queue-card.tsx
@@ -6,9 +6,8 @@ import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { EmptyState } from "@/components/ui/empty-state";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { lightHaptic } from "@/lib/haptics";
@@ -55,8 +54,10 @@ export function UsenetQueueCard({ slotId, adapter }: Props) {
     USENET_QUEUE_DEFAULT_SETTINGS,
   );
 
-  const allInstances = useEnabledInstances(adapter.serviceId);
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances(
+    adapter.serviceId,
+    settings.instanceIds,
+  );
 
   const queueQueries = useQueries({
     queries: instances.map((inst) => adapter.queueQueryOptions(inst.id)),

--- a/components/dashboard/widget-settings/combined-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/combined-now-playing-settings.tsx
@@ -2,7 +2,7 @@ import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
 import { TextInput } from "@/components/ui/text-input";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedEnabledInstances } from "@/hooks/use-workspace-instances";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
   InstancePickerRow,
@@ -49,11 +49,11 @@ export function CombinedNowPlayingSettings({ slotId }: WidgetSettingsComponentPr
     COMBINED_NOW_PLAYING_DEFAULT_SETTINGS,
   );
 
-  // Only offer an instance picker for a kind the user actually runs. Deselect
-  // all of a kind's instances to drop it from the widget.
-  const hasPlex = useEnabledInstances("plex").length > 0;
-  const hasJellyfin = useEnabledInstances("jellyfin").length > 0;
-  const hasEmby = useEnabledInstances("emby").length > 0;
+  // Only offer an instance picker for a kind attached to this workspace.
+  // Deselect all of a kind's instances to drop it from the widget.
+  const hasPlex = useAttachedEnabledInstances("plex").length > 0;
+  const hasJellyfin = useAttachedEnabledInstances("jellyfin").length > 0;
+  const hasEmby = useAttachedEnabledInstances("emby").length > 0;
 
   return (
     <View className="px-4 py-2 gap-5">

--- a/components/dashboard/widget-settings/instance-picker-row.tsx
+++ b/components/dashboard/widget-settings/instance-picker-row.tsx
@@ -1,6 +1,7 @@
 import { View, Text, ScrollView } from "react-native";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
 
 // Special sentinel used in widget settings to mean "aggregate across every
@@ -85,12 +86,23 @@ export function InstancePickerRow({
   onChange,
   label,
 }: InstancePickerRowProps) {
-  const instances = useEnabledInstances(serviceId);
+  const allEnabled = useEnabledInstances(serviceId);
+  const attached = useAttachedInstances();
   const heading =
     label ?? `${SERVICE_DEFAULTS[serviceId].name} instance`;
 
   const isAll = value === INSTANCE_BINDING_ALL;
   const selectedSet = new Set<string>(isAll ? [] : value);
+
+  // Only offer instances attached to the active workspace — a curated dashboard
+  // shouldn't list instances it didn't attach (#148 review Rec #7). Any id
+  // already in the binding stays visible so an existing pick (e.g. whose
+  // instance was later un-attached) can still be seen and removed rather than
+  // silently orphaned. "All instances" then means "all attached", matching the
+  // card's aggregate.
+  const instances = allEnabled.filter(
+    (i) => attached.has(i.id) || selectedSet.has(i.id),
+  );
 
   const toggleInstance = (id: string) => {
     if (isAll) {

--- a/components/dashboard/widget-settings/service-health-settings.tsx
+++ b/components/dashboard/widget-settings/service-health-settings.tsx
@@ -26,11 +26,16 @@ export interface ServiceHealthSettingsValue extends Record<string, unknown> {
   // second qBittorrent later auto-shows it on this widget instead of being
   // silently ignored. Each rendered instance gets its own indicator chip.
   instances: Partial<Record<ServiceId, InstanceBindingValue>>;
+  // Whether to show the L/R corner badge (#148) marking each instance as using
+  // its local or remote URL. Defaults on; legacy slots without the field merge
+  // to the default at read time (see useWidgetSettings).
+  showUrlBadge: boolean;
 }
 
 export const SERVICE_HEALTH_DEFAULT_SETTINGS: ServiceHealthSettingsValue = {
   hiddenKinds: [],
   instances: {},
+  showUrlBadge: true,
 };
 
 export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -167,6 +172,14 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
 
   return (
     <View className="px-4 py-2 gap-5">
+      <View className="bg-surface-light rounded-2xl border border-border px-4">
+        <Toggle
+          label="Local/remote badge"
+          description="Mark each service with an L or R for the URL it's currently using"
+          value={settings.showUrlBadge}
+          onValueChange={(v) => update({ showUrlBadge: v })}
+        />
+      </View>
       {configuredKinds.length > 1 && (
         <Text className="text-zinc-500 text-xs">
           Long-press a row to drag it. Order is shared with the Services tab.

--- a/components/dashboard/widget-settings/service-health-settings.tsx
+++ b/components/dashboard/widget-settings/service-health-settings.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@/components/ui/icon";
 import { Toggle } from "@/components/ui/toggle";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useConfigStore } from "@/store/config-store";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { lightHaptic } from "@/lib/haptics";
@@ -46,15 +47,16 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
   const servicesOrder = useConfigStore((s) => s.servicesOrder);
   const setServicesOrder = useConfigStore((s) => s.setServicesOrder);
+  const attached = useAttachedInstances();
 
-  // Only surface kinds the user has actually configured + enabled, in the
-  // user-defined order. Hiding a kind in app settings already removes it from
-  // the dashboard, so there's no point listing it here — the widget can't
-  // show what isn't reachable. The order is the shared servicesOrder so the
-  // Status widget and the Services tab agree.
+  // Only surface kinds with an instance attached to the active workspace, in
+  // the user-defined order. The Services card itself only renders attached
+  // instances (#148), so listing an unattached kind here would let the user
+  // configure something the card never shows. The order is the shared
+  // servicesOrder so the Status widget and the Services tab agree.
   const fullOrder = applyServicesOrder(servicesOrder);
-  const configuredKinds = fullOrder.filter(
-    (id) => (serviceInstances[id] ?? []).some((i) => i.enabled),
+  const configuredKinds = fullOrder.filter((id) =>
+    (serviceInstances[id] ?? []).some((i) => i.enabled && attached.has(i.id)),
   );
 
   // Project a reordered list of *configured* kinds back onto the full order,
@@ -114,7 +116,11 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
   const renderRow = (id: ServiceId) => {
     const isShown = !hiddenSet.has(id);
     const instances = serviceInstances[id] ?? [];
-    const enabledInstances = instances.filter((i) => i.enabled);
+    // Scoped to the workspace so the "N instances enabled" subtitle and the
+    // (> 1) picker gate below match what the card actually shows (#148).
+    const enabledInstances = instances.filter(
+      (i) => i.enabled && attached.has(i.id),
+    );
     const binding = settings.instances[id] ?? INSTANCE_BINDING_ALL;
     const idx = configuredKinds.indexOf(id);
     const isFirst = idx === 0;

--- a/components/dashboard/widget-settings/speed-stats-settings.tsx
+++ b/components/dashboard/widget-settings/speed-stats-settings.tsx
@@ -5,7 +5,7 @@ import { ConfirmModal } from "@/components/common/confirm-modal";
 import { Toggle } from "@/components/ui/toggle";
 import { TextInput } from "@/components/ui/text-input";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedEnabledInstances } from "@/hooks/use-workspace-instances";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
   InstancePickerRow,
@@ -112,11 +112,14 @@ export function SpeedStatsSettings({ slotId }: WidgetSettingsComponentProps) {
     slotId,
     SPEED_STATS_DEFAULT_SETTINGS,
   );
-  const qbitInstances = useEnabledInstances("qbittorrent");
-  const sabInstances = useEnabledInstances("sabnzbd");
-  const nzbgetInstances = useEnabledInstances("nzbget");
-  const rtInstances = useEnabledInstances("rtorrent");
-  const glancesInstances = useEnabledInstances("glances");
+  // Scoped to the active workspace so every source gate (clients/network,
+  // SAB/NZBGet toggles, "only source" shortcuts) and the pickers match what the
+  // card actually renders (#148).
+  const qbitInstances = useAttachedEnabledInstances("qbittorrent");
+  const sabInstances = useAttachedEnabledInstances("sabnzbd");
+  const nzbgetInstances = useAttachedEnabledInstances("nzbget");
+  const rtInstances = useAttachedEnabledInstances("rtorrent");
+  const glancesInstances = useAttachedEnabledInstances("glances");
   const hasClients =
     qbitInstances.length +
       sabInstances.length +

--- a/components/dashboard/widget-settings/stream-monitor-settings.tsx
+++ b/components/dashboard/widget-settings/stream-monitor-settings.tsx
@@ -2,7 +2,7 @@ import { View } from "react-native";
 import { Toggle } from "@/components/ui/toggle";
 import { TextInput } from "@/components/ui/text-input";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedEnabledInstances } from "@/hooks/use-workspace-instances";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
   InstancePickerRow,
@@ -47,9 +47,9 @@ export function StreamMonitorSettings({ slotId }: WidgetSettingsComponentProps) 
     STREAM_MONITOR_DEFAULT_SETTINGS,
   );
 
-  // Only offer an instance picker for a monitor the user actually runs.
-  const hasTautulli = useEnabledInstances("tautulli").length > 0;
-  const hasTracearr = useEnabledInstances("tracearr").length > 0;
+  // Only offer an instance picker for a monitor attached to this workspace.
+  const hasTautulli = useAttachedEnabledInstances("tautulli").length > 0;
+  const hasTracearr = useAttachedEnabledInstances("tracearr").length > 0;
 
   return (
     <View className="px-4 py-2 gap-5">

--- a/components/dashboard/widget-settings/streaming-bandwidth-settings.tsx
+++ b/components/dashboard/widget-settings/streaming-bandwidth-settings.tsx
@@ -1,7 +1,7 @@
 import { View } from "react-native";
 import { TextInput } from "@/components/ui/text-input";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedEnabledInstances } from "@/hooks/use-workspace-instances";
 import { SERVICE_DEFAULTS } from "@/lib/constants";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
 import {
@@ -47,11 +47,12 @@ export function StreamingBandwidthSettings({ slotId }: WidgetSettingsComponentPr
     STREAMING_BANDWIDTH_DEFAULT_SETTINGS,
   );
 
-  // Called unconditionally (stable hook order); cheap selectors.
-  const tautulli = useEnabledInstances("tautulli");
-  const plex = useEnabledInstances("plex");
-  const jellyfin = useEnabledInstances("jellyfin");
-  const emby = useEnabledInstances("emby");
+  // Called unconditionally (stable hook order); cheap selectors. Scoped to the
+  // active workspace so the Source dropdown only lists attached servers (#148).
+  const tautulli = useAttachedEnabledInstances("tautulli");
+  const plex = useAttachedEnabledInstances("plex");
+  const jellyfin = useAttachedEnabledInstances("jellyfin");
+  const emby = useAttachedEnabledInstances("emby");
   const countByService: Record<StreamingServiceId, number> = {
     tautulli: tautulli.length,
     plex: plex.length,

--- a/components/media-server/media-server-now-playing-card.tsx
+++ b/components/media-server/media-server-now-playing-card.tsx
@@ -5,15 +5,14 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getSessions } from "@/services/jellyfin-api";
-import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import type { MediaServerId } from "@/lib/media-server-config";
 import {
   STREAMING_NOW_PLAYING_DEFAULT_SETTINGS,
   type StreamingNowPlayingSettingsValue,
 } from "@/components/dashboard/widget-settings/streaming-now-playing-settings";
-import { resolveBoundInstances } from "@/components/dashboard/widget-settings/instance-picker-row";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
@@ -33,8 +32,7 @@ export function MediaServerNowPlayingCard({
     slotId,
     STREAMING_NOW_PLAYING_DEFAULT_SETTINGS,
   );
-  const allInstances = useEnabledInstances(serviceId);
-  const instances = resolveBoundInstances(settings.instanceIds, allInstances);
+  const instances = useWorkspaceScopedInstances(serviceId, settings.instanceIds);
   const router = useRouter();
 
   const queries = useQueries({

--- a/hooks/use-instance-target.ts
+++ b/hooks/use-instance-target.ts
@@ -35,9 +35,12 @@ export function useInstanceTarget(
   serviceId: ServiceId,
   instanceId?: string,
 ): { instanceId: string | null; enabled: boolean } {
-  const activeId = useConfigStore(
-    (s) => s.activeInstance[serviceId] ?? s.serviceInstances[serviceId]?.[0]?.id ?? null,
-  );
+  // Only the workspace-resolved active instance (attachment + enabled aware).
+  // No raw serviceInstances[serviceId][0] tail: when nothing is enabled+attached
+  // in the active workspace this is null, which gates dependent queries off via
+  // `enabled` below — instead of silently following another workspace's
+  // instance and rendering its data (#3).
+  const activeId = useConfigStore((s) => s.activeInstance[serviceId] ?? null);
   const targetId = instanceId ?? activeId;
   const enabled = useConfigStore((s) => {
     if (!targetId) return false;

--- a/hooks/use-network.ts
+++ b/hooks/use-network.ts
@@ -1,52 +1,53 @@
 import { useEffect } from "react";
 import NetInfo from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
+import { evaluateHomeNetwork } from "@/lib/network";
 
 /**
- * Tracks whether the phone is on a configured home network and writes the
- * result to `networkAwayFromHome` in the config store. The URL resolver
- * combines that runtime flag with the per-instance `useRemote` *user
- * override* — so the user's "always use remote" toggle never gets clobbered
- * by network events, and the situational auto-switch still flips URLs
- * transparently as the user moves between networks.
+ * Keeps the store's ephemeral `networkAwayFromHome` flag in sync with the actual
+ * network, which drives local/remote URL selection (see lib/network.ts). Local
+ * URLs are used only on a confirmed home network; everywhere else the app uses
+ * remote (never the private local URL, which would leak the API key to a
+ * stranger's device on an untrusted LAN).
  *
- * Home-network matching:
- *   - SSID must match exactly.
- *   - If the entry has an empty `bssid`, SSID alone is enough.
- *   - If the entry has a `bssid` set, it must match the live BSSID. If the OS
- *     doesn't surface a BSSID on this build, the pinned entry fails closed —
- *     don't trust local URLs without the AP fingerprint we asked for.
+ * Triggers:
+ *   - eager evaluation on mount — fixes the stale cold-start state behind #106
+ *     (the old code only attached a listener and waited for NetInfo's first
+ *     event, so the first requests ran against last session's flag).
+ *   - debounced evaluation on every NetInfo change — collapses the burst of
+ *     events a single network transition emits.
+ *   - app-resume evaluation is wired in app/_layout.tsx's onAppStateChange, since
+ *     a VPN can be toggled while the JS runtime is suspended (no event delivered).
  */
 export function useNetworkAutoSwitch() {
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
   const homeNetworks = useConfigStore((s) => s.homeNetworks);
-  const setNetworkAwayFromHome = useConfigStore((s) => s.setNetworkAwayFromHome);
 
   useEffect(() => {
-    if (!autoSwitchNetwork || homeNetworks.length === 0) return;
+    // Auto-switch off → the flag is ignored by getActiveUrl; nothing to do.
+    if (!autoSwitchNetwork) return;
 
-    const unsubscribe = NetInfo.addEventListener((state) => {
-      let isHome: boolean;
-      if (state.type !== "wifi" || !state.details) {
-        isHome = false;
-      } else {
-        const currentSsid = state.details.ssid ?? "";
-        const currentBssid =
-          typeof state.details.bssid === "string"
-            ? state.details.bssid.toLowerCase()
-            : "";
-        isHome = homeNetworks.some((n) => {
-          if (n.ssid !== currentSsid) return false;
-          if (!n.bssid) return true;
-          if (!currentBssid) return false;
-          return n.bssid === currentBssid;
-        });
-      }
-      // Setter is a no-op when the value hasn't changed, so NetInfo's chatty
-      // event stream doesn't cause spurious store updates / re-renders.
-      setNetworkAwayFromHome(!isHome);
-    });
+    // No home networks → we can never confirm "home", so force the safe default
+    // (away → remote) rather than leaving a stale "home" flag that would use the
+    // private local URL off-network. The Home Networks screen warns the user.
+    if (homeNetworks.length === 0) {
+      useConfigStore.getState().setNetworkAwayFromHome(true);
+      return;
+    }
 
-    return unsubscribe;
-  }, [autoSwitchNetwork, homeNetworks, setNetworkAwayFromHome]);
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const evaluate = () => void evaluateHomeNetwork();
+    const scheduleEvaluate = () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(evaluate, 800);
+    };
+
+    evaluate(); // eager startup evaluation
+    const unsubscribe = NetInfo.addEventListener(scheduleEvaluate);
+
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      unsubscribe();
+    };
+  }, [autoSwitchNetwork, homeNetworks]);
 }

--- a/hooks/use-network.ts
+++ b/hooks/use-network.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 import NetInfo from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
-import { evaluateHomeNetwork } from "@/lib/network";
+import {
+  evaluateHomeNetwork,
+  resolveEffectiveHomeNetworks,
+} from "@/lib/network";
 
 /**
  * Keeps the store's ephemeral `networkAwayFromHome` flag in sync with the actual
@@ -21,16 +24,33 @@ import { evaluateHomeNetwork } from "@/lib/network";
  */
 export function useNetworkAutoSwitch() {
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
-  const homeNetworks = useConfigStore((s) => s.homeNetworks);
+  // Re-evaluate whenever the global list changes OR the active dashboard's
+  // selection changes (#148). Both are raw store refs, so they stay stable
+  // until actually mutated; switching workspaces changes activeDashboardId —
+  // and so the selected `overrideIds` ref — which re-runs the effect. We depend
+  // on these inputs rather than the resolved list, since resolving a custom
+  // subset allocates a new array every render and would loop the effect.
+  const globalHomeNetworks = useConfigStore((s) => s.homeNetworks);
+  const overrideIds = useConfigStore(
+    (s) => s.dashboards.find((d) => d.id === s.activeDashboardId)?.homeNetworkIds,
+  );
 
   useEffect(() => {
     // Auto-switch off → the flag is ignored by getActiveUrl; nothing to do.
     if (!autoSwitchNetwork) return;
 
-    // No home networks → we can never confirm "home", so force the safe default
-    // (away → remote) rather than leaving a stale "home" flag that would use the
-    // private local URL off-network. The Home Networks screen warns the user.
-    if (homeNetworks.length === 0) {
+    // No effective home networks (none configured, or an empty custom
+    // selection) → we can never confirm "home", so force the safe default
+    // (away → remote) rather than leaving a stale "home" flag that would use
+    // the private local URL off-network. The Home Networks screen warns the user.
+    const { dashboards, activeDashboardId, homeNetworks } =
+      useConfigStore.getState();
+    const effective = resolveEffectiveHomeNetworks(
+      dashboards,
+      activeDashboardId,
+      homeNetworks,
+    );
+    if (effective.length === 0) {
       useConfigStore.getState().setNetworkAwayFromHome(true);
       return;
     }
@@ -42,12 +62,12 @@ export function useNetworkAutoSwitch() {
       debounceTimer = setTimeout(evaluate, 800);
     };
 
-    evaluate(); // eager startup evaluation
+    evaluate(); // eager startup / workspace-switch evaluation
     const unsubscribe = NetInfo.addEventListener(scheduleEvaluate);
 
     return () => {
       if (debounceTimer) clearTimeout(debounceTimer);
       unsubscribe();
     };
-  }, [autoSwitchNetwork, homeNetworks]);
+  }, [autoSwitchNetwork, globalHomeNetworks, overrideIds]);
 }

--- a/hooks/use-notification-watchers.tsx
+++ b/hooks/use-notification-watchers.tsx
@@ -6,7 +6,6 @@ import { getTorrents } from "@/services/qbittorrent-api";
 import { useRadarrHistory } from "@/hooks/use-radarr";
 import { useSonarrHistory } from "@/hooks/use-sonarr";
 import { useServiceHealth } from "@/hooks/use-service-health";
-import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { useOverseerrRequests } from "@/hooks/use-overseerr";
 import { useSabHistory } from "@/hooks/use-sabnzbd";
 import { useNzbgetHistory } from "@/hooks/use-nzbget";
@@ -228,7 +227,7 @@ function SabnzbdHistoryWatcher({
   instanceId: string;
   active: boolean;
 }) {
-  const { data: sabHistory } = useSabHistory(20, instanceId);
+  const { data: sabHistory } = useSabHistory(20, instanceId, active);
   const prevSabHistoryIds = useRef<Set<string> | null>(null);
 
   useEffect(() => {
@@ -266,7 +265,7 @@ function NzbgetHistoryWatcher({
   instanceId: string;
   active: boolean;
 }) {
-  const { data: history } = useNzbgetHistory(20, instanceId);
+  const { data: history } = useNzbgetHistory(20, instanceId, active);
   const prevIds = useRef<Set<number> | null>(null);
 
   useEffect(() => {
@@ -323,7 +322,7 @@ function RadarrImportWatcher({
   instanceId: string;
   active: boolean;
 }) {
-  const { data: history } = useRadarrHistory(instanceId);
+  const { data: history } = useRadarrHistory(instanceId, active);
   const prevIds = useRef<Set<number> | null>(null);
 
   useEffect(() => {
@@ -366,7 +365,7 @@ function SonarrImportWatcher({
   instanceId: string;
   active: boolean;
 }) {
-  const { data: history } = useSonarrHistory(instanceId);
+  const { data: history } = useSonarrHistory(instanceId, active);
   const prevIds = useRef<Set<number> | null>(null);
 
   useEffect(() => {
@@ -417,11 +416,13 @@ function ServiceHealthWatcher({
   settings: import("@/store/config-store").NotificationSettings;
 }) {
   const { data: health } = useServiceHealth();
-  // Scope offline alerts to the active workspace so a server that lives on
-  // another dashboard (e.g. a Cabin-only qBit) doesn't push "unreachable" while
-  // you're on the Home dashboard (#148 review Rec #5). Single-dashboard /
-  // auto-attach setups attach every instance, so they behave exactly as before.
-  const attached = useAttachedInstances();
+  // Offline alerts are GLOBAL: you're notified about any configured instance
+  // going down regardless of which workspace is active — matching the
+  // completion/import/request watchers above, so a drop on a server that lives
+  // on another dashboard still reaches you. Tapping the alert jumps to a
+  // workspace that has the instance attached (activateDashboardForInstance in
+  // app/_layout.tsx). The usable-URL guard below still suppresses false
+  // "offline" alerts for an instance with no reachable URL on this network.
   const prevHealth = useRef<Map<string, boolean> | null>(null);
 
   useEffect(() => {
@@ -433,7 +434,6 @@ function ServiceHealthWatcher({
     const currentMap = new Map<string, boolean>();
     for (const kind of health) {
       for (const inst of kind.instances) {
-        if (!attached.has(inst.instanceId)) continue;
         const key = `${kind.id}:${inst.instanceId}`;
         currentMap.set(key, inst.online);
         if (prev !== null) {
@@ -465,7 +465,7 @@ function ServiceHealthWatcher({
       }
     }
     prevHealth.current = currentMap;
-  }, [health, gate.backendActive, gate.hydrated, gate.enabled, settings, attached]);
+  }, [health, gate.backendActive, gate.hydrated, gate.enabled, settings]);
 
   return null;
 }
@@ -483,6 +483,7 @@ function OverseerrRequestWatcher({
     "pending",
     "added",
     instanceId,
+    active,
   );
   const prevRequestIds = useRef<Set<number> | null>(null);
   const overseerrShapeWarned = useRef(false);

--- a/hooks/use-notification-watchers.tsx
+++ b/hooks/use-notification-watchers.tsx
@@ -6,11 +6,13 @@ import { getTorrents } from "@/services/qbittorrent-api";
 import { useRadarrHistory } from "@/hooks/use-radarr";
 import { useSonarrHistory } from "@/hooks/use-sonarr";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { useOverseerrRequests } from "@/hooks/use-overseerr";
 import { useSabHistory } from "@/hooks/use-sabnzbd";
 import { useNzbgetHistory } from "@/hooks/use-nzbget";
 import { useConfigStore } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
+import type { ServiceId } from "@/lib/constants";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { sendLocalNotification } from "@/lib/notifications";
 import { shouldNotifyForInstance } from "@/lib/notification-categories";
@@ -415,6 +417,11 @@ function ServiceHealthWatcher({
   settings: import("@/store/config-store").NotificationSettings;
 }) {
   const { data: health } = useServiceHealth();
+  // Scope offline alerts to the active workspace so a server that lives on
+  // another dashboard (e.g. a Cabin-only qBit) doesn't push "unreachable" while
+  // you're on the Home dashboard (#148 review Rec #5). Single-dashboard /
+  // auto-attach setups attach every instance, so they behave exactly as before.
+  const attached = useAttachedInstances();
   const prevHealth = useRef<Map<string, boolean> | null>(null);
 
   useEffect(() => {
@@ -422,9 +429,11 @@ function ServiceHealthWatcher({
     if (!gate.hydrated || !gate.enabled) return;
     if (!Array.isArray(health)) return;
     const prev = prevHealth.current;
+    const store = useConfigStore.getState();
     const currentMap = new Map<string, boolean>();
     for (const kind of health) {
       for (const inst of kind.instances) {
+        if (!attached.has(inst.instanceId)) continue;
         const key = `${kind.id}:${inst.instanceId}`;
         currentMap.set(key, inst.online);
         if (prev !== null) {
@@ -432,7 +441,15 @@ function ServiceHealthWatcher({
           if (
             wasOnline === true &&
             inst.online === false &&
-            shouldNotifyForInstance("serviceOffline", inst.instanceId, settings)
+            shouldNotifyForInstance("serviceOffline", inst.instanceId, settings) &&
+            // Don't cry "unreachable" when the instance only went offline
+            // because the current network has no URL to reach it on — e.g.
+            // leaving home resolves a local-only server to "" (see
+            // getActiveUrl). That's a network change, not a server going down;
+            // a server with a usable URL that stops responding still fires.
+            // kind.id is widened to string on ServiceHealthStatus but is always
+            // a ServiceId here (results are built from SERVICE_IDS).
+            store.getActiveUrl(kind.id as ServiceId, inst.instanceId)
           ) {
             sendLocalNotification({
               title: "Service offline",
@@ -448,7 +465,7 @@ function ServiceHealthWatcher({
       }
     }
     prevHealth.current = currentMap;
-  }, [health, gate.backendActive, gate.hydrated, gate.enabled, settings]);
+  }, [health, gate.backendActive, gate.hydrated, gate.enabled, settings, attached]);
 
   return null;
 }

--- a/hooks/use-nzbget.ts
+++ b/hooks/use-nzbget.ts
@@ -27,13 +27,14 @@ export function useNzbgetGroups(instanceId?: string) {
   );
 }
 
-export function useNzbgetHistory(limit = 50, instanceId?: string) {
+export function useNzbgetHistory(limit = 50, instanceId?: string, active = true) {
   return useServiceQuery(
     "nzbget",
     ["history", limit],
     (id) => getNzbgetHistory(limit, id),
     POLLING_INTERVALS.queue,
     instanceId,
+    active,
   );
 }
 

--- a/hooks/use-overseerr.ts
+++ b/hooks/use-overseerr.ts
@@ -42,13 +42,14 @@ export function useOverseerrRequests(
   filter?: "all" | "approved" | "pending" | "processing" | "available",
   sort: "added" | "modified" = "added",
   instanceId?: string,
+  active = true,
 ) {
   const { instanceId: id, enabled } = useInstanceTarget("overseerr", instanceId);
   return useQuery({
     queryKey: ["overseerr", id, "requests", page, filter, sort],
     queryFn: () => getRequests(page, 20, filter, sort, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
-    enabled: enabled && !!id,
+    enabled: enabled && !!id && active,
   });
 }
 

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -70,13 +70,13 @@ export function useRadarrQueue(instanceId?: string) {
   });
 }
 
-export function useRadarrHistory(instanceId?: string) {
+export function useRadarrHistory(instanceId?: string, active = true) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
     queryKey: ["radarr", id, "history"],
     queryFn: () => getHistory(1, 50, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
-    enabled: enabled && !!id,
+    enabled: enabled && !!id && active,
   });
 }
 

--- a/hooks/use-sabnzbd.ts
+++ b/hooks/use-sabnzbd.ts
@@ -27,13 +27,14 @@ export function useSabQueue(instanceId?: string) {
   );
 }
 
-export function useSabHistory(limit = 50, instanceId?: string) {
+export function useSabHistory(limit = 50, instanceId?: string, active = true) {
   return useServiceQuery(
     "sabnzbd",
     ["history", limit],
     (id) => getSabHistory(limit, id),
     POLLING_INTERVALS.queue,
     instanceId,
+    active,
   );
 }
 

--- a/hooks/use-service-health.test.ts
+++ b/hooks/use-service-health.test.ts
@@ -59,7 +59,8 @@ interface Opts {
 }
 
 // Compute the signature with a resolveUrl that mirrors getActiveUrl's
-// local/remote choice (useRemote OR away-while-auto-switching → remote).
+// local/remote choice: useRemote override → remote; auto-switch off → local;
+// away → remote only; home → local.
 function sig(opts: Opts): string {
   const autoSwitchNetwork = opts.autoSwitchNetwork ?? false;
   const networkAwayFromHome = opts.networkAwayFromHome ?? false;
@@ -72,9 +73,10 @@ function sig(opts: Opts): string {
     resolveUrl: (id, instanceId) => {
       const inst = (opts.instances[id] ?? []).find((x) => x.id === instanceId);
       if (!inst) return "";
-      const useRemote =
-        inst.useRemote || (autoSwitchNetwork && networkAwayFromHome);
-      return useRemote ? inst.remoteUrl : inst.localUrl;
+      if (inst.useRemote) return inst.remoteUrl || inst.localUrl;
+      if (!autoSwitchNetwork) return inst.localUrl || inst.remoteUrl;
+      if (networkAwayFromHome) return inst.remoteUrl;
+      return inst.localUrl || inst.remoteUrl;
     },
   };
   return buildHealthProbeSignature(inputs);

--- a/hooks/use-service-health.ts
+++ b/hooks/use-service-health.ts
@@ -14,8 +14,8 @@ import type {
 
 // The exact inputs each per-instance probe depends on. `resolveUrl` is
 // store.getActiveUrl, which already folds in useRemote + autoSwitchNetwork +
-// networkAwayFromHome, so the network flags are passed only to keep them in
-// the signature (and as honest deps).
+// networkAwayFromHome, so the network flags are passed only to keep them in the
+// signature (and as honest deps).
 export interface HealthProbeInputs {
   serviceInstances: Record<ServiceId, ServiceInstance[]>;
   instanceSecrets: Record<string, ServiceSecrets>;
@@ -38,7 +38,8 @@ export interface HealthProbeInputs {
  * start while the persisted away flag was still stale-true — stayed frozen
  * until a reconnect event (toggling a VPN) or an app relaunch forced a
  * refetch. That is the #106 report: services work on the LAN but the dot is
- * stuck red, and only Tailscale on/off changes it.
+ * stuck red, and only Tailscale on/off changes it. Now `networkAwayFromHome` is
+ * ephemeral and re-evaluated on launch/resume, so the key tracks reality.
  *
  * Credential *values* are intentionally reduced to presence so secrets never
  * land in a query key; a same-presence key edit is picked up by the interval.

--- a/hooks/use-service-query.ts
+++ b/hooks/use-service-query.ts
@@ -13,13 +13,17 @@ export function useServiceQuery<T>(
   fetcher: (instanceId: string | undefined) => Promise<T>,
   refetchInterval: number,
   instanceId?: string,
+  // Extra gate ANDed onto the internal enabled. Defaults to true so screens are
+  // unaffected; background watchers pass their `active` flag so they stop
+  // polling entirely when notifications are off / the backend is pushing.
+  active = true,
 ) {
   const { instanceId: id, enabled } = useInstanceTarget(serviceId, instanceId);
   return useQuery({
     queryKey: [serviceId, id, ...keyParts] as const,
     queryFn: () => fetcher(id ?? undefined),
     refetchInterval,
-    enabled: enabled && !!id,
+    enabled: enabled && !!id && active,
   });
 }
 

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -91,13 +91,13 @@ export function useSonarrQueue(instanceId?: string) {
   });
 }
 
-export function useSonarrHistory(instanceId?: string) {
+export function useSonarrHistory(instanceId?: string, active = true) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "history"],
     queryFn: () => getHistory(1, 50, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
-    enabled: enabled && !!id,
+    enabled: enabled && !!id && active,
   });
 }
 

--- a/hooks/use-workspace-instances.test.ts
+++ b/hooks/use-workspace-instances.test.ts
@@ -1,0 +1,61 @@
+// Mock native storage before importing — use-workspace-instances pulls in
+// use-instance-target → config-store → AsyncStorage/SecureStore at module load.
+// The function under test is pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { scopeInstancesToWorkspace } from "./use-workspace-instances";
+
+const inst = (id: string) => ({ id, name: id });
+
+describe("scopeInstancesToWorkspace", () => {
+  const a = inst("a");
+  const b = inst("b");
+  const c = inst("c");
+  const resolved = [a, b, c];
+  const attached = new Set(["a", "c"]); // b is NOT attached to this workspace
+
+  it("filters the default 'all' binding down to attached instances", () => {
+    expect(scopeInstancesToWorkspace(resolved, "all", attached)).toEqual([a, c]);
+  });
+
+  it("treats undefined / null bindings as the 'all' default (also filtered)", () => {
+    expect(scopeInstancesToWorkspace(resolved, undefined, attached)).toEqual([a, c]);
+    expect(scopeInstancesToWorkspace(resolved, null, attached)).toEqual([a, c]);
+  });
+
+  it("keeps an explicit subset binding unchanged — the deliberate pick wins", () => {
+    // The card already resolved to [b] via resolveBoundInstances; even though b
+    // isn't attached, an explicit per-widget pick is honored (the #106 rule).
+    expect(scopeInstancesToWorkspace([b], ["b"], attached)).toEqual([b]);
+  });
+
+  it("keeps a legacy scalar-id binding unchanged (also explicit)", () => {
+    expect(scopeInstancesToWorkspace([b], "b", attached)).toEqual([b]);
+  });
+
+  it("returns empty for the default binding when nothing is attached", () => {
+    expect(scopeInstancesToWorkspace(resolved, "all", new Set<string>())).toEqual([]);
+  });
+
+  it("returns everything when all resolved instances are attached", () => {
+    expect(
+      scopeInstancesToWorkspace(resolved, "all", new Set(["a", "b", "c"])),
+    ).toEqual([a, b, c]);
+  });
+});

--- a/hooks/use-workspace-instances.ts
+++ b/hooks/use-workspace-instances.ts
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+import type { ServiceId } from "@/lib/constants";
+import type { ServiceInstance } from "@/store/config-store";
+import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useAttachedInstances } from "@/hooks/use-active-dashboard";
+import {
+  resolveBoundInstances,
+  isExplicitInstanceBinding,
+  type StoredInstanceBinding,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+
+/**
+ * Apply the active workspace's attachment filter to an already binding-resolved
+ * instance list.
+ *
+ * An EXPLICIT per-widget binding (a specific id or a non-empty subset) is a
+ * deliberate choice and WINS over the workspace filter — the picker lists every
+ * enabled instance, so a user who pins one that isn't attached reasonably
+ * expects it to show (mirrors ServiceHealthCard and the #106 rule). The default
+ * "all" aggregate is scoped to the dashboard's attached instances so a curated
+ * workspace never shows — or polls — an instance it didn't attach (#148 review
+ * Rec #1, which was previously enforced only inside ServiceHealthCard).
+ */
+export function scopeInstancesToWorkspace<T extends { id: string }>(
+  resolved: T[],
+  binding: StoredInstanceBinding,
+  attached: ReadonlySet<string>,
+): T[] {
+  return isExplicitInstanceBinding(binding)
+    ? resolved
+    : resolved.filter((i) => attached.has(i.id));
+}
+
+/**
+ * Enabled instances of a kind that are attached to the active workspace —
+ * ignoring any per-widget binding. This is the set a workspace's widget SETTINGS
+ * should reason about: which kinds to surface, and which instances the picker
+ * may offer (#148 review Rec #7). Auto-attach dashboards (attachedInstances ===
+ * undefined) resolve to every enabled instance, so nothing is hidden there.
+ *
+ * Memoized for a stable reference across renders.
+ */
+export function useAttachedEnabledInstances(
+  serviceId: ServiceId,
+): ServiceInstance[] {
+  const enabled = useEnabledInstances(serviceId);
+  const attached = useAttachedInstances();
+  return useMemo(
+    () => enabled.filter((i) => attached.has(i.id)),
+    [enabled, attached],
+  );
+}
+
+/**
+ * Workspace-scoped, binding-resolved enabled instances for a kind — the
+ * one-call replacement for the `useEnabledInstances(kind)` + `resolveBoundInstances`
+ * pattern in fan-out dashboard cards. Pass `undefined`/`"all"` as the binding
+ * for cards without a per-widget instance picker.
+ *
+ * Memoized so the returned array keeps a stable reference across renders when
+ * nothing changed — the resolve+filter would otherwise allocate a fresh array
+ * every render, which matters for the `useQueries` consumers downstream.
+ */
+export function useWorkspaceScopedInstances(
+  serviceId: ServiceId,
+  binding: StoredInstanceBinding,
+): ServiceInstance[] {
+  const allEnabled = useEnabledInstances(serviceId);
+  const attached = useAttachedInstances();
+  return useMemo(
+    () =>
+      scopeInstancesToWorkspace(
+        resolveBoundInstances(binding, allEnabled),
+        binding,
+        attached,
+      ),
+    [binding, allEnabled, attached],
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -132,6 +132,11 @@ export const DEFAULT_DASHBOARD_WIDGETS: WidgetId[] = [
 // dashboard picker on fresh installs and after legacy migration.
 export const DEFAULT_DASHBOARD_NAME = "Default";
 
+// Cap on home-WiFi entries — applies both to the global list and to each
+// dashboard's optional per-workspace override (v29). Enforced by the editors,
+// the store, and the import schema so the three agree on one bound.
+export const MAX_HOME_NETWORKS = 20;
+
 // Old widget ids that have been renamed. Hydrate + import use this to remap
 // stored values so users keep their dashboard layout across upgrades.
 export const WIDGET_ID_RENAMES: Record<string, WidgetId> = {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -168,11 +168,11 @@ export const STORAGE_KEYS = {
   // any SERVICE_IDS missing from the list are appended in their canonical
   // order — so adding a new service kind ships with a sensible default.
   servicesOrder: "app.servicesOrder",
-  // v18: cached network-state ("am I off my home network right now?"). The
-  // auto-switch hook updates this on every home↔away transition. Persisted
-  // so cold launches use last-known state for the brief moment before
-  // NetInfo fires; NetInfo overwrites it on first event.
-  networkAwayFromHome: "app.networkAwayFromHome",
+  // (removed) persisted app.networkAwayFromHome — it is now EPHEMERAL runtime
+  // state (config-store.networkAwayFromHome), recomputed each launch by
+  // evaluateHomeNetwork() in lib/network.ts. Persisting a live network
+  // observation caused the stale-cold-start half of #106; the orphaned key is
+  // purged in hydrate.
   // v18 one-shot marker: pre-v18 builds clobbered useRemote with derived
   // network state. On first v18 launch the hydrate path resets useRemote
   // (only for installs that had auto-switch on) so the user starts from a

--- a/lib/network.test.ts
+++ b/lib/network.test.ts
@@ -15,7 +15,11 @@ jest.mock("@/store/config-store", () => ({
   useConfigStore: { getState: () => mockGetState() },
 }));
 
-import { isHomeNetwork, evaluateHomeNetwork } from "./network";
+import {
+  isHomeNetwork,
+  evaluateHomeNetwork,
+  resolveEffectiveHomeNetworks,
+} from "./network";
 
 const wifi = (ssid: string | null, bssid: string | null = null) =>
   ({ type: "wifi", isConnected: true, details: { ssid, bssid } }) as any;
@@ -66,6 +70,10 @@ describe("evaluateHomeNetwork", () => {
       demoMode: false,
       autoSwitchNetwork: true,
       homeNetworks: [{ id: "1", ssid: "Home", bssid: "" }],
+      // No dashboards by default → resolveEffectiveHomeNetworks falls back to
+      // the global list, so the pre-v29 cases below keep exercising it.
+      dashboards: [],
+      activeDashboardId: "",
       setNetworkAwayFromHome: jest.fn(),
       ...over,
     };
@@ -119,5 +127,121 @@ describe("evaluateHomeNetwork", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+
+  // --- v29: per-dashboard selection (#148) ---
+
+  // Two global networks; dashboards select a subset of them by id.
+  const twoNetworks = [
+    { id: "home", ssid: "Home", bssid: "" },
+    { id: "cabin", ssid: "Cabin", bssid: "" },
+  ];
+  const dashWithIds = (homeNetworkIds?: any) => ({
+    id: "d1",
+    name: "Cabin",
+    widgets: [],
+    ...(homeNetworkIds !== undefined ? { homeNetworkIds } : {}),
+  });
+
+  it("uses only the active dashboard's selected networks", async () => {
+    const store = fakeStore({
+      homeNetworks: twoNetworks,
+      dashboards: [dashWithIds(["cabin"])],
+      activeDashboardId: "d1",
+    });
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(wifi("Cabin"));
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("treats a deselected network as away even though it's in the global list", async () => {
+    const store = fakeStore({
+      homeNetworks: twoNetworks,
+      dashboards: [dashWithIds(["cabin"])], // Home not selected
+      activeDashboardId: "d1",
+    });
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(wifi("Home"));
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+  });
+
+  it("no-ops when the active dashboard's selection is empty (always away)", async () => {
+    const store = fakeStore({
+      homeNetworks: twoNetworks,
+      dashboards: [dashWithIds([])],
+      activeDashboardId: "d1",
+    });
+    mockGetState.mockReturnValue(store);
+
+    await evaluateHomeNetwork();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+
+  it("uses all networks when the active dashboard has no selection", async () => {
+    const store = fakeStore({
+      homeNetworks: twoNetworks,
+      dashboards: [dashWithIds(undefined)],
+      activeDashboardId: "d1",
+    });
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(wifi("Home"));
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("resolveEffectiveHomeNetworks", () => {
+  const global = [
+    { id: "home", ssid: "Home", bssid: "" },
+    { id: "cabin", ssid: "Cabin", bssid: "" },
+  ];
+  const dash = (homeNetworkIds?: any) =>
+    ({
+      id: "d1",
+      name: "Cabin",
+      widgets: [],
+      ...(homeNetworkIds !== undefined ? { homeNetworkIds } : {}),
+    }) as any;
+
+  it("returns the whole global list when the dashboard uses all", () => {
+    expect(resolveEffectiveHomeNetworks([dash(undefined)], "d1", global)).toBe(
+      global,
+    );
+  });
+
+  it("returns only the selected subset, in global order", () => {
+    expect(
+      resolveEffectiveHomeNetworks([dash(["cabin"])], "d1", global),
+    ).toEqual([{ id: "cabin", ssid: "Cabin", bssid: "" }]);
+  });
+
+  it("ignores stale ids that no longer match a live network", () => {
+    expect(
+      resolveEffectiveHomeNetworks([dash(["cabin", "gone"])], "d1", global),
+    ).toEqual([{ id: "cabin", ssid: "Cabin", bssid: "" }]);
+  });
+
+  it("returns an empty list for an explicit empty selection", () => {
+    expect(resolveEffectiveHomeNetworks([dash([])], "d1", global)).toEqual([]);
+  });
+
+  it("falls back to the global list when there are no dashboards", () => {
+    expect(resolveEffectiveHomeNetworks([], "d1", global)).toBe(global);
+  });
+
+  it("falls back to the first dashboard when the active id doesn't match", () => {
+    expect(
+      resolveEffectiveHomeNetworks([dash(["cabin"])], "missing", global),
+    ).toEqual([{ id: "cabin", ssid: "Cabin", bssid: "" }]);
   });
 });

--- a/lib/network.test.ts
+++ b/lib/network.test.ts
@@ -1,0 +1,123 @@
+// Mock NetInfo (native) and the config store so importing network.ts pulls in
+// no native modules and the store is fully controllable.
+const mockFetch = jest.fn();
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: {
+    configure: jest.fn(),
+    fetch: (...args: any[]) => mockFetch(...args),
+    addEventListener: jest.fn(() => jest.fn()),
+  },
+}));
+
+const mockGetState = jest.fn();
+jest.mock("@/store/config-store", () => ({
+  useConfigStore: { getState: () => mockGetState() },
+}));
+
+import { isHomeNetwork, evaluateHomeNetwork } from "./network";
+
+const wifi = (ssid: string | null, bssid: string | null = null) =>
+  ({ type: "wifi", isConnected: true, details: { ssid, bssid } }) as any;
+const vpn = () => ({ type: "vpn", isConnected: true, details: null }) as any;
+const cellular = () => ({ type: "cellular", isConnected: true, details: {} }) as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("isHomeNetwork", () => {
+  const ssidOnly = [{ id: "1", ssid: "Home", bssid: "" }];
+  const pinned = [{ id: "1", ssid: "Home", bssid: "aa:bb:cc" }];
+
+  it("is false when no home networks are configured", () => {
+    expect(isHomeNetwork(wifi("Home"), [])).toBe(false);
+  });
+
+  it("is false under a VPN (SSID masked) — the safe default that prevents the leak", () => {
+    expect(isHomeNetwork(vpn(), ssidOnly)).toBe(false);
+    expect(isHomeNetwork(cellular(), ssidOnly)).toBe(false);
+  });
+
+  it("is true on an SSID-only match", () => {
+    expect(isHomeNetwork(wifi("Home"), ssidOnly)).toBe(true);
+  });
+
+  it("is false on a non-matching SSID", () => {
+    expect(isHomeNetwork(wifi("Cafe"), ssidOnly)).toBe(false);
+  });
+
+  it("is true when a pinned BSSID matches (case-insensitive)", () => {
+    expect(isHomeNetwork(wifi("Home", "AA:BB:CC"), pinned)).toBe(true);
+  });
+
+  it("is false when the SSID matches but a pinned BSSID does not (rogue-AP guard)", () => {
+    expect(isHomeNetwork(wifi("Home", "ff:ff:ff"), pinned)).toBe(false);
+  });
+
+  it("fails closed (false) when a BSSID is pinned but the OS hides it", () => {
+    expect(isHomeNetwork(wifi("Home", null), pinned)).toBe(false);
+  });
+});
+
+describe("evaluateHomeNetwork", () => {
+  function fakeStore(over: Record<string, any> = {}) {
+    return {
+      demoMode: false,
+      autoSwitchNetwork: true,
+      homeNetworks: [{ id: "1", ssid: "Home", bssid: "" }],
+      setNetworkAwayFromHome: jest.fn(),
+      ...over,
+    };
+  }
+
+  it("sets away=false on a confirmed home network", async () => {
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(wifi("Home"));
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("sets away=true when not on a home network (VPN masks the SSID)", async () => {
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(vpn());
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+  });
+
+  it("no-ops (no fetch, no write) when auto-switch is off", async () => {
+    const store = fakeStore({ autoSwitchNetwork: false });
+    mockGetState.mockReturnValue(store);
+
+    await evaluateHomeNetwork();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when no home networks are configured (flag stays at its safe default)", async () => {
+    const store = fakeStore({ homeNetworks: [] });
+    mockGetState.mockReturnValue(store);
+
+    await evaluateHomeNetwork();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+
+  it("no-ops in demo mode", async () => {
+    const store = fakeStore({ demoMode: true });
+    mockGetState.mockReturnValue(store);
+
+    await evaluateHomeNetwork();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+});

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -1,6 +1,6 @@
 import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
-import type { HomeNetwork } from "@/store/config-store";
+import type { Dashboard, HomeNetwork } from "@/store/config-store";
 
 /**
  * Home-network detection — the single signal behind local/remote URL switching.
@@ -43,6 +43,31 @@ export function isHomeNetwork(
   });
 }
 
+/**
+ * The home-WiFi networks that actually govern local/remote switching right now:
+ * the active dashboard's selection resolved against the global list (#148).
+ * `homeNetworkIds === undefined` on a dashboard means "use ALL home networks"
+ * (the default); an explicit array selects that subset by id (stale ids that no
+ * longer match a live network are ignored), and an empty array means "none →
+ * always remote". Falls back to all when the active dashboard can't be resolved,
+ * so callers without a dashboard set (and pre-v29 state) keep global behavior.
+ *
+ * Only the active dashboard is consulted — switching workspaces re-evaluates
+ * (the useNetworkAutoSwitch effect re-runs when the selection or list changes).
+ */
+export function resolveEffectiveHomeNetworks(
+  dashboards: Dashboard[],
+  activeDashboardId: string,
+  globalHomeNetworks: HomeNetwork[],
+): HomeNetwork[] {
+  const active =
+    dashboards.find((d) => d.id === activeDashboardId) ?? dashboards[0];
+  const ids = active?.homeNetworkIds;
+  if (ids === undefined) return globalHomeNetworks;
+  const selected = new Set(ids);
+  return globalHomeNetworks.filter((n) => selected.has(n.id));
+}
+
 // Shared in-flight gate so startup / NetInfo-change / resume callers don't race.
 let evalInFlight = false;
 
@@ -57,15 +82,16 @@ export async function evaluateHomeNetwork(): Promise<void> {
   evalInFlight = true;
   try {
     const store = useConfigStore.getState();
-    if (
-      store.demoMode ||
-      !store.autoSwitchNetwork ||
-      store.homeNetworks.length === 0
-    ) {
+    const effective = resolveEffectiveHomeNetworks(
+      store.dashboards,
+      store.activeDashboardId,
+      store.homeNetworks,
+    );
+    if (store.demoMode || !store.autoSwitchNetwork || effective.length === 0) {
       return;
     }
     const state = await NetInfo.fetch();
-    store.setNetworkAwayFromHome(!isHomeNetwork(state, store.homeNetworks));
+    store.setNetworkAwayFromHome(!isHomeNetwork(state, effective));
   } finally {
     evalInFlight = false;
   }

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -1,0 +1,72 @@
+import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
+import { useConfigStore } from "@/store/config-store";
+import type { HomeNetwork } from "@/store/config-store";
+
+/**
+ * Home-network detection — the single signal behind local/remote URL switching.
+ *
+ * SSID matching is the only "am I home?" signal we trust, deliberately: the
+ * local URL is a private address (192.168.x / 10.x / mDNS name) that is only
+ * meaningful and safe on your actual home LAN. We never use it on a network we
+ * can't confirm is home, because a stranger's device at the same private address
+ * (airport/cafe WiFi) would receive the API key the app sends. So:
+ *   - confirmed home network → local URL.
+ *   - anything else (away / cellular / other WiFi / VPN that masks the SSID / no
+ *     home networks configured) → remote URL only; never the local URL.
+ *
+ * `evaluateHomeNetwork()` recomputes this on startup, on every (debounced)
+ * NetInfo change, and on app resume, writing the ephemeral
+ * `networkAwayFromHome` flag the synchronous `getActiveUrl` reads.
+ */
+
+/**
+ * True only when on a configured home network: the SSID must match, and a pinned
+ * BSSID must also match (fails closed if the OS hides the BSSID — guards against
+ * a rogue AP cloning the SSID). Under a VPN the SSID is masked (not "wifi" / no
+ * details) → false → treated as away → remote, which is the safe default.
+ */
+export function isHomeNetwork(
+  state: NetInfoState,
+  homeNetworks: HomeNetwork[],
+): boolean {
+  if (state.type !== "wifi" || !state.details) return false;
+  const ssid = state.details.ssid ?? "";
+  const bssid =
+    typeof state.details.bssid === "string"
+      ? state.details.bssid.toLowerCase()
+      : "";
+  return homeNetworks.some((n) => {
+    if (n.ssid !== ssid) return false;
+    if (!n.bssid) return true;
+    if (!bssid) return false;
+    return n.bssid === bssid;
+  });
+}
+
+// Shared in-flight gate so startup / NetInfo-change / resume callers don't race.
+let evalInFlight = false;
+
+/**
+ * Recompute whether we're on a home network and store the away flag. Safe to
+ * call unconditionally — early-returns when auto-switch is off, in demo mode, or
+ * no home networks are configured (in which case the flag stays at its default
+ * `true`, i.e. away → remote, so we never use the private local URL off-home).
+ */
+export async function evaluateHomeNetwork(): Promise<void> {
+  if (evalInFlight) return;
+  evalInFlight = true;
+  try {
+    const store = useConfigStore.getState();
+    if (
+      store.demoMode ||
+      !store.autoSwitchNetwork ||
+      store.homeNetworks.length === 0
+    ) {
+      return;
+    }
+    const state = await NetInfo.fetch();
+    store.setNetworkAwayFromHome(!isHomeNetwork(state, store.homeNetworks));
+  } finally {
+    evalInFlight = false;
+  }
+}

--- a/lib/query-client.ts
+++ b/lib/query-client.ts
@@ -1,11 +1,30 @@
 import { QueryClient } from "@tanstack/react-query";
 
+// Auth failures (401/403) mean the API key/token is wrong, not that the network
+// is flaky — retrying just burns JS-thread cycles and delays the error state.
+// Skip retries for those; keep 2 retries (with backoff) for transient errors.
+// Status is duck-typed (HttpError carries a numeric `status`) rather than
+// imported, to avoid a require cycle: http-client imports the config store,
+// which imports this module.
+function retryQuery(failureCount: number, error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status;
+  if (status === 401 || status === 403) return false;
+  return failureCount < 2;
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 2,
+      retry: retryQuery,
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
       staleTime: 5000,
       gcTime: 300000,
+      // The app polls on its own intervals and offers pull-to-refresh, so the
+      // default "refetch every query on focus/reconnect" just causes a
+      // thundering herd of refetches + re-renders each time the app resumes or
+      // the network blips. Opt out; the active screen's polling keeps it fresh.
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   },
 });

--- a/lib/url-validation.test.ts
+++ b/lib/url-validation.test.ts
@@ -1,4 +1,8 @@
-import { validateServiceUrl, normalizeServiceUrl } from "./url-validation";
+import {
+  validateServiceUrl,
+  normalizeServiceUrl,
+  resolveActiveUrlKind,
+} from "./url-validation";
 
 describe("validateServiceUrl", () => {
   describe("empty input", () => {
@@ -97,5 +101,46 @@ describe("normalizeServiceUrl", () => {
 
   it("trims input", () => {
     expect(normalizeServiceUrl("  localhost:8989  ")).toBe("http://localhost:8989");
+  });
+});
+
+describe("resolveActiveUrlKind", () => {
+  const inst = (over: Partial<{ localUrl: string; remoteUrl: string; useRemote: boolean }> = {}) => ({
+    localUrl: "192.168.1.10:7878",
+    remoteUrl: "https://remote.example.com",
+    useRemote: false,
+    ...over,
+  });
+
+  it("returns null when neither URL is configured", () => {
+    expect(resolveActiveUrlKind({ localUrl: "", remoteUrl: "", useRemote: false }, true, false)).toBeNull();
+  });
+
+  it("is remote when the per-instance useRemote override is set", () => {
+    expect(resolveActiveUrlKind(inst({ useRemote: true }), true, false)).toBe("remote");
+  });
+
+  it("falls back to local when useRemote is set but no remote is configured", () => {
+    expect(resolveActiveUrlKind(inst({ useRemote: true, remoteUrl: "" }), true, false)).toBe("local");
+  });
+
+  it("is local when auto-switch is off (uses local regardless of network)", () => {
+    expect(resolveActiveUrlKind(inst(), false, true)).toBe("local");
+  });
+
+  it("falls back to remote when auto-switch is off and no local is configured", () => {
+    expect(resolveActiveUrlKind(inst({ localUrl: "" }), false, true)).toBe("remote");
+  });
+
+  it("is remote when away from home (no local fallback — the security invariant)", () => {
+    expect(resolveActiveUrlKind(inst(), true, true)).toBe("remote");
+  });
+
+  it("is local on a confirmed home network", () => {
+    expect(resolveActiveUrlKind(inst(), true, false)).toBe("local");
+  });
+
+  it("falls back to remote at home when no local is configured", () => {
+    expect(resolveActiveUrlKind(inst({ localUrl: "" }), true, false)).toBe("remote");
   });
 });

--- a/lib/url-validation.ts
+++ b/lib/url-validation.ts
@@ -57,3 +57,25 @@ export function normalizeServiceUrl(raw: string): string {
   if (/^[a-z]+:\/\//i.test(trimmed)) return trimmed;
   return `http://${trimmed}`;
 }
+
+/**
+ * Which URL bucket a service instance is actively using right now: "local",
+ * "remote", or null when neither URL is configured. This MIRRORS the decision
+ * tree in `getActiveUrl` (store/config-store.ts) — keep the two in sync — but
+ * reports the chosen bucket instead of the URL string, so UI can surface an
+ * L/R indicator. The away branch is "remote" with no local fallback (the
+ * security invariant: never the private local URL off a confirmed home WiFi).
+ */
+export function resolveActiveUrlKind(
+  inst: { localUrl: string; remoteUrl: string; useRemote: boolean },
+  autoSwitchNetwork: boolean,
+  networkAwayFromHome: boolean,
+): "local" | "remote" | null {
+  const local = normalizeServiceUrl(inst.localUrl);
+  const remote = normalizeServiceUrl(inst.remoteUrl);
+  if (!local && !remote) return null;
+  if (inst.useRemote) return remote ? "remote" : "local";
+  if (!autoSwitchNetwork) return local ? "local" : "remote";
+  if (networkAwayFromHome) return "remote";
+  return local ? "local" : "remote";
+}

--- a/lib/url-validation.ts
+++ b/lib/url-validation.ts
@@ -70,11 +70,17 @@ export function resolveActiveUrlKind(
   inst: { localUrl: string; remoteUrl: string; useRemote: boolean },
   autoSwitchNetwork: boolean,
   networkAwayFromHome: boolean,
+  // True when the active workspace explicitly selected no live home networks
+  // (homeNetworkIds: [] or only stale ids) → "always remote", honored even when
+  // global auto-switch is off. Mirrors getActiveUrl step 2 (#148). Defaults to
+  // false so callers without workspace context keep the legacy behavior.
+  workspaceForcesRemote = false,
 ): "local" | "remote" | null {
   const local = normalizeServiceUrl(inst.localUrl);
   const remote = normalizeServiceUrl(inst.remoteUrl);
   if (!local && !remote) return null;
   if (inst.useRemote) return remote ? "remote" : "local";
+  if (workspaceForcesRemote) return "remote";
   if (!autoSwitchNetwork) return local ? "local" : "remote";
   if (networkAwayFromHome) return "remote";
   return local ? "local" : "remote";

--- a/lib/wifi.ts
+++ b/lib/wifi.ts
@@ -41,3 +41,55 @@ export async function detectSSID(): Promise<string | null> {
 export function normalizeBssid(value: string): string {
   return value.trim().toLowerCase();
 }
+
+// Permissive MAC charset — accepts colon/dash/dot separators and hex. We only
+// guard against obviously-wrong input; NetInfo's BSSID format varies by OS.
+const HOME_NETWORK_MAC_RE = /^[0-9a-f:.\-]+$/i;
+
+/** Minimal shape a home-network entry needs for validation — kept structural so
+ *  this module doesn't import the store (avoids a needless dependency). */
+interface HomeNetworkLike {
+  id: string;
+  ssid: string;
+  bssid: string;
+}
+
+export type HomeNetworkValidation =
+  | { ok: true; ssid: string; bssid: string }
+  | { ok: false; error: string };
+
+/**
+ * Validate + normalize a home-network form entry. Shared by the global Home
+ * Networks screen and the per-dashboard override editor (#148) so both apply
+ * identical rules: SSID required (≤64 chars), optional MAC-shaped BSSID (≤64),
+ * and no exact (ssid, bssid) duplicate within `existing` (the entry being
+ * edited, identified by `editingId`, is excluded). Returns the normalized
+ * values on success so callers persist exactly what was validated.
+ */
+export function validateHomeNetworkInput(
+  rawSsid: string,
+  rawBssid: string,
+  existing: readonly HomeNetworkLike[],
+  editingId?: string | null,
+): HomeNetworkValidation {
+  const ssid = rawSsid.trim();
+  if (!ssid) return { ok: false, error: "WiFi name (SSID) is required" };
+  if (ssid.length > 64) return { ok: false, error: "WiFi name is too long" };
+
+  const trimmedBssid = rawBssid.trim();
+  if (trimmedBssid && !HOME_NETWORK_MAC_RE.test(trimmedBssid)) {
+    return {
+      ok: false,
+      error: "BSSID looks invalid — use a MAC like aa:bb:cc:dd:ee:ff",
+    };
+  }
+  if (trimmedBssid.length > 64) return { ok: false, error: "BSSID is too long" };
+
+  const bssid = normalizeBssid(trimmedBssid);
+  const duplicate = existing.some(
+    (n) => n.id !== editingId && n.ssid === ssid && n.bssid === bssid,
+  );
+  if (duplicate) return { ok: false, error: "This network is already saved" };
+
+  return { ok: true, ssid, bssid };
+}

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -112,8 +112,12 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         networks", so the existing list keeps governing every dashboard and
  *         older exports just need the version field bumped. coerceDashboard
  *         validates the field on import.
+ *   v30 — optional per-workspace `servicesOrder` on each Dashboard: a custom
+ *         Services-tab tile order per workspace. Pure version stamp — absent
+ *         means "use the global servicesOrder", so older exports just need the
+ *         version field bumped. coerceDashboard validates the field on import.
  */
-export const CURRENT_CONFIG_VERSION = 29;
+export const CURRENT_CONFIG_VERSION = 30;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -589,6 +593,12 @@ const migrations: Record<number, (payload: any) => any> = {
   // means "use all home networks", so older exports are already correct.
   // coerceDashboard coerces/validates the field on import.
   28: (payload) => ({ ...payload, version: 29 }),
+
+  // v29 → v30: optional per-workspace `servicesOrder` on each Dashboard. Pure
+  // version stamp — the field is optional and absent means "use the global
+  // servicesOrder", so older exports are already correct. coerceDashboard
+  // coerces/validates the field on import.
+  29: (payload) => ({ ...payload, version: 30 }),
 };
 
 /**

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -106,8 +106,14 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *   v28 — added the jellystat service entry. Pure version stamp — defaultInstances()
  *         iterates SERVICE_IDS and backfills a disabled jellystat instance at
  *         import time, so older exports just need the version field bumped.
+ *   v29 — optional per-workspace home-network selection (#148): each Dashboard
+ *         may carry a `homeNetworkIds: string[]` selecting a subset of the
+ *         global homeNetworks. Pure version stamp — absent means "use all home
+ *         networks", so the existing list keeps governing every dashboard and
+ *         older exports just need the version field bumped. coerceDashboard
+ *         validates the field on import.
  */
-export const CURRENT_CONFIG_VERSION = 28;
+export const CURRENT_CONFIG_VERSION = 29;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -577,6 +583,12 @@ const migrations: Record<number, (payload: any) => any> = {
   // defaultInstances() afterward, so older payloads that lack a jellystat entry
   // get the disabled default automatically — nothing to transform here.
   27: (payload) => ({ ...payload, version: 28 }),
+
+  // v28 → v29: optional per-workspace `homeNetworkIds` selection on each
+  // Dashboard (#148). Pure version stamp — the field is optional and absent
+  // means "use all home networks", so older exports are already correct.
+  // coerceDashboard coerces/validates the field on import.
+  28: (payload) => ({ ...payload, version: 29 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -420,6 +420,105 @@ describe("validateExportPayload — dashboard.activeInstance (v22)", () => {
   });
 });
 
+describe("validateExportPayload — dashboard.homeNetworkIds (v29)", () => {
+  it("omits dashboard.homeNetworkIds when not provided (uses all networks)", () => {
+    const result = validateExportPayload(baseValid());
+    expect(result.dashboards[0].homeNetworkIds).toBeUndefined();
+  });
+
+  it("preserves a valid per-dashboard homeNetworkIds selection", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      dashboards: [
+        {
+          id: TEST_DASHBOARD_ID,
+          name: "Cabin",
+          widgets: [],
+          homeNetworkIds: ["net-cabin", "net-home"],
+        },
+      ],
+    });
+    expect(result.dashboards[0].homeNetworkIds).toEqual([
+      "net-cabin",
+      "net-home",
+    ]);
+  });
+
+  it("preserves an explicit empty selection (no home network → always remote)", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      dashboards: [
+        { id: TEST_DASHBOARD_ID, name: "Cabin", widgets: [], homeNetworkIds: [] },
+      ],
+    });
+    expect(result.dashboards[0].homeNetworkIds).toEqual([]);
+  });
+
+  it("dedupes and drops empty/non-string ids (import-tolerant)", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      dashboards: [
+        {
+          id: TEST_DASHBOARD_ID,
+          name: "Cabin",
+          widgets: [],
+          homeNetworkIds: ["net-a", "net-a", "", 42, "net-b"] as any,
+        },
+      ],
+    });
+    expect(result.dashboards[0].homeNetworkIds).toEqual(["net-a", "net-b"]);
+  });
+
+  it("keeps a stale id — the resolver ignores it at read time", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      dashboards: [
+        {
+          id: TEST_DASHBOARD_ID,
+          name: "Cabin",
+          widgets: [],
+          homeNetworkIds: ["id-from-another-device"],
+        },
+      ],
+    });
+    expect(result.dashboards[0].homeNetworkIds).toEqual([
+      "id-from-another-device",
+    ]);
+  });
+
+  it("truncates to MAX_HOME_NETWORKS (20)", () => {
+    const many = Array.from({ length: 25 }, (_, i) => `net-${i}`);
+    const result = validateExportPayload({
+      ...baseValid(),
+      dashboards: [
+        {
+          id: TEST_DASHBOARD_ID,
+          name: "Cabin",
+          widgets: [],
+          homeNetworkIds: many,
+        },
+      ],
+    });
+    expect(result.dashboards[0].homeNetworkIds).toHaveLength(20);
+  });
+
+  it("rejects a dashboard with a non-array homeNetworkIds", () => {
+    expect(() =>
+      validateExportPayload({
+        ...baseValid(),
+        dashboards: [
+          {
+            id: TEST_DASHBOARD_ID,
+            name: "Cabin",
+            widgets: [],
+            homeNetworkIds: "nope" as any,
+          },
+        ],
+      }),
+    ).toThrow(/dashboards entry is invalid/);
+  });
+});
+
 describe("validateExportPayload — WOL devices", () => {
   const baseWol = () => ({ id: "d1", name: "Server", mac: "aa:bb:cc:dd:ee:ff" });
 

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -1,4 +1,9 @@
-import { SERVICE_IDS, DASHBOARD_WIDGET_IDS, UI_SCALES } from "@/lib/constants";
+import {
+  SERVICE_IDS,
+  DASHBOARD_WIDGET_IDS,
+  UI_SCALES,
+  MAX_HOME_NETWORKS,
+} from "@/lib/constants";
 import type { ServiceId, WidgetId } from "@/lib/constants";
 import type {
   Dashboard,
@@ -42,7 +47,6 @@ function isHttpUrlOrEmpty(v: unknown): v is string {
 // CR/LF in values closes off header-injection if someone hand-edits an export.
 const HEADER_NAME_RE = /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/;
 const MAX_HEADERS_PER_SCOPE = 32;
-const MAX_HOME_NETWORKS = 20;
 
 function coerceHeaderMap(v: unknown): Record<string, string> | null {
   if (!isPlainObject(v)) return null;
@@ -206,6 +210,24 @@ function coerceDashboard(v: unknown): Dashboard | null {
     if (Object.keys(cleaned).length > 0) {
       out.activeInstance = cleaned;
     }
+  }
+  // v29: optional per-workspace home-network selection (#148). Present-but-not-
+  // array is rejected; otherwise dedupe + drop empties (import-tolerant, like
+  // attachedInstances), and cap at MAX_HOME_NETWORKS. Ids aren't validated
+  // against the live list — the resolver ignores stale ids. An explicit empty
+  // array is preserved — it's a valid selection ("no home network here").
+  if (v.homeNetworkIds !== undefined && v.homeNetworkIds !== null) {
+    if (!Array.isArray(v.homeNetworkIds)) return null;
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const id of v.homeNetworkIds) {
+      if (typeof id !== "string" || id.length === 0 || id.length > 128) continue;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+      if (ids.length >= MAX_HOME_NETWORKS) break;
+    }
+    out.homeNetworkIds = ids;
   }
   return out;
 }

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -229,6 +229,22 @@ function coerceDashboard(v: unknown): Dashboard | null {
     }
     out.homeNetworkIds = ids;
   }
+  // v30: optional per-workspace Services-tab order. Present-but-not-array is
+  // rejected; otherwise dedupe + drop unknown service ids (forward-compat, like
+  // the global servicesOrder). Absence means "use the global order".
+  if (v.servicesOrder !== undefined && v.servicesOrder !== null) {
+    if (!Array.isArray(v.servicesOrder)) return null;
+    const seen = new Set<string>();
+    const order: ServiceId[] = [];
+    for (const sid of v.servicesOrder) {
+      if (typeof sid !== "string") continue;
+      if (!SERVICE_ID_SET.has(sid)) continue; // forward-compat: drop unknowns
+      if (seen.has(sid)) continue;
+      seen.add(sid);
+      order.push(sid as ServiceId);
+    }
+    out.servicesOrder = order;
+  }
   return out;
 }
 

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -22,6 +22,8 @@ jest.mock("expo-secure-store", () => ({
 }));
 
 import { useConfigStore } from "./config-store";
+import { setJSON } from "./storage";
+import { STORAGE_KEYS } from "@/lib/constants";
 import { queryClient } from "@/lib/query-client";
 
 // Smoke-test that getActiveUrl always returns a fetch-safe URL, even when the
@@ -529,5 +531,431 @@ describe("setActiveDashboard — query invalidation on forced away (#4)", () => 
     expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+// #148: a workspace that explicitly selected NO live home networks
+// (homeNetworkIds: [] or only stale ids) is "always remote" and must be honored
+// even when the GLOBAL auto-switch toggle is off — otherwise turning off
+// auto-switch silently re-exposes the private local URL for a remote-only
+// workspace. undefined (auto-attach all networks) keeps the legacy behavior.
+describe("getActiveUrl — workspace 'always remote' honored with auto-switch off (#148)", () => {
+  const LOCAL = "http://192.168.1.50:7878";
+  const REMOTE = "https://radarr.example.com";
+
+  function seedWorkspace(opts: {
+    homeNetworkIds: string[] | undefined;
+    homeNetworks: { id: string; ssid: string; bssid: string }[];
+    autoSwitchNetwork: boolean;
+    networkAwayFromHome: boolean;
+  }) {
+    useConfigStore.setState({
+      serviceInstances: {
+        ...useConfigStore.getState().serviceInstances,
+        radarr: [
+          {
+            id: INSTANCE_ID,
+            enabled: true,
+            name: "Radarr",
+            localUrl: LOCAL,
+            remoteUrl: REMOTE,
+            useRemote: false,
+          },
+        ],
+      },
+      activeInstance: {
+        ...useConfigStore.getState().activeInstance,
+        radarr: INSTANCE_ID,
+      },
+      homeNetworks: opts.homeNetworks,
+      dashboards: [
+        {
+          id: "A",
+          name: "A",
+          widgets: [],
+          ...(opts.homeNetworkIds !== undefined
+            ? { homeNetworkIds: opts.homeNetworkIds }
+            : {}),
+        },
+      ],
+      activeDashboardId: "A",
+      autoSwitchNetwork: opts.autoSwitchNetwork,
+      networkAwayFromHome: opts.networkAwayFromHome,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("returns remote for homeNetworkIds:[] even when auto-switch is off", () => {
+    seedWorkspace({
+      homeNetworkIds: [],
+      homeNetworks: [{ id: "home", ssid: "home", bssid: "" }],
+      autoSwitchNetwork: false,
+      networkAwayFromHome: false,
+    });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(REMOTE);
+  });
+
+  it("returns remote when the selection only references stale (deleted) networks", () => {
+    seedWorkspace({
+      homeNetworkIds: ["deleted-id"],
+      homeNetworks: [{ id: "home", ssid: "home", bssid: "" }],
+      autoSwitchNetwork: false,
+      networkAwayFromHome: false,
+    });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(REMOTE);
+  });
+
+  it("keeps legacy local behavior for undefined (auto-attach) with auto-switch off", () => {
+    seedWorkspace({
+      homeNetworkIds: undefined,
+      homeNetworks: [{ id: "home", ssid: "home", bssid: "" }],
+      autoSwitchNetwork: false,
+      networkAwayFromHome: false,
+    });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(LOCAL);
+  });
+
+  it("does NOT force remote when the selection has a live match (auto-switch off → local)", () => {
+    seedWorkspace({
+      homeNetworkIds: ["home"],
+      homeNetworks: [{ id: "home", ssid: "home", bssid: "" }],
+      autoSwitchNetwork: false,
+      networkAwayFromHome: false,
+    });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(LOCAL);
+  });
+});
+
+// #148: editing the ACTIVE workspace's home-network selection can shrink the
+// trusted set, so it must reset the away flag the same way a workspace SWITCH
+// does — a stale `false` would keep serving the local URL on a network the
+// workspace no longer trusts (the in-place-edit analogue of the switch-race).
+describe("setDashboardHomeNetworkIds — away-flag reset on active-workspace edit (#148)", () => {
+  const net = (id: string) => ({ id, ssid: id, bssid: "" });
+
+  function seedDashboards(opts: {
+    homeNetworks: { id: string; ssid: string; bssid: string }[];
+    dashboards: { id: string; homeNetworkIds?: string[] }[];
+    activeId: string;
+    autoSwitchNetwork: boolean;
+    networkAwayFromHome: boolean;
+  }) {
+    useConfigStore.setState({
+      homeNetworks: opts.homeNetworks,
+      dashboards: opts.dashboards.map((d) => ({
+        id: d.id,
+        name: d.id,
+        widgets: [],
+        ...(d.homeNetworkIds !== undefined
+          ? { homeNetworkIds: d.homeNetworkIds }
+          : {}),
+      })),
+      activeDashboardId: opts.activeId,
+      autoSwitchNetwork: opts.autoSwitchNetwork,
+      networkAwayFromHome: opts.networkAwayFromHome,
+      demoMode: false,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("forces away=true when narrowing the active workspace's networks", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [{ id: "A", homeNetworkIds: ["home", "cabin"] }],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+
+    useConfigStore.getState().setDashboardHomeNetworkIds("A", ["home"]);
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it("forces away=true when switching the active workspace to 'always remote' ([])", () => {
+    seedDashboards({
+      homeNetworks: [net("home")],
+      dashboards: [{ id: "A", homeNetworkIds: ["home"] }],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+
+    useConfigStore.getState().setDashboardHomeNetworkIds("A", []);
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+  });
+
+  it("does NOT touch the flag when editing a non-active workspace", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        { id: "A", homeNetworkIds: ["home"] },
+        { id: "B", homeNetworkIds: ["home", "cabin"] },
+      ],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+
+    useConfigStore.getState().setDashboardHomeNetworkIds("B", ["cabin"]);
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+  });
+
+  it("leaves the flag alone when the effective set is unchanged (all → select-all)", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [{ id: "A", homeNetworkIds: undefined }], // all = {home, cabin}
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+
+    useConfigStore
+      .getState()
+      .setDashboardHomeNetworkIds("A", ["home", "cabin"]);
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+  });
+});
+
+// #148: the per-dashboard homeNetworkIds is persisted into STORAGE_KEYS.dashboards
+// by its setter, so hydrate MUST read it back — dropping it on cold start would
+// silently revert a "remote-only"/subset workspace to "all home networks" and
+// re-expose the local URL. This test seeds the persisted shape and rehydrates.
+describe("hydrate — preserves per-dashboard homeNetworkIds (#148)", () => {
+  it("round-trips [] (always remote), a subset, and undefined (all) through hydrate", async () => {
+    setJSON(STORAGE_KEYS.dashboards, [
+      { id: "A", name: "Remote-only", widgets: [], homeNetworkIds: [] },
+      { id: "B", name: "Subset", widgets: [], homeNetworkIds: ["n1"] },
+      { id: "C", name: "All", widgets: [] },
+    ]);
+
+    await useConfigStore.getState().hydrate();
+
+    const dashboards = useConfigStore.getState().dashboards;
+    const a = dashboards.find((d) => d.id === "A");
+    const b = dashboards.find((d) => d.id === "B");
+    const c = dashboards.find((d) => d.id === "C");
+    // Explicit empty selection ("always remote") survives — NOT dropped to undefined.
+    expect(a?.homeNetworkIds).toEqual([]);
+    // Subset selection survives verbatim.
+    expect(b?.homeNetworkIds).toEqual(["n1"]);
+    // Absent stays absent (auto-attach all networks).
+    expect(c?.homeNetworkIds).toBeUndefined();
+  });
+
+  // v30: per-workspace Services-tab order is persisted onto the dashboard, so
+  // hydrate must read it back like homeNetworkIds.
+  it("round-trips per-dashboard servicesOrder through hydrate (#12)", async () => {
+    setJSON(STORAGE_KEYS.dashboards, [
+      { id: "A", name: "A", widgets: [], servicesOrder: ["sonarr", "radarr"] },
+      { id: "B", name: "B", widgets: [] },
+    ]);
+    await useConfigStore.getState().hydrate();
+    const dashboards = useConfigStore.getState().dashboards;
+    expect(dashboards.find((d) => d.id === "A")?.servicesOrder).toEqual([
+      "sonarr",
+      "radarr",
+    ]);
+    expect(dashboards.find((d) => d.id === "B")?.servicesOrder).toBeUndefined();
+  });
+});
+
+// #6: duplicateDashboard clones a workspace with a fresh id + fresh slot ids and
+// deep-copied fields, so the two dashboards never share mutable references and
+// the global slot-id uniqueness invariant holds.
+describe("duplicateDashboard (#6)", () => {
+  const src = {
+    id: "src",
+    name: "Home",
+    widgets: [
+      { id: "slot-1", widgetId: "service-health" },
+      { id: "slot-2", widgetId: "speed-stats", settings: { foo: 1 } },
+    ],
+    attachedInstances: ["a", "b"],
+    pinnedTabs: ["services"],
+    activeInstance: { radarr: "a" },
+    homeNetworkIds: [] as string[],
+    servicesOrder: ["radarr", "sonarr"],
+    icon: "Film",
+    color: "#3b82f6",
+  };
+
+  it("clones with fresh ids, a ' copy' name, and deep-copied fields", () => {
+    useConfigStore.setState({
+      dashboards: [src],
+      activeDashboardId: "src",
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+
+    const clone = useConfigStore.getState().duplicateDashboard("src")!;
+    expect(clone).not.toBeNull();
+    expect(clone.id).not.toBe("src");
+    expect(clone.name).toBe("Home copy");
+    // Fresh slot ids (uniqueness invariant), settings deep-copied.
+    expect(clone.widgets.map((w) => w.id)).not.toContain("slot-1");
+    expect(clone.widgets.map((w) => w.id)).not.toContain("slot-2");
+    expect(clone.widgets[1].settings).toEqual({ foo: 1 });
+    expect(clone.widgets[1].settings).not.toBe(src.widgets[1].settings);
+    // Explicit empty homeNetworkIds ("always remote") preserved, by value.
+    expect(clone.homeNetworkIds).toEqual([]);
+    expect(clone.servicesOrder).toEqual(["radarr", "sonarr"]);
+    expect(clone.attachedInstances).toEqual(["a", "b"]);
+    expect(clone.attachedInstances).not.toBe(src.attachedInstances);
+    expect(useConfigStore.getState().dashboards).toHaveLength(2);
+  });
+
+  it("dedupes the copy name", () => {
+    useConfigStore.setState({
+      dashboards: [
+        { id: "x", name: "Home", widgets: [] },
+        { id: "y", name: "Home copy", widgets: [] },
+      ],
+      activeDashboardId: "x",
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+    const clone = useConfigStore.getState().duplicateDashboard("x")!;
+    expect(clone.name).toBe("Home copy 2");
+  });
+
+  it("returns null for an unknown id", () => {
+    useConfigStore.setState({
+      dashboards: [{ id: "only", name: "Only", widgets: [] }],
+      activeDashboardId: "only",
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+    expect(useConfigStore.getState().duplicateDashboard("nope")).toBeNull();
+  });
+});
+
+// #6: copySlotToDashboard places a copy of a widget (with its settings) on
+// another dashboard, with a fresh slot id.
+describe("copySlotToDashboard (#6)", () => {
+  it("copies a slot with its settings onto the target, with a new id", () => {
+    useConfigStore.setState({
+      dashboards: [
+        {
+          id: "A",
+          name: "A",
+          widgets: [{ id: "s1", widgetId: "speed-stats", settings: { n: 5 } }],
+        },
+        { id: "B", name: "B", widgets: [] },
+      ],
+      activeDashboardId: "A",
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+
+    useConfigStore.getState().copySlotToDashboard("s1", "B");
+    const b = useConfigStore.getState().dashboards.find((d) => d.id === "B")!;
+    expect(b.widgets).toHaveLength(1);
+    expect(b.widgets[0].id).not.toBe("s1");
+    expect(b.widgets[0].widgetId).toBe("speed-stats");
+    expect(b.widgets[0].settings).toEqual({ n: 5 });
+    // Source untouched.
+    const a = useConfigStore.getState().dashboards.find((d) => d.id === "A")!;
+    expect(a.widgets).toHaveLength(1);
+  });
+});
+
+// #7: notifications are global; tapping one switches to the first workspace that
+// has the instance attached so the destination screen is populated.
+describe("activateDashboardForInstance (#7)", () => {
+  function seed(active: string) {
+    useConfigStore.setState({
+      dashboards: [
+        { id: "A", name: "A", widgets: [], attachedInstances: ["x"] },
+        { id: "B", name: "B", widgets: [], attachedInstances: ["y"] },
+        { id: "C", name: "C", widgets: [] }, // auto-attach (undefined)
+      ],
+      activeDashboardId: active,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("switches to the first dashboard attaching the instance", () => {
+    seed("B");
+    useConfigStore.getState().activateDashboardForInstance("x");
+    expect(useConfigStore.getState().activeDashboardId).toBe("A");
+  });
+
+  it("is a no-op when the active dashboard already attaches it", () => {
+    seed("A");
+    useConfigStore.getState().activateDashboardForInstance("x");
+    expect(useConfigStore.getState().activeDashboardId).toBe("A");
+  });
+
+  it("treats an auto-attach dashboard as attaching every instance", () => {
+    useConfigStore.setState({
+      dashboards: [{ id: "C", name: "C", widgets: [] }],
+      activeDashboardId: "C",
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+    useConfigStore.getState().activateDashboardForInstance("anything");
+    expect(useConfigStore.getState().activeDashboardId).toBe("C"); // no-op
+  });
+});
+
+// #10: setDashboardActiveInstance must reject a pin the resolver would ignore
+// (disabled or not attached), so the persisted pin always matches resolution.
+describe("setDashboardActiveInstance — rejects un-resolvable pins (#10)", () => {
+  const inst = (id: string, enabled: boolean) => ({
+    id,
+    enabled,
+    name: id,
+    localUrl: "",
+    remoteUrl: "",
+    useRemote: false,
+  });
+
+  beforeEach(() => {
+    useConfigStore.setState({
+      serviceInstances: {
+        ...useConfigStore.getState().serviceInstances,
+        radarr: [inst("A", true), inst("B", true), inst("D", false)],
+      },
+      dashboards: [
+        { id: "dash", name: "dash", widgets: [], attachedInstances: ["A", "D"] },
+      ],
+      activeDashboardId: "dash",
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  });
+
+  const pinOf = () =>
+    useConfigStore.getState().dashboards.find((d) => d.id === "dash")
+      ?.activeInstance?.radarr;
+
+  it("accepts an enabled + attached instance", () => {
+    useConfigStore.getState().setDashboardActiveInstance("dash", "radarr", "A");
+    expect(pinOf()).toBe("A");
+  });
+
+  it("rejects an enabled but NOT attached instance", () => {
+    useConfigStore.getState().setDashboardActiveInstance("dash", "radarr", "B");
+    expect(pinOf()).toBeUndefined();
+  });
+
+  it("rejects an attached but DISABLED instance", () => {
+    useConfigStore.getState().setDashboardActiveInstance("dash", "radarr", "D");
+    expect(pinOf()).toBeUndefined();
+  });
+});
+
+// #14: broadening the active workspace's home-network set (a superset) must NOT
+// flash remote — the network we're home on is still trusted.
+describe("setActiveDashboard — superset switch stays home (#14)", () => {
+  const net = (id: string) => ({ id, ssid: id, bssid: "" });
+  it("does not force away when the new set is a superset of the old", () => {
+    useConfigStore.setState({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        { id: "A", name: "A", widgets: [], homeNetworkIds: ["home"] },
+        { id: "B", name: "B", widgets: [], homeNetworkIds: ["home", "cabin"] },
+      ],
+      activeDashboardId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false, // home on "home"
+      demoMode: false,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+    useConfigStore.getState().setActiveDashboard("B");
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
   });
 });

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -333,6 +333,31 @@ describe("updateInstance — invalidates cached queries on URL change (#4)", () 
   });
 });
 
+describe("updateInstanceSecrets — invalidates on credential change (#4)", () => {
+  it("invalidates this instance's queries on a secrets save", async () => {
+    const SECRET_ID = "00000000-0000-0000-0000-00000000bbbb";
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    await useConfigStore
+      .getState()
+      .updateInstanceSecrets(SECRET_ID, { apiKey: "new-key" });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const filters = spy.mock.calls[0]?.[0] as
+      | { predicate?: (q: never) => boolean }
+      | undefined;
+    expect(filters?.predicate).toBeDefined();
+    // Matches [serviceId, instanceId, …] for this instance, nothing else.
+    expect(
+      filters?.predicate?.({ queryKey: ["radarr", SECRET_ID, "tags"] } as never),
+    ).toBe(true);
+    expect(
+      filters?.predicate?.({ queryKey: ["radarr", "other", "tags"] } as never),
+    ).toBe(false);
+    spy.mockRestore();
+  });
+});
+
 // #148 Rec #8: switching workspaces must not leave the new dashboard running
 // against the old dashboard's home/away verdict. When the incoming workspace
 // governs a different home-network set, the flag resets to the safe away
@@ -449,5 +474,60 @@ describe("setActiveDashboard — away-flag safe reset on workspace switch (#148)
     useConfigStore.getState().setActiveDashboard("B");
 
     expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+  });
+});
+
+// #4: the forced away reset on a workspace switch is set inline (not via
+// setNetworkAwayFromHome), so it must invalidate queries itself — otherwise an
+// instance shared with the previous workspace keeps its Infinity-cached data
+// from the old (local) URL after switching to an away workspace.
+describe("setActiveDashboard — query invalidation on forced away (#4)", () => {
+  const net = (id: string) => ({ id, ssid: id, bssid: "" });
+
+  function seedTwo(aIds: string[] | undefined, bIds: string[] | undefined) {
+    useConfigStore.setState({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        {
+          id: "A",
+          name: "A",
+          widgets: [],
+          ...(aIds !== undefined ? { homeNetworkIds: aIds } : {}),
+        },
+        {
+          id: "B",
+          name: "B",
+          widgets: [],
+          ...(bIds !== undefined ? { homeNetworkIds: bIds } : {}),
+        },
+      ],
+      activeDashboardId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+      demoMode: false,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("invalidates when the switch forces away (different home-network set)", () => {
+    seedTwo(["home"], ["cabin"]);
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    useConfigStore.getState().setActiveDashboard("B");
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith();
+    spy.mockRestore();
+  });
+
+  it("does NOT invalidate when both workspaces share the home-network set", () => {
+    seedTwo(["home"], ["home"]);
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    useConfigStore.getState().setActiveDashboard("B");
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -184,3 +184,122 @@ describe("setNetworkAwayFromHome", () => {
     expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
   });
 });
+
+// #148 Rec #8: switching workspaces must not leave the new dashboard running
+// against the old dashboard's home/away verdict. When the incoming workspace
+// governs a different home-network set, the flag resets to the safe away
+// default (the async re-eval in useNetworkAutoSwitch then clears it if we're
+// actually home). Same-network switches leave the flag alone.
+describe("setActiveDashboard — away-flag safe reset on workspace switch (#148)", () => {
+  const net = (id: string) => ({ id, ssid: id, bssid: "" });
+
+  function seedDashboards(opts: {
+    homeNetworks: { id: string; ssid: string; bssid: string }[];
+    dashboards: { id: string; homeNetworkIds?: string[] }[];
+    activeId: string;
+    autoSwitchNetwork: boolean;
+    networkAwayFromHome: boolean;
+    demoMode?: boolean;
+  }) {
+    useConfigStore.setState({
+      homeNetworks: opts.homeNetworks,
+      dashboards: opts.dashboards.map((d) => ({
+        id: d.id,
+        name: d.id,
+        widgets: [],
+        ...(d.homeNetworkIds !== undefined
+          ? { homeNetworkIds: d.homeNetworkIds }
+          : {}),
+      })),
+      activeDashboardId: opts.activeId,
+      autoSwitchNetwork: opts.autoSwitchNetwork,
+      networkAwayFromHome: opts.networkAwayFromHome,
+      demoMode: opts.demoMode ?? false,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("forces away=true when the new workspace governs a different network set", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        { id: "A", homeNetworkIds: ["home"] },
+        { id: "B", homeNetworkIds: ["cabin"] },
+      ],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false, // currently "home" on dashboard A
+    });
+
+    useConfigStore.getState().setActiveDashboard("B");
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+  });
+
+  it("leaves the flag alone when both workspaces govern the same network set", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        { id: "A", homeNetworkIds: ["home"] },
+        { id: "B", homeNetworkIds: ["home"] },
+      ],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+
+    useConfigStore.getState().setActiveDashboard("B");
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+  });
+
+  it("treats 'use all' (undefined) and 'select every network' as the same set", () => {
+    seedDashboards({
+      homeNetworks: [net("home")],
+      dashboards: [
+        { id: "A", homeNetworkIds: undefined }, // all = {home}
+        { id: "B", homeNetworkIds: ["home"] }, // {home}
+      ],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: false,
+    });
+
+    useConfigStore.getState().setActiveDashboard("B");
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+  });
+
+  it("does not touch the flag when auto-switch is off (flag is ignored anyway)", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        { id: "A", homeNetworkIds: ["home"] },
+        { id: "B", homeNetworkIds: ["cabin"] },
+      ],
+      activeId: "A",
+      autoSwitchNetwork: false,
+      networkAwayFromHome: false,
+    });
+
+    useConfigStore.getState().setActiveDashboard("B");
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+  });
+
+  it("is a no-op when already away (already at the safe default)", () => {
+    seedDashboards({
+      homeNetworks: [net("home"), net("cabin")],
+      dashboards: [
+        { id: "A", homeNetworkIds: ["home"] },
+        { id: "B", homeNetworkIds: ["cabin"] },
+      ],
+      activeId: "A",
+      autoSwitchNetwork: true,
+      networkAwayFromHome: true,
+    });
+
+    useConfigStore.getState().setActiveDashboard("B");
+
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+  });
+});

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -22,6 +22,7 @@ jest.mock("expo-secure-store", () => ({
 }));
 
 import { useConfigStore } from "./config-store";
+import { queryClient } from "@/lib/query-client";
 
 // Smoke-test that getActiveUrl always returns a fetch-safe URL, even when the
 // persisted value lacks a scheme. See #106 — health probes were failing on
@@ -182,6 +183,153 @@ describe("setNetworkAwayFromHome", () => {
 
     useConfigStore.getState().setNetworkAwayFromHome(true);
     expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
+  });
+});
+
+// #3: the read helpers must trust only the workspace-resolved active instance
+// (attachment + enabled aware). They must NOT fall back to
+// serviceInstances[kind][0] — activeInstance[kind] is null exactly when nothing
+// is enabled+attached, so a first-instance fallback can only resolve a disabled
+// or other-workspace instance, leaking its URL + API key on the next request.
+describe("instance resolution — no raw first-instance fallback (#3)", () => {
+  const OTHER_ID = "00000000-0000-0000-0000-0000000000ff";
+
+  // An enabled instance exists, but the active workspace resolved nothing for
+  // the kind (deriveActiveInstance → null because it isn't attached here).
+  function seedUnattached() {
+    useConfigStore.setState({
+      serviceInstances: {
+        ...useConfigStore.getState().serviceInstances,
+        radarr: [
+          {
+            id: OTHER_ID,
+            enabled: true,
+            name: "Other-workspace Radarr",
+            localUrl: "http://192.168.1.50:7878",
+            remoteUrl: "",
+            useRemote: false,
+          },
+        ],
+      },
+      instanceSecrets: {
+        ...useConfigStore.getState().instanceSecrets,
+        [OTHER_ID]: { apiKey: "leak-key", customHeaders: { "X-Leak": "secret" } },
+      },
+      globalCustomHeaders: { "X-Global": "ok" },
+      activeInstance: {
+        ...useConfigStore.getState().activeInstance,
+        radarr: null,
+      },
+      autoSwitchNetwork: false,
+      networkAwayFromHome: false,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("getActiveInstanceId returns null instead of the first instance", () => {
+    seedUnattached();
+    expect(useConfigStore.getState().getActiveInstanceId("radarr")).toBeNull();
+  });
+
+  it("getActiveUrl returns '' instead of the unattached instance's URL", () => {
+    seedUnattached();
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe("");
+  });
+
+  it("getMergedHeaders omits the unattached instance's custom headers", () => {
+    seedUnattached();
+    const headers = useConfigStore.getState().getMergedHeaders("radarr");
+    expect(headers).toEqual({ "X-Global": "ok" });
+  });
+
+  it("still resolves an explicit instanceId (explicit binding wins)", () => {
+    seedUnattached();
+    expect(useConfigStore.getState().getActiveUrl("radarr", OTHER_ID)).toBe(
+      "http://192.168.1.50:7878",
+    );
+  });
+});
+
+// #4: getActiveUrl flips local↔remote with the away flag, but query keys don't
+// encode the URL, so staleTime:Infinity reads must be invalidated when the
+// resolved URL can change — on a home/away flip and on a settings URL edit.
+describe("setNetworkAwayFromHome — query invalidation on flip (#4)", () => {
+  it("invalidates all queries on an actual change, but not on a no-op", () => {
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    useConfigStore.setState({
+      networkAwayFromHome: false,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+    spy.mockClear();
+
+    useConfigStore.getState().setNetworkAwayFromHome(false); // unchanged → no-op
+    expect(spy).not.toHaveBeenCalled();
+
+    useConfigStore.getState().setNetworkAwayFromHome(true); // flip → invalidate
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(); // unfiltered (every kind's URL may flip)
+
+    spy.mockRestore();
+  });
+});
+
+describe("updateInstance — invalidates cached queries on URL change (#4)", () => {
+  const ID = "00000000-0000-0000-0000-00000000aaaa";
+
+  function seedOne() {
+    useConfigStore.setState({
+      serviceInstances: {
+        ...useConfigStore.getState().serviceInstances,
+        radarr: [
+          {
+            id: ID,
+            enabled: true,
+            name: "Radarr",
+            localUrl: "http://192.168.1.10:7878",
+            remoteUrl: "",
+            useRemote: false,
+          },
+        ],
+      },
+      activeInstance: {
+        ...useConfigStore.getState().activeInstance,
+        radarr: ID,
+      },
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+  }
+
+  it("invalidates [serviceId, instanceId] when a URL field changes", () => {
+    seedOne();
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    useConfigStore
+      .getState()
+      .updateInstance("radarr", ID, { localUrl: "http://10.0.0.5:7878" });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ["radarr", ID] });
+    spy.mockRestore();
+  });
+
+  it("does NOT invalidate on an unrelated edit (e.g. rename)", () => {
+    seedOne();
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    useConfigStore.getState().updateInstance("radarr", ID, { name: "Renamed" });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does NOT invalidate when the URL value is unchanged", () => {
+    seedOne();
+    const spy = jest
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    useConfigStore
+      .getState()
+      .updateInstance("radarr", ID, { localUrl: "http://192.168.1.10:7878" });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -96,7 +96,7 @@ describe("getActiveUrl — URL normalization on read (#106)", () => {
     expect(useConfigStore.getState().getActiveUrl("radarr")).toBe("");
   });
 
-  it("picks remoteUrl when auto-switch decides we're away from home", () => {
+  it("picks remoteUrl when auto-switch is on and away from home", () => {
     seed({
       localUrl: "192.168.1.10:7878",
       remoteUrl: "radarr.example.com",
@@ -121,5 +121,66 @@ describe("getActiveUrl — URL normalization on read (#106)", () => {
       },
     } as Partial<ReturnType<typeof useConfigStore.getState>>);
     expect(useConfigStore.getState().getActiveUrl("radarr")).toBe("");
+  });
+});
+
+describe("getActiveUrl — secure local/remote selection (#106, #161)", () => {
+  const both = {
+    localUrl: "192.168.1.10:7878",
+    remoteUrl: "radarr.example.com",
+    useRemote: false,
+    autoSwitchNetwork: true,
+  };
+  const LOCAL = "http://192.168.1.10:7878";
+  const REMOTE = "http://radarr.example.com";
+
+  it("uses local on a confirmed home network", () => {
+    seed({ ...both, networkAwayFromHome: false });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(LOCAL);
+  });
+
+  it("uses remote when away from home", () => {
+    seed({ ...both, networkAwayFromHome: true });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(REMOTE);
+  });
+
+  it("honors the useRemote override even on a home network", () => {
+    seed({ ...both, useRemote: true, networkAwayFromHome: false });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(REMOTE);
+  });
+
+  it("uses local when auto-switch is off, regardless of the away flag", () => {
+    seed({ ...both, autoSwitchNetwork: false, networkAwayFromHome: true });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(LOCAL);
+  });
+
+  // The core security property: off-home, never fall through to the private
+  // local URL even when there's no remote to use — that would leak the API key
+  // to whatever device answers that address on an untrusted LAN (airport WiFi).
+  it("away with NO remote configured returns '' — never the local URL (credential-leak guard)", () => {
+    seed({ ...both, remoteUrl: "", networkAwayFromHome: true });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe("");
+  });
+
+  it("uses remote at home when no local URL is configured", () => {
+    seed({ ...both, localUrl: "", networkAwayFromHome: false });
+    expect(useConfigStore.getState().getActiveUrl("radarr")).toBe(REMOTE);
+  });
+});
+
+describe("setNetworkAwayFromHome", () => {
+  it("updates the flag and is a no-op when unchanged", () => {
+    useConfigStore.setState({
+      networkAwayFromHome: true,
+    } as Partial<ReturnType<typeof useConfigStore.getState>>);
+
+    useConfigStore.getState().setNetworkAwayFromHome(false);
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+
+    useConfigStore.getState().setNetworkAwayFromHome(false); // no-op
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+
+    useConfigStore.getState().setNetworkAwayFromHome(true);
+    expect(useConfigStore.getState().networkAwayFromHome).toBe(true);
   });
 });

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -235,12 +235,15 @@ interface ConfigState {
   secrets: Record<ServiceId, ServiceSecrets>;
 
   autoSwitchNetwork: boolean;
-  // Runtime-cached network state: true when the phone is not on a configured
-  // home network. Driven by the NetInfo listener in `useNetworkAutoSwitch`.
-  // The URL resolver combines this with the per-instance `useRemote` config
-  // (which is a user override — "force remote even at home") so the toggle
-  // never gets clobbered by the auto-switch. Persisted between launches so
-  // requests fired before NetInfo's first event use last-known state.
+  // EPHEMERAL (never persisted). True when we are NOT on a confirmed home
+  // network, so the URL resolver prefers remote. Recomputed fresh each launch +
+  // on every network change + on app resume by evaluateHomeNetwork() in
+  // lib/network.ts. Defaults to TRUE (away → remote): we must never send the
+  // private local URL to an untrusted network before confirming we're home, or a
+  // stranger's device at the same private address harvests the API key. Local is
+  // therefore used ONLY on a confirmed home network. Was persisted; persisting a
+  // live network observation across launches caused the stale-cold-start half of
+  // #106.
   networkAwayFromHome: boolean;
   homeNetworks: HomeNetwork[];
   // v17: per-user display order for the Services tab. Unknown ids are skipped
@@ -344,6 +347,8 @@ interface ConfigActions {
   updateSecrets: (id: ServiceId, secrets: Partial<ServiceSecrets>) => Promise<void>;
 
   setAutoSwitch: (enabled: boolean) => void;
+  // Set by evaluateHomeNetwork() (lib/network.ts) on every network change.
+  // EPHEMERAL — never persisted.
   setNetworkAwayFromHome: (away: boolean) => void;
   addHomeNetwork: (network: Omit<HomeNetwork, "id">) => HomeNetwork;
   updateHomeNetwork: (id: string, patch: Partial<Omit<HomeNetwork, "id">>) => void;
@@ -725,7 +730,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   services: deriveLegacyServices(initialInstances, initialActiveInstance),
   secrets: emptyLegacySecrets(),
   autoSwitchNetwork: false,
-  networkAwayFromHome: false,
+  networkAwayFromHome: true,
   homeNetworks: [],
   servicesOrder: [],
   dashboards: initialDashboards,
@@ -909,7 +914,11 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     // Stash the legacy value and apply after the dashboards array exists.
 
     const autoSwitchNetwork = getBoolean(STORAGE_KEYS.autoSwitchNetwork);
-    const networkAwayFromHome = getBoolean(STORAGE_KEYS.networkAwayFromHome);
+    // Purge the orphaned persisted flag from older builds. networkAwayFromHome is
+    // now ephemeral runtime state, recomputed fresh each launch by
+    // evaluateHomeNetwork() (lib/network.ts) — persisting a live network
+    // observation caused #106's stale-cold-start false-red.
+    deleteKey("app.networkAwayFromHome");
 
     // Read the new array; if absent, migrate from legacy single-SSID keys so
     // upgraders who never re-import keep their auto-switch configuration.
@@ -1214,7 +1223,6 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       services,
       secrets,
       autoSwitchNetwork,
-      networkAwayFromHome,
       homeNetworks,
       servicesOrder,
       dashboards,
@@ -1515,8 +1523,9 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   },
 
   setNetworkAwayFromHome: (away) => {
+    // No-op when unchanged so NetInfo's chatty event stream doesn't re-key the
+    // health query for an identical value. EPHEMERAL — never persisted.
     if (get().networkAwayFromHome === away) return;
-    setBoolean(STORAGE_KEYS.networkAwayFromHome, away);
     set({ networkAwayFromHome: away });
   },
 
@@ -1906,18 +1915,28 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     const targetId = instanceId ?? state.activeInstance[id] ?? list[0]?.id;
     const inst = list.find((i) => i.id === targetId);
     if (!inst) return "";
-    // useRemote is the user's force-remote override. autoSwitchNetwork +
-    // networkAwayFromHome handle the situational case (we're off the home
-    // network, so prefer remote). Either path picks remoteUrl.
-    const useRemote =
-      inst.useRemote ||
-      (state.autoSwitchNetwork && state.networkAwayFromHome);
     // Normalize on read so every consumer (serviceRequest, pingService, health
     // probes, widgets) sees a scheme-prefixed URL even when the stored value
-    // was saved without one. The editor's onBlur normalizes on edit, but
-    // historical/migrated values can lack http://, which causes fetch to
-    // throw "Invalid URL" — see #106.
-    return normalizeServiceUrl(useRemote ? inst.remoteUrl : inst.localUrl);
+    // was saved without one. Historical/migrated values can lack http://, which
+    // causes fetch to throw "Invalid URL" — see #106.
+    const local = normalizeServiceUrl(inst.localUrl);
+    const remote = normalizeServiceUrl(inst.remoteUrl);
+
+    // 1. The per-instance "always use remote" user override always wins.
+    if (inst.useRemote) return remote || local;
+    // 2. Auto-switch off → user opted out of switching; use local (or remote if
+    //    no local is configured).
+    if (!state.autoSwitchNetwork) return local || remote;
+    // 3. AWAY from a confirmed home network → REMOTE ONLY. We deliberately do
+    //    NOT fall back to the private local URL on an untrusted network: a
+    //    stranger's device at the same private address (e.g. 192.168.1.x on
+    //    airport WiFi) would receive our API key. No remote configured → "" → the
+    //    service is simply offline while away, which is the honest, safe result.
+    //    `networkAwayFromHome` defaults to true, so this also holds during the
+    //    brief cold-start window before evaluateHomeNetwork() confirms we're home.
+    if (state.networkAwayFromHome) return remote;
+    // 4. On a confirmed home network → local (or remote if no local configured).
+    return local || remote;
   },
 
   getActiveDashboard: () => {

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -160,6 +160,17 @@ export interface Dashboard {
   // ignored by the resolver — they don't need to be cleaned eagerly, except
   // on instance delete (we prune to keep storage tidy).
   activeInstance?: Partial<Record<ServiceId, string>>;
+  // v29: optional per-workspace home-network selection (#148). Missing/undefined
+  // means "use ALL home networks" (the default), mirroring how
+  // `attachedInstances === undefined` means auto-attach. An explicit array
+  // selects a subset of the GLOBAL homeNetworks by id — ids that no longer match
+  // a live network are ignored at resolve time, and an empty array means "no
+  // home network for this workspace → always remote". Home networks themselves
+  // are created/edited/deleted only on the Home Networks screen; this is purely
+  // which of them attach to this workspace. Only the *active* dashboard's
+  // selection is evaluated (see resolveEffectiveHomeNetworks /
+  // evaluateHomeNetwork in lib/network.ts).
+  homeNetworkIds?: string[];
 }
 
 // Legacy widget-settings shape carried by v13 exports. v13→v14 migration folds
@@ -369,6 +380,12 @@ interface ConfigActions {
   setDashboardColor: (dashboardId: string, color: string) => void;
   setDashboardAttachedInstances: (dashboardId: string, instanceIds: string[]) => void;
   setDashboardPinnedTabs: (dashboardId: string, tabIds: string[]) => void;
+  // v29: per-workspace home-network selection (#148). Pass an array of global
+  // home-network ids to attach a custom subset, or `undefined` to use all.
+  setDashboardHomeNetworkIds: (
+    dashboardId: string,
+    ids: string[] | undefined,
+  ) => void;
 
   // Slots (v14+). Operate on the active dashboard's widget list. addWidget
   // returns the new slot so callers can reference it (e.g. open settings sheet).
@@ -1750,6 +1767,35 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     });
   },
 
+  setDashboardHomeNetworkIds: (dashboardId, ids) => {
+    set((state) => {
+      const dashboards = state.dashboards.map((d) => {
+        if (d.id !== dashboardId) return d;
+        // `undefined` → drop the key so the workspace uses ALL home networks
+        // again (and picks up future ones), exactly like attachedInstances.
+        if (ids === undefined) {
+          const { homeNetworkIds: _omit, ...rest } = d;
+          return rest;
+        }
+        // Dedupe + drop empties. We don't validate ids against the live
+        // network list — cross-device imports may reference ids not present
+        // yet; the resolver ignores stale ids at read time. An empty result is
+        // a valid selection ("no home network here → always remote").
+        const seen = new Set<string>();
+        const sanitized: string[] = [];
+        for (const id of ids) {
+          if (typeof id !== "string" || id.length === 0) continue;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          sanitized.push(id);
+        }
+        return { ...d, homeNetworkIds: sanitized };
+      });
+      setJSON(STORAGE_KEYS.dashboards, dashboards);
+      return { dashboards };
+    });
+  },
+
   // --- Slots (v14+) ---
 
   addWidget: (widgetId) => {
@@ -1919,6 +1965,9 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     // probes, widgets) sees a scheme-prefixed URL even when the stored value
     // was saved without one. Historical/migrated values can lack http://, which
     // causes fetch to throw "Invalid URL" — see #106.
+    // NOTE: resolveActiveUrlKind (lib/url-validation.ts) mirrors this exact
+    // decision tree to report local-vs-remote for the L/R health-grid badge —
+    // keep the two in sync.
     const local = normalizeServiceUrl(inst.localUrl);
     const remote = normalizeServiceUrl(inst.remoteUrl);
 

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -612,8 +612,11 @@ function deriveLegacyServices(
   const out = {} as Record<ServiceId, ServiceConfig>;
   for (const id of SERVICE_IDS) {
     const list = instances[id] ?? [];
-    const activeId = activeInstance[id] ?? list[0]?.id ?? null;
-    const inst = activeId ? list.find((i) => i.id === activeId) : list[0];
+    // No raw first-instance tail (#3): when the workspace has no enabled+
+    // attached instance of this kind, the legacy view falls to the default
+    // (disabled) config rather than projecting an other-workspace instance.
+    const activeId = activeInstance[id];
+    const inst = activeId ? list.find((i) => i.id === activeId) : undefined;
     if (inst) {
       const { id: _id, ...cfg } = inst;
       out[id] = cfg;
@@ -635,7 +638,9 @@ function deriveLegacySecrets(
   const out = emptyLegacySecrets();
   for (const id of SERVICE_IDS) {
     const list = instances[id] ?? [];
-    const activeId = activeInstance[id] ?? list[0]?.id ?? null;
+    // No raw first-instance tail (#3): an unattached workspace gets empty
+    // secrets for the kind, never another workspace's API key.
+    const activeId = activeInstance[id];
     if (activeId && instanceSecrets[activeId]) {
       out[id] = instanceSecrets[activeId];
     }
@@ -1401,6 +1406,9 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   },
 
   updateInstance: (id, instanceId, patch) => {
+    // Captured before the commit so the invalidate below can tell whether a
+    // URL-affecting field actually changed.
+    const prevInst = get().serviceInstances[id]?.find((i) => i.id === instanceId);
     set((state) => {
       const list = state.serviceInstances[id] ?? [];
       const idx = list.findIndex((i) => i.id === instanceId);
@@ -1435,6 +1443,20 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       );
       return { serviceInstances, services, secrets };
     });
+    // A URL edit changes the resolved base URL without changing the instance id
+    // (the query key), so staleTime:Infinity reads wouldn't refetch (#4).
+    // Invalidate this instance's cached queries when a URL field actually
+    // changed — scoped so an unrelated save (e.g. rename) doesn't refetch.
+    // TanStack v5 prefix-matches [id, instanceId] against [id, instanceId, …].
+    if (prevInst) {
+      const urlChanged =
+        ("localUrl" in patch && patch.localUrl !== prevInst.localUrl) ||
+        ("remoteUrl" in patch && patch.remoteUrl !== prevInst.remoteUrl) ||
+        ("useRemote" in patch && patch.useRemote !== prevInst.useRemote);
+      if (urlChanged) {
+        void queryClient.invalidateQueries({ queryKey: [id, instanceId] });
+      }
+    }
   },
 
   toggleInstance: (id, instanceId) => {
@@ -1589,6 +1611,13 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     // health query for an identical value. EPHEMERAL — never persisted.
     if (get().networkAwayFromHome === away) return;
     set({ networkAwayFromHome: away });
+    // The resolved base URL flips local↔remote with this flag (getActiveUrl),
+    // but query keys don't encode the URL — so staleTime:Infinity reads
+    // (profiles, root folders, tags) would keep serving data fetched against
+    // the OLD url after a home/away switch (#4). Invalidate so active queries
+    // refetch against the new URL; previous data stays visible during the
+    // refetch (invalidate, not reset → no skeleton flash).
+    void queryClient.invalidateQueries();
   },
 
   addHomeNetwork: (network) => {
@@ -2008,7 +2037,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
 
   getActiveInstanceId: (id) => {
     const state = get();
-    return state.activeInstance[id] ?? state.serviceInstances[id]?.[0]?.id ?? null;
+    // Only the workspace-resolved instance (attachment + enabled aware, kept in
+    // sync by recomputeDerivedFromActive). NO raw serviceInstances[id][0] tail:
+    // activeInstance[id] is null exactly when nothing is enabled+attached, so a
+    // first-instance fallback could only resolve a disabled or other-workspace
+    // instance — leaking its URL + API key on the next request (#3).
+    return state.activeInstance[id] ?? null;
   },
 
   getEnabledInstances: (id) => {
@@ -2017,8 +2051,9 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
 
   getMergedHeaders: (id, instanceId) => {
     const state = get();
-    const targetId =
-      instanceId ?? state.activeInstance[id] ?? state.serviceInstances[id]?.[0]?.id;
+    // Explicit instanceId wins; otherwise the workspace-resolved active
+    // instance. No raw first-instance tail — see getActiveInstanceId (#3).
+    const targetId = instanceId ?? state.activeInstance[id];
     const perInstance = targetId
       ? state.instanceSecrets[targetId]?.customHeaders
       : undefined;
@@ -2028,7 +2063,11 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   getActiveUrl: (id, instanceId) => {
     const state = get();
     const list = state.serviceInstances[id] ?? [];
-    const targetId = instanceId ?? state.activeInstance[id] ?? list[0]?.id;
+    // Explicit instanceId wins; otherwise the workspace-resolved active
+    // instance. No raw first-instance tail (#3) — when neither resolves,
+    // targetId is undefined, list.find misses, and we return "" below, which is
+    // the same "service offline in this workspace" result the away path gives.
+    const targetId = instanceId ?? state.activeInstance[id];
     const inst = list.find((i) => i.id === targetId);
     if (!inst) return "";
     // Normalize on read so every consumer (serviceRequest, pingService, health

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -1576,6 +1576,14 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       );
       return { instanceSecrets, secrets };
     });
+    // Credentials (API key / custom headers) feed request auth but aren't part
+    // of the query key, so staleTime:Infinity reads would keep results fetched
+    // with the OLD credentials (#4). A secrets save is inherently a credential
+    // change, so no field-level guard — invalidate this instance's queries by
+    // matching the instanceId slot of the key ([serviceId, instanceId, …]).
+    void queryClient.invalidateQueries({
+      predicate: (q) => q.queryKey[1] === instanceId,
+    });
   },
 
   // --- Legacy single-instance shims ---
@@ -1696,6 +1704,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   },
 
   removeDashboard: (dashboardId) => {
+    let forcedAway = false;
     set((state) => {
       // Refuse to delete the last dashboard — the screen always needs one.
       if (state.dashboards.length <= 1) return state;
@@ -1724,6 +1733,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
           state.dashboards.find((d) => d.id === dashboardId),
           dashboards.find((d) => d.id === activeDashboardId),
         );
+        forcedAway = forceAway;
         return {
           dashboards,
           activeDashboardId,
@@ -1733,6 +1743,10 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       }
       return { dashboards, activeDashboardId };
     });
+    // Same as setActiveDashboard: the inline away reset bypasses
+    // setNetworkAwayFromHome's invalidate, so refetch shared-instance queries
+    // against the new (remote) URL (#4).
+    if (forcedAway) void queryClient.invalidateQueries();
   },
 
   renameDashboard: (dashboardId, name) => {
@@ -1746,6 +1760,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   },
 
   setActiveDashboard: (dashboardId) => {
+    let forcedAway = false;
     set((state) => {
       if (!state.dashboards.some((d) => d.id === dashboardId)) return state;
       if (state.activeDashboardId === dashboardId) return state;
@@ -1767,12 +1782,19 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         state.dashboards.find((d) => d.id === state.activeDashboardId),
         state.dashboards.find((d) => d.id === dashboardId),
       );
+      forcedAway = forceAway;
       return {
         activeDashboardId: dashboardId,
         ...derived,
         ...(forceAway ? { networkAwayFromHome: true } : {}),
       };
     });
+    // The forced away→remote reset flips the resolved URL for any instance
+    // shared with the previous workspace (same query key); the flag is set
+    // inline above (not via setNetworkAwayFromHome) so it bypasses that
+    // invalidate (#4). Refetch so shared-instance Infinity reads don't keep the
+    // old workspace's URL data.
+    if (forcedAway) void queryClient.invalidateQueries();
   },
 
   moveDashboard: (dashboardId, direction) => {

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -7,6 +7,7 @@ import {
   initStorage,
   getJSON,
   setJSON,
+  setMany,
   getBoolean,
   setBoolean,
   getString,
@@ -27,6 +28,7 @@ import {
   DASHBOARD_WIDGET_IDS,
   UI_SCALES,
   DEFAULT_UI_SCALE,
+  MAX_HOME_NETWORKS,
 } from "@/lib/constants";
 import type { UiScale } from "@/lib/constants";
 import { DEFAULT_DASHBOARD_ICON } from "@/lib/dashboard-icons";
@@ -171,6 +173,12 @@ export interface Dashboard {
   // selection is evaluated (see resolveEffectiveHomeNetworks /
   // evaluateHomeNetwork in lib/network.ts).
   homeNetworkIds?: string[];
+  // v30: optional per-workspace Services-tab tile order. Missing/undefined means
+  // "use the global servicesOrder" so existing dashboards keep the shared order.
+  // Unknown ids are skipped at render time; kinds missing from the list fall in
+  // at the end in canonical order (same forgiving semantics as the global
+  // servicesOrder), so adding a new service kind never hides it.
+  servicesOrder?: ServiceId[];
 }
 
 // Legacy widget-settings shape carried by v13 exports. v13→v14 migration folds
@@ -362,9 +370,19 @@ interface ConfigActions {
   // dashboard is rejected by the action — every install always has at least
   // one dashboard so the screen never has nothing to render.
   addDashboard: (name: string) => Dashboard;
+  // Deep-clone an existing dashboard: fresh dashboard id + fresh slot ids for
+  // every widget (so the global slot-id uniqueness invariant holds), name
+  // suffixed " copy" (deduped), all workspace fields preserved. Returns the new
+  // dashboard, or null if the source id doesn't exist.
+  duplicateDashboard: (dashboardId: string) => Dashboard | null;
   removeDashboard: (dashboardId: string) => void;
   renameDashboard: (dashboardId: string, name: string) => void;
   setActiveDashboard: (dashboardId: string) => void;
+  // Switch the active workspace to the first dashboard that has `instanceId`
+  // attached (auto-attach dashboards count). No-op when the active dashboard
+  // already includes it or none does. Used by the notification tap handler so a
+  // tapped alert lands on a workspace where its instance is actually present.
+  activateDashboardForInstance: (instanceId: string) => void;
   moveDashboard: (dashboardId: string, direction: "up" | "down") => void;
   // v20: dashboard identity + workspace filter + bottom-tab pinning. All four
   // setters persist via setJSON(STORAGE_KEYS.dashboards, ...).
@@ -378,12 +396,22 @@ interface ConfigActions {
     dashboardId: string,
     ids: string[] | undefined,
   ) => void;
+  // v30: per-workspace Services-tab tile order. Pass an array to set a custom
+  // order for this dashboard, or `undefined` to fall back to the global
+  // `servicesOrder`. Mirrors the optional-field pattern of homeNetworkIds.
+  setDashboardServicesOrder: (
+    dashboardId: string,
+    order: ServiceId[] | undefined,
+  ) => void;
 
   // Slots (v14+). Operate on the active dashboard's widget list. addWidget
   // returns the new slot so callers can reference it (e.g. open settings sheet).
   addWidget: (widgetId: WidgetId) => WidgetSlot | null;
   removeSlot: (slotId: string) => void;
   moveSlot: (slotId: string, direction: "up" | "down") => void;
+  // Deep-copy a widget slot (with its settings) onto another dashboard, giving
+  // it a fresh slot id. Used by the edit-mode "copy to dashboard" affordance.
+  copySlotToDashboard: (slotId: string, targetDashboardId: string) => void;
   setSlotSettings: (slotId: string, settings: WidgetSlotSettings) => void;
   resetSlotSettings: (slotId: string) => void;
 
@@ -560,13 +588,17 @@ function effectiveHomeNetworkIdSet(
 // Whether switching the active workspace from `oldDashboard` to `newDashboard`
 // should reset networkAwayFromHome to the safe default (away → remote). The
 // cached flag was computed against the OUTGOING dashboard's home networks; if
-// the incoming dashboard governs a different set, a stale `false` would briefly
-// send the private local URL on a network the new workspace doesn't trust —
-// the switch-race exposure window (#148 review Rec #8). When the sets match the
-// flag is still valid, so same-network switches don't needlessly flap to
-// remote. Only meaningful while auto-switch is on and we're not already away;
-// useNetworkAutoSwitch re-evaluates against the real SSID a tick later and
-// clears the flag if we're actually home on the new workspace.
+// the incoming dashboard might not trust the network we're currently home on, a
+// stale `false` would briefly send the private local URL on a network the new
+// workspace doesn't trust — the switch-race exposure window (#148 review Rec #8).
+//
+// Reached only while auto-switch is on and we're currently HOME (flag false), so
+// the network we're on is in `oldSet`. The incoming set keeps us home iff it
+// still contains every old id (a SUPERSET) — then the current network is
+// guaranteed to be trusted and we must NOT flash remote (#14). Otherwise the
+// network we're home on might be one the new workspace dropped, so we can't be
+// sure → force away; useNetworkAutoSwitch re-confirms against the real SSID a
+// tick later and clears the flag if we're actually still home.
 function switchInvalidatesAwayFlag(
   state: {
     autoSwitchNetwork: boolean;
@@ -581,7 +613,9 @@ function switchInvalidatesAwayFlag(
   if (state.networkAwayFromHome) return false; // already at the safe default
   const oldSet = effectiveHomeNetworkIdSet(oldDashboard, state.homeNetworks);
   const newSet = effectiveHomeNetworkIdSet(newDashboard, state.homeNetworks);
-  if (oldSet.size !== newSet.size) return true;
+  // Force away only when the new set is NOT a superset of the old one. If every
+  // network the old workspace trusted is still trusted, the one we're home on is
+  // among them, so we stay home — no needless remote flash on broaden/equal.
   for (const id of oldSet) if (!newSet.has(id)) return true;
   return false;
 }
@@ -1109,6 +1143,40 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
               dashboard.activeInstance = cleaned;
             }
           }
+          // v29: per-workspace home-network selection (#148). MUST be rehydrated
+          // here too — the setter persists it into STORAGE_KEYS.dashboards, so
+          // dropping it on cold start would silently revert a "remote-only" (or
+          // subset) workspace to "all home networks", re-exposing the private
+          // local URL + API key on networks it was configured not to trust.
+          // Mirror coerceDashboard: dedupe, drop empties, cap; preserve an
+          // explicit empty array ("no home network here → always remote").
+          if (Array.isArray(d.homeNetworkIds)) {
+            const seen = new Set<string>();
+            const ids: string[] = [];
+            for (const id of d.homeNetworkIds) {
+              if (typeof id !== "string" || id.length === 0) continue;
+              if (seen.has(id)) continue;
+              seen.add(id);
+              ids.push(id);
+              if (ids.length >= MAX_HOME_NETWORKS) break;
+            }
+            dashboard.homeNetworkIds = ids;
+          }
+          // v30: per-workspace Services-tab order. Same forgiving coercion as
+          // the global servicesOrder — dedupe + drop unknown ids; absence means
+          // "use the global order".
+          if (Array.isArray(d.servicesOrder)) {
+            const seen = new Set<string>();
+            const order: ServiceId[] = [];
+            for (const sid of d.servicesOrder) {
+              if (typeof sid !== "string") continue;
+              if (!(SERVICE_IDS as readonly string[]).includes(sid)) continue;
+              if (seen.has(sid)) continue;
+              seen.add(sid);
+              order.push(sid as ServiceId);
+            }
+            dashboard.servicesOrder = order;
+          }
           // Backfill v20 fields one-time for users upgrading from a v14-v19
           // local install (the AsyncStorage payload is the legacy shape, even
           // though the export migration handles them at import time).
@@ -1173,8 +1241,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     }
 
     if (dashboardsNeedPersist) {
-      setJSON(STORAGE_KEYS.dashboards, dashboards);
-      setString(STORAGE_KEYS.activeDashboardId, activeDashboardId);
+      // Atomic pair-write so a crash can't persist the dashboards list without
+      // its matching activeDashboardId (or vice versa) and leave them desynced.
+      setMany([
+        [STORAGE_KEYS.dashboards, JSON.stringify(dashboards)],
+        [STORAGE_KEYS.activeDashboardId, activeDashboardId],
+      ]);
     }
 
     const servicesOrder = sanitizeServicesOrder(
@@ -1483,13 +1555,23 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   setDashboardActiveInstance: (dashboardId, id, instanceId) => {
     set((state) => {
       const list = state.serviceInstances[id] ?? [];
-      // Reject ids that don't refer to an existing instance — keeps state
-      // consistent if a stale UUID slips through (e.g. from a prop).
-      if (instanceId !== null && !list.some((i) => i.id === instanceId)) {
-        return state;
-      }
       const dashboard = state.dashboards.find((d) => d.id === dashboardId);
       if (!dashboard) return state;
+      // Reject a pin the resolver would silently ignore. deriveActiveInstance
+      // only honors a pin that's enabled AND attached to this dashboard (or any
+      // instance when the dashboard is auto-attach), so validating those same
+      // conditions at write time keeps the persisted pin in lockstep with what
+      // resolution returns — no dead cruft that survives export/import or
+      // diverges from the rendered selection.
+      if (instanceId !== null) {
+        const inst = list.find((i) => i.id === instanceId);
+        const isAttached =
+          dashboard.attachedInstances === undefined ||
+          dashboard.attachedInstances.includes(instanceId);
+        if (!inst || !inst.enabled || !isAttached) {
+          return state;
+        }
+      }
 
       const prevMap = dashboard.activeInstance ?? {};
       const nextMap: Partial<Record<ServiceId, string>> = { ...prevMap };
@@ -1672,6 +1754,59 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     return dashboard;
   },
 
+  duplicateDashboard: (dashboardId) => {
+    const src = get().dashboards.find((d) => d.id === dashboardId);
+    if (!src) return null;
+    // Unique " copy" name: "X copy", then "X copy 2", "X copy 3", … Names aren't
+    // a key (ids are) so this is a soft nicety to keep the picker readable.
+    const existing = new Set(get().dashboards.map((d) => d.name));
+    let name = `${src.name} copy`;
+    for (let n = 2; existing.has(name); n++) name = `${src.name} copy ${n}`;
+    const clone: Dashboard = {
+      ...src,
+      id: generateInstanceId(),
+      name,
+      // Fresh slot id per widget: slot ids must be globally unique (the
+      // slot-keyed settings store + query cache collide otherwise). Deep-copy
+      // each slot's settings so tweaking one dashboard's widget can't mutate the
+      // other through a shared object reference.
+      widgets: src.widgets.map((w) => ({
+        id: generateInstanceId(),
+        widgetId: w.widgetId,
+        ...(w.settings ? { settings: { ...w.settings } } : {}),
+      })),
+      // Clone the optional arrays/maps by value (truthy `[]` is preserved, e.g.
+      // an "always remote" homeNetworkIds or an empty attachment set); undefined
+      // stays undefined so an auto-attach source clones to auto-attach.
+      ...(src.attachedInstances
+        ? { attachedInstances: [...src.attachedInstances] }
+        : {}),
+      ...(src.pinnedTabs ? { pinnedTabs: [...src.pinnedTabs] } : {}),
+      ...(src.activeInstance ? { activeInstance: { ...src.activeInstance } } : {}),
+      ...(src.homeNetworkIds ? { homeNetworkIds: [...src.homeNetworkIds] } : {}),
+      ...(src.servicesOrder ? { servicesOrder: [...src.servicesOrder] } : {}),
+    };
+    set((state) => {
+      const dashboards = [...state.dashboards, clone];
+      setJSON(STORAGE_KEYS.dashboards, dashboards);
+      return { dashboards };
+    });
+    return clone;
+  },
+
+  activateDashboardForInstance: (instanceId) => {
+    const state = get();
+    // Auto-attach dashboards (attachedInstances === undefined) include every
+    // instance; explicit lists must contain the id.
+    const attaches = (d: Dashboard) =>
+      d.attachedInstances === undefined ||
+      d.attachedInstances.includes(instanceId);
+    const active = state.dashboards.find((d) => d.id === state.activeDashboardId);
+    if (active && attaches(active)) return; // already visible on the active one
+    const target = state.dashboards.find(attaches);
+    if (target) get().setActiveDashboard(target.id);
+  },
+
   removeDashboard: (dashboardId) => {
     let forcedAway = false;
     set((state) => {
@@ -1683,9 +1818,15 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       const activeChanged = activeDashboardId === dashboardId;
       if (activeChanged) {
         activeDashboardId = dashboards[0].id;
-        setString(STORAGE_KEYS.activeDashboardId, activeDashboardId);
+        // Atomic pair-write so the trimmed list and its new active id can't
+        // land desynced if the app is killed mid-delete.
+        setMany([
+          [STORAGE_KEYS.dashboards, JSON.stringify(dashboards)],
+          [STORAGE_KEYS.activeDashboardId, activeDashboardId],
+        ]);
+      } else {
+        setJSON(STORAGE_KEYS.dashboards, dashboards);
       }
-      setJSON(STORAGE_KEYS.dashboards, dashboards);
       // v22: deleting the active workspace re-resolves the active instance
       // per kind against the new active workspace.
       if (activeChanged) {
@@ -1858,6 +1999,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   },
 
   setDashboardHomeNetworkIds: (dashboardId, ids) => {
+    let forcedAway = false;
     set((state) => {
       const dashboards = state.dashboards.map((d) => {
         if (d.id !== dashboardId) return d;
@@ -1880,6 +2022,56 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
           sanitized.push(id);
         }
         return { ...d, homeNetworkIds: sanitized };
+      });
+      setJSON(STORAGE_KEYS.dashboards, dashboards);
+      // v29: editing the ACTIVE workspace's home-network set can shrink the
+      // trusted set (e.g. narrow to a subset that excludes the current SSID, or
+      // switch to "always remote"). The cached `networkAwayFromHome` flag was
+      // computed against the OLD selection, so a stale `false` would keep
+      // serving the private local URL on a network this workspace no longer
+      // trusts — the in-place-edit analogue of the setActiveDashboard
+      // switch-race (#148 Rec #8). Reset to the safe away default; the
+      // useNetworkAutoSwitch effect re-confirms a tick later and clears it if
+      // we're genuinely still home under the new selection.
+      if (dashboardId === state.activeDashboardId) {
+        const forceAway = switchInvalidatesAwayFlag(
+          state,
+          state.dashboards.find((d) => d.id === dashboardId),
+          dashboards.find((d) => d.id === dashboardId),
+        );
+        if (forceAway) {
+          forcedAway = true;
+          return { dashboards, networkAwayFromHome: true };
+        }
+      }
+      return { dashboards };
+    });
+    // The inline away reset bypasses setNetworkAwayFromHome's invalidate, so
+    // refetch any local-resolved instance against the new (remote) URL (#4).
+    if (forcedAway) void queryClient.invalidateQueries();
+  },
+
+  setDashboardServicesOrder: (dashboardId, order) => {
+    set((state) => {
+      const dashboards = state.dashboards.map((d) => {
+        if (d.id !== dashboardId) return d;
+        // `undefined` → drop the key so the workspace reuses the GLOBAL
+        // servicesOrder (and any future default), like homeNetworkIds.
+        if (order === undefined) {
+          const { servicesOrder: _omit, ...rest } = d;
+          return rest;
+        }
+        // Dedupe + drop unknown ids (forward-compat). Missing kinds fall in at
+        // the end in canonical order at render time, so we don't pad here.
+        const seen = new Set<string>();
+        const sanitized: ServiceId[] = [];
+        for (const id of order) {
+          if (!(SERVICE_IDS as readonly string[]).includes(id)) continue;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          sanitized.push(id);
+        }
+        return { ...d, servicesOrder: sanitized };
       });
       setJSON(STORAGE_KEYS.dashboards, dashboards);
       return { dashboards };
@@ -1930,6 +2122,37 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         return { ...d, widgets };
       });
       if (!mutated) return state;
+      setJSON(STORAGE_KEYS.dashboards, dashboards);
+      return { dashboards };
+    });
+  },
+
+  copySlotToDashboard: (slotId, targetDashboardId) => {
+    set((state) => {
+      // Slot ids are globally unique, so the first match across all dashboards
+      // is the source slot.
+      let source: WidgetSlot | undefined;
+      for (const d of state.dashboards) {
+        const hit = d.widgets.find((w) => w.id === slotId);
+        if (hit) {
+          source = hit;
+          break;
+        }
+      }
+      if (!source) return state;
+      if (!state.dashboards.some((d) => d.id === targetDashboardId)) return state;
+      // Fresh slot id keeps the uniqueness invariant; deep-copy settings so the
+      // two placements stay independent.
+      const copy: WidgetSlot = {
+        id: generateInstanceId(),
+        widgetId: source.widgetId,
+        ...(source.settings ? { settings: { ...source.settings } } : {}),
+      };
+      const dashboards = state.dashboards.map((d) =>
+        d.id === targetDashboardId
+          ? { ...d, widgets: [...d.widgets, copy] }
+          : d,
+      );
       setJSON(STORAGE_KEYS.dashboards, dashboards);
       return { dashboards };
     });
@@ -2073,10 +2296,25 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
 
     // 1. The per-instance "always use remote" user override always wins.
     if (inst.useRemote) return remote || local;
-    // 2. Auto-switch off → user opted out of switching; use local (or remote if
+    // 2. A workspace that explicitly selected NO (live) home networks
+    //    (homeNetworkIds: [] — or only stale ids) is "always remote". Honor that
+    //    even when global auto-switch is off, so the per-workspace remote-only
+    //    choice can't be silently overridden by the global toggle and re-expose
+    //    the local URL (#148). `undefined` (auto-attach all networks) is NOT
+    //    remote-only, so it falls through to the auto-switch/away logic below.
+    const activeDash = state.dashboards.find(
+      (d) => d.id === state.activeDashboardId,
+    );
+    if (
+      Array.isArray(activeDash?.homeNetworkIds) &&
+      effectiveHomeNetworkIdSet(activeDash, state.homeNetworks).size === 0
+    ) {
+      return remote;
+    }
+    // 3. Auto-switch off → user opted out of switching; use local (or remote if
     //    no local is configured).
     if (!state.autoSwitchNetwork) return local || remote;
-    // 3. AWAY from a confirmed home network → REMOTE ONLY. We deliberately do
+    // 4. AWAY from a confirmed home network → REMOTE ONLY. We deliberately do
     //    NOT fall back to the private local URL on an untrusted network: a
     //    stranger's device at the same private address (e.g. 192.168.1.x on
     //    airport WiFi) would receive our API key. No remote configured → "" → the
@@ -2084,7 +2322,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     //    `networkAwayFromHome` defaults to true, so this also holds during the
     //    brief cold-start window before evaluateHomeNetwork() confirms we're home.
     if (state.networkAwayFromHome) return remote;
-    // 4. On a confirmed home network → local (or remote if no local configured).
+    // 5. On a confirmed home network → local (or remote if no local configured).
     return local || remote;
   },
 
@@ -2399,6 +2637,13 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       servicesOrder: importedServicesOrder,
       dashboards: importedDashboards,
       activeDashboardId: importedActiveDashboardId,
+      // Reset the ephemeral away flag to its safe default. Import can change the
+      // active dashboard, its homeNetworkIds, the global home-network list, and
+      // flip autoSwitchNetwork on — all while a pre-import in-memory `false`
+      // (confirmed-home) flag would otherwise survive and let getActiveUrl serve
+      // the freshly-imported local URLs against the current, un-re-evaluated
+      // network (#148). useNetworkAutoSwitch re-confirms and clears it if home.
+      networkAwayFromHome: true,
       wolDevices: payload.wolDevices ?? [],
       hapticsEnabled: importedHapticsEnabled,
       globalCustomHeaders: importedGlobalCustomHeaders,

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -349,14 +349,6 @@ interface ConfigActions {
     secrets: Partial<ServiceSecrets>,
   ) => Promise<void>;
 
-  // Legacy single-instance helpers. These operate on the active instance for
-  // the given kind and exist so consumers that haven't been migrated to be
-  // instance-aware keep working. They'll be retired once the rest of the
-  // codebase passes instanceId explicitly.
-  updateService: (id: ServiceId, config: Partial<ServiceConfig>) => void;
-  toggleService: (id: ServiceId) => void;
-  updateSecrets: (id: ServiceId, secrets: Partial<ServiceSecrets>) => Promise<void>;
-
   setAutoSwitch: (enabled: boolean) => void;
   // Set by evaluateHomeNetwork() (lib/network.ts) on every network change.
   // EPHEMERAL — never persisted.
@@ -1584,29 +1576,6 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     void queryClient.invalidateQueries({
       predicate: (q) => q.queryKey[1] === instanceId,
     });
-  },
-
-  // --- Legacy single-instance shims ---
-
-  updateService: (id, config) => {
-    const activeId =
-      get().activeInstance[id] ?? get().serviceInstances[id]?.[0]?.id ?? null;
-    if (!activeId) return;
-    get().updateInstance(id, activeId, config);
-  },
-
-  toggleService: (id) => {
-    const activeId =
-      get().activeInstance[id] ?? get().serviceInstances[id]?.[0]?.id ?? null;
-    if (!activeId) return;
-    get().toggleInstance(id, activeId);
-  },
-
-  updateSecrets: async (id, newSecrets) => {
-    const activeId =
-      get().activeInstance[id] ?? get().serviceInstances[id]?.[0]?.id ?? null;
-    if (!activeId) return;
-    await get().updateInstanceSecrets(activeId, newSecrets);
   },
 
   setAutoSwitch: (enabled) => {

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -549,6 +549,51 @@ function recomputeDerivedFromActive(
   return { activeInstance, services, secrets };
 }
 
+// The home-network ids that actually govern local/remote switching for a
+// dashboard: its explicit selection (filtered to still-existing networks), or
+// every global network when it has none (undefined = all). Mirrors
+// resolveEffectiveHomeNetworks in lib/network.ts but returns just the id set —
+// inlined here to avoid a config-store → lib/network import cycle.
+function effectiveHomeNetworkIdSet(
+  dashboard: Dashboard | undefined,
+  globalHomeNetworks: HomeNetwork[],
+): Set<string> {
+  const allIds = globalHomeNetworks.map((n) => n.id);
+  const ids = dashboard?.homeNetworkIds;
+  if (ids === undefined) return new Set(allIds);
+  const valid = new Set(allIds);
+  return new Set(ids.filter((id) => valid.has(id)));
+}
+
+// Whether switching the active workspace from `oldDashboard` to `newDashboard`
+// should reset networkAwayFromHome to the safe default (away → remote). The
+// cached flag was computed against the OUTGOING dashboard's home networks; if
+// the incoming dashboard governs a different set, a stale `false` would briefly
+// send the private local URL on a network the new workspace doesn't trust —
+// the switch-race exposure window (#148 review Rec #8). When the sets match the
+// flag is still valid, so same-network switches don't needlessly flap to
+// remote. Only meaningful while auto-switch is on and we're not already away;
+// useNetworkAutoSwitch re-evaluates against the real SSID a tick later and
+// clears the flag if we're actually home on the new workspace.
+function switchInvalidatesAwayFlag(
+  state: {
+    autoSwitchNetwork: boolean;
+    demoMode: boolean;
+    networkAwayFromHome: boolean;
+    homeNetworks: HomeNetwork[];
+  },
+  oldDashboard: Dashboard | undefined,
+  newDashboard: Dashboard | undefined,
+): boolean {
+  if (!state.autoSwitchNetwork || state.demoMode) return false;
+  if (state.networkAwayFromHome) return false; // already at the safe default
+  const oldSet = effectiveHomeNetworkIdSet(oldDashboard, state.homeNetworks);
+  const newSet = effectiveHomeNetworkIdSet(newDashboard, state.homeNetworks);
+  if (oldSet.size !== newSet.size) return true;
+  for (const id of oldSet) if (!newSet.has(id)) return true;
+  return false;
+}
+
 function emptyLegacySecrets(): Record<ServiceId, ServiceSecrets> {
   const secrets = {} as Record<ServiceId, ServiceSecrets>;
   for (const id of SERVICE_IDS) {
@@ -1643,7 +1688,19 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
           state.serviceInstances,
           state.instanceSecrets,
         );
-        return { dashboards, activeDashboardId, ...derived };
+        // Same safe-default reset as setActiveDashboard: the auto-selected
+        // replacement workspace may govern a different home-network set (#148).
+        const forceAway = switchInvalidatesAwayFlag(
+          state,
+          state.dashboards.find((d) => d.id === dashboardId),
+          dashboards.find((d) => d.id === activeDashboardId),
+        );
+        return {
+          dashboards,
+          activeDashboardId,
+          ...derived,
+          ...(forceAway ? { networkAwayFromHome: true } : {}),
+        };
       }
       return { dashboards, activeDashboardId };
     });
@@ -1672,7 +1729,20 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         state.serviceInstances,
         state.instanceSecrets,
       );
-      return { activeDashboardId: dashboardId, ...derived };
+      // v29: if the incoming workspace governs a different home-network set,
+      // reset to the safe away default so the old dashboard's "home" flag can't
+      // briefly expose the local URL on a network the new one doesn't trust
+      // (#148 review Rec #8). useNetworkAutoSwitch re-evaluates a tick later.
+      const forceAway = switchInvalidatesAwayFlag(
+        state,
+        state.dashboards.find((d) => d.id === state.activeDashboardId),
+        state.dashboards.find((d) => d.id === dashboardId),
+      );
+      return {
+        activeDashboardId: dashboardId,
+        ...derived,
+        ...(forceAway ? { networkAwayFromHome: true } : {}),
+      };
     });
   },
 

--- a/store/storage.ts
+++ b/store/storage.ts
@@ -68,3 +68,12 @@ export function setJSON(key: string, value: unknown): void {
   cache[key] = json;
   AsyncStorage.setItem(key, json);
 }
+
+// Atomic multi-key write. Use when two keys must land together or not at all
+// (e.g. `dashboards` + `activeDashboardId`): `multiSet` batches them into one
+// AsyncStorage operation, so a crash/kill can't persist one without the other
+// and leave the pair desynced. Each value is pre-serialized by the caller.
+export function setMany(entries: [string, string][]): void {
+  for (const [key, value] of entries) cache[key] = value;
+  AsyncStorage.multiSet(entries);
+}


### PR DESCRIPTION
## Summary
- Per-dashboard home network selection: each dashboard picks which WiFi networks count as "home", and the local/LAN URL is used **only** on a confirmed home network (away → remote only, guarding against API-key leaks). Refs #106, #161
- Scope instance resolution, query cache, dashboard cards, Activity tab, offline notifications, and widget settings to the active workspace; reset the away flag and invalidate queries on workspace switch / credential edits. Refs #148
- local/remote URL badge on the services widget
- Dashboard perf: instant edit-mode toggle, progressive widget mount, less idle re-render jank
- Cleanup: drop legacy single-instance store shims and the redundant active-instance picker/tag in Settings

## Test plan
- `tsc --noEmit` clean (excluding backend)
- New/updated unit tests pass: `network`, `url-validation`, `config-store`, `config-schema`, `use-workspace-instances`, `use-service-health`
- Manual: switch dashboards/workspaces and confirm local URL is used only on home WiFi, remote when away