### PR TITLE
Away-from-home indicators for remote-only services (Refs #168)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -60,6 +60,7 @@ import {
   type NotifCategory,
 } from "@/lib/notification-categories";
 import { validateServiceUrl, normalizeServiceUrl } from "@/lib/url-validation";
+import { reevaluateHomeNetworkAfterImport } from "@/lib/network";
 import { brrrHaptic } from "@/lib/haptics";
 import { AppVersionCard } from "@/components/common/app-version-card";
 import {
@@ -279,6 +280,12 @@ export default function SettingsScreen() {
       if (success) {
         if (capturedResult) await syncRememberedState(capturedResult);
         toast("Configuration imported successfully", "success");
+        // Import resets the away flag to its safe default, so local-only
+        // services start "remote-only" until home is re-confirmed. Prompt for
+        // Location + re-evaluate now so they come back online on the home WiFi
+        // without the user hunting for a permission (#168). Fire-and-forget —
+        // the import already succeeded; this just resolves home/away.
+        void reevaluateHomeNetworkAfterImport();
       }
     } catch (e) {
       toastError("Invalid config file", e);
@@ -1111,6 +1118,22 @@ function ServiceEditor({
     if (testUrl !== rawTestUrl) {
       if (useRemote) setRemoteUrl(testUrl);
       else setLocalUrl(testUrl);
+    }
+    // The URL the app would actually use is empty — explain *why* instead of
+    // letting the fetch layer surface a bare "invalid URL" (#168). The common
+    // case: auto-switch decided we're away from home, so it's remote-only, but
+    // no remote URL is set for this service.
+    if (!testUrl) {
+      setTesting(false);
+      if (useRemote && !config.useRemote && autoSwitchNetwork && networkAwayFromHome) {
+        toast(
+          "Away from home: Dashboarr is using remote URLs only, but none is set here. Add a remote URL, or turn off Auto-switch network if this device stays on your home WiFi.",
+          "error",
+        );
+      } else {
+        toast(`No ${which} URL set for this service`, "error");
+      }
+      return;
     }
     const result = await testServiceConnection(serviceId, {
       url: testUrl,

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -1,6 +1,8 @@
 import { View, Text, Pressable, Platform } from "react-native";
 import Animated, { LinearTransition } from "react-native-reanimated";
 import { useRouter } from "expo-router";
+import { WifiOff } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
 import { ServiceLogo, hasServiceLogo } from "@/components/ui/service-logo";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -8,7 +10,7 @@ import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { ICON, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
-import { resolveActiveUrlKind } from "@/lib/url-validation";
+import { resolveActiveUrlKind, isRemoteOnlyOffline } from "@/lib/url-validation";
 import { useConfigStore } from "@/store/config-store";
 import { useAttachedInstances, useActiveDashboard } from "@/hooks/use-active-dashboard";
 import {
@@ -40,6 +42,10 @@ interface RenderEntry {
   // Which URL this instance is actively using ("local"/"remote"), or null when
   // neither is configured. Drives the L/R corner badge (#148).
   urlKind: "local" | "remote" | null;
+  // True when this instance is offline purely because the app is remote-only
+  // (away from home / workspace pinned remote) but has no remote URL set — the
+  // #168 case. Drives the away badge, which takes the L/R badge's corner.
+  awayBlocked: boolean;
 }
 
 // Tailwind class + iOS shadow color for the small corner dot, by tri-state.
@@ -147,6 +153,12 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
           networkAwayFromHome,
           workspaceForcesRemote,
         ),
+        awayBlocked: isRemoteOnlyOffline(
+          inst,
+          autoSwitchNetwork,
+          networkAwayFromHome,
+          workspaceForcesRemote,
+        ),
       });
     }
   }
@@ -187,7 +199,16 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
                     online={entry.status !== "offline"}
                   />
                 </View>
-                {settings.showUrlBadge && entry.urlKind && (
+                {settings.showAwayBadge && entry.awayBlocked ? (
+                  // Offline because we're remote-only with no remote URL (#168).
+                  // Takes the L/R corner and supersedes it — resolveActiveUrlKind
+                  // would otherwise read "R" here, which is misleading since no
+                  // remote URL exists. Amber signals "network state", distinct
+                  // from the red offline dot in the opposite corner.
+                  <View className="absolute -top-0.5 -left-0.5 w-4 h-4 rounded-full border-2 border-surface items-center justify-center bg-amber-500">
+                    <Icon icon={WifiOff} size={9} color="#fff" />
+                  </View>
+                ) : settings.showUrlBadge && entry.urlKind ? (
                   <View
                     className={`absolute -top-0.5 -left-0.5 w-4 h-4 rounded-full border-2 border-surface items-center justify-center ${URL_KIND_BG[entry.urlKind]}`}
                   >
@@ -195,7 +216,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
                       {entry.urlKind === "local" ? "L" : "R"}
                     </Text>
                   </View>
-                )}
+                ) : null}
                 <View
                   className={`absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-surface ${DOT_BG[entry.status]}`}
                   style={Platform.OS === "ios" ? {

--- a/components/dashboard/widget-settings/service-health-settings.tsx
+++ b/components/dashboard/widget-settings/service-health-settings.tsx
@@ -31,12 +31,17 @@ export interface ServiceHealthSettingsValue extends Record<string, unknown> {
   // its local or remote URL. Defaults on; legacy slots without the field merge
   // to the default at read time (see useWidgetSettings).
   showUrlBadge: boolean;
+  // Whether to flag a service that's offline *because* the app is remote-only
+  // (away from home, or a workspace pinned to always-remote) while it has only a
+  // local URL — the #168 case. Defaults on; merged for legacy slots like above.
+  showAwayBadge: boolean;
 }
 
 export const SERVICE_HEALTH_DEFAULT_SETTINGS: ServiceHealthSettingsValue = {
   hiddenKinds: [],
   instances: {},
   showUrlBadge: true,
+  showAwayBadge: true,
 };
 
 export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -184,6 +189,14 @@ export function ServiceHealthSettings({ slotId }: WidgetSettingsComponentProps) 
           description="Mark each service with an L or R for the URL it's currently using"
           value={settings.showUrlBadge}
           onValueChange={(v) => update({ showUrlBadge: v })}
+        />
+      </View>
+      <View className="bg-surface-light rounded-2xl border border-border px-4">
+        <Toggle
+          label="Away indicator"
+          description="Flag services that are offline because you're away from home and have no remote URL set"
+          value={settings.showAwayBadge}
+          onValueChange={(v) => update({ showAwayBadge: v })}
         />
       </View>
       {configuredKinds.length > 1 && (

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -1,6 +1,7 @@
 import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
 import type { Dashboard, HomeNetwork } from "@/store/config-store";
+import { detectWifi } from "@/lib/wifi";
 
 /**
  * Home-network detection — the single signal behind local/remote URL switching.
@@ -95,4 +96,33 @@ export async function evaluateHomeNetwork(): Promise<void> {
   } finally {
     evalInFlight = false;
   }
+}
+
+/**
+ * Re-resolve home/away right after a config import (#168). Import resets
+ * `networkAwayFromHome` to its safe `true` default, so a freshly set-up device
+ * starts "away" → remote-only. The normal startup/NetInfo evaluation can't clear
+ * it on its own: reading the SSID/BSSID needs Location permission, which the new
+ * device almost certainly hasn't granted yet — so local-only services stay stuck
+ * "invalid URL" until the user stumbles onto the permission.
+ *
+ * This requests the permission (via detectWifi, which also ensures NetInfo is
+ * configured to surface the SSID on iOS) *while the user is actively setting the
+ * device up*, then evaluates. No-op when auto-switch is off or no home networks
+ * are configured — in those cases the SSID is never needed, so we don't prompt.
+ */
+export async function reevaluateHomeNetworkAfterImport(): Promise<void> {
+  const store = useConfigStore.getState();
+  if (store.demoMode || !store.autoSwitchNetwork) return;
+  const effective = resolveEffectiveHomeNetworks(
+    store.dashboards,
+    store.activeDashboardId,
+    store.homeNetworks,
+  );
+  if (effective.length === 0) return;
+  // Prompt for Location now; if granted, the subsequent evaluate reads the real
+  // SSID and clears the away flag when we're home. If denied, we stay safely
+  // "away" (remote-only) — the honest result.
+  await detectWifi();
+  await evaluateHomeNetwork();
 }

--- a/lib/url-validation.test.ts
+++ b/lib/url-validation.test.ts
@@ -2,6 +2,7 @@ import {
   validateServiceUrl,
   normalizeServiceUrl,
   resolveActiveUrlKind,
+  isRemoteOnlyOffline,
   isPrivateHost,
   isPrivateUrl,
 } from "./url-validation";
@@ -189,5 +190,42 @@ describe("resolveActiveUrlKind", () => {
 
   it("falls back to remote at home when no local is configured", () => {
     expect(resolveActiveUrlKind(inst({ localUrl: "" }), true, false)).toBe("remote");
+  });
+});
+
+describe("isRemoteOnlyOffline (#168)", () => {
+  const inst = (over: Partial<{ localUrl: string; remoteUrl: string; useRemote: boolean }> = {}) => ({
+    localUrl: "192.168.1.10:7878",
+    remoteUrl: "",
+    useRemote: false,
+    ...over,
+  });
+
+  it("is true when away from home with a local URL but no remote", () => {
+    expect(isRemoteOnlyOffline(inst(), true, true)).toBe(true);
+  });
+
+  it("is false at home (local URL is usable)", () => {
+    expect(isRemoteOnlyOffline(inst(), true, false)).toBe(false);
+  });
+
+  it("is false when a remote URL exists (reachable while away)", () => {
+    expect(isRemoteOnlyOffline(inst({ remoteUrl: "https://remote.example.com" }), true, true)).toBe(false);
+  });
+
+  it("is false when no local URL is configured (just unconfigured, not blocked)", () => {
+    expect(isRemoteOnlyOffline(inst({ localUrl: "" }), true, true)).toBe(false);
+  });
+
+  it("is false when auto-switch is off (uses local regardless of network)", () => {
+    expect(isRemoteOnlyOffline(inst(), false, true)).toBe(false);
+  });
+
+  it("is false when the useRemote override is set (falls back to local)", () => {
+    expect(isRemoteOnlyOffline(inst({ useRemote: true }), true, true)).toBe(false);
+  });
+
+  it("is true when the workspace is pinned to remote-only and no remote URL exists", () => {
+    expect(isRemoteOnlyOffline(inst(), false, false, true)).toBe(true);
   });
 });

--- a/lib/url-validation.ts
+++ b/lib/url-validation.ts
@@ -128,3 +128,33 @@ export function resolveActiveUrlKind(
   if (networkAwayFromHome) return "remote";
   return local ? "local" : "remote";
 }
+
+/**
+ * True when an instance is effectively offline *because* the app is in
+ * remote-only mode — away from a confirmed home network, or a workspace pinned
+ * to "always remote" — while it has a local URL but NO remote URL to fall back
+ * to. This is the #168 failure mode: a local-only service tests/loads as
+ * "invalid URL" (right after an import, before the home network is re-confirmed,
+ * or simply when the device is genuinely away) even though its local URL is
+ * fine. Callers surface a dedicated indicator so the bare red dot isn't mistaken
+ * for the service being down. Mirrors the remote-only branches of `getActiveUrl`
+ * (store/config-store.ts) — keep in sync.
+ */
+export function isRemoteOnlyOffline(
+  inst: { localUrl: string; remoteUrl: string; useRemote: boolean },
+  autoSwitchNetwork: boolean,
+  networkAwayFromHome: boolean,
+  workspaceForcesRemote = false,
+): boolean {
+  const local = normalizeServiceUrl(inst.localUrl);
+  const remote = normalizeServiceUrl(inst.remoteUrl);
+  // Only meaningful when a local URL exists but there's no remote fallback. With
+  // no local URL the service is simply unconfigured; with a remote URL it stays
+  // reachable while away, so neither case is the #168 "offline because remote-
+  // only" state.
+  if (!local || remote) return false;
+  if (inst.useRemote) return false; // override falls back to local (getActiveUrl step 1)
+  if (workspaceForcesRemote) return true; // forced remote, no remote URL → offline
+  if (!autoSwitchNetwork) return false; // auto-switch off → uses local
+  return networkAwayFromHome; // away → remote-only, no remote URL → offline
+}


### PR DESCRIPTION
Surfaces the remote-only/away state so a local-only service doesn't look like it's simply down (#168).

- **Health card:** amber `WifiOff` badge when a service is offline *only* because we're away from home with no remote URL set (new "Away indicator" widget toggle, on by default).
- **Service editor Test:** when the URL the app would actually use is empty, explain the remote-only case instead of a bare "invalid URL".
- **After import:** prompt for Location + re-evaluate the home network, so local-only services come back online on home WiFi without hunting for the permission.
- Adds `isRemoteOnlyOffline` helper, mirroring `getActiveUrl`'s remote-only branches.

## Test plan
- `npx jest lib/url-validation.test.ts` — 33 passing (7 new for `isRemoteOnlyOffline`)
- `npx tsc --noEmit` clean