### PR TITLE
feat(backend): Tracearr webhook support

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -93,6 +93,7 @@ const WEBHOOK_KINDS = new Set<ServiceId>([
   "tautulli",
   "overseerr",
   "bazarr",
+  "tracearr",
 ]);
 
 // Display name for the service kind (used in the main settings list, before

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -123,6 +123,10 @@ function NotificationRouter() {
         case "overseerr":
           router.push("/(tabs)/requests");
           break;
+        case "tracearr":
+          // All Tracearr webhook events (streams + alerts) surface in Activity.
+          router.push("/(tabs)/activity");
+          break;
         case "health":
           router.push("/(tabs)/services");
           break;

--- a/backend/dashboarr-backend/README.md
+++ b/backend/dashboarr-backend/README.md
@@ -192,6 +192,7 @@ docker run -d --name dashboarr-backend \
 | `POST` | `/webhooks/bazarr/:secret` | path | Bazarr back-compat |
 | `POST` | `/webhooks/tautulli` | header | Tautulli webhook (logged only) |
 | `POST` | `/webhooks/tautulli/:secret` | path | Tautulli back-compat |
+| `POST` | `/webhooks/tracearr/:secret` | path secret | Tracearr "JSON Webhook". Tracearr can't send a custom header, so use the path-secret form. Optional `?instance=<uuid>` — **required** for the per-instance Tracearr toggles to apply |
 
 Copy-paste-ready webhook URLs (and the `X-Dashboarr-Secret` value) are written
 at startup to `${DATA_DIR}/webhook-urls.txt` with mode 0600 — i.e. readable
@@ -235,7 +236,7 @@ Where to find the instance UUID: in the Dashboarr app, open **Settings →
 &lt;service&gt; → &lt;instance&gt;**. The "Webhook Attribution" card shows the
 instance UUID with a tap-to-copy button. The card only appears when a backend
 is paired and the service has a webhook integration (Radarr, Sonarr, Seerr,
-Tautulli, Bazarr).
+Tautulli, Bazarr, Tracearr).
 
 The single shared `X-Dashboarr-Secret` (or `:secret` path segment) keeps
 working unchanged — the query param is a pure additive opt-in.
@@ -258,6 +259,13 @@ because of a stale URL would be worse than emitting a generic push.
 Tautulli and Bazarr webhooks accept the param too but only record events (no
 push), so attribution there is a no-op until those categories are added.
 
+Tracearr is the one case where `?instance=<uuid>` is more than cosmetic. Its
+notification toggles live **per-instance** (in each Tracearr instance's editor;
+there are no global Tracearr toggles), and a per-instance override only applies
+when the push carries `data.instanceId`. So without the `?instance=` param a
+Tracearr webhook falls back to the built-in defaults (alerts + server status on,
+trust-score + stream events off) and the per-instance toggles have no effect.
+
 ---
 
 ## Notification event sources
@@ -272,6 +280,7 @@ push), so attribution there is a no-op until those categories are added.
 | **Seerr** | ✅ (preferred) | ✅ 60s | Webhook for `MEDIA_PENDING`; poll diffs pending requests |
 | **Bazarr** | ✅ (logged) | — | Payload is unstructured; no default category yet |
 | **Tautulli** | ✅ (logged) | — | User-scripted payloads; no default category yet |
