### PR TITLE
feat(arr): sort movies & series by release date (Refs #135)

### DIFF
--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -60,8 +60,21 @@ const SORT_OPTIONS: { key: MoviesSortKey; label: string }[] = [
   { key: "title-desc", label: "Title: Z → A" },
   { key: "year-desc", label: "Year: Newest First" },
   { key: "year-asc", label: "Year: Oldest First" },
+  { key: "release-desc", label: "Release Date: Newest First" },
+  { key: "release-asc", label: "Release Date: Oldest First" },
   { key: "size-desc", label: "Size: Largest First" },
 ];
+
+// Original release of the film: earliest of the cinema/digital/physical dates
+// (theatrical typically comes first; min() picks it, but stays robust for
+// straight-to-streaming titles that only carry a digital date).
+function releaseTime(m: RadarrMovie): number | null {
+  const times = [m.inCinemas, m.digitalRelease, m.physicalRelease]
+    .filter((d): d is string => Boolean(d))
+    .map((d) => new Date(d).getTime())
+    .filter((t) => Number.isFinite(t));
+  return times.length ? Math.min(...times) : null;
+}
 
 function nextReleaseTime(m: RadarrMovie): number | null {
   const times = [m.inCinemas, m.digitalRelease, m.physicalRelease]
@@ -87,6 +100,16 @@ function compareMovies(a: RadarrMovie, b: RadarrMovie, sort: MoviesSortKey): num
       return b.year - a.year;
     case "year-asc":
       return a.year - b.year;
+    case "release-desc":
+    case "release-asc": {
+      const aT = releaseTime(a);
+      const bT = releaseTime(b);
+      if (aT === null && bT === null)
+        return (a.sortTitle || a.title).localeCompare(b.sortTitle || b.title);
+      if (aT === null) return 1;
+      if (bT === null) return -1;
+      return sort === "release-desc" ? bT - aT : aT - bT;
+    }
     case "size-desc":
       return (b.sizeOnDisk ?? 0) - (a.sizeOnDisk ?? 0);
     case "next-airing-asc": {

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -83,6 +83,8 @@ const SORT_OPTIONS: { key: SeriesSortKey; label: string }[] = [
   { key: "title-desc", label: "Title: Z → A" },
   { key: "year-desc", label: "Year: Newest First" },
   { key: "year-asc", label: "Year: Oldest First" },
+  { key: "release-desc", label: "Release Date: Newest First" },
+  { key: "release-asc", label: "Release Date: Oldest First" },
   { key: "size-desc", label: "Size: Largest First" },
 ];
 
@@ -102,6 +104,17 @@ function compareSeries(
       return b.year - a.year;
     case "year-asc":
       return a.year - b.year;
+    case "release-desc":
+    case "release-asc": {
+      // Series premiere date is the natural "release date" for TV.
+      const aT = a.firstAired ? new Date(a.firstAired).getTime() : null;
+      const bT = b.firstAired ? new Date(b.firstAired).getTime() : null;
+      if (aT === null && bT === null)
+        return (a.sortTitle || a.title).localeCompare(b.sortTitle || b.title);
+      if (aT === null) return 1;
+      if (bT === null) return -1;
+      return sort === "release-desc" ? bT - aT : aT - bT;
+    }
     case "size-desc": {
       const aSize = a.statistics?.sizeOnDisk ?? a.sizeOnDisk ?? 0;
       const bSize = b.statistics?.sizeOnDisk ?? b.sizeOnDisk ?? 0;

--- a/store/sort-store.ts
+++ b/store/sort-store.ts
@@ -9,6 +9,8 @@ export type MoviesSortKey =
   | "title-desc"
   | "year-desc"
   | "year-asc"
+  | "release-desc"
+  | "release-asc"
   | "size-desc"
   | "next-airing-asc";
 


### PR DESCRIPTION
Adds **Release Date: Newest/Oldest First** sort to the Radarr and Sonarr lists, via the existing FilterSortSheet.

- Movies: earliest of `inCinemas`/`digitalRelease`/`physicalRelease`
- Series: `firstAired` (premiere)
- Items with no release date sort to the bottom (tie-broken by title), matching the Next Airing behavior

Refs #135

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Movies/TV lists sort correctly both directions; undated items fall to the end