### PR TITLE
fix: proportional progress fills on library poster bars

### DIFF
--- a/components/common/monitored-library-grid.tsx
+++ b/components/common/monitored-library-grid.tsx
@@ -17,11 +17,19 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { usePosterCellLayout } from "@/hooks/use-poster-cell";
 import { useUiScale } from "@/hooks/use-ui-scale";
+import { BAR_TRACK_COLOR } from "@/lib/arr-poster-status";
 
 /** Sonarr/Radarr-style poster overlay: bottom status bar + top-right corner triangle. */
 export interface PosterStatus {
   barColor: string | null;
   cornerColor: string | null;
+  /**
+   * Fill percentage (0–100) for the bottom bar. Omitted ⇒ 100 (a solid bar in
+   * `barColor`, matching Radarr's hardcoded full poster bar). Sonarr series and
+   * Lidarr artists pass a real progress so the bar is a gray track with a
+   * `barColor` fill sized to the percentage, like the *arr index posters.
+   */
+  progress?: number;
 }
 
 export type MonitorFilter = "monitored" | "unmonitored" | "all";
@@ -239,10 +247,20 @@ function LibraryPoster<T extends MonitoredItem>({
         )}
         {status?.cornerColor ? <PosterCornerTriangle color={status.cornerColor} /> : null}
         {status?.barColor ? (
+          // Gray track + a `barColor` fill sized to progress%, mirroring the *arr
+          // index posters. progress omitted ⇒ 100% (a solid bar, like Radarr).
           <View
             className="absolute bottom-0 left-0 right-0 h-1.5"
-            style={{ backgroundColor: status.barColor }}
-          />
+            style={{ backgroundColor: BAR_TRACK_COLOR }}
+          >
+            <View
+              className="absolute left-0 top-0 bottom-0"
+              style={{
+                backgroundColor: status.barColor,
+                width: `${Math.max(0, Math.min(100, status.progress ?? 100))}%`,
+              }}
+            />
+          </View>
         ) : null}
       </View>
       <Text className="text-zinc-300 text-sm mt-1" numberOfLines={1}>

--- a/components/lidarr/music-view.tsx
+++ b/components/lidarr/music-view.tsx
@@ -48,6 +48,7 @@ import {
   BAR_KIND_COLOR,
   cornerColorFor,
   lidarrArtistBarKind,
+  lidarrArtistBarProgress,
   lidarrAlbumBarKind,
 } from "@/lib/arr-poster-status";
 import type { LidarrArtist, LidarrAlbum, LidarrQueueItem } from "@/lib/types";
@@ -464,6 +465,7 @@ function ArtistLibrary({
       posterStatus={(a) => ({
         barColor: BAR_KIND_COLOR[lidarrArtistBarKind(a, downloading.has(a.id))],
         cornerColor: cornerColorFor(a.status),
+        progress: lidarrArtistBarProgress(a),
       })}
       onItemPress={(a) => router.push(`/artist/${a.id}`)}
       onItemLongPress={onLongPress}

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -59,6 +59,7 @@ import {
   BAR_KIND_COLOR,
   cornerColorFor,
   sonarrBarKind,
+  sonarrBarProgress,
 } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
@@ -496,6 +497,7 @@ function SeriesLibrary({
       posterStatus={(s) => ({
         barColor: BAR_KIND_COLOR[sonarrBarKind(s, downloading.has(s.id))],
         cornerColor: cornerColorFor(s.status),
+        progress: sonarrBarProgress(s),
       })}
       onItemPress={(s) => router.push(`/series/${s.id}`)}
       onItemLongPress={onLongPress}

--- a/lib/arr-poster-status.test.ts
+++ b/lib/arr-poster-status.test.ts
@@ -1,4 +1,9 @@
-import { radarrBarKind, sonarrBarKind, cornerColorFor } from "@/lib/arr-poster-status";
+import {
+  radarrBarKind,
+  sonarrBarKind,
+  sonarrBarProgress,
+  cornerColorFor,
+} from "@/lib/arr-poster-status";
 import type { RadarrMovie, SonarrSeries } from "@/lib/types";
 
 function series(over: Partial<SonarrSeries>): SonarrSeries {
@@ -86,6 +91,36 @@ describe("sonarrBarKind", () => {
       },
     });
     expect(sonarrBarKind(s, false)).toBe("danger");
+  });
+});
+
+describe("sonarrBarProgress", () => {
+  it("empty series (no countable episodes) is treated as 100%", () => {
+    expect(sonarrBarProgress(series({ episodeCount: 0, episodeFileCount: 0 }))).toBe(100);
+  });
+
+  it("aired-but-undownloaded reads 0% — gray track, not a solid bar (issue #171)", () => {
+    expect(sonarrBarProgress(series({ episodeCount: 10, episodeFileCount: 0 }))).toBe(0);
+  });
+
+  it("partially downloaded reads the percentage", () => {
+    expect(sonarrBarProgress(series({ episodeCount: 10, episodeFileCount: 5 }))).toBe(50);
+  });
+
+  it("prefers statistics over top-level counts", () => {
+    const s = series({
+      episodeCount: 0,
+      episodeFileCount: 0,
+      statistics: {
+        seasonCount: 1,
+        episodeCount: 8,
+        episodeFileCount: 2,
+        totalEpisodeCount: 8,
+        sizeOnDisk: 0,
+        percentOfEpisodes: 25,
+      },
+    });
+    expect(sonarrBarProgress(s)).toBe(25);
   });
 });
 

