### PR TITLE
feat(interactive-search): saved *arr custom filters + filter/sort sheet

### DIFF
--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -44,6 +44,7 @@ import {
   useDeleteEpisodeFile,
   useSearchForEpisodes,
   useSearchForSeason,
+  useSearchForSeries,
   useToggleSeriesMonitored,
   useDeleteSeries,
   useSonarrQualityProfiles,
@@ -74,7 +75,6 @@ export default function SeriesDetailScreen() {
     id: string;
     instanceId?: string;
   }>();
-  const router = useRouter();
   const deferredBack = useDeferredBack();
   const {
     data: series,
@@ -84,6 +84,7 @@ export default function SeriesDetailScreen() {
   const { data: episodes } = useSonarrEpisodes(Number(id), instanceId);
   const { data: episodeFiles } = useSonarrEpisodeFiles(Number(id), instanceId);
   const toggleSeries = useToggleSeriesMonitored(instanceId);
+  const searchSeries = useSearchForSeries(instanceId);
   const deleteSeries = useDeleteSeries(instanceId);
   const { data: qualityProfiles } = useSonarrQualityProfiles(instanceId);
   const updateProfile = useUpdateSeriesQualityProfile(instanceId);
@@ -92,6 +93,7 @@ export default function SeriesDetailScreen() {
   const { data: tags } = useSonarrTags(instanceId);
 
   const [actionsVisible, setActionsVisible] = useState(false);
+  const [pendingSeriesSearch, setPendingSeriesSearch] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
   const [rootFolderVisible, setRootFolderVisible] = useState(false);
   const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(
@@ -206,12 +208,8 @@ export default function SeriesDetailScreen() {
       key: "search",
       icon: Search,
       label: "Search",
-      onPress: () =>
-        router.push(
-          instanceId
-            ? `/series/releases/${series.id}?instanceId=${instanceId}`
-            : `/series/releases/${series.id}`,
-        ),
+      loading: searchSeries.isPending,
+      onPress: () => setPendingSeriesSearch(true),
     },
     {
       key: "more",
@@ -459,6 +457,19 @@ export default function SeriesDetailScreen() {
         onConfirm={confirmDelete}
         onCancel={() => setPendingDelete(null)}
         onClosed={deferredBack.onClosed}
+      />
+
+      <ConfirmModal
+        visible={pendingSeriesSearch}
+        title="Search for releases?"
+        message={`Sonarr will search your indexers for all monitored episodes of "${series.title}" and automatically download the best matches.`}
+        icon={Search}
+        confirmLabel="Search"
+        onConfirm={() => {
+          searchSeries.mutate(series.id);
+          setPendingSeriesSearch(false);
+        }}
+        onCancel={() => setPendingSeriesSearch(false)}
       />
     </>
   );

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -4,22 +4,20 @@ import {
   Text,
   FlatList,
   RefreshControl,
-  ScrollView,
   ActivityIndicator,
   Pressable,
 } from "react-native";
-import { Search, AlertTriangle, X, Check } from "lucide-react-native";
+import { Search, AlertTriangle, X } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type { ArrRelease, SonarrRelease } from "@/lib/types";
+import type { ArrRelease, SonarrRelease, ArrCustomFilter } from "@/lib/types";
 import { ReleaseListItem } from "@/components/common/release-list-item";
 import { ReleaseDetailSheet } from "@/components/common/release-detail-sheet";
-import { FilterChip } from "@/components/ui/filter-chip";
-import { SortButton } from "@/components/ui/sort-button";
+import { FilterSortButton } from "@/components/common/filter-sort-button";
 import {
-  ActionSheet,
-  type ActionSheetAction,
-} from "@/components/ui/action-sheet";
+  FilterSortSheet,
+  type SheetSection,
+} from "@/components/common/filter-sort-sheet";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -27,6 +25,8 @@ import { lightHaptic } from "@/lib/haptics";
 import { getHttpErrorMessage } from "@/lib/http-client";
 import { useDeferredBack } from "@/hooks/use-deferred-back";
 import { useSortStore, type ReleasesSortKey } from "@/store/sort-store";
+import { useArrCustomFilters } from "@/hooks/use-arr-custom-filters";
+import { applyArrCustomFilter } from "@/lib/arr-custom-filters";
 
 type Release = ArrRelease | SonarrRelease;
 
@@ -53,6 +53,17 @@ const SORT_OPTIONS: ReleasesSortKey[] = [
   "score-desc",
   "title-asc",
 ];
+
+// Compact labels for the filter+sort pill summary; the sheet uses the full
+// SORT_LABELS.
+const SORT_SUMMARY: Record<ReleasesSortKey, string> = {
+  "seeders-desc": "Seeders",
+  "size-desc": "Largest",
+  "size-asc": "Smallest",
+  "age-asc": "Newest",
+  "score-desc": "Score",
+  "title-asc": "Title",
+};
 
 type ProtocolFilter = "all" | "torrent" | "usenet";
 
@@ -174,8 +185,23 @@ export function ReleasesPicker({
   const [autoFlippedRejected, setAutoFlippedRejected] = useState(false);
   const [protocolFilter, setProtocolFilter] = useState<ProtocolFilter>("all");
   const [qualityFilter, setQualityFilter] = useState<string | null>(null);
-  const [sortSheetOpen, setSortSheetOpen] = useState(false);
+  const [filterSortOpen, setFilterSortOpen] = useState(false);
+  const [selectedFilterId, setSelectedFilterId] = useState<number | null>(null);
   const [selected, setSelected] = useState<Release | null>(null);
+
+  // Saved interactive-search filters configured in the *arr web UI. Only the
+  // "releases" section is relevant here; the control is hidden when there are
+  // none. Selection is resolved by id at render so a refetch/deletion in *arr
+  // can't leave a stale pointer to a filter that no longer exists.
+  const customFiltersQuery = useArrCustomFilters(service, instanceId);
+  const releaseFilters = useMemo(
+    () => (customFiltersQuery.data ?? []).filter((f) => f.type === "releases"),
+    [customFiltersQuery.data],
+  );
+  const selectedFilter = useMemo<ArrCustomFilter | null>(
+    () => releaseFilters.find((f) => f.id === selectedFilterId) ?? null,
+    [releaseFilters, selectedFilterId],
+  );
 
   const { data, isLoading, isError, error, isFetching, refetch, dataUpdatedAt } =
     query;
@@ -232,8 +258,11 @@ export function ReleasesPicker({
       out = out.filter((r) => r.protocol === protocolFilter);
     if (qualityFilter)
       out = out.filter((r) => r.quality?.quality?.name === qualityFilter);
+    // Apply the saved *arr filter last (and before sorting) so it AND-combines
+    // with the quick chips, matching how the *arr web UI stacks them.
+    if (selectedFilter) out = applyArrCustomFilter(out, selectedFilter);
     return sortReleases(out, sortKey);
-  }, [data, hideRejected, protocolFilter, qualityFilter, sortKey]);
+  }, [data, hideRejected, protocolFilter, qualityFilter, selectedFilter, sortKey]);
 
   // If every result was rejected and the user has hideRejected on, auto-flip
   // it once so they aren't staring at an empty list. Track that we did this
@@ -264,18 +293,64 @@ export function ReleasesPicker({
     setHideRejected(false);
     setProtocolFilter("all");
     setQualityFilter(null);
+    setSelectedFilterId(null);
   }
 
-  const sortActions: ActionSheetAction[] = SORT_OPTIONS.map((key) => ({
-    label: SORT_LABELS[key],
-    icon:
-      sortKey === key ? (
-        <Icon icon={Check} size={16} color="#3b82f6" />
-      ) : (
-        <View className="w-[1.15rem] h-[1.15rem]" />
-      ),
-    onPress: () => setSortKey(key),
-  }));
+  // Pill summary + highlight. Leads with the saved filter (the headline) when
+  // one is active, otherwise the rejection state; the dot/highlight signals any
+  // additional protocol/quality filtering.
+  const filterSortActive =
+    !hideRejected ||
+    protocolFilter !== "all" ||
+    qualityFilter !== null ||
+    selectedFilter !== null ||
+    sortKey !== "seeders-desc";
+  const filterSummary = selectedFilter
+    ? selectedFilter.label
+    : hideRejected
+      ? "Accepted only"
+      : "All releases";
+  const summary = `${filterSummary} · ${SORT_SUMMARY[sortKey]}`;
+
+  // Extra single-select sections shown beneath Show/Sort in the sheet, each
+  // conditional on the result set (protocol only when both appear, quality only
+  // when there's more than one, saved filters only when the server has any). The
+  // sheet auto-adds a search box to long sections (e.g. many qualities/filters).
+  const extraSections: SheetSection[] = [];
+  if (releaseFilters.length > 0) {
+    extraSections.push({
+      label: "Saved filters",
+      options: [
+        { key: "none", label: "All releases" },
+        ...releaseFilters.map((f) => ({ key: String(f.id), label: f.label })),
+      ],
+      value: selectedFilterId === null ? "none" : String(selectedFilterId),
+      onChange: (k) => setSelectedFilterId(k === "none" ? null : Number(k)),
+    });
+  }
+  if (protocols.size > 1) {
+    extraSections.push({
+      label: "Protocol",
+      options: [
+        { key: "all", label: "All" },
+        { key: "torrent", label: "Torrent" },
+        { key: "usenet", label: "Usenet" },
+      ],
+      value: protocolFilter,
+      onChange: (k) => setProtocolFilter(k as ProtocolFilter),
+    });
+  }
+  if (qualityNames.length > 1) {
+    extraSections.push({
+      label: "Quality",
+      options: [
+        { key: "all", label: "All qualities" },
+        ...qualityNames.map((n) => ({ key: n, label: n })),
+      ],
+      value: qualityFilter ?? "all",
+      onChange: (k) => setQualityFilter(k === "all" ? null : k),
+    });
+  }
 
   const showSkeleton = (isLoading || isFetching) && !data;
   const showSearchingMessage = showSkeleton && elapsed >= 8;
@@ -310,67 +385,16 @@ export function ReleasesPicker({
         </View>
       </View>
 
-      {/* Filter + sort row */}
+      {/* Filter + sort */}
       {data && data.length > 0 && (
-        <View className="flex-row items-center mb-3 gap-2">
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerClassName="gap-2 pr-2"
-            className="flex-1"
-          >
-            <FilterChip
-              label={hideRejected ? "Hide rejected" : "All releases"}
-              selected={hideRejected}
-              onPress={() => {
-                lightHaptic();
-                setHideRejected((v) => !v);
-                setAutoFlippedRejected(false);
-              }}
-            />
-            {protocols.size > 1 && (
-              <>
-                <FilterChip
-                  label="Torrent"
-                  selected={protocolFilter === "torrent"}
-                  onPress={() => {
-                    lightHaptic();
-                    setProtocolFilter((v) =>
-                      v === "torrent" ? "all" : "torrent",
-                    );
-                  }}
-                />
-                <FilterChip
-                  label="Usenet"
-                  selected={protocolFilter === "usenet"}
-                  onPress={() => {
-                    lightHaptic();
-                    setProtocolFilter((v) =>
-                      v === "usenet" ? "all" : "usenet",
-                    );
-                  }}
-                />
-              </>
-            )}
-            {qualityNames.length > 1 &&
-              qualityNames.slice(0, 6).map((name) => (
-                <FilterChip
-                  key={name}
-                  label={name}
-                  selected={qualityFilter === name}
-                  onPress={() => {
-                    lightHaptic();
-                    setQualityFilter((v) => (v === name ? null : name));
-                  }}
-                />
-              ))}
-          </ScrollView>
-          <SortButton
+        <View className="mb-3">
+          <FilterSortButton
+            summary={summary}
+            active={filterSortActive}
             onPress={() => {
               lightHaptic();
-              setSortSheetOpen(true);
+              setFilterSortOpen(true);
             }}
-            active={sortKey !== "seeders-desc"}
           />
         </View>
       )}
@@ -435,11 +459,27 @@ export function ReleasesPicker({
         />
       )}
 
-      <ActionSheet
-        visible={sortSheetOpen}
-        onClose={() => setSortSheetOpen(false)}
-        title="Sort releases"
-        actions={sortActions}
+      <FilterSortSheet
+        visible={filterSortOpen}
+        onClose={() => setFilterSortOpen(false)}
+        title="Filter & sort releases"
+        filterLabel="Show"
+        filterOptions={[
+          { key: "hide", label: "Accepted only" },
+          { key: "all", label: "All releases" },
+        ]}
+        filterValue={hideRejected ? "hide" : "all"}
+        onFilterChange={(v) => {
+          setHideRejected(v === "hide");
+          setAutoFlippedRejected(false);
+        }}
+        extraSections={extraSections}
+        sortOptions={SORT_OPTIONS.map((key) => ({
+          key,
+          label: SORT_LABELS[key],
+        }))}
+        sortValue={sortKey}
+        onSortChange={setSortKey}
       />
 
       <ReleaseDetailSheet

--- a/hooks/use-arr-custom-filters.ts
+++ b/hooks/use-arr-custom-filters.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { getArrCustomFilters } from "@/services/arr-custom-filters";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
+
+// Fetch a service's saved custom filters. `useInstanceTarget` takes a runtime
+// ServiceId, so one combined hook covers both Radarr and Sonarr — `service`
+// only flows into the query key and fetcher, never into a conditional hook call.
+// Custom filters change rarely, so we keep them fresh for a few minutes.
+export function useArrCustomFilters(
+  service: "radarr" | "sonarr",
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled } = useInstanceTarget(service, instanceId);
+  return useQuery({
+    queryKey: [service, id, "customFilters"],
+    queryFn: () => getArrCustomFilters(service, id ?? undefined),
+    enabled: enabled && !!id,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/lib/arr-custom-filters.test.ts
+++ b/lib/arr-custom-filters.test.ts
@@ -1,0 +1,194 @@
+import { applyArrCustomFilter } from "@/lib/arr-custom-filters";
+import type { ArrCustomFilter, ArrFilterClause, ArrRelease } from "@/lib/types";
+
+function release(over: Partial<ArrRelease>): ArrRelease {
+  return {
+    guid: "g",
+    indexerId: 1,
+    indexer: "Indexer",
+    title: "Some.Release.1080p.WEB-DL",
+    size: 1_000_000_000,
+    age: 5,
+    ageHours: 120,
+    publishDate: "2024-01-01T00:00:00Z",
+    quality: { quality: { id: 7, name: "1080p" } },
+    protocol: "torrent",
+    rejected: false,
+    ...over,
+  } as ArrRelease;
+}
+
+function filter(filters: ArrFilterClause[]): ArrCustomFilter {
+  return { id: 1, type: "releases", label: "Test", filters };
+}
+
+describe("applyArrCustomFilter", () => {
+  it("empty filters passes everything through", () => {
+    const list = [release({ guid: "a" }), release({ guid: "b" })];
+    expect(applyArrCustomFilter(list, filter([])).length).toBe(2);
+  });
+
+  it("quality equal matches by id (number value)", () => {
+    const list = [
+      release({ guid: "hd", quality: { quality: { id: 7, name: "1080p" } } }),
+      release({ guid: "uhd", quality: { quality: { id: 9, name: "2160p" } } }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "quality", value: [7], type: "equal" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["hd"]);
+  });
+
+  it("quality equal tolerates a string-serialized value", () => {
+    const list = [release({ guid: "hd", quality: { quality: { id: 7, name: "1080p" } } })];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "quality", value: ["7"], type: "equal" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["hd"]);
+  });
+
+  it("protocol equal filters by string", () => {
+    const list = [
+      release({ guid: "t", protocol: "torrent" }),
+      release({ guid: "u", protocol: "usenet" }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "protocol", value: ["torrent"], type: "equal" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["t"]);
+  });
+
+  it("seeders greaterThan; usenet release with no seeders defaults to 0", () => {
+    const list = [
+      release({ guid: "lots", protocol: "torrent", seeders: 50 }),
+      release({ guid: "few", protocol: "torrent", seeders: 2 }),
+      release({ guid: "usenet", protocol: "usenet" }), // no seeders key
+    ];
+    const gt5 = applyArrCustomFilter(
+      list,
+      filter([{ key: "seeders", value: 5, type: "greaterThan" }]),
+    );
+    expect(gt5.map((r) => r.guid)).toEqual(["lots"]);
+
+    const gte0 = applyArrCustomFilter(
+      list,
+      filter([{ key: "seeders", value: 0, type: "greaterThanOrEqual" }]),
+    );
+    expect(gte0.map((r) => r.guid)).toEqual(["lots", "few", "usenet"]);
+  });
+
+  it("peers = seeders + leechers", () => {
+    const list = [
+      release({ guid: "a", seeders: 10, leechers: 5 }), // 15
+      release({ guid: "b", seeders: 1, leechers: 1 }), // 2
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "peers", value: 10, type: "greaterThan" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["a"]);
+  });
+
+  it("languages contains by name", () => {
+    const list = [
+      release({ guid: "en", languages: [{ id: 1, name: "English" }] }),
+      release({ guid: "fr", languages: [{ id: 2, name: "French" }] }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "languages", value: ["English"], type: "contains" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["en"]);
+  });
+
+  it("rejectionCount equal 0 keeps only clean releases", () => {
+    const list = [
+      release({ guid: "clean", rejected: false, rejections: [] }),
+      release({ guid: "bad", rejected: true, rejections: ["too small"] }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "rejectionCount", value: 0, type: "equal" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["clean"]);
+  });
+
+  it("size greaterThan in bytes", () => {
+    const list = [
+      release({ guid: "big", size: 5_000_000_000 }),
+      release({ guid: "small", size: 500_000_000 }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "size", value: 1_000_000_000, type: "greaterThan" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["big"]);
+  });
+
+  it("multiple clauses combine with AND", () => {
+    const list = [
+      release({ guid: "ok", protocol: "torrent", seeders: 20 }),
+      release({ guid: "noseed", protocol: "torrent", seeders: 1 }),
+      release({ guid: "usenet", protocol: "usenet", seeders: 99 }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([
+        { key: "protocol", value: ["torrent"], type: "equal" },
+        { key: "seeders", value: 5, type: "greaterThan" },
+      ]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["ok"]);
+  });
+
+  it("array notEqual uses .every (excludes if value matches any)", () => {
+    const list = [
+      release({ guid: "hd", quality: { quality: { id: 7, name: "1080p" } } }),
+      release({ guid: "sd", quality: { quality: { id: 1, name: "SD" } } }),
+    ];
+    // notEqual to [7, 1] → exclude id 7 AND id 1 → both dropped
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "quality", value: [7, 1], type: "notEqual" }]),
+    );
+    expect(out.length).toBe(0);
+
+    // notEqual to [1] → keep id 7
+    const out2 = applyArrCustomFilter(
+      list,
+      filter([{ key: "quality", value: [1], type: "notEqual" }]),
+    );
+    expect(out2.map((r) => r.guid)).toEqual(["hd"]);
+  });
+
+  it("title contains is case-insensitive substring", () => {
+    const list = [
+      release({ guid: "web", title: "Movie.1080p.WEB-DL.x265" }),
+      release({ guid: "bluray", title: "Movie.1080p.BluRay.x265" }),
+    ];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "title", value: "web-dl", type: "contains" }]),
+    );
+    expect(out.map((r) => r.guid)).toEqual(["web"]);
+  });
+
+  it("a malformed clause rejects only its own row, never throws", () => {
+    const list = [release({ guid: "a" })];
+    const bad = filter([{ key: "quality", value: 7, type: "bogusOperator" }]);
+    expect(() => applyArrCustomFilter(list, bad)).not.toThrow();
+    expect(applyArrCustomFilter(list, bad).length).toBe(0);
+  });
+
+  it("unknown column rejects everything (matches *arr fallthrough)", () => {
+    const list = [release({ guid: "a" })];
+    const out = applyArrCustomFilter(
+      list,
+      filter([{ key: "nonexistentField", value: "x", type: "equal" }]),
+    );
+    expect(out.length).toBe(0);
+  });
+});

--- a/lib/arr-custom-filters.ts
+++ b/lib/arr-custom-filters.ts
@@ -1,0 +1,164 @@
+import type { ArrCustomFilter, ArrFilterClause, ArrRelease } from "@/lib/types";
+
+// Faithful port of Sonarr/Radarr's CLIENT-SIDE custom-filter engine, so a saved
+// "interactive search" filter applies in Dashboarr exactly as it does in the
+// *arr web UI. Saved filters are stored server-side (GET /api/v3/customfilter)
+// but *arr never filters releases on the server — the web app does it in the
+// browser. We reproduce that here against our own release objects.
+//
+// Sources (Sonarr & Radarr `frontend/src`, identical semantics):
+//   - Helpers/Props/filterTypePredicates.js  (the generic operators below)
+//   - Helpers/Props/filterTypes.js           (the operator string values)
+//   - Store/Actions/releaseActions.js        (the per-key release predicates)
+//   - Store/Selectors/createClientSideCollectionSelector.js (the clause loop)
+
+// Operator string values as stored in a clause's `type`.
+type Operator =
+  | "contains"
+  | "equal"
+  | "greaterThan"
+  | "greaterThanOrEqual"
+  | "lessThan"
+  | "lessThanOrEqual"
+  | "notContains"
+  | "notEqual"
+  | "startsWith"
+  | "notStartsWith"
+  | "endsWith"
+  | "notEndsWith";
+
+function lower(v: unknown): string {
+  return String(v ?? "").toLowerCase();
+}
+
+// Port of filterTypePredicates. `contains`/`notContains` treat an array
+// itemValue as set-membership (=== on each element, matching *arr which does NOT
+// lowercase array elements); a scalar itemValue is a case-insensitive substring
+// test. Numeric operators coerce both sides with Number() — *arr coerces
+// numerics server-side, and a clause `value` can serialize as a string in some
+// *arr versions, so this keeps comparisons apples-to-apples.
+const OPERATORS: Record<Operator, (itemValue: unknown, filterValue: unknown) => boolean> = {
+  contains: (i, f) =>
+    Array.isArray(i) ? i.some((v) => v === f) : lower(i).includes(lower(f)),
+  notContains: (i, f) =>
+    Array.isArray(i) ? !i.some((v) => v === f) : !lower(i).includes(lower(f)),
+  equal: (i, f) => i === f,
+  notEqual: (i, f) => i !== f,
+  greaterThan: (i, f) => Number(i) > Number(f),
+  greaterThanOrEqual: (i, f) => Number(i) >= Number(f),
+  lessThan: (i, f) => Number(i) < Number(f),
+  lessThanOrEqual: (i, f) => Number(i) <= Number(f),
+  startsWith: (i, f) => lower(i).startsWith(lower(f)),
+  notStartsWith: (i, f) => !lower(i).startsWith(lower(f)),
+  endsWith: (i, f) => lower(i).endsWith(lower(f)),
+  notEndsWith: (i, f) => !lower(i).endsWith(lower(f)),
+};
+
+function isOperator(type: string): type is Operator {
+  return type in OPERATORS;
+}
+
+// Coerce common boolean serializations (true/false, "true"/"false", 1/0) used by
+// the EXACT bool columns: fullSeason, episodeRequested, movieRequested.
+function toBool(v: unknown): boolean {
+  return v === true || v === "true" || v === 1 || v === "1";
+}
+
+// Per-key predicates that *arr special-cases for the "releases" section. These
+// take precedence over the generic operator path. Each returns whether a single
+// `release` matches a single (already-unwrapped) `value` under `op`.
+const KEY_PREDICATES: Record<
+  string,
+  (release: ArrRelease, value: unknown, op: Operator) => boolean
+> = {
+  // quality compares by quality id and only supports equal / notEqual. Number()
+  // both sides so a value serialized as "7" still matches id 7.
+  quality: (release, value, op) => {
+    const id = release.quality?.quality?.id;
+    if (op === "equal") return Number(id) === Number(value);
+    if (op === "notEqual") return Number(id) !== Number(value);
+    return false;
+  },
+  // languages filters on language NAMES (the *arr options selector uses
+  // language.name as the option id), via the generic operator over the array.
+  languages: (release, value, op) =>
+    OPERATORS[op]((release.languages ?? []).map((l) => l.name), value),
+  // peers = seeders + leechers (each defaulting to 0, so usenet releases compare
+  // as 0 rather than being dropped).
+  peers: (release, value, op) =>
+    OPERATORS[op]((release.seeders ?? 0) + (release.leechers ?? 0), value),
+  rejectionCount: (release, value, op) =>
+    OPERATORS[op]((release.rejections ?? []).length, value),
+};
+
+// Known optional numeric columns that *arr materializes as 0. JSON from the
+// `/release` API omits these for usenet releases, so we default them to 0
+// instead of treating the key as "missing" (which would over-filter usenet
+// results versus what the *arr UI shows).
+const NUMERIC_DEFAULT_ZERO = new Set([
+  "seeders",
+  "leechers",
+  "customFormatScore",
+]);
+const BOOL_KEYS = new Set(["fullSeason", "episodeRequested", "movieRequested"]);
+
+// Evaluate one clause against one release for a single scalar value.
+function matchOne(release: ArrRelease, key: string, value: unknown, op: Operator): boolean {
+  const keyPredicate = KEY_PREDICATES[key];
+  if (keyPredicate) return keyPredicate(release, value, op);
+
+  const record = release as unknown as Record<string, unknown>;
+
+  if (BOOL_KEYS.has(key)) {
+    const itemValue = record[key];
+    if (op === "equal") return toBool(itemValue) === toBool(value);
+    if (op === "notEqual") return toBool(itemValue) !== toBool(value);
+    return false;
+  }
+
+  const has = Object.prototype.hasOwnProperty.call(release, key);
+  if (!has && !NUMERIC_DEFAULT_ZERO.has(key)) {
+    // Genuinely unknown / absent column → reject, matching *arr's fallthrough.
+    return false;
+  }
+  const itemValue = has ? record[key] : 0; // NUMERIC_DEFAULT_ZERO and missing
+  return OPERATORS[op](itemValue, value);
+}
+
+// Evaluate one clause (which may carry an array `value`) against one release.
+function matchClause(release: ArrRelease, clause: ArrFilterClause): boolean {
+  const op = clause.type ?? "equal";
+  if (!isOperator(op)) return false;
+
+  const { key, value } = clause;
+  try {
+    if (Array.isArray(value)) {
+      // Array values OR together (.some), except negation operators which AND
+      // (.every) — exactly as *arr's selector does.
+      if (op === "notContains" || op === "notEqual") {
+        return value.every((v) => matchOne(release, key, v, op));
+      }
+      return value.some((v) => matchOne(release, key, v, op));
+    }
+    return matchOne(release, key, value, op);
+  } catch {
+    // One malformed clause must never blank the whole list.
+    return false;
+  }
+}
+
+/**
+ * Apply a saved *arr custom filter to a list of releases, reproducing the *arr
+ * web UI's behaviour. Clauses combine with AND; an empty `filters` array passes
+ * everything through. Pure — safe to call inside a useMemo.
+ */
+export function applyArrCustomFilter<T extends ArrRelease>(
+  releases: T[],
+  filter: ArrCustomFilter,
+): T[] {
+  const clauses = filter.filters ?? [];
+  if (clauses.length === 0) return releases;
+  return releases.filter((release) =>
+    clauses.every((clause) => matchClause(release, clause)),
+  );
+}

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1367,6 +1367,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "HD-1080p" }, { id: 2, name: "Ultra-HD" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/movies", freeSpace: 2199023255552 }];
       if (normalized.startsWith("/tag")) return [];
+      if (normalized.startsWith("/customfilter")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
       if (normalized.startsWith("/movie/lookup")) return [];
       return undefined;
@@ -1379,6 +1380,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "Any" }, { id: 2, name: "HD-1080p" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/tv", freeSpace: 2199023255552 }];
       if (normalized.startsWith("/tag")) return [];
+      if (normalized.startsWith("/customfilter")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
       if (normalized.startsWith("/series/lookup")) return [];
       if (normalized.startsWith("/episode")) return [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -440,7 +440,11 @@ export interface ArrRelease {
   releaseGroup?: string;
 }
 
-export type RadarrRelease = ArrRelease;
+export interface RadarrRelease extends ArrRelease {
+  // Radarr returns this on `/release`; it's only typed so a saved custom filter
+  // keyed on `movieRequested` can be evaluated (see lib/arr-custom-filters.ts).
+  movieRequested?: boolean;
+}
 
 export interface SonarrRelease extends ArrRelease {
   mappedSeasonNumber?: number;
@@ -449,6 +453,26 @@ export interface SonarrRelease extends ArrRelease {
   isAbsoluteNumbering?: boolean;
   isDaily?: boolean;
   episodeRequested?: boolean;
+}
+
+// --- *arr saved custom filters (interactive search) ---
+
+// `GET /api/v3/customfilter` returns these. They are stored server-side but
+// evaluated entirely client-side by the *arr web app — Dashboarr re-implements
+// that engine in lib/arr-custom-filters.ts. `type` is the "section"; for
+// interactive search it is "releases". Each clause's `type` is the operator
+// (defaults to "equal"); `value` is a scalar or an array.
+export interface ArrFilterClause {
+  key: string;
+  value: unknown;
+  type?: string;
+}
+
+export interface ArrCustomFilter {
+  id: number;
+  type: string;
+  label: string;
+  filters: ArrFilterClause[];
 }
 
 // --- Sonarr Types ---

--- a/services/arr-custom-filters.ts
+++ b/services/arr-custom-filters.ts
@@ -1,0 +1,14 @@
+import { serviceRequest } from "@/lib/http-client";
+import type { ArrCustomFilter } from "@/lib/types";
+
+// Radarr and Sonarr both expose saved custom filters at /api/v3/customfilter
+// with X-Api-Key auth, so one function serves both. The web UI evaluates these
+// client-side (see lib/arr-custom-filters.ts).
+export function getArrCustomFilters(
+  service: "radarr" | "sonarr",
+  instanceId?: string,
+): Promise<ArrCustomFilter[]> {
+  return serviceRequest<ArrCustomFilter[]>(service, "/customfilter", {
+    instanceId,
+  });
+}


### PR DESCRIPTION
Lets you apply your saved Sonarr/Radarr interactive-search custom filters from Dashboarr, and brings the releases picker in line with the Movies/TV filter+sort UX.

## Changes
- **Saved custom filters:** fetch `/api/v3/customfilter` and apply the server's saved `releases` filters client-side — a faithful port of the *arr filter engine (operators, AND/OR array handling, quality/languages/peers/rejectionCount predicates). Unit-tested.
- **Canonical filter/sort:** the releases picker now uses `FilterSortButton` + `FilterSortSheet` (Show / Sort / Saved filters / Protocol / Quality), replacing the chip row + ad-hoc sheets. All qualities are listed and searchable (no longer capped at 6).
- **Series search fix:** the series-level Search button opened an invalid "Season NaN" interactive view; it now runs an automatic series search behind a confirm modal.

## Test plan
- `tsc --noEmit` clean; `jest` 560/560 (incl. 14 new engine tests).
- Manual: create a `releases` custom filter in Sonarr/Radarr → interactive search in Dashboarr (season ⋯ / episode ⋯) → filter/sort pill → Saved filters → result set matches the *arr web UI.
- Series-level Search → confirm modal → automatic search.

Refs #133
