### PR TITLE
feat(seerr): quick + 4K requests and trailers (Refs #86)

### DIFF
--- a/components/overseerr/media-detail-modal.tsx
+++ b/components/overseerr/media-detail-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Modal,
   View,
@@ -6,9 +6,22 @@ import {
   Pressable,
   ScrollView,
   Dimensions,
+  ActivityIndicator,
+  Linking,
 } from "react-native";
 import { Image } from "expo-image";
-import { X, Star, Check, Clock, Film, Tv, Plus } from "lucide-react-native";
+import {
+  X,
+  Star,
+  Check,
+  Clock,
+  Film,
+  Tv,
+  Plus,
+  Play,
+  SlidersHorizontal,
+  ExternalLink,
+} from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { BlurView } from "expo-blur";
 import Animated, {
@@ -16,11 +29,31 @@ import Animated, {
   useAnimatedStyle,
   withTiming,
 } from "react-native-reanimated";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { getPosterUrl, getBackdropUrl } from "@/services/overseerr-api";
+import { toast } from "@/components/ui/toast";
+import { getHttpErrorMessage, formatErrorForCopy } from "@/lib/http-client";
+import {
+  getPosterUrl,
+  getBackdropUrl,
+  pickTrailer,
+} from "@/services/overseerr-api";
 import { RequestOptionsSheet } from "@/components/overseerr/request-options-sheet";
-import type { OverseerrMediaResult } from "@/lib/types";
+import {
+  RequestErrorBanner,
+  type RequestError,
+} from "@/components/overseerr/request-error-banner";
+import {
+  useOverseerrMediaDetails,
+  useOverseerrRadarrServers,
+  useOverseerrSonarrServers,
+  useRequestMovie,
+  useRequestTV,
+} from "@/hooks/use-overseerr";
+import type {
+  OverseerrMediaResult,
+  OverseerrMovieDetails,
+  OverseerrTVDetails,
+} from "@/lib/types";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 
@@ -30,38 +63,152 @@ interface MediaDetailModalProps {
   onClose: () => void;
 }
 
+// Compact availability indicator used when a quality tier can't be requested
+// (already available or already requested).
+function StatusPill({
+  tone,
+  icon,
+  label,
+}: {
+  tone: "success" | "warning";
+  icon: React.ComponentType<any>;
+  label: string;
+}) {
+  const s =
+    tone === "success"
+      ? {
+          bg: "bg-green-600/10",
+          border: "border-green-600/30",
+          text: "text-green-500",
+          color: "#22c55e",
+        }
+      : {
+          bg: "bg-yellow-600/10",
+          border: "border-yellow-600/30",
+          text: "text-yellow-500",
+          color: "#eab308",
+        };
+  return (
+    <View
+      className={`flex-row items-center justify-center gap-2 py-3 rounded-xl border ${s.bg} ${s.border}`}
+    >
+      <Icon icon={icon} size={18} color={s.color} />
+      <Text className={`font-medium ${s.text}`}>{label}</Text>
+    </View>
+  );
+}
+
 export function MediaDetailModal({
   item,
   visible,
   onClose,
 }: MediaDetailModalProps) {
   const [optionsVisible, setOptionsVisible] = useState(false);
+  const [optionsIs4k, setOptionsIs4k] = useState(false);
+  const [quickKind, setQuickKind] = useState<null | "hd" | "4k">(null);
+  const [quickError, setQuickError] = useState<RequestError | null>(null);
+
   const backdropOpacity = useSharedValue(0);
   const posterModalOpacity = useSharedValue(0);
   const backdropFadeStyle = useAnimatedStyle(() => ({ opacity: withTiming(backdropOpacity.value, { duration: 300 }) }));
   const posterFadeStyle = useAnimatedStyle(() => ({ opacity: withTiming(posterModalOpacity.value, { duration: 400 }) }));
 
+  const isTv = item?.mediaType === "tv";
+
+  // Full details give us trailers + per-tier (4K) status. Only fetched while the
+  // sheet is open for this title.
+  const detailsQuery = useOverseerrMediaDetails(
+    item?.id ?? 0,
+    isTv ? "tv" : "movie",
+    undefined,
+    visible,
+  );
+  const detailsData = detailsQuery.data as
+    | OverseerrMovieDetails
+    | OverseerrTVDetails
+    | undefined;
+
+  const radarrServersQuery = useOverseerrRadarrServers();
+  const sonarrServersQuery = useOverseerrSonarrServers();
+  const servers =
+    (isTv ? sonarrServersQuery.data : radarrServersQuery.data) ?? [];
+  const has4kServer = servers.some((s) => s.is4k);
+
+  const requestMovie = useRequestMovie();
+  const requestTV = useRequestTV();
+
+  useEffect(() => {
+    if (visible) {
+      setQuickError(null);
+      setQuickKind(null);
+    }
+  }, [visible, item?.id]);
+
+  useEffect(() => {
+    if (!visible) setOptionsVisible(false);
+  }, [visible]);
+
   if (!item) return null;
 
   const title = item.title || item.name || "Unknown";
-  const year =
-    item.releaseDate?.slice(0, 4) || item.firstAirDate?.slice(0, 4);
+  const year = item.releaseDate?.slice(0, 4) || item.firstAirDate?.slice(0, 4);
   const backdropUrl = getBackdropUrl(item.backdropPath);
   const posterUrl = getPosterUrl(item.posterPath, "w342");
-  const isAvailable = item.mediaInfo?.status === 5;
-  const isPending =
-    item.mediaInfo?.status === 2 || item.mediaInfo?.status === 3;
-  const canRequest = !isAvailable && !isPending;
 
-  const handleRequest = () => {
-    setOptionsVisible(true);
+  // Prefer the freshly fetched detail status (has status4k); fall back to the
+  // list item's mediaInfo while details load.
+  const mediaInfo = detailsData?.mediaInfo ?? item.mediaInfo;
+  const statusHd = mediaInfo?.status;
+  const status4k = mediaInfo?.status4k;
+
+  const isAvailableHd = statusHd === 5;
+  const isPendingHd = statusHd === 2 || statusHd === 3;
+  const canRequestHd = !isAvailableHd && !isPendingHd;
+
+  const isAvailable4k = status4k === 5;
+  const isPending4k = status4k === 2 || status4k === 3;
+  const canRequest4k = has4kServer && !isAvailable4k && !isPending4k;
+
+  const trailer = pickTrailer(detailsData?.relatedVideos);
+  const submitting = quickKind !== null;
+
+  // YouTube blocks embedding for most titles, so open the trailer in the
+  // YouTube app (or browser) rather than an in-app player.
+  const openTrailer = () => {
+    if (!trailer) return;
+    const url = trailer.url || `https://www.youtube.com/watch?v=${trailer.key}`;
+    Linking.openURL(url).catch(() => {});
   };
 
-  const statusBadge = isAvailable
-    ? { label: "Available", variant: "success" as const }
-    : isPending
-      ? { label: "Requested", variant: "warning" as const }
-      : null;
+  // One-tap request using Seerr's server defaults (4K resolves the default 4K
+  // server). The advanced sheet covers picking a specific server/profile/root.
+  const handleQuickRequest = async (kind: "hd" | "4k") => {
+    setQuickError(null);
+    setQuickKind(kind);
+    const options = kind === "4k" ? { is4k: true } : undefined;
+    try {
+      if (isTv) {
+        await requestTV.mutateAsync({ tmdbId: item.id, seasons: "all", options });
+      } else {
+        await requestMovie.mutateAsync({ tmdbId: item.id, options });
+      }
+      toast(`${title} has been requested${kind === "4k" ? " in 4K" : ""}`);
+      onClose();
+    } catch (err) {
+      const message =
+        getHttpErrorMessage(err) ??
+        (err instanceof Error ? err.message : "Failed to request");
+      setQuickError({ message, copyText: formatErrorForCopy(err) });
+    } finally {
+      setQuickKind(null);
+    }
+  };
+
+  const openCustomize = () => {
+    // Default the advanced sheet to the tier the user can actually request.
+    setOptionsIs4k(!canRequestHd && canRequest4k);
+    setOptionsVisible(true);
+  };
 
   return (
     <Modal
@@ -92,6 +239,21 @@ export function MediaDetailModal({
             <View className="absolute inset-0 bg-background/40">
               <BlurView intensity={20} tint="dark" style={{ flex: 1 }} />
             </View>
+
+            {/* Play overlay — quick access to the trailer from the backdrop.
+                Rendered before the close button so the close tap stays on top. */}
+            {trailer ? (
+              <Pressable
+                onPress={openTrailer}
+                accessibilityRole="button"
+                accessibilityLabel="Watch trailer"
+                className="absolute inset-0 items-center justify-center active:opacity-80"
+              >
+                <View className="bg-black/55 rounded-full p-4 border border-white/25">
+                  <Icon icon={Play} size={28} color="#fff" fill="#fff" />
+                </View>
+              </Pressable>
+            ) : null}
 
             {/* Close button */}
             <Pressable
@@ -146,50 +308,105 @@ export function MediaDetailModal({
                     {item.mediaType === "movie" ? "Movie" : "TV Show"}
                   </Text>
                 </View>
-                <View className="flex-row items-center gap-3 mt-2">
-                  {item.voteAverage > 0 && (
-                    <View className="flex-row items-center gap-1">
-                      <Icon icon={Star} size={14} color="#eab308" fill="#eab308" />
-                      <Text className="text-yellow-500 text-sm font-medium">
-                        {item.voteAverage.toFixed(1)}
-                      </Text>
-                    </View>
-                  )}
-                  {statusBadge && (
-                    <Badge
-                      label={statusBadge.label}
-                      variant={statusBadge.variant}
-                    />
-                  )}
-                </View>
+                {item.voteAverage > 0 && (
+                  <View className="flex-row items-center gap-1 mt-2">
+                    <Icon icon={Star} size={14} color="#eab308" fill="#eab308" />
+                    <Text className="text-yellow-500 text-sm font-medium">
+                      {item.voteAverage.toFixed(1)}
+                    </Text>
+                  </View>
+                )}
               </View>
             </View>
 
-            {/* Request button */}
-            <View className="mt-5">
-              {canRequest ? (
+            {/* Trailer — opens in the YouTube app / browser */}
+            {trailer ? (
+              <Pressable
+                onPress={openTrailer}
+                accessibilityRole="button"
+                accessibilityLabel="Watch trailer"
+                className="mt-5 flex-row items-center justify-center gap-2 py-3 rounded-xl border border-border bg-surface-light active:opacity-70"
+              >
+                <Icon icon={Play} size={16} color="#e4e4e7" fill="#e4e4e7" />
+                <Text className="text-zinc-100 font-semibold text-sm">
+                  Watch Trailer
+                </Text>
+                <Icon icon={ExternalLink} size={14} color="#a1a1aa" />
+              </Pressable>
+            ) : null}
+
+            {/* Request actions */}
+            <View className="mt-3 gap-2.5">
+              {/* HD / regular */}
+              {canRequestHd ? (
                 <Button
-                  label={`Request ${item.mediaType === "movie" ? "Movie" : "TV Show"}`}
-                  onPress={handleRequest}
+                  label="Request"
+                  onPress={() => handleQuickRequest("hd")}
+                  loading={quickKind === "hd"}
+                  disabled={submitting}
                   icon={<Icon icon={Plus} size={16} color="#fff" />}
                   size="lg"
                   className="w-full"
                 />
-              ) : isAvailable ? (
-                <View className="flex-row items-center justify-center gap-2 py-3 bg-green-600/10 rounded-xl border border-green-600/30">
-                  <Icon icon={Check} size={18} color="#22c55e" />
-                  <Text className="text-green-500 font-medium">
-                    Already Available
-                  </Text>
-                </View>
+              ) : isAvailableHd ? (
+                <StatusPill tone="success" icon={Check} label="Available" />
               ) : (
-                <View className="flex-row items-center justify-center gap-2 py-3 bg-yellow-600/10 rounded-xl border border-yellow-600/30">
-                  <Icon icon={Clock} size={18} color="#eab308" />
-                  <Text className="text-yellow-500 font-medium">
-                    Already Requested
-                  </Text>
-                </View>
+                <StatusPill tone="warning" icon={Clock} label="Requested" />
               )}
+
+              {/* 4K — only when Seerr has a 4K-capable server for this type */}
+              {has4kServer ? (
+                canRequest4k ? (
+                  <Pressable
+                    onPress={() => handleQuickRequest("4k")}
+                    disabled={submitting}
+                    accessibilityRole="button"
+                    accessibilityLabel="Request in 4K"
+                    className={`flex-row items-center justify-center gap-2 px-6 py-3.5 rounded-xl bg-violet-600 ${submitting ? "opacity-50" : "active:opacity-80"}`}
+                  >
+                    {quickKind === "4k" ? (
+                      <ActivityIndicator size="small" color="#fff" />
+                    ) : (
+                      <>
+                        <Icon icon={Plus} size={16} color="#fff" />
+                        <Text className="text-white font-semibold text-base">
+                          Request 4K
+                        </Text>
+                      </>
+                    )}
+                  </Pressable>
+                ) : isAvailable4k ? (
+                  <StatusPill
+                    tone="success"
+                    icon={Check}
+                    label="Available in 4K"
+                  />
+                ) : (
+                  <StatusPill
+                    tone="warning"
+                    icon={Clock}
+                    label="Requested in 4K"
+                  />
+                )
+              ) : null}
+
+              {/* Advanced options */}
+              {canRequestHd || canRequest4k ? (
+                <Pressable
+                  onPress={openCustomize}
+                  disabled={submitting}
+                  accessibilityRole="button"
+                  accessibilityLabel="Customize request"
+                  className="flex-row items-center justify-center gap-1.5 py-2 active:opacity-60"
+                >
+                  <Icon icon={SlidersHorizontal} size={14} color="#a1a1aa" />
+                  <Text className="text-zinc-400 text-sm">
+                    Customize request
+                  </Text>
+                </Pressable>
+              ) : null}
+
+              <RequestErrorBanner error={quickError} />
             </View>
 
             {/* Overview */}
@@ -211,6 +428,7 @@ export function MediaDetailModal({
         <RequestOptionsSheet
           item={item}
           visible={optionsVisible}
+          initialIs4k={optionsIs4k}
           onClose={() => setOptionsVisible(false)}
           onRequested={onClose}
         />

--- a/components/overseerr/request-error-banner.tsx
+++ b/components/overseerr/request-error-banner.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { AlertCircle, Copy, Check } from "lucide-react-native";
+import * as Clipboard from "expo-clipboard";
+import { Icon } from "@/components/ui/icon";
+import { brrrHaptic } from "@/lib/haptics";
+
+export interface RequestError {
+  // Friendly message shown inline.
+  message: string;
+  // Verbose payload (HTTP body / stack) copied to the clipboard so users can
+  // share or search the real failure.
+  copyText: string;
+}
+
+interface RequestErrorBannerProps {
+  error: RequestError | null;
+  className?: string;
+}
+
+// Inline error used by the Seerr request flows. Toasts fired from inside a
+// <Modal> render behind it on Android, so request failures (which keep the
+// modal open) are surfaced inline instead. Shared by RequestOptionsSheet and
+// MediaDetailModal's quick-request path.
+export function RequestErrorBanner({ error, className = "" }: RequestErrorBannerProps) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    };
+  }, []);
+
+  // A new error resets the "Copied" affordance.
+  useEffect(() => {
+    setCopied(false);
+  }, [error?.copyText]);
+
+  const handleCopy = async () => {
+    if (!error) return;
+    await Clipboard.setStringAsync(error.copyText);
+    brrrHaptic();
+    setCopied(true);
+    if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    copiedTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  if (!error) return null;
+
+  return (
+    <View
+      className={`flex-row items-start gap-2 rounded-xl border border-red-600/40 bg-red-600/10 px-3 py-2.5 ${className}`}
+    >
+      <View className="pt-0.5">
+        <Icon icon={AlertCircle} size={16} color="#f87171" />
+      </View>
+      <Text className="text-red-300 text-sm flex-1">{error.message}</Text>
+      <Pressable
+        onPress={handleCopy}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={copied ? "Error copied" : "Copy error"}
+        className="flex-row items-center gap-1 pl-2 py-0.5 active:opacity-60"
+      >
+        <Icon
+          icon={copied ? Check : Copy}
+          size={14}
+          color={copied ? "#4ade80" : "#fca5a5"}
+        />
+        <Text className={`text-xs ${copied ? "text-green-400" : "text-red-300"}`}>
+          {copied ? "Copied" : "Copy"}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/components/overseerr/request-options-sheet.tsx
+++ b/components/overseerr/request-options-sheet.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Modal, View, Text, ScrollView, Pressable } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { Modal, View, Text, ScrollView } from "react-native";
 import { Image } from "expo-image";
-import { Plus, Film, Tv, AlertCircle, Copy, Check } from "lucide-react-native";
-import * as Clipboard from "expo-clipboard";
+import { Plus, Film, Tv } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
 import { FilterChip } from "@/components/ui/filter-chip";
+import { Toggle } from "@/components/ui/toggle";
 import { SheetHeader } from "@/components/ui/sheet-header";
 import { toast } from "@/components/ui/toast";
+import {
+  RequestErrorBanner,
+  type RequestError,
+} from "@/components/overseerr/request-error-banner";
 import { getHttpErrorMessage, formatErrorForCopy } from "@/lib/http-client";
-import { brrrHaptic } from "@/lib/haptics";
 import { getPosterUrl } from "@/services/overseerr-api";
 import {
   useOverseerrRadarrServers,
@@ -29,6 +32,8 @@ interface RequestOptionsSheetProps {
   visible: boolean;
   onClose: () => void;
   onRequested?: () => void;
+  // Preselect the 4K quality tier (e.g. when opened from a "Request 4K" action).
+  initialIs4k?: boolean;
 }
 
 export function RequestOptionsSheet({
@@ -36,6 +41,7 @@ export function RequestOptionsSheet({
   visible,
   onClose,
   onRequested,
+  initialIs4k = false,
 }: RequestOptionsSheetProps) {
   const isTv = item?.mediaType === "tv";
 
@@ -44,17 +50,42 @@ export function RequestOptionsSheet({
   const serversQuery = isTv ? sonarrServersQuery : radarrServersQuery;
   const servers = serversQuery.data ?? [];
 
+  // Seerr models 4K as separate Radarr/Sonarr servers (each flagged is4k). The
+  // active quality tier picks which bucket the server/profile/root come from.
+  const [is4k, setIs4k] = useState(initialIs4k);
+  const servers4k = useMemo(() => servers.filter((s) => s.is4k), [servers]);
+  const serversHd = useMemo(() => servers.filter((s) => !s.is4k), [servers]);
+  const has4kServer = servers4k.length > 0;
+  const activeServers = useMemo(
+    () => (is4k ? servers4k : serversHd),
+    [is4k, servers4k, serversHd],
+  );
+
   const [serverId, setServerId] = useState<number | undefined>();
 
+  // Reset the tier whenever a new title opens.
   useEffect(() => {
-    if (servers.length === 0) {
+    if (visible) setIs4k(initialIs4k);
+  }, [visible, item?.id, initialIs4k]);
+
+  // Clamp the tier to what's actually configured: fall back to 4K if only 4K
+  // servers exist, and off if no 4K server exists.
+  useEffect(() => {
+    if (is4k && !has4kServer) setIs4k(false);
+    else if (!is4k && serversHd.length === 0 && servers4k.length > 0)
+      setIs4k(true);
+  }, [is4k, has4kServer, serversHd.length, servers4k.length]);
+
+  useEffect(() => {
+    if (activeServers.length === 0) {
       setServerId(undefined);
       return;
     }
-    if (serverId !== undefined && servers.some((s) => s.id === serverId)) return;
-    const def = servers.find((s) => s.isDefault) ?? servers[0];
+    if (serverId !== undefined && activeServers.some((s) => s.id === serverId))
+      return;
+    const def = activeServers.find((s) => s.isDefault) ?? activeServers[0];
     setServerId(def?.id);
-  }, [servers, serverId]);
+  }, [activeServers, serverId]);
 
   const radarrDetailsQuery = useOverseerrRadarrServerDetails(
     !isTv ? serverId : undefined,
@@ -81,37 +112,11 @@ export function RequestOptionsSheet({
     if (visible) setSeasonSelection("all");
   }, [visible, item?.id]);
 
-  // The visible banner text is the friendly message; the clipboard payload is
-  // the verbose error (HTTP body / stack) so users can share/search the real
-  // failure. Mirrors the Copy behavior in error toasts.
-  const [submitError, setSubmitError] = useState<{
-    message: string;
-    copyText: string;
-  } | null>(null);
-  const [copied, setCopied] = useState(false);
-  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [submitError, setSubmitError] = useState<RequestError | null>(null);
 
   useEffect(() => {
-    if (visible) {
-      setSubmitError(null);
-      setCopied(false);
-    }
+    if (visible) setSubmitError(null);
   }, [visible, item?.id]);
-
-  useEffect(() => {
-    return () => {
-      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
-    };
-  }, []);
-
-  const handleCopyError = async () => {
-    if (!submitError) return;
-    await Clipboard.setStringAsync(submitError.copyText);
-    brrrHaptic();
-    setCopied(true);
-    if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
-    copiedTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-  };
 
   const tvDetailsQuery = useOverseerrMediaDetails(
     item?.id ?? 0,
@@ -162,10 +167,11 @@ export function RequestOptionsSheet({
   const handleSubmit = async () => {
     if (!item) return;
     setSubmitError(null);
-    const options =
-      servers.length > 0
-        ? { serverId, profileId, rootFolder, tags }
-        : undefined;
+    const baseOptions =
+      servers.length > 0 ? { serverId, profileId, rootFolder, tags } : undefined;
+    const options = is4k
+      ? { ...(baseOptions ?? {}), is4k: true }
+      : baseOptions;
 
     try {
       if (isTv) {
@@ -178,7 +184,7 @@ export function RequestOptionsSheet({
         await requestMovie.mutateAsync({ tmdbId: item.id, options });
       }
       const title = item.title || item.name || "Title";
-      toast(`${title} has been requested`);
+      toast(`${title} has been requested${is4k ? " in 4K" : ""}`);
       onRequested?.();
       onClose();
     } catch (err) {
@@ -251,6 +257,17 @@ export function RequestOptionsSheet({
             </View>
           </View>
 
+          {has4kServer ? (
+            <View className="rounded-xl border border-border bg-surface-light px-4 mb-4">
+              <Toggle
+                label="Request in 4K"
+                description="Send this to your 4K Radarr/Sonarr server"
+                value={is4k}
+                onValueChange={setIs4k}
+              />
+            </View>
+          ) : null}
+
           {servers.length === 0 ? (
             <View className="rounded-xl border border-border bg-surface-light px-4 py-3 mb-4">
               <Text className="text-zinc-300 text-sm">
@@ -260,11 +277,11 @@ export function RequestOptionsSheet({
             </View>
           ) : null}
 
-          {servers.length > 1 ? (
+          {activeServers.length > 1 ? (
             <Select
               label={isTv ? "Sonarr Server" : "Radarr Server"}
               value={serverId}
-              options={servers.map((s) => ({
+              options={activeServers.map((s) => ({
                 value: s.id,
                 label: s.name,
                 description: s.isDefault ? "Default" : undefined,
@@ -363,34 +380,9 @@ export function RequestOptionsSheet({
         </ScrollView>
 
         <View className="px-4 pb-6 pt-3 border-t border-border bg-background">
-          {submitError ? (
-            <View className="mb-3 flex-row items-start gap-2 rounded-xl border border-red-600/40 bg-red-600/10 px-3 py-2.5">
-              <View className="pt-0.5">
-                <Icon icon={AlertCircle} size={16} color="#f87171" />
-              </View>
-              <Text className="text-red-300 text-sm flex-1">{submitError.message}</Text>
-              <Pressable
-                onPress={handleCopyError}
-                hitSlop={8}
-                accessibilityRole="button"
-                accessibilityLabel={copied ? "Error copied" : "Copy error"}
-                className="flex-row items-center gap-1 pl-2 py-0.5 active:opacity-60"
-              >
-                <Icon
-                  icon={copied ? Check : Copy}
-                  size={14}
-                  color={copied ? "#4ade80" : "#fca5a5"}
-                />
-                <Text
-                  className={`text-xs ${copied ? "text-green-400" : "text-red-300"}`}
-                >
-                  {copied ? "Copied" : "Copy"}
-                </Text>
-              </Pressable>
-            </View>
-          ) : null}
+          <RequestErrorBanner error={submitError} className="mb-3" />
           <Button
-            label="Send Request"
+            label={is4k ? "Send 4K Request" : "Send Request"}
             onPress={handleSubmit}
             disabled={!canSubmit}
             loading={isPending}

--- a/hooks/use-overseerr.ts
+++ b/hooks/use-overseerr.ts
@@ -76,6 +76,7 @@ export function useOverseerrMediaDetails(
   tmdbId: number,
   mediaType: OverseerrMediaType,
   instanceId?: string,
+  active = true,
 ) {
   const { instanceId: id, enabled } = useInstanceTarget("overseerr", instanceId);
   return useQuery<OverseerrMovieDetails | OverseerrTVDetails>({
@@ -85,7 +86,7 @@ export function useOverseerrMediaDetails(
         ? getMovieDetails(tmdbId, id ?? undefined)
         : getTVDetails(tmdbId, id ?? undefined),
     staleTime: 600000, // 10 min — titles don't change
-    enabled: enabled && !!id,
+    enabled: enabled && !!id && tmdbId > 0 && active,
   });
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -838,6 +838,10 @@ export interface OverseerrMediaResult {
   voteAverage: number;
   mediaInfo?: {
     status: OverseerrMediaStatus;
+    // 4K availability is tracked separately from the regular status. Present in
+    // real responses (Media entity has both columns) even though the published
+    // OpenAPI spec omits it.
+    status4k?: OverseerrMediaStatus;
   };
 }
 
@@ -856,14 +860,34 @@ export interface OverseerrGenreSliderItem {
   backdrops: string[];
 }
 
+// A YouTube (or other site) video attached to a TMDB title — trailers, teasers,
+// clips, etc. Shape per Overseerr's RelatedVideo schema.
+export interface OverseerrRelatedVideo {
+  url: string;
+  key: string;
+  name: string;
+  size?: number;
+  type:
+    | "Clip"
+    | "Teaser"
+    | "Trailer"
+    | "Featurette"
+    | "Opening Credits"
+    | "Behind the Scenes"
+    | "Bloopers";
+  site: string; // "YouTube"
+}
+
 export interface OverseerrMovieDetails {
   id: number;
   title: string;
   posterPath?: string;
   releaseDate?: string;
+  relatedVideos?: OverseerrRelatedVideo[];
   mediaInfo?: {
     id: number;
     status: OverseerrMediaStatus;
+    status4k?: OverseerrMediaStatus;
   };
 }
 
@@ -881,6 +905,12 @@ export interface OverseerrTVDetails {
   posterPath?: string;
   firstAirDate?: string;
   seasons?: OverseerrSeasonInfo[];
+  relatedVideos?: OverseerrRelatedVideo[];
+  mediaInfo?: {
+    id: number;
+    status: OverseerrMediaStatus;
+    status4k?: OverseerrMediaStatus;
+  };
 }
 
 // --- Overseerr Service Discovery (Radarr/Sonarr instances configured in Seerr) ---

--- a/services/overseerr-api.ts
+++ b/services/overseerr-api.ts
@@ -11,6 +11,7 @@ import type {
   OverseerrTVDetails,
   OverseerrServerInfo,
   OverseerrServerDetails,
+  OverseerrRelatedVideo,
 } from "@/lib/types";
 
 export interface OverseerrRequestOptions {
@@ -18,6 +19,9 @@ export interface OverseerrRequestOptions {
   profileId?: number;
   rootFolder?: string;
   tags?: number[];
+  // When true, the request targets the 4K Radarr/Sonarr server. Seerr resolves
+  // the default 4K server when serverId is omitted.
+  is4k?: boolean;
 }
 
 const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p";
@@ -308,4 +312,28 @@ export function getPosterUrl(posterPath: string | undefined | null, size: "w185"
 export function getBackdropUrl(backdropPath: string | undefined | null): string | null {
   if (!backdropPath) return null;
   return `${TMDB_IMAGE_BASE}/w780${backdropPath}`;
+}
+
+// Pick the best playable trailer from a title's related videos. We can only
+// embed YouTube, and prefer an official trailer, then teaser, then any clip.
+const TRAILER_TYPE_PRIORITY: OverseerrRelatedVideo["type"][] = [
+  "Trailer",
+  "Teaser",
+  "Clip",
+  "Featurette",
+  "Behind the Scenes",
+];
+
+export function pickTrailer(
+  videos: OverseerrRelatedVideo[] | undefined | null,
+): OverseerrRelatedVideo | null {
+  const youtube = (videos ?? []).filter(
+    (v) => v.site === "YouTube" && !!v.key,
+  );
+  if (youtube.length === 0) return null;
+  for (const type of TRAILER_TYPE_PRIORITY) {
+    const match = youtube.find((v) => v.type === type);
+    if (match) return match;
+  }
+  return youtube[0];
 }


### PR DESCRIPTION
Implements the two Seerr feature requests from #86.

## Changes
- One-tap **Request** / **Request 4K** on the media detail screen (4K appears only when Seerr has a 4K-capable server)
- 4K toggle + per-tier server/profile/root folder in the advanced request sheet
- **Watch Trailer** opens the YouTube app/browser
- Added `status4k` / `relatedVideos` types; extracted a shared inline request-error banner

## Test plan
- `tsc --noEmit` clean
- `jest` — 560/560 pass
- JS-only, no native dependency

Refs #86