--- a/lib/arr-poster-status.ts
+++ b/lib/arr-poster-status.ts
@@ -31,8 +31,29 @@ export const BAR_KIND_COLOR: Record<PosterBarKind, string> = {
   inverse: "#52525b",
 };
 
+/**
+ * Neutral track behind the poster bar's proportional fill, matching the *arr
+ * ProgressBar (a gray track + a kind-colored fill sized to the progress %). A
+ * 0%-progress item therefore reads as this gray track, not a solid color block.
+ */
+export const BAR_TRACK_COLOR = "#3f3f46"; // zinc-700
+
 const CORNER_ENDED = "#ef4444"; // danger
 const CORNER_DELETED = "#71717a"; // gray
+
+/**
+ * Series poster bar fill percentage (0–100), matching Sonarr's
+ * SeriesIndexProgressBar: episodeFileCount / episodeCount, with an empty series
+ * (no countable episodes) treated as 100% via Sonarr's own `: 100` fallback.
+ * The bar is a track + proportional fill, so a 0%-progress series shows the gray
+ * track even though its color (kind) is danger/warning (issue #171).
+ */
+export function sonarrBarProgress(series: SonarrSeries): number {
+  const episodeCount = series.statistics?.episodeCount ?? series.episodeCount ?? 0;
+  const episodeFileCount =
+    series.statistics?.episodeFileCount ?? series.episodeFileCount ?? 0;
+  return episodeCount ? (episodeFileCount / episodeCount) * 100 : 100;
+}
 
 /**
  * Port of Sonarr's getProgressBarKind(status, monitored, progress, isDownloading).
@@ -41,10 +62,7 @@ const CORNER_DELETED = "#71717a"; // gray
 export function sonarrBarKind(series: SonarrSeries, isDownloading: boolean): PosterBarKind {
   if (isDownloading) return "purple";
 
-  const episodeCount = series.statistics?.episodeCount ?? series.episodeCount ?? 0;
-  const episodeFileCount =
-    series.statistics?.episodeFileCount ?? series.episodeFileCount ?? 0;
-  const progress = episodeCount ? (episodeFileCount / episodeCount) * 100 : 100;
+  const progress = sonarrBarProgress(series);
 
   if (progress === 100) {
     return series.status === "ended" ? "success" : "primary";
@@ -73,14 +91,20 @@ export function radarrBarKind(movie: RadarrMovie, isDownloading: boolean): Poste
  * artist that's fully downloaded reads green; an in-progress monitored artist
  * reads red (missing), unmonitored reads amber.
  */
+/** Artist poster bar fill percentage (0–100) — trackFileCount / trackCount, the
+ * Sonarr-style proportional fill Lidarr's ArtistIndexProgressBar uses. */
+export function lidarrArtistBarProgress(artist: LidarrArtist): number {
+  const trackCount = artist.statistics?.trackCount ?? 0;
+  const fileCount = artist.statistics?.trackFileCount ?? 0;
+  return trackCount ? (fileCount / trackCount) * 100 : 100;
+}
+
 export function lidarrArtistBarKind(
   artist: LidarrArtist,
   isDownloading: boolean,
 ): PosterBarKind {
   if (isDownloading) return "purple";
-  const trackCount = artist.statistics?.trackCount ?? 0;
-  const fileCount = artist.statistics?.trackFileCount ?? 0;
-  const progress = trackCount ? (fileCount / trackCount) * 100 : 100;
+  const progress = lidarrArtistBarProgress(artist);
   if (progress >= 100) {
     return artist.status === "ended" ? "success" : "primary";
   }


### PR DESCRIPTION
Library poster status bars were a solid color block, so a show with no downloaded files showed a full amber/red bar where Sonarr shows an empty gray track. They now render a gray track + a kind-colored fill sized to download %, matching the *arr index ProgressBar.

- Sonarr TV + Lidarr artists: proportional fill
- Radarr movies + Lidarr albums: unchanged (Radarr hardcodes movie progress=100)

## Test plan
- `jest lib/arr-poster-status.test.ts` — 21 pass (incl. new sonarrBarProgress cases)
- `tsc --noEmit` clean on changed files
- TV → Library → Unmonitored: bars match Sonarr side-by-side

Refs #171