### PR TITLE
Manage per-torrent category (qBittorrent)

### DIFF
--- a/app/torrent/[hash].tsx
+++ b/app/torrent/[hash].tsx
@@ -9,6 +9,7 @@ import {
   ArrowUp,
   Gauge,
   Megaphone,
+  Tag,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -21,15 +22,18 @@ import { Button } from "@/components/ui/button";
 import { ActionSheet } from "@/components/ui/action-sheet";
 import { toast, toastError } from "@/components/ui/toast";
 import { ShareLimitsSheet } from "@/components/qbittorrent/share-limits-sheet";
+import { CategorySheet } from "@/components/qbittorrent/category-sheet";
 import { useDeferredBack } from "@/hooks/use-deferred-back";
 import {
   useTorrent,
   useTorrentFiles,
   useTorrentTrackers,
+  useTorrentCategories,
   usePauseTorrent,
   useResumeTorrent,
   useReannounceTorrent,
   useDeleteTorrent,
+  useSetTorrentCategory,
 } from "@/hooks/use-qbittorrent";
 import { formatBytes, formatSpeed, formatEta } from "@/lib/utils";
 import { isTorrentPaused } from "@/lib/types";
@@ -39,11 +43,14 @@ export default function TorrentDetailScreen() {
   const { data: torrent, isLoading, error } = useTorrent(hash);
   const { data: files } = useTorrentFiles(hash);
   const { data: trackers } = useTorrentTrackers(hash);
+  const { data: categories } = useTorrentCategories();
   const pauseMutation = usePauseTorrent();
   const resumeMutation = useResumeTorrent();
   const reannounceMutation = useReannounceTorrent();
   const deleteMutation = useDeleteTorrent();
+  const setCategoryMutation = useSetTorrentCategory();
   const [shareLimitsOpen, setShareLimitsOpen] = useState(false);
+  const [categoryOpen, setCategoryOpen] = useState(false);
   const [deleteSheetOpen, setDeleteSheetOpen] = useState(false);
   const deferredBack = useDeferredBack();
 
@@ -77,6 +84,19 @@ export default function TorrentDetailScreen() {
       onSuccess: () => toast("Reannounce requested"),
       onError: (err) => toastError("Failed to reannounce", err),
     });
+  };
+
+  const handleSetCategory = (category: string) => {
+    setCategoryMutation.mutate(
+      { hashes: [hash], category },
+      {
+        onSuccess: () => {
+          toast("Category updated", "success");
+          setCategoryOpen(false);
+        },
+        onError: (err) => toastError("Failed to set category", err),
+      },
+    );
   };
 
   const runDelete = (deleteFiles: boolean) => {
@@ -130,6 +150,7 @@ export default function TorrentDetailScreen() {
           <InfoRow label="Size" value={formatBytes(torrent.size)} />
           <InfoRow label="Downloaded" value={formatBytes(torrent.downloaded)} />
           <InfoRow label="Uploaded" value={formatBytes(torrent.uploaded)} />
+          <InfoRow label="Category" value={torrent.category || "None"} />
           <InfoRow label="Ratio" value={torrent.ratio.toFixed(2)} />
           <InfoRow
             label="Ratio Limit"
@@ -218,6 +239,15 @@ export default function TorrentDetailScreen() {
             className="flex-1"
           />
         </View>
+
+        <View className="mt-3">
+          <Button
+            label="Category"
+            variant="outline"
+            onPress={() => setCategoryOpen(true)}
+            icon={<Icon icon={Tag} size={16} color="#a1a1aa" />}
+          />
+        </View>
       </ScreenWrapper>
 
       <ShareLimitsSheet
@@ -226,6 +256,15 @@ export default function TorrentDetailScreen() {
         hash={hash}
         ratioLimit={torrent.ratio_limit ?? -2}
         seedingTimeLimit={torrent.seeding_time_limit ?? -2}
+      />
+
+      <CategorySheet
+        visible={categoryOpen}
+        onClose={() => setCategoryOpen(false)}
+        categories={categories ?? []}
+        current={torrent.category}
+        saving={setCategoryMutation.isPending}
+        onSave={handleSetCategory}
       />
 
       <ActionSheet

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -660,6 +660,16 @@ function TorrentListItem({
         <Badge label={torrent.statusLabel} variant={badgeVariant} />
       </View>
 
+      {/* Category (qBittorrent) / label (rtorrent) pill — only when set. */}
+      {torrent.label ? (
+        <View className="flex-row items-center gap-1 self-start max-w-full bg-surface-light rounded-full px-2 py-0.5 mb-1">
+          <Icon icon={Tag} size={12} color="#a1a1aa" />
+          <Text className="text-zinc-400 text-xs shrink" numberOfLines={1}>
+            {torrent.label}
+          </Text>
+        </View>
+      ) : null}
+
       <ProgressBar progress={torrent.progress} showLabel className="my-2" />
 
       <View className="flex-row items-center justify-between">

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -7,16 +7,18 @@ import {
   FlatList,
   RefreshControl,
   ActivityIndicator,
+  ScrollView,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { BottomTabBarHeightContext } from "@react-navigation/bottom-tabs";
-import { toastError } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect } from "expo-router";
 import {
   Pause,
   Play,
   Trash2,
   Plus,
+  Tag,
   CheckCircle2,
   Circle,
   AlertCircle,
@@ -35,6 +37,7 @@ import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import { ActionSheet } from "@/components/ui/action-sheet";
+import { CategorySheet } from "@/components/qbittorrent/category-sheet";
 import { errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
 import {
@@ -98,6 +101,7 @@ export function TorrentDownloadsView({
   const setSort = useSortStore((s) => s.setDownloads);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [bulkDelete, setBulkDelete] = useState<{ count: number } | null>(null);
+  const [categoryBulkOpen, setCategoryBulkOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
 
@@ -122,6 +126,7 @@ export function TorrentDownloadsView({
   const pauseMutation = adapter.usePauseTorrent();
   const resumeMutation = adapter.useResumeTorrent();
   const deleteMutation = adapter.useDeleteTorrent();
+  const setCategoryMutation = adapter.useSetCategory();
   const router = useRouter();
 
   const caveat = adapter.capabilities.deleteWithDataCaveat ?? false;
@@ -220,6 +225,27 @@ export function TorrentDownloadsView({
     multiSelect.clear();
   };
 
+  const handleBulkCategory = () => {
+    if (selectedHashes().length === 0) return;
+    setCategoryBulkOpen(true);
+  };
+
+  const runBulkCategory = (category: string) => {
+    const hashes = selectedHashes();
+    if (hashes.length === 0) return;
+    setCategoryMutation.mutate(
+      { hashes, category },
+      {
+        onSuccess: () => {
+          toast("Category updated", "success");
+          multiSelect.clear();
+          setCategoryBulkOpen(false);
+        },
+        onError: (err) => toastError("Failed to set category", err),
+      },
+    );
+  };
+
   const handleTorrentPress = (torrent: UnifiedTorrent) => {
     if (multiSelect.isActive) {
       multiSelect.toggle(torrent);
@@ -235,7 +261,10 @@ export function TorrentDownloadsView({
   };
 
   const bulkBusy =
-    pauseMutation.isPending || resumeMutation.isPending || deleteMutation.isPending;
+    pauseMutation.isPending ||
+    resumeMutation.isPending ||
+    deleteMutation.isPending ||
+    setCategoryMutation.isPending;
 
   // Category filter is qBittorrent-only and only worth showing once the server
   // actually has categories defined.
@@ -276,6 +305,7 @@ export function TorrentDownloadsView({
       onPause={handleBulkPause}
       onResume={handleBulkResume}
       onDelete={handleBulkDelete}
+      onCategory={showCategoryFilter ? handleBulkCategory : undefined}
       busy={bulkBusy}
     />
   ) : (
@@ -488,6 +518,16 @@ export function TorrentDownloadsView({
           },
         ]}
       />
+
+      <CategorySheet
+        visible={categoryBulkOpen}
+        onClose={() => setCategoryBulkOpen(false)}
+        categories={categories}
+        current=""
+        saving={setCategoryMutation.isPending}
+        subtitle={`${multiSelect.count} selected`}
+        onSave={runBulkCategory}
+      />
     </SafeAreaView>
   );
 }
@@ -498,6 +538,7 @@ function SelectionBar({
   onPause,
   onResume,
   onDelete,
+  onCategory,
   busy,
 }: {
   count: number;
@@ -505,6 +546,9 @@ function SelectionBar({
   onPause: () => void;
   onResume: () => void;
   onDelete: () => void;
+  // Bulk set-category — only provided when the client supports categories
+  // (qBittorrent). Undefined hides the button.
+  onCategory?: () => void;
   busy: boolean;
 }) {
   return (
@@ -518,7 +562,13 @@ function SelectionBar({
         </Text>
         <View className="w-16" />
       </View>
-      <View className="flex-row gap-2">
+      {/* Horizontal scroll so the action buttons don't clip when categories add
+          a 4th button or at higher uiScale (see CLAUDE.md chip-row rule). */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerClassName="gap-2"
+      >
         <Button
           label="Pause"
           variant="outline"
@@ -526,7 +576,7 @@ function SelectionBar({
           onPress={onPause}
           disabled={busy || count === 0}
           icon={<Icon icon={Pause} size={14} color="#f59e0b" />}
-          className="flex-1"
+          className="min-w-[6rem]"
         />
         <Button
           label="Resume"
@@ -535,8 +585,19 @@ function SelectionBar({
           onPress={onResume}
           disabled={busy || count === 0}
           icon={<Icon icon={Play} size={14} color="#3b82f6" />}
-          className="flex-1"
+          className="min-w-[6rem]"
         />
+        {onCategory ? (
+          <Button
+            label="Category"
+            variant="outline"
+            size="sm"
+            onPress={onCategory}
+            disabled={busy || count === 0}
+            icon={<Icon icon={Tag} size={14} color="#a1a1aa" />}
+            className="min-w-[6rem]"
+          />
+        ) : null}
         <Button
           label="Delete"
           variant="danger"
@@ -544,9 +605,9 @@ function SelectionBar({
           onPress={onDelete}
           disabled={busy || count === 0}
           icon={<Icon icon={Trash2} size={14} color="white" />}
-          className="flex-1"
+          className="min-w-[6rem]"
         />
-      </View>
+      </ScrollView>
     </View>
   );
 }

--- a/components/qbittorrent/category-sheet.tsx
+++ b/components/qbittorrent/category-sheet.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import { Modal, View, Text, Pressable, ScrollView } from "react-native";
+import { Check } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { lightHaptic } from "@/lib/haptics";
+
+interface CategorySheetProps {
+  visible: boolean;
+  onClose: () => void;
+  // Existing category names (from useTorrentCategories) — the picker offers
+  // these plus a "No category" choice. No free-text entry: creating new
+  // categories is out of scope.
+  categories: string[];
+  // The currently-assigned category to preselect. "" / undefined → "No
+  // category". For bulk edits where selected torrents may differ, pass "".
+  current?: string;
+  saving?: boolean;
+  subtitle?: string;
+  onSave: (category: string) => void;
+}
+
+// Sentinel value for the "No category" row. qBittorrent clears a torrent's
+// category when setCategory is called with an empty string.
+const NONE = "";
+
+export function CategorySheet({
+  visible,
+  onClose,
+  categories,
+  current,
+  saving = false,
+  subtitle,
+  onSave,
+}: CategorySheetProps) {
+  const [selected, setSelected] = useState(current ?? NONE);
+
+  // Reseed the selection from the torrent's current category each time the
+  // sheet opens (mirrors how ShareLimitsSheet seeds its form on `visible`).
+  useEffect(() => {
+    if (visible) setSelected(current ?? NONE);
+  }, [visible, current]);
+
+  const rows: { value: string; label: string }[] = [
+    { value: NONE, label: "No category" },
+    ...categories.map((c) => ({ value: c, label: c })),
+  ];
+
+  const handleSelect = (value: string) => {
+    lightHaptic();
+    setSelected(value);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Category" onClose={onClose} />
+
+        {subtitle ? (
+          <Text className="text-zinc-500 text-sm px-4 pt-3">{subtitle}</Text>
+        ) : null}
+
+        <ScrollView
+          contentContainerClassName="px-4 py-4"
+          showsVerticalScrollIndicator={false}
+        >
+          {rows.map((row) => {
+            const isSelected = row.value === selected;
+            return (
+              <Pressable
+                key={row.value || "__none__"}
+                onPress={() => handleSelect(row.value)}
+                className={`flex-row items-center gap-3 rounded-2xl px-4 py-3 mb-1 ${
+                  isSelected ? "bg-surface-light/70" : "active:bg-surface-light/70"
+                }`}
+              >
+                <Text
+                  className={`flex-1 text-base ${
+                    isSelected
+                      ? "text-primary font-semibold"
+                      : row.value === NONE
+                        ? "text-zinc-400 font-medium"
+                        : "text-zinc-100 font-medium"
+                  }`}
+                  numberOfLines={1}
+                >
+                  {row.label}
+                </Text>
+                {isSelected ? (
+                  <Icon icon={Check} size={18} color="#3b82f6" />
+                ) : null}
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        <View className="px-4 pb-8 pt-2 border-t border-border">
+          <Button
+            label="Save Category"
+            onPress={() => onSave(selected)}
+            loading={saving}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/hooks/use-qbittorrent.ts
+++ b/hooks/use-qbittorrent.ts
@@ -13,6 +13,7 @@ import {
   setDownloadLimit,
   setUploadLimit,
   setShareLimits,
+  setTorrentCategory,
   getSpeedLimitsMode,
   toggleSpeedLimitsMode,
   getSpeedPreferences,
@@ -252,6 +253,26 @@ export function useSetShareLimits(instanceId?: string) {
       ratioLimit: number;
       seedingTimeLimit: number;
     }) => setShareLimits(hashes, ratioLimit, seedingTimeLimit, id ?? undefined),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] });
+    },
+  });
+}
+
+// --- Category ---
+
+export function useSetTorrentCategory(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("qbittorrent", instanceId);
+  return useMutation({
+    // category "" clears the torrent's category (uncategorized).
+    mutationFn: ({
+      hashes,
+      category,
+    }: {
+      hashes: string[];
+      category: string;
+    }) => setTorrentCategory(hashes, category, id ?? undefined),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] });
     },

--- a/lib/torrent-adapter.ts
+++ b/lib/torrent-adapter.ts
@@ -170,6 +170,14 @@ export interface TorrentAdapter {
     instanceId?: string,
   ) => UseMutationResult<unknown, Error, { uri: string; label?: string; savePath?: string }>;
 
+  // Assign/clear a torrent's category (qBittorrent only — gated by
+  // capabilities.categories). category "" clears it. Always called by the
+  // shared view (like useCategories), so clients without categories return a
+  // stub mutation that's never invoked.
+  useSetCategory: (
+    instanceId?: string,
+  ) => UseMutationResult<unknown, Error, { hashes: string[]; category: string }>;
+
   // Optional self-contained speed-limits header control (button + sheet + its
   // own hooks). Rendered in the speed-summary row when present. Owning all the
   // client-specific speed-limit hooks here keeps the shared view free of any

--- a/lib/torrent-adapters/qbittorrent.ts
+++ b/lib/torrent-adapters/qbittorrent.ts
@@ -10,6 +10,7 @@ import {
   usePauseTorrent as useQbPauseTorrent,
   useResumeTorrent as useQbResumeTorrent,
   useDeleteTorrent as useQbDeleteTorrent,
+  useSetTorrentCategory,
 } from "@/hooks/use-qbittorrent";
 import {
   getServerState,
@@ -207,6 +208,7 @@ export const qbittorrentTorrentAdapter: TorrentAdapter = {
   usePauseTorrent: (instanceId?: string) => useQbPauseTorrent(instanceId),
   useResumeTorrent: (instanceId?: string) => useQbResumeTorrent(instanceId),
   useDeleteTorrent: (instanceId?: string) => useQbDeleteTorrent(instanceId),
+  useSetCategory: (instanceId?: string) => useSetTorrentCategory(instanceId),
 
   useAddTorrent: (instanceId?: string) => {
     const queryClient = useQueryClient();

--- a/lib/torrent-adapters/rtorrent.ts
+++ b/lib/torrent-adapters/rtorrent.ts
@@ -185,5 +185,15 @@ export const rtorrentTorrentAdapter: TorrentAdapter = {
     });
   },
 
+  // rtorrent has freeform single labels (custom1), not qBittorrent-style
+  // categories, so capabilities.categories is false and this is never surfaced.
+  // It exists only to satisfy the shared adapter contract (always called).
+  useSetCategory: () =>
+    useMutation({
+      mutationFn: async (_vars: { hashes: string[]; category: string }) => {
+        throw new Error("Categories are not supported on rtorrent");
+      },
+    }),
+
   SpeedLimitsControl: RtorrentSpeedLimitsControl,
 };

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -561,6 +561,32 @@ export function setShareLimits(
   );
 }
 
+// --- Category (per-torrent) ---
+
+// /torrents/setCategory assigns `category` to the given hashes. An empty string
+// clears the category (uncategorized). qBittorrent returns 409 only when the
+// category name doesn't exist — we only ever pass a name returned by
+// getCategories() or "", so that path is never hit.
+export function setTorrentCategory(
+  hashes: string[],
+  category: string,
+  instanceId?: string,
+): Promise<void> {
+  const body = new URLSearchParams({
+    hashes: hashes.join("|"),
+    category,
+  }).toString();
+  return qbRequest(
+    "/torrents/setCategory",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    },
+    instanceId,
+  );
+}
+
 // --- Alternative Speed Mode ---
 
 // /transfer/speedLimitsMode returns "0" (off) or "1" (on) as plain text.


### PR DESCRIPTION
Adds the ability to assign/change a qBittorrent torrent's category from the app (useful with Sonarr/Radarr). Refs #155.

## Changes
- `setTorrentCategory` API + `useSetTorrentCategory` hook (`POST /torrents/setCategory`; empty string clears).
- `useSetCategory` on the shared torrent adapter — qBittorrent wires the real hook; rtorrent gets a never-surfaced stub (categories capability is false).
- New `CategorySheet` picker: existing categories + "No category" (no inline creation, so the 409 "category doesn't exist" path can't trigger).
- Detail screen: Category info row + button to edit.
- Downloads multi-select: bulk "Set Category". Selection action row is now horizontally scrollable so the extra button doesn't clip at higher UI scale.
- List items show the category as a pill when set.

## Test plan
- `npx tsc --noEmit` passes.
- Detail screen: open a torrent → Category → pick one → Save (row updates, toast); pick "No category" to clear.
- Bulk: long-press to multi-select → Category → applies to all selected.
- List: items with a category show a pill below the name.
- rtorrent unaffected (no Category button).