### PR TITLE
fix: paint preloaded TextInput value on iOS without focus (Refs #149)

### DIFF
--- a/components/ui/text-input.tsx
+++ b/components/ui/text-input.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { TextInput as RNTextInput, View, Text, Platform } from "react-native";
 import type {
   TextInputProps as RNTextInputProps,
@@ -23,81 +23,67 @@ export function TextInput({
 }: TextInputProps) {
   const isIOS = Platform.OS === "ios";
 
-  // iOS New Architecture (Fabric) intermittently fails to PAINT a controlled
-  // TextInput's initial non-empty `value` until the field is focused — the
-  // "Remote URL blank until you tap it" bug (#149).
+  // iOS New Architecture (Fabric) intermittently renders a controlled
+  // TextInput's initial non-empty `value` as BLANK until the field is focused —
+  // the "Remote URL blank until you tap it" bug (#149). It is iOS-version
+  // dependent (reproduced on iOS 18, not 26) and more likely inside the
+  // deferred-layout KeyboardAwareScrollView, which is why it looks intermittent
+  // and is hard to reproduce.
   //
-  // Root cause (verified in this app's pinned RN 0.81.5 source,
-  // React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm):
-  // the value IS delivered to the native field at mount via
-  // -updateState: -> -_setAttributedString:, which assigns
-  // `_backedTextInputView.attributedText` (~line 765). But that method issues
-  // NO setNeedsLayout / setNeedsDisplay afterwards, and the field's frame is set
-  // in a SEPARATE Fabric commit (-updateLayoutMetrics:). Those two commits have
-  // no guaranteed ordering on first mount, so the text can be assigned while the
-  // field still has a zero/late frame — UIKit stores the glyphs but never paints
-  // them. Focusing forces a relayout and the (already-present) text finally
-  // shows. It is a RACE: iOS-only, intermittent, and made more likely by living
-  // inside the deferred-layout KeyboardAwareScrollView. Whether a given device
-  // shows the bug just depends on which commit wins the race.
+  // Proven mechanism (read from this app's pinned RN 0.81.5 Fabric source).
+  // When a view is first mounted, RCTMountingManager applies its mutations in a
+  // FIXED order within one commit — updateProps, then updateState, then
+  // updateLayoutMetrics (RCTMountingManager.mm, the `Insert` case). For
+  // TextInput, updateState -> -_setAttributedString: assigns
+  // `_backedTextInputView.attributedText` (RCTTextInputComponentView.mm:765)
+  // while the backing UITextView still has a ZERO frame; its real frame is only
+  // applied by the LATER updateLayoutMetrics call (line 360). UIKit lays the
+  // glyphs out against the zero-sized text container and, on the affected iOS
+  // builds, never re-lays them out when the frame subsequently grows — the text
+  // exists but is never painted. Focusing forces a relayout, so it finally
+  // appears.
   //
-  // Why the previous setNativeProps({ text }) nudge did NOT fix it: on Fabric
-  // setNativeProps is a legacy-bridge no-op for TextInput (RN #47266), and even
-  // if it landed, -_setAttributedString: early-returns when the new string
-  // equals the current one (~line 760) — it re-asserted the SAME value, but the
-  // value was never missing; a relayout was. A one-shot rAF also guessed the
-  // timing and lost the race against later re-renders.
+  // Why prior fixes failed: setNativeProps({ text }) is a no-op for TextInput on
+  // Fabric (RN #47266); a one-shot rAF only guessed the timing; and remounting
+  // via `key` re-runs the SAME `Insert` path — attributedText is assigned against
+  // a fresh zero frame every time — so it structurally cannot fix the race.
   //
-  // The fix: the missing piece is a relayout, not the value — so force one by
-  // REMOUNTING the native input (bump its React `key`), but only AFTER onLayout
-  // confirms the field has a real (non-zero) on-screen frame. On that second
-  // mount the value is committed against an already-laid-out, in-window view, so
-  // UIKit paints it without focus. We wait for proof of layout instead of
-  // guessing a frame (that's what the old fix got wrong), remount at most once
-  // per distinct value, stop entirely once the field has been focused (after
-  // which iOS paints value changes normally), and never remount mid-edit. The
-  // field stays fully controlled (`value` is unchanged), so the
-  // normalize-on-blur / Test / Save write-backs keep working. No-op on Android.
-  const [remountKey, setRemountKey] = useState(0);
-  const hasRealFrame = useRef(false);
-  const lastPaintedValue = useRef<string | null>(null);
-  const everFocused = useRef(false);
-
-  const repaintIfNeeded = useCallback(() => {
-    if (!isIOS) return;
-    if (everFocused.current) return; // once focused, iOS paints value changes itself
-    if (!hasRealFrame.current) return; // wait until the field has an on-screen size
-    if (typeof value !== "string" || value.length === 0) return; // keep placeholder
-    if (lastPaintedValue.current === value) return; // already forced a paint for this text
-    lastPaintedValue.current = value;
-    setRemountKey((k) => k + 1); // remount -> commit value against a laid-out view
-  }, [isIOS, value]);
-
-  // Fires for the value present at mount and for any value that arrives or
-  // changes before first focus; the frame gate above defers the actual remount
-  // until onLayout has reported a real size.
-  useEffect(() => {
-    repaintIfNeeded();
-  }, [repaintIfNeeded]);
+  // The fix: keep the non-empty value off the initial mount entirely. On iOS we
+  // render the field EMPTY first (empty text against a zero frame is a harmless
+  // no-op), then feed it the real `value` only once `onLayout` proves a real
+  // on-screen frame. That value now arrives via the `Update` mutation path
+  // (RCTMountingManager.mm), whose updateState assigns attributedText against an
+  // already-laid-out, in-window UITextView — the path UIKit paints reliably (the
+  // same one any mid-screen setState uses). The field stays fully controlled, so
+  // normalize-on-blur / Test / Save write-backs are unaffected; after first
+  // layout/focus the value always passes through verbatim. No-op on Android.
+  const [primed, setPrimed] = useState(false);
+  const prime = useCallback(() => setPrimed(true), []);
 
   const handleLayout = useCallback(
     (e: LayoutChangeEvent) => {
       onLayout?.(e);
-      if (isIOS && !hasRealFrame.current && e.nativeEvent.layout.width > 0) {
-        hasRealFrame.current = true;
-        repaintIfNeeded();
-      }
+      // A real (non-zero width) frame means the next value assignment lands
+      // against a valid text container and will paint without needing focus.
+      if (isIOS && e.nativeEvent.layout.width > 0) prime();
     },
-    [isIOS, onLayout, repaintIfNeeded],
+    [isIOS, onLayout, prime],
   );
 
   const handleFocus = useCallback<NonNullable<RNTextInputProps["onFocus"]>>(
     (e) => {
-      everFocused.current = true;
+      prime(); // safety net for the rare focus-before-layout case
       onFocus?.(e);
     },
-    [onFocus],
+    [prime, onFocus],
   );
+
+  // Withhold a non-empty initial value on iOS until the field has a confirmed
+  // frame, so it is never assigned against a zero frame. Empty values, undefined
+  // (uncontrolled), and Android are untouched; once primed the real value flows
+  // through unchanged.
+  const displayValue =
+    !isIOS || primed || typeof value !== "string" ? value : "";
 
   return (
     <View className={containerClassName}>
@@ -105,8 +91,7 @@ export function TextInput({
         <Text className="text-zinc-400 text-sm mb-1.5">{label}</Text>
       )}
       <RNTextInput
-        key={isIOS ? remountKey : undefined}
-        value={value}
+        value={displayValue}
         onLayout={handleLayout}
         onFocus={handleFocus}
         className={`bg-surface-light border rounded-xl px-4 py-3 text-zinc-100 text-base ${


### PR DESCRIPTION
Fixes the iOS "Remote URL blank until you tap it" bug (#149).

## Root cause
On mount, Fabric applies mutations in a fixed order — `updateState` (which sets `attributedText`) runs *before* `updateLayoutMetrics` (which sets the frame). So on iOS 18 the glyphs are laid out against a zero frame and never repaint once the frame grows; the field stays blank until focus forces a relayout. The "only Remote URL" reports are just because that's the only pre-loaded field for those users. The v1.9.0 remount-by-`key` attempt re-ran the same mount path, so it couldn't fix it.

## Fix
On iOS, render the field empty on first mount, then feed the real `value` once `onLayout` confirms a real frame — so the value lands via the Update path, which paints reliably. Stays fully controlled (normalize-on-blur / Test / Save unaffected); no-op on Android. Applies to every shared-`TextInput` consumer (settings, backend, home-networks, dashboard-edit).

## Test plan
- [ ] iOS 18: open a service with a saved Remote URL → value shows immediately (was blank until tapped)
- [ ] Edit + Save and normalize-on-blur still work
- [ ] Empty inputs and Android unchanged
- `tsc --noEmit` clean