### PR TITLE
fix(config): avoid Keychain auth race when exporting via FileBrowser (Refs #180)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -224,8 +224,20 @@ export default function SettingsScreen() {
     const result = await requestPassphrase("export");
     if (!result) return;
     try {
-      await exportConfig(result.passphrase, setExportStage);
-      await syncRememberedState(result);
+      await exportConfig(result.passphrase, setExportStage, async () => {
+        // Reflect the "Remember on this device" choice while the app is still
+        // foregrounded, before the share app-switch (see exportConfig / #180).
+        // Best-effort: the export file is already written, so failing to
+        // remember the passphrase must not abort the share or read as an export
+        // failure. Mirror loadRememberedPassphrase, which degrades silently — a
+        // user who cancels the biometric prompt knows it, and a genuine failure
+        // just means they re-enter the passphrase next time.
+        try {
+          await syncRememberedState(result);
+        } catch (err) {
+          console.warn("Failed to persist remembered passphrase", err);
+        }
+      });
     } catch (e) {
       toastError("Failed to export config", e);
     } finally {

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -486,7 +486,15 @@ interface ConfigActions {
 
   enableDemoMode: () => void;
   disableDemoMode: () => Promise<void>;
-  exportConfig: (passphrase: string, onStage?: (stage: ExportStage) => void) => Promise<void>;
+  exportConfig: (
+    passphrase: string,
+    onStage?: (stage: ExportStage) => void,
+    // Runs after the file is written and just before the share/app-switch,
+    // while the app is still fully foregrounded. Use it for side effects that
+    // must not race the foreground-resume transition (e.g. a biometric-gated
+    // Keychain write — see #180). Keep it from blocking/aborting the share.
+    onBeforeShare?: () => Promise<void>,
+  ) => Promise<void>;
   importConfig: (
     requestPassphrase: () => Promise<string | null>,
     onStage?: (stage: ImportStage) => void,
@@ -2437,7 +2445,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     await get().hydrate();
   },
 
-  exportConfig: async (passphrase: string, onStage) => {
+  exportConfig: async (passphrase: string, onStage, onBeforeShare) => {
     onStage?.("preparing");
     await yieldToPaint();
     // Require device auth so a bystander with a momentarily-unlocked phone
@@ -2507,6 +2515,16 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     if (!(await Sharing.isAvailableAsync())) {
       throw new Error("Sharing is not available on this device");
     }
+
+    // Persist the user's "remember passphrase" choice now, while the app is
+    // still fully foregrounded and we know the share is about to happen. The
+    // Keychain write uses requireAuthentication, which fails during the
+    // foreground-resume transition when it runs AFTER the share hands off to a
+    // separate app like FileBrowser (#180). The file is already on disk, so the
+    // export has materially succeeded. Best-effort — the caller handles errors
+    // so a failed/declined remember-write cannot abort the share.
+    await onBeforeShare?.();
+
     await Sharing.shareAsync(file.uri, {
       mimeType: "application/json",
       dialogTitle: "Export Dashboarr Config",


### PR DESCRIPTION
## What
The "Remember on this device" passphrase write (`SecureStore.setItemAsync` with `requireAuthentication`) ran *after* the share sheet. On iOS `Sharing.shareAsync` resolves only when the app returns to foreground from a full app-switch (FileBrowser), so the biometric-gated write fired during the resume transition and failed with `setValueWithKeyAsync … Authentication…`. The native Files picker is in-app, so it never reproduced.

Fix: run that write *before* the share via a new optional `onBeforeShare` callback on `exportConfig` — while the app is still foregrounded. Made the step best-effort so a declined/failed write can't abort the share or be mislabeled "Failed to export config". `requireAuthentication` unchanged on read and write.

Refs #180

## Test plan
- [x] `tsc --noEmit` clean
- [ ] iOS: export with "Remember" ticked → save via FileBrowser → no error, file saved
- [ ] iOS: re-export while already remembered → Face ID write prompt presents cleanly, share follows
- [ ] Native Files export + import still work (regression)