+| **Tracearr** | ✅ | — | "JSON Webhook" agent → per-event categories: violation / new device / trust score / server down / server up (on by default) and stream started / stopped (off by default). Toggles are per-instance only — use `?instance=<uuid>`. Path-secret URL only (Tracearr can't send a custom header) |
 | **Prowlarr** | ❌ | ✅ 5m | Currently advisory — no user-facing category yet |
 | **Glances** | ❌ | ✅ 30s | Health-only; threshold alerts TBD |
 | **Plex** | ❌ | — | Nothing polled; reserved |

--- a/backend/dashboarr-backend/src/index.ts
+++ b/backend/dashboarr-backend/src/index.ts
@@ -21,6 +21,7 @@ import { sonarrWebhook } from "./routes/webhooks/sonarr.js";
 import { overseerrWebhook } from "./routes/webhooks/overseerr.js";
 import { bazarrWebhook } from "./routes/webhooks/bazarr.js";
 import { tautulliWebhook } from "./routes/webhooks/tautulli.js";
+import { tracearrWebhook } from "./routes/webhooks/tracearr.js";
 
 const BANNER = `
 ===============================================================================
@@ -48,7 +49,7 @@ async function writeWebhookUrlsFile(publicUrl: string, dataDir: string): Promise
     "# Back-compat — secret in the URL path (works with services that can't send custom headers):",
   ];
   for (const id of SERVICE_IDS) {
-    if (id === "qbittorrent" || id === "prowlarr" || id === "plex" || id === "jellyfin" || id === "emby" || id === "glances" || id === "tracearr") continue;
+    if (id === "qbittorrent" || id === "prowlarr" || id === "plex" || id === "jellyfin" || id === "emby" || id === "glances") continue;
     lines.push(`${id.padEnd(10)} ${webhookBase}/${id}/${webhookSecret}`);
   }
   const content = lines.join("\n") + "\n";
@@ -177,6 +178,7 @@ async function main(): Promise<void> {
     await overseerrWebhook(scope);
     await bazarrWebhook(scope);
     await tautulliWebhook(scope);
+    await tracearrWebhook(scope);
   });
 
   // Everything else (bearer-authed app traffic): a reasonable ceiling that

--- a/backend/dashboarr-backend/src/routes/webhooks/tracearr.ts
+++ b/backend/dashboarr-backend/src/routes/webhooks/tracearr.ts
@@ -1,0 +1,215 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { recordWebhook } from "../../db/repos/events.js";
+import { dispatchPush } from "../../push/dispatcher.js";
+import {
+  checkWebhookSecret,
+  resolveWebhookInstance,
+  webhookTitlePrefix,
+} from "./shared.js";
+
+/**
+ * Tracearr "JSON Webhook" notification agent payload. Every event arrives as
+ * `{ event, timestamp, data }`; the `data` shape varies per `event`. We type it
+ * loosely (all optional) because the upstream shape isn't a contract we control
+ * and we only read a handful of fields per event.
+ *
+ * Tracearr can only send `Content-Type: application/json` (plus an optional
+ * `Authorization: Basic` extracted from URL-embedded credentials) — it cannot
+ * add a custom header. So the user must point it at the path-secret URL form
+ * (`/webhooks/tracearr/<secret>`), which `checkWebhookSecret` accepts.
+ *
+ * Default channel routing in Tracearr enables violation/new_device/server_*
+ * out of the box and leaves trust_score/stream_* off (the user opts in). Our
+ * per-category defaults below mirror that.
+ */
+interface TracearrUser {
+  username?: string;
+  displayName?: string;
+}
+interface TracearrWebhookPayload {
+  event?: string;
+  timestamp?: string;
+  data?: {
+    message?: string;
+    // violation_detected
+    user?: TracearrUser;
+    rule?: { name?: string };
+    violation?: { id?: string | number; severity?: string };
+    // new_device
+    userName?: string;
+    deviceName?: string;
+    location?: string | null;
+    // trust_score_changed
+    previousScore?: number;
+    newScore?: number;
+    reason?: string | null;
+    // server_down / server_up
+    serverName?: string;
+    // stream_started / stream_stopped
+    media?: { title?: string; year?: number | null };
+  };
+}
+
+type WebhookReq = FastifyRequest<{
+  Params: { secret?: string };
+  Querystring: { instance?: string };
+}>;
+
+export async function tracearrWebhook(app: FastifyInstance): Promise<void> {
+  const handler = async (request: WebhookReq, reply: FastifyReply) => {
+    if (!(await checkWebhookSecret(request, reply))) return;
+
+    const payload = (request.body ?? {}) as TracearrWebhookPayload;
+    recordWebhook("tracearr", payload);
+
+    // Optional ?instance=<uuid> attribution. For Tracearr this matters more
+    // than for other services: the notification toggles live per-instance
+    // (Tracearr has no global category rows), so the per-instance override only
+    // applies when `data.instanceId` is set — i.e. when the user appended the
+    // instance id to the webhook URL. Without it, the global default applies.
+    const inst = resolveWebhookInstance(request, "tracearr");
+    const prefix = webhookTitlePrefix(inst, "tracearr");
+    const ns = inst ? inst.id : "any";
+    const data = payload.data ?? {};
+
+    const who = data.user?.displayName ?? data.user?.username ?? "Someone";
+
+    switch (payload.event) {
+      case "test":
+        await dispatchPush({
+          category: "tracearrViolation",
+          title: `${prefix}Tracearr webhook connected`,
+          body: data.message ?? "Test notification received successfully",
+          bypassCategory: true,
+        });
+        return { ok: true, test: true };
+
+      case "violation_detected": {
+        const rule = data.rule?.name ?? "rule";
+        const sev = data.violation?.severity;
+        await dispatchPush({
+          category: "tracearrViolation",
+          title: `${prefix}Rule violation`,
+          body: sev ? `${who} — ${rule} (${sev})` : `${who} — ${rule}`,
+          data: {
+            type: "tracearr",
+            event: "violation_detected",
+            violationId: data.violation?.id,
+            instanceId: inst?.id,
+          },
+          dedupeKey: `tracearr:${ns}:violation:${data.violation?.id ?? who}`,
+        });
+        break;
+      }
+
+      case "new_device": {
+        const name = data.userName ?? who;
+        const device = data.deviceName ?? "a new device";
+        const loc = data.location ? ` (${data.location})` : "";
+        await dispatchPush({
+          category: "tracearrNewDevice",
+          title: `${prefix}New device`,
+          body: `${name} signed in from ${device}${loc}`,
+          data: { type: "tracearr", event: "new_device", instanceId: inst?.id },
+          // No stable id in the payload — dedupe is best-effort on user+device.
+          dedupeKey: `tracearr:${ns}:device:${name}:${device}`,
+        });
+        break;
+      }
+
+      case "trust_score_changed": {
+        const name = data.userName ?? who;
+        const reason = data.reason ? ` (${data.reason})` : "";
+        await dispatchPush({
+          category: "tracearrTrustScore",
+          title: `${prefix}Trust score changed`,
+          body: `${name}: ${data.previousScore} → ${data.newScore}${reason}`,
+          data: {
+            type: "tracearr",
+            event: "trust_score_changed",
+            instanceId: inst?.id,
+          },
+          // Best-effort: key on the new score so a later change isn't collapsed.
+          dedupeKey: `tracearr:${ns}:trust:${name}:${data.newScore}`,
+        });
+        break;
+      }
+
+      case "server_down": {
+        const server = data.serverName ?? "A server";
+        await dispatchPush({
+          category: "tracearrServerDown",
+          title: `${prefix}Server offline`,
+          body: `${server} is offline`,
+          data: { type: "tracearr", event: "server_down", instanceId: inst?.id },
+          dedupeKey: `tracearr:${ns}:server:${server}:down`,
+        });
+        break;
+      }
+
+      case "server_up": {
+        const server = data.serverName ?? "A server";
+        await dispatchPush({
+          category: "tracearrServerUp",
+          title: `${prefix}Server back online`,
+          body: `${server} is back online`,
+          data: { type: "tracearr", event: "server_up", instanceId: inst?.id },
+          dedupeKey: `tracearr:${ns}:server:${server}:up`,
+        });
+        break;
+      }
+
+      case "stream_started": {
+        const title = data.media?.title ?? "something";
+        await dispatchPush({
+          category: "tracearrStreamStarted",
+          title: `${prefix}Stream started`,
+          body: `${who} started ${title}`,
+          data: {
+            type: "tracearr",
+            event: "stream_started",
+            instanceId: inst?.id,
+          },
+          // No session id in the webhook payload — dedupe is best-effort.
+          dedupeKey: `tracearr:${ns}:stream:start:${who}:${title}`,
+        });
+        break;
+      }
+
+      case "stream_stopped": {
+        const title = data.media?.title ?? "something";
+        await dispatchPush({
+          category: "tracearrStreamStopped",
+          title: `${prefix}Stream stopped`,
+          body: `${who} stopped ${title}`,
+          data: {
+            type: "tracearr",
+            event: "stream_stopped",
+            instanceId: inst?.id,
+          },
+          dedupeKey: `tracearr:${ns}:stream:stop:${who}:${title}`,
+        });
+        break;
+      }
+
+      // Unknown / unmapped event — already recorded above. Don't 4xx: Tracearr
+      // won't retry on a 4xx and we'd drop a future event type silently.
+      default:
+        break;
+    }
+
+    return { ok: true };
+  };
+
+  // Preferred form (header secret) — registered for symmetry, though Tracearr
+  // can't send a custom header so users will use the path form below.
+  app.post<{ Params: { secret?: string }; Querystring: { instance?: string } }>(
+    "/webhooks/tracearr",
+    handler,
+  );
+  // Path-secret form — what Tracearr's JSON webhook actually uses.
+  app.post<{ Params: { secret?: string }; Querystring: { instance?: string } }>(
+    "/webhooks/tracearr/:secret",
+    handler,
+  );
+}

--- a/backend/dashboarr-backend/src/types.ts
+++ b/backend/dashboarr-backend/src/types.ts
@@ -92,6 +92,16 @@ export const notifCategoryEnum = z.enum([
   "sonarrDownloaded",
   "serviceOffline",
   "overseerrNewRequest",
+  // Tracearr webhook events. Surfaced per-instance only (no global toggle),
+  // so a Tracearr push only respects these when the webhook URL carries
+  // ?instance=<uuid>; otherwise the global defaults below apply.
+  "tracearrViolation",
+  "tracearrNewDevice",
+  "tracearrTrustScore",
+  "tracearrServerDown",
+  "tracearrServerUp",
+  "tracearrStreamStarted",
+  "tracearrStreamStopped",
 ]);
 
 export type NotifCategory = z.infer<typeof notifCategoryEnum>;
@@ -111,6 +121,14 @@ export const notificationSettingsSchema = z.object({
   sonarrDownloaded: z.boolean().default(true),
   serviceOffline: z.boolean().default(true),
   overseerrNewRequest: z.boolean().default(true),
+  // Tracearr — defaults mirror Tracearr's own webhook-channel routing.
+  tracearrViolation: z.boolean().default(true),
+  tracearrNewDevice: z.boolean().default(true),
+  tracearrTrustScore: z.boolean().default(false),
+  tracearrServerDown: z.boolean().default(true),
+  tracearrServerUp: z.boolean().default(true),
+  tracearrStreamStarted: z.boolean().default(false),
+  tracearrStreamStopped: z.boolean().default(false),
   perInstance: perInstanceOverridesSchema,
 });
 
@@ -125,6 +143,13 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   sonarrDownloaded: true,
   serviceOffline: true,
   overseerrNewRequest: true,
+  tracearrViolation: true,
+  tracearrNewDevice: true,
+  tracearrTrustScore: false,
+  tracearrServerDown: true,
+  tracearrServerUp: true,
+  tracearrStreamStarted: false,
+  tracearrStreamStopped: false,
 };
 
 /**
@@ -205,7 +230,14 @@ export type NotificationCategory =
   | "radarrDownloaded"
   | "sonarrDownloaded"
   | "serviceOffline"
-  | "overseerrNewRequest";
+  | "overseerrNewRequest"
+  | "tracearrViolation"
+  | "tracearrNewDevice"
+  | "tracearrTrustScore"
+  | "tracearrServerDown"
+  | "tracearrServerUp"
+  | "tracearrStreamStarted"
+  | "tracearrStreamStopped";
 
 export interface PushEvent {
   category: NotificationCategory;

--- a/lib/notification-categories.ts
+++ b/lib/notification-categories.ts
@@ -23,7 +23,20 @@ export const CATEGORIES_FOR_KIND: Record<ServiceId, NotifCategory[]> = {
   overseerr:   ["overseerrNewRequest", "serviceOffline"],
   prowlarr:    ["serviceOffline"],
   tautulli:    ["serviceOffline"],
-  tracearr:    ["serviceOffline"],
+  // Tracearr webhook events. These have no global toggle rows in Settings →
+  // Notifications; they're controlled per-instance here (each Tracearr instance
+  // editor), so point its webhook at /webhooks/tracearr/<secret>?instance=<id>
+  // for these overrides to apply.
+  tracearr: [
+    "tracearrViolation",
+    "tracearrNewDevice",
+    "tracearrTrustScore",
+    "tracearrServerDown",
+    "tracearrServerUp",
+    "tracearrStreamStarted",
+    "tracearrStreamStopped",
+    "serviceOffline",
+  ],
   jellystat:   ["serviceOffline"],
   plex:        ["serviceOffline"],
   bazarr:      ["serviceOffline"],
@@ -40,6 +53,13 @@ export const CATEGORY_LABELS: Record<NotifCategory, string> = {
   sonarrDownloaded: "Episode downloaded",
   serviceOffline: "Service offline",
   overseerrNewRequest: "New Seerr request",
+  tracearrViolation: "Rule violation",
+  tracearrNewDevice: "New device",
+  tracearrTrustScore: "Trust score change",
+  tracearrServerDown: "Server offline",
+  tracearrServerUp: "Server back online",
+  tracearrStreamStarted: "Stream started",
+  tracearrStreamStopped: "Stream stopped",
 };
 
 export const NOTIF_CATEGORIES = Object.keys(CATEGORY_LABELS) as NotifCategory[];

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -116,8 +116,15 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         Services-tab tile order per workspace. Pure version stamp — absent
  *         means "use the global servicesOrder", so older exports just need the
  *         version field bumped. coerceDashboard validates the field on import.
+ *   v31 — added seven per-event Tracearr notification categories
+ *         (tracearrViolation / tracearrNewDevice / tracearrTrustScore /
+ *         tracearrServerDown / tracearrServerUp / tracearrStreamStarted /
+ *         tracearrStreamStopped) for the backend Tracearr webhook. Pure version
+ *         stamp — coerceNotificationSettings treats them as optional keys, so
+ *         older exports without them validate and the missing entries fall back
+ *         to DEFAULT_NOTIFICATION_SETTINGS at hydrate time.
  */
-export const CURRENT_CONFIG_VERSION = 30;
+export const CURRENT_CONFIG_VERSION = 31;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -599,6 +606,12 @@ const migrations: Record<number, (payload: any) => any> = {
   // servicesOrder", so older exports are already correct. coerceDashboard
   // coerces/validates the field on import.
   29: (payload) => ({ ...payload, version: 30 }),
+
+  // v30 → v31: seven per-event Tracearr notification categories added for the
+  // backend Tracearr webhook. Pure version stamp — coerceNotificationSettings
+  // treats them as optional keys, so older exports without them validate and the
+  // missing entries fall back to DEFAULT_NOTIFICATION_SETTINGS at hydrate time.
+  30: (payload) => ({ ...payload, version: 31 }),
 };
 
 /**

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -262,7 +262,17 @@ function coerceNotificationSettings(v: unknown): NotificationSettings | null {
     "serviceOffline",
     "overseerrNewRequest",
   ] as const;
-  const optionalKeys = ["sabnzbdCompleted", "nzbgetCompleted"] as const;
+  const optionalKeys = [
+    "sabnzbdCompleted",
+    "nzbgetCompleted",
+    "tracearrViolation",
+    "tracearrNewDevice",
+    "tracearrTrustScore",
+    "tracearrServerDown",
+    "tracearrServerUp",
+    "tracearrStreamStarted",
+    "tracearrStreamStopped",
+  ] as const;
   const out: Partial<NotificationSettings> = {};
   for (const key of requiredKeys) {
     if (typeof v[key] !== "boolean") return null;

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -200,7 +200,17 @@ export type NotifCategory =
   | "radarrDownloaded"
   | "sonarrDownloaded"
   | "serviceOffline"
-  | "overseerrNewRequest";
+  | "overseerrNewRequest"
+  // Tracearr webhook events. Exposed per-instance only (in each Tracearr
+  // instance's editor) — no global toggle rows — so the per-instance override
+  // is the primary control; these globals are the inherit/fallback defaults.
+  | "tracearrViolation"
+  | "tracearrNewDevice"
+  | "tracearrTrustScore"
+  | "tracearrServerDown"
+  | "tracearrServerUp"
+  | "tracearrStreamStarted"
+  | "tracearrStreamStopped";
 
 export interface NotificationSettings {
   enabled: boolean;
@@ -211,6 +221,13 @@ export interface NotificationSettings {
   sonarrDownloaded: boolean;
   serviceOffline: boolean;
   overseerrNewRequest: boolean;
+  tracearrViolation: boolean;
+  tracearrNewDevice: boolean;
+  tracearrTrustScore: boolean;
+  tracearrServerDown: boolean;
+  tracearrServerUp: boolean;
+  tracearrStreamStarted: boolean;
+  tracearrStreamStopped: boolean;
   // v21: per-instance overrides keyed by instance UUID. A category absent from
   // an instance's override map falls through to the global toggle. Allows
   // "notify me from the primary Radarr but stay silent from the testing one"
@@ -227,6 +244,15 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   sonarrDownloaded: true,
   serviceOffline: true,
   overseerrNewRequest: true,
+  // Tracearr defaults mirror Tracearr's own webhook-channel routing: alerts and
+  // server status on, trust-score and stream chatter off (opt-in per instance).
+  tracearrViolation: true,
+  tracearrNewDevice: true,
+  tracearrTrustScore: false,
+  tracearrServerDown: true,
+  tracearrServerUp: true,
+  tracearrStreamStarted: false,
+  tracearrStreamStopped: false,
 };
 
 interface ConfigState {


### PR DESCRIPTION
Backend now ingests Tracearr's JSON Webhook and relays per-event push notifications. Refs #159.

## What
- New `/webhooks/tracearr[/:secret]` handler mapping Tracearr's 7 events (violation, new device, trust score, server down/up, stream started/stopped) to per-event push categories, plus a `test` connected-push.
- 7 per-event notification categories, surfaced **per-instance only** (each Tracearr instance editor), not the global Notifications screen.
- Path-secret URL + `?instance=<uuid>` attribution — Tracearr can't send a custom header, and the per-instance toggles only apply when `?instance` is present.
- README + config migration v30→31.

## Test plan
- Backend + app `tsc --noEmit`: clean.
- Live backend smoke test: valid events → 200, `test` → `{ok,test}`, bad/missing secret → 401. DB inspection confirmed dispatch routing — `seen_state` dedupe keys present for default-ON events (violation/server-down/new-device) and correctly absent for default-OFF `stream_started`, proving the event→category mapping and default gating.