### PR TITLE
fix(network): VPN-aware LAN guard + opt-in "Treat VPN as home" (Refs #185)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ ios/
 !modules/*/android/**
 !modules/*/ios/
 !modules/*/ios/**
+# ...but never the Gradle build output the un-ignore above would otherwise sweep in.
+modules/*/android/build/
 .env
 .env.local
 .claude/

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Pick whichever fits you:
   3. Add your home WiFi under **Settings → Home Networks**, turn on auto-switch, and leave **Always use Remote URL** off
 
   At home Dashboarr uses the direct LAN URL; away it uses Tailscale.
+- **VPN that routes your LAN (WireGuard, OpenVPN, Tailscale subnet router):** if your tunnel makes the plain `192.168.x` addresses reachable from anywhere, you have two options. With **Auto-switch network** off, nothing to configure: Dashboarr always uses the Local URL and, while a VPN is connected, no longer marks private addresses offline. With auto-switch on, also enable **Settings → Treat VPN as home** (the toggle appears once auto-switch is on): while any VPN is connected, Dashboarr behaves as if you were on your home WiFi and uses the local URLs directly. The app can only detect that *a* VPN is up, not which one, so enable this only if your VPN reaches your home network.
 
-> **Avoid** putting a `192.168.x` or `10.x` address in the **Remote URL** slot. Private LAN addresses can't be reached over mobile data, so Dashboarr marks them offline when you're off WiFi. If you only reach your server through a Tailscale **subnet router** (so it has no `100.x` address of its own), install Tailscale directly on that server so it gets its own Tailscale address, then use that.
+> Without a VPN connected, avoid putting a `192.168.x` or `10.x` address in the **Remote URL** slot. Private LAN addresses can't be reached over mobile data, so Dashboarr marks them offline when you're off WiFi (when a VPN is connected it will still try them). If you only reach your server through a Tailscale **subnet router** (so it has no `100.x` address of its own), this VPN handling covers you; alternatively, install Tailscale directly on that server so it gets its own Tailscale address.
 
 ## Project Structure
 

--- a/app/(tabs)/glances.tsx
+++ b/app/(tabs)/glances.tsx
@@ -4,6 +4,7 @@ import { HardDrive, Activity, Gpu, ChevronDown, ChevronUp, Container, Network } 
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { CachedDataBanner } from "@/components/common/cached-data-banner";
 import { WorkspaceServiceGuard } from "@/components/common/workspace-service-guard";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
@@ -67,6 +68,7 @@ function GlancesScreenInner() {
   return (
     <ScreenWrapper refreshing={refreshing} onRefresh={onRefresh}>
       <ServiceHeader name="Server" online={glancesHealth?.online} serviceId="glances" />
+      <CachedDataBanner serviceId="glances" label="Server" />
       <View className="gap-4">
         <CpuCard />
         <MemoryCard />

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -186,6 +186,8 @@ export default function SettingsScreen() {
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
   const homeNetworksCount = useConfigStore((s) => s.homeNetworks.length);
   const setAutoSwitch = useConfigStore((s) => s.setAutoSwitch);
+  const treatVpnAsHome = useConfigStore((s) => s.treatVpnAsHome);
+  const setTreatVpnAsHome = useConfigStore((s) => s.setTreatVpnAsHome);
   const exportConfig = useConfigStore((s) => s.exportConfig);
   const importConfig = useConfigStore((s) => s.importConfig);
   const wolDevices = useConfigStore((s) => s.wolDevices);
@@ -421,17 +423,27 @@ export default function SettingsScreen() {
           icon={Wifi}
           label="Home Networks"
           subtitle={
-            autoSwitchNetwork && homeNetworksCount === 0
+            autoSwitchNetwork && homeNetworksCount === 0 && !treatVpnAsHome
               ? "Add at least one — without it the app stays on remote URLs"
               : homeNetworksCount > 0
                 ? `${homeNetworksCount} network${homeNetworksCount > 1 ? "s" : ""} configured`
                 : "Configure your home WiFi networks"
           }
           subtitleTone={
-            autoSwitchNetwork && homeNetworksCount === 0 ? "warn" : "default"
+            autoSwitchNetwork && homeNetworksCount === 0 && !treatVpnAsHome
+              ? "warn"
+              : "default"
           }
           onPress={() => router.push("/home-networks")}
         />
+        {autoSwitchNetwork ? (
+          <SettingsToggleRow
+            label="Treat VPN as home"
+            description="While a VPN is connected, use local URLs as if on home WiFi. The app can only detect that some VPN is up — enable this only if your VPN reaches your home network."
+            value={treatVpnAsHome}
+            onValueChange={setTreatVpnAsHome}
+          />
+        ) : null}
         <SettingsRow
           icon={Zap}
           label="Wake-on-LAN"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,7 +38,8 @@ function onAppStateChange(status: AppStateStatus) {
     // door, or toggled a VPN like Tailscale (whose interface changes don't
     // deliver NetInfo events to a suspended JS runtime). Re-evaluate the home
     // network so URLs and health dots reflect reality on resume (#161). Shares
-    // the evaluator's in-flight gate and no-ops when auto-switch is off.
+    // the evaluator's in-flight gate; with auto-switch off it still refreshes
+    // the isVpnActive flag the LAN guard reads (#185), then no-ops.
     void evaluateHomeNetwork();
   }
 }

--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -19,6 +19,7 @@ type Mode = "list" | "add" | "edit";
 
 export default function HomeNetworksScreen() {
   const homeNetworks = useConfigStore((s) => s.homeNetworks);
+  const treatVpnAsHome = useConfigStore((s) => s.treatVpnAsHome);
   const addHomeNetwork = useConfigStore((s) => s.addHomeNetwork);
   const updateHomeNetwork = useConfigStore((s) => s.updateHomeNetwork);
   const removeHomeNetwork = useConfigStore((s) => s.removeHomeNetwork);
@@ -231,8 +232,12 @@ export default function HomeNetworksScreen() {
           </Text>
           <Text className="text-zinc-500 text-sm text-center px-6">
             Add the WiFi networks you trust as "home". Local URLs are used only
-            on these networks; everywhere else the app uses your remote URLs, so
-            your API keys are never sent to an untrusted LAN.
+            on these networks
+            {treatVpnAsHome
+              ? ' or while your VPN is connected ("Treat VPN as home" is on)'
+              : ""}
+            ; everywhere else the app uses your remote URLs, so your API keys
+            are never sent to an untrusted LAN.
           </Text>
           <View className="flex-row gap-2 mt-2">
             <Button

--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from "react";
-import { View, Text, Pressable, ActivityIndicator } from "react-native";
-import { Wifi, Plus, Pencil, Trash2 } from "lucide-react-native";
+import { View, Text, Pressable, ActivityIndicator, Platform } from "react-native";
+import Animated, { FadeIn } from "react-native-reanimated";
+import { Wifi, Plus, Pencil, Trash2, Activity, ChevronDown, ChevronUp } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { lightHaptic } from "@/lib/haptics";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { Card } from "@/components/ui/card";
@@ -11,11 +13,35 @@ import { toast } from "@/components/ui/toast";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useConfigStore } from "@/store/config-store";
 import { detectWifi, validateHomeNetworkInput } from "@/lib/wifi";
+import { detectVpnActive, isVpnModuleAvailable } from "@/lib/vpn";
 import type { HomeNetwork } from "@/store/config-store";
 import { MAX_HOME_NETWORKS } from "@/lib/constants";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 
 type Mode = "list" | "add" | "edit";
+
+// One label/value line in the Network diagnostics panel. Kept compact so the
+// whole panel is screenshot-friendly for bug reports.
+function DiagRow({
+  label,
+  value,
+  bad,
+}: {
+  label: string;
+  value: string;
+  bad?: boolean;
+}) {
+  return (
+    <View className="flex-row justify-between items-center">
+      <Text className="text-zinc-500 text-xs">{label}</Text>
+      <Text
+        className={`text-xs font-medium ${bad ? "text-amber-400" : "text-zinc-200"}`}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
 
 export default function HomeNetworksScreen() {
   const homeNetworks = useConfigStore((s) => s.homeNetworks);
@@ -24,6 +50,19 @@ export default function HomeNetworksScreen() {
   const updateHomeNetwork = useConfigStore((s) => s.updateHomeNetwork);
   const removeHomeNetwork = useConfigStore((s) => s.removeHomeNetwork);
   const dashboards = useConfigStore((s) => s.dashboards);
+
+  // Network diagnostics (#185): the home/away machine is otherwise invisible.
+  // Surfaced as a collapsed panel so it's out of the way day-to-day but easy to
+  // expand and screenshot when triaging a "wrong URL / can't reach service" report.
+  const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
+  const isOnWifi = useConfigStore((s) => s.isOnWifi);
+  const isVpnActive = useConfigStore((s) => s.isVpnActive);
+  const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
+  // A live native read, independent of the cached store flag — if these two
+  // disagree, the store just hasn't re-evaluated yet.
+  const liveVpn = detectVpnActive();
+  const vpnModule = isVpnModuleAvailable();
+  const [diagOpen, setDiagOpen] = useState(false);
 
   // Read-only cross-reference: which workspaces use each network (#148). A
   // dashboard with `homeNetworkIds === undefined` uses ALL networks; one with a
@@ -223,6 +262,61 @@ export default function HomeNetworksScreen() {
           </Pressable>
         }
       />
+
+      {/* Collapsed by default — a screenshot aid for bug reports (#185). */}
+      <Card className="mb-4">
+        <Pressable
+          onPress={() => {
+            lightHaptic();
+            setDiagOpen((v) => !v);
+          }}
+          className="flex-row items-center justify-between active:opacity-70"
+        >
+          <View className="flex-row items-center gap-2">
+            <Icon icon={Activity} size={16} color="#a1a1aa" />
+            <Text className="text-zinc-300 text-sm font-semibold">
+              Network diagnostics
+            </Text>
+          </View>
+          <View className="flex-row items-center gap-2">
+            {!diagOpen ? (
+              <Text className="text-zinc-600 text-xs">For bug reports</Text>
+            ) : null}
+            <Icon icon={diagOpen ? ChevronUp : ChevronDown} size={18} color="#71717a" />
+          </View>
+        </Pressable>
+
+        {diagOpen ? (
+          <Animated.View entering={FadeIn.duration(150)} className="gap-1 mt-3">
+            <DiagRow label="Platform" value={Platform.OS} />
+            <DiagRow
+              label="VPN native module"
+              value={vpnModule ? "present" : "MISSING (needs native rebuild)"}
+              bad={!vpnModule}
+            />
+            <DiagRow
+              label="VPN detected (live)"
+              value={liveVpn ? "yes" : "no"}
+              bad={!liveVpn}
+            />
+            <DiagRow label="VPN flag (store)" value={isVpnActive ? "yes" : "no"} />
+            <DiagRow
+              label="On WiFi"
+              value={isOnWifi === null ? "unknown" : isOnWifi ? "yes" : "no"}
+            />
+            <DiagRow label="Auto-switch" value={autoSwitchNetwork ? "on" : "off"} />
+            <DiagRow
+              label="Treat VPN as home"
+              value={treatVpnAsHome ? "on" : "off"}
+            />
+            <DiagRow
+              label="Away from home"
+              value={networkAwayFromHome ? "yes (remote-only)" : "no (local OK)"}
+              bad={networkAwayFromHome}
+            />
+          </Animated.View>
+        ) : null}
+      </Card>
 
       {!homeNetworks.length ? (
         <View className="items-center justify-center py-20 gap-3">

--- a/components/common/cached-data-banner.tsx
+++ b/components/common/cached-data-banner.tsx
@@ -1,0 +1,48 @@
+import { Text } from "react-native";
+import Animated, { FadeIn } from "react-native-reanimated";
+import { CloudOff } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { useActiveInstance } from "@/hooks/use-active-instance";
+import { useServiceHealth } from "@/hooks/use-service-health";
+import type { ServiceId } from "@/lib/constants";
+
+/**
+ * Banner for a service screen whose active instance is currently unreachable.
+ *
+ * TanStack Query keeps the last successful `data` on a failed refetch and the
+ * app holds it for `gcTime` (5 min, lib/query-client.ts), so the cards keep
+ * rendering the last-known values with nothing to signal they're stale — easy
+ * to mistake for live data when the server is actually offline (away from home,
+ * VPN down, server stopped, …). This makes that state explicit.
+ *
+ * Keyed on the ACTIVE instance's health `status` (the same signal as the red
+ * status dot), so it tracks whichever instance the screen is scoped to. Renders
+ * nothing while health is still loading, or when the server answered at all —
+ * `ok` and `auth_failed` both mean the data on screen is live, not cached.
+ */
+export function CachedDataBanner({
+  serviceId,
+  label,
+}: {
+  serviceId: ServiceId;
+  label?: string;
+}) {
+  const { activeId } = useActiveInstance(serviceId);
+  const { data: health } = useServiceHealth();
+  const kind = health?.find((s) => s.id === serviceId);
+  const instance = kind?.instances.find((i) => i.instanceId === activeId);
+  if (!instance || instance.status !== "offline") return null;
+
+  const name = label ?? instance.instanceName ?? kind?.name ?? "This service";
+  return (
+    <Animated.View
+      entering={FadeIn.duration(150)}
+      className="flex-row items-center gap-2.5 mb-4 px-3 py-2.5 rounded-xl border border-amber-500/30 bg-amber-500/10"
+    >
+      <Icon icon={CloudOff} size={16} color="#f59e0b" />
+      <Text className="text-amber-300 text-xs flex-1">
+        {name} is unreachable — any data shown may be out of date.
+      </Text>
+    </Animated.View>
+  );
+}

--- a/hooks/use-network.ts
+++ b/hooks/use-network.ts
@@ -5,6 +5,7 @@ import {
   evaluateHomeNetwork,
   resolveEffectiveHomeNetworks,
 } from "@/lib/network";
+import { detectVpnActive } from "@/lib/vpn";
 
 /**
  * Keeps the store's ephemeral `networkAwayFromHome` flag in sync with the actual
@@ -34,17 +35,46 @@ export function useNetworkAutoSwitch() {
   const overrideIds = useConfigStore(
     (s) => s.dashboards.find((d) => d.id === s.activeDashboardId)?.homeNetworkIds,
   );
+  // VPN-as-home (#185) changes what "home" means — re-evaluate on toggle, and
+  // keep listening even with zero configured SSIDs (the VPN check alone can
+  // confirm home then).
+  const treatVpnAsHome = useConfigStore((s) => s.treatVpnAsHome);
 
-  // Always-on WiFi-vs-not tracker, independent of auto-switch. The off-WiFi LAN
-  // guard in lib/http-client needs to know whether we're on WiFi even when
-  // auto-switch is off (a LAN URL is then used regardless of network, and on
-  // cellular it hangs — freezing the whole health grid red, the Glances/#106
-  // report). Eager fetch + listener so it's accurate by the first probe.
+  // Always-on WiFi-vs-not + VPN tracker, independent of auto-switch. The
+  // off-WiFi LAN guard in lib/http-client needs to know whether we're on WiFi
+  // even when auto-switch is off (a LAN URL is then used regardless of network,
+  // and on cellular it hangs — freezing the whole health grid red, the
+  // Glances/#106 report) — and whether a VPN is up, which makes that same LAN
+  // URL reachable after all (#185). NetInfo can't see the VPN itself, but
+  // toggling one changes the default network, so its events are the right
+  // moments to re-run the native check. Eager fetch + listener so both are
+  // accurate by the first probe.
   useEffect(() => {
-    const apply = (state: NetInfoState) =>
-      useConfigStore.getState().setIsOnWifi(state.type === "wifi");
+    const apply = (state: NetInfoState) => {
+      const store = useConfigStore.getState();
+      store.setIsOnWifi(state.type === "wifi");
+      store.setIsVpnActive(detectVpnActive());
+    };
     void NetInfo.fetch().then(apply).catch(() => {});
-    return NetInfo.addEventListener(apply);
+    const unsubscribe = NetInfo.addEventListener(apply);
+    // Liveness re-check: on iOS a tunnel dying over WiFi emits NO NetInfo
+    // event (its SCNetworkReachability backend maps VPN-up and VPN-down to the
+    // same "wifi" state), so without this a silent VPN drop would leave the
+    // guard down — and with treatVpnAsHome, keep serving local URLs on
+    // whatever network the device is actually on. The native check is a cheap
+    // sync call; setIsVpnActive no-ops when unchanged.
+    const vpnLiveness = setInterval(() => {
+      const store = useConfigStore.getState();
+      const live = detectVpnActive();
+      if (live !== store.isVpnActive) {
+        store.setIsVpnActive(live);
+        void evaluateHomeNetwork();
+      }
+    }, 15000);
+    return () => {
+      clearInterval(vpnLiveness);
+      unsubscribe();
+    };
   }, []);
 
   useEffect(() => {
@@ -52,9 +82,11 @@ export function useNetworkAutoSwitch() {
     if (!autoSwitchNetwork) return;
 
     // No effective home networks (none configured, or an empty custom
-    // selection) → we can never confirm "home", so force the safe default
-    // (away → remote) rather than leaving a stale "home" flag that would use
-    // the private local URL off-network. The Home Networks screen warns the user.
+    // selection) → we can never confirm "home" by SSID, so force the safe
+    // default (away → remote) rather than leaving a stale "home" flag that
+    // would use the private local URL off-network. The Home Networks screen
+    // warns the user. With treatVpnAsHome on, fall through instead: the VPN
+    // check can still confirm home, so we must evaluate and keep listening.
     const { dashboards, activeDashboardId, homeNetworks } =
       useConfigStore.getState();
     const effective = resolveEffectiveHomeNetworks(
@@ -62,7 +94,7 @@ export function useNetworkAutoSwitch() {
       activeDashboardId,
       homeNetworks,
     );
-    if (effective.length === 0) {
+    if (effective.length === 0 && !treatVpnAsHome) {
       useConfigStore.getState().setNetworkAwayFromHome(true);
       return;
     }
@@ -81,5 +113,5 @@ export function useNetworkAutoSwitch() {
       if (debounceTimer) clearTimeout(debounceTimer);
       unsubscribe();
     };
-  }, [autoSwitchNetwork, globalHomeNetworks, overrideIds]);
+  }, [autoSwitchNetwork, globalHomeNetworks, overrideIds, treatVpnAsHome]);
 }

--- a/hooks/use-service-health.test.ts
+++ b/hooks/use-service-health.test.ts
@@ -57,6 +57,7 @@ interface Opts {
   autoSwitchNetwork?: boolean;
   networkAwayFromHome?: boolean;
   isOnWifi?: boolean | null;
+  isVpnActive?: boolean;
 }
 
 // Compute the signature with a resolveUrl that mirrors getActiveUrl's
@@ -72,6 +73,7 @@ function sig(opts: Opts): string {
     autoSwitchNetwork,
     networkAwayFromHome,
     isOnWifi: opts.isOnWifi ?? null,
+    isVpnActive: opts.isVpnActive ?? false,
     resolveUrl: (id, instanceId) => {
       const inst = (opts.instances[id] ?? []).find((x) => x.id === instanceId);
       if (!inst) return "";
@@ -141,6 +143,12 @@ describe("buildHealthProbeSignature — health query re-keys on its inputs (#106
       globalCustomHeaders: { "CF-Access-Client-Id": "x" },
     });
     expect(withHeader).not.toBe(before);
+  });
+
+  it("changes when a VPN comes up (the LAN guard stands down, #185)", () => {
+    const noVpn = sig({ instances: oneRadarr(), isOnWifi: false });
+    const vpn = sig({ instances: oneRadarr(), isOnWifi: false, isVpnActive: true });
+    expect(vpn).not.toBe(noVpn);
   });
 
   it("ignores disabled instances", () => {

--- a/hooks/use-service-health.test.ts
+++ b/hooks/use-service-health.test.ts
@@ -58,6 +58,7 @@ interface Opts {
   networkAwayFromHome?: boolean;
   isOnWifi?: boolean | null;
   isVpnActive?: boolean;
+  treatVpnAsHome?: boolean;
 }
 
 // Compute the signature with a resolveUrl that mirrors getActiveUrl's
@@ -74,6 +75,7 @@ function sig(opts: Opts): string {
     networkAwayFromHome,
     isOnWifi: opts.isOnWifi ?? null,
     isVpnActive: opts.isVpnActive ?? false,
+    treatVpnAsHome: opts.treatVpnAsHome ?? false,
     resolveUrl: (id, instanceId) => {
       const inst = (opts.instances[id] ?? []).find((x) => x.id === instanceId);
       if (!inst) return "";
@@ -149,6 +151,19 @@ describe("buildHealthProbeSignature — health query re-keys on its inputs (#106
     const noVpn = sig({ instances: oneRadarr(), isOnWifi: false });
     const vpn = sig({ instances: oneRadarr(), isOnWifi: false, isVpnActive: true });
     expect(vpn).not.toBe(noVpn);
+  });
+
+  it("changes when 'treat VPN as home' is toggled (it gates the guard, #185)", () => {
+    // The opt-in flips both the LAN guard's VPN stand-down and the URL choice,
+    // so the verdict can change even with isVpnActive/away unchanged — re-key.
+    const off = sig({ instances: oneRadarr(), isOnWifi: false, isVpnActive: true });
+    const on = sig({
+      instances: oneRadarr(),
+      isOnWifi: false,
+      isVpnActive: true,
+      treatVpnAsHome: true,
+    });
+    expect(on).not.toBe(off);
   });
 
   it("ignores disabled instances", () => {

--- a/hooks/use-service-health.ts
+++ b/hooks/use-service-health.ts
@@ -29,6 +29,10 @@ export interface HealthProbeInputs {
   // VPN up/down also flips that guard (a VPN makes LAN URLs reachable off
   // WiFi, #185) — re-key so toggling the tunnel re-probes immediately.
   isVpnActive: boolean;
+  // The opt-in gates BOTH the LAN guard's VPN stand-down (checkInstanceHealth)
+  // and what `resolveUrl` returns under a VPN, so toggling it changes verdicts
+  // even when isVpnActive/networkAwayFromHome haven't settled yet — re-key on it.
+  treatVpnAsHome: boolean;
   resolveUrl: (id: ServiceId, instanceId: string) => string;
 }
 
@@ -78,7 +82,7 @@ export function buildHealthProbeSignature(inputs: HealthProbeInputs): string {
   const globalHeaderKeys = Object.keys(inputs.globalCustomHeaders);
   const wifi = inputs.isOnWifi === null ? "u" : inputs.isOnWifi ? 1 : 0;
   const parts: string[] = [
-    `net:${inputs.autoSwitchNetwork ? 1 : 0}:${inputs.networkAwayFromHome ? 1 : 0}:${wifi}:${inputs.isVpnActive ? 1 : 0}`,
+    `net:${inputs.autoSwitchNetwork ? 1 : 0}:${inputs.networkAwayFromHome ? 1 : 0}:${wifi}:${inputs.isVpnActive ? 1 : 0}:${inputs.treatVpnAsHome ? 1 : 0}`,
   ];
   for (const id of SERVICE_IDS) {
     for (const inst of inputs.serviceInstances[id] ?? []) {
@@ -117,6 +121,7 @@ export function useServiceHealth() {
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
   const isOnWifi = useConfigStore((s) => s.isOnWifi);
   const isVpnActive = useConfigStore((s) => s.isVpnActive);
+  const treatVpnAsHome = useConfigStore((s) => s.treatVpnAsHome);
   const globalCustomHeaders = useConfigStore((s) => s.globalCustomHeaders);
 
   const probeSignature = useMemo(
@@ -129,6 +134,7 @@ export function useServiceHealth() {
         networkAwayFromHome,
         isOnWifi,
         isVpnActive,
+        treatVpnAsHome,
         resolveUrl: (id, instanceId) =>
           useConfigStore.getState().getActiveUrl(id, instanceId),
       }),
@@ -140,6 +146,7 @@ export function useServiceHealth() {
       networkAwayFromHome,
       isOnWifi,
       isVpnActive,
+      treatVpnAsHome,
     ],
   );
 

--- a/hooks/use-service-health.ts
+++ b/hooks/use-service-health.ts
@@ -26,6 +26,9 @@ export interface HealthProbeInputs {
   // checkInstanceHealth, so re-key the query when it changes (coming back onto
   // WiFi must re-probe the LAN services that were short-circuited offline).
   isOnWifi: boolean | null;
+  // VPN up/down also flips that guard (a VPN makes LAN URLs reachable off
+  // WiFi, #185) — re-key so toggling the tunnel re-probes immediately.
+  isVpnActive: boolean;
   resolveUrl: (id: ServiceId, instanceId: string) => string;
 }
 
@@ -75,7 +78,7 @@ export function buildHealthProbeSignature(inputs: HealthProbeInputs): string {
   const globalHeaderKeys = Object.keys(inputs.globalCustomHeaders);
   const wifi = inputs.isOnWifi === null ? "u" : inputs.isOnWifi ? 1 : 0;
   const parts: string[] = [
-    `net:${inputs.autoSwitchNetwork ? 1 : 0}:${inputs.networkAwayFromHome ? 1 : 0}:${wifi}`,
+    `net:${inputs.autoSwitchNetwork ? 1 : 0}:${inputs.networkAwayFromHome ? 1 : 0}:${wifi}:${inputs.isVpnActive ? 1 : 0}`,
   ];
   for (const id of SERVICE_IDS) {
     for (const inst of inputs.serviceInstances[id] ?? []) {
@@ -113,6 +116,7 @@ export function useServiceHealth() {
   const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
   const isOnWifi = useConfigStore((s) => s.isOnWifi);
+  const isVpnActive = useConfigStore((s) => s.isVpnActive);
   const globalCustomHeaders = useConfigStore((s) => s.globalCustomHeaders);
 
   const probeSignature = useMemo(
@@ -124,6 +128,7 @@ export function useServiceHealth() {
         autoSwitchNetwork,
         networkAwayFromHome,
         isOnWifi,
+        isVpnActive,
         resolveUrl: (id, instanceId) =>
           useConfigStore.getState().getActiveUrl(id, instanceId),
       }),
@@ -134,6 +139,7 @@ export function useServiceHealth() {
       autoSwitchNetwork,
       networkAwayFromHome,
       isOnWifi,
+      isVpnActive,
     ],
   );
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -150,6 +150,9 @@ export const WIDGET_ID_RENAMES: Record<string, WidgetId> = {
 export const STORAGE_KEYS = {
   services: "services",
   autoSwitchNetwork: "app.autoSwitchNetwork",
+  // v32: opt-in "VPN connected counts as home" — while a VPN is up the app
+  // behaves as on a confirmed home network (#185).
+  treatVpnAsHome: "app.treatVpnAsHome",
   homeNetworks: "app.homeNetworks",
   // v14: per-user named dashboards, each with their own widget slots and
   // per-slot settings (so the same widget can appear with different instance

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -33,6 +33,10 @@ interface FakeSecrets {
 // without having to know the synthetic UUID.
 interface FakeState {
   demoMode: boolean;
+  // Off-WiFi LAN guard inputs (#106/#185). Absent in most tests → undefined →
+  // the guard never trips, same as the cold-start `null` in the real store.
+  isOnWifi?: boolean | null;
+  isVpnActive?: boolean;
   serviceInstances: Record<string, FakeInstance[]>;
   instanceSecrets: Record<string, FakeSecrets>;
   activeInstance: Record<string, string | null>;
@@ -250,5 +254,65 @@ describe("pingService — custom header injection", () => {
     expect(init.headers.get("X-Override")).toBe("svc");
     // Service auth still wins on the ping path too.
     expect(init.headers.get("X-Api-Key")).toBe("radarr-key");
+  });
+});
+
+// The fixtures use .local (mDNS) URLs, which isPrivateUrl flags — exactly the
+// shape the guard exists for.
+describe("off-WiFi LAN guard — VPN awareness (#185)", () => {
+  let originalFetch: typeof global.fetch;
+  let fetchSpy: jest.Mock;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchSpy = fetchMock();
+    global.fetch = fetchSpy as any;
+    mockStateRef.current = makeState();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("short-circuits a private URL off WiFi with no VPN (the #106 behavior)", async () => {
+    mockStateRef.current.isOnWifi = false;
+    mockStateRef.current.isVpnActive = false;
+    await expect(serviceRequest("radarr", "/system/status")).rejects.toThrow(
+      "private LAN address not reachable off Wi-Fi",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await pingService("radarr")).toBeNull();
+  });
+
+  it("attempts a private URL off WiFi while a VPN is up (the tunnel can route it)", async () => {
+    mockStateRef.current.isOnWifi = false;
+    mockStateRef.current.isVpnActive = true;
+    await serviceRequest("radarr", "/system/status");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a private URL even in the remote slot with useRemote forced (no VPN)", async () => {
+    // The reporter's workaround attempt in #185: LAN address in the Remote URL
+    // field + "Always use Remote URL". The guard keys on the URL's host, not
+    // the slot, so without a VPN it still trips.
+    const inst = mockStateRef.current.serviceInstances.radarr[0];
+    inst.remoteUrl = "http://192.168.1.50:7878";
+    inst.useRemote = true;
+    mockStateRef.current.isOnWifi = false;
+    mockStateRef.current.isVpnActive = false;
+    await expect(serviceRequest("radarr", "/system/status")).rejects.toThrow(
+      "private LAN address not reachable off Wi-Fi",
+    );
+
+    mockStateRef.current.isVpnActive = true;
+    await serviceRequest("radarr", "/system/status");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("never short-circuits while WiFi state is still unknown (cold start)", async () => {
+    mockStateRef.current.isOnWifi = null;
+    mockStateRef.current.isVpnActive = false;
+    await serviceRequest("radarr", "/system/status");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -37,6 +37,9 @@ interface FakeState {
   // the guard never trips, same as the cold-start `null` in the real store.
   isOnWifi?: boolean | null;
   isVpnActive?: boolean;
+  // Opt-in that lets a VPN stand the guard down (#185). Falsy by default, so an
+  // untrusted VPN does NOT make a private URL reachable off Wi-Fi.
+  treatVpnAsHome?: boolean;
   serviceInstances: Record<string, FakeInstance[]>;
   instanceSecrets: Record<string, FakeSecrets>;
   activeInstance: Record<string, string | null>;
@@ -284,11 +287,25 @@ describe("off-WiFi LAN guard — VPN awareness (#185)", () => {
     expect(await pingService("radarr")).toBeNull();
   });
 
-  it("attempts a private URL off WiFi while a VPN is up (the tunnel can route it)", async () => {
+  it("attempts a private URL off WiFi while a trusted VPN is up (the tunnel can route it)", async () => {
     mockStateRef.current.isOnWifi = false;
     mockStateRef.current.isVpnActive = true;
+    mockStateRef.current.treatVpnAsHome = true;
     await serviceRequest("radarr", "/system/status");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("still blocks a private URL off WiFi when a VPN is up but not opted-in (#185)", async () => {
+    // Bug: without this, ANY VPN — even one to a hostile network the user never
+    // chose to trust — would silently make the LAN URL "work" off Wi-Fi.
+    mockStateRef.current.isOnWifi = false;
+    mockStateRef.current.isVpnActive = true;
+    mockStateRef.current.treatVpnAsHome = false;
+    await expect(serviceRequest("radarr", "/system/status")).rejects.toThrow(
+      "private LAN address not reachable off Wi-Fi",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await pingService("radarr")).toBeNull();
   });
 
   it("blocks a private URL even in the remote slot with useRemote forced (no VPN)", async () => {
@@ -305,6 +322,7 @@ describe("off-WiFi LAN guard — VPN awareness (#185)", () => {
     );
 
     mockStateRef.current.isVpnActive = true;
+    mockStateRef.current.treatVpnAsHome = true;
     await serviceRequest("radarr", "/system/status");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -21,12 +21,18 @@ const DEFAULT_TIMEOUT = 15000;
  * we still attempt it — the bounded probe timeout handles that case, and the
  * existing away→remote URL resolution already keeps the LAN URL out of those
  * requests when auto-switch is on.
+ *
+ * An active VPN voids the premise entirely: WireGuard/OpenVPN/Tailscale
+ * subnet routes carry the private ranges into the tunnel, so the LAN URL may
+ * be reachable from anywhere (#185). Stand down and let the bounded timeout
+ * handle the genuinely-unreachable case.
  */
 function lanUnreachableOffWifi(url: string): boolean {
   const store = useConfigStore.getState();
   // Demo mode never hits the network (probes return canned data), so don't let
   // the guard short-circuit demo services to offline when testing on cellular.
   if (store.demoMode) return false;
+  if (store.isVpnActive) return false;
   return store.isOnWifi === false && isPrivateUrl(url);
 }
 
@@ -163,8 +169,12 @@ export async function serviceRequest<T>(
     throw new Error(`No URL configured for ${serviceId}`);
   }
   // Fail fast instead of hanging on an unreachable LAN address off WiFi.
+  // Slot-neutral wording: the guard keys on the URL's host, so a private
+  // address in the Remote URL slot trips it too (#185).
   if (lanUnreachableOffWifi(baseUrl)) {
-    throw new Error(`${serviceId}: local URL not reachable off Wi-Fi`);
+    throw new Error(
+      `${serviceId}: private LAN address not reachable off Wi-Fi (no VPN detected)`,
+    );
   }
 
   // SABnzbd auth lives in the query string (?apikey=…&output=json), not
@@ -494,7 +504,10 @@ export async function checkInstanceHealth(
   // This is the core of the Glances/#106 fix: without it the doomed connect
   // hangs and stalls every other probe in the batch.
   if (lanUnreachableOffWifi(url)) {
-    return { kind: "unreachable", message: "Local URL not reachable off Wi-Fi" };
+    return {
+      kind: "unreachable",
+      message: "Private LAN address not reachable off Wi-Fi (no VPN detected)",
+    };
   }
   const secrets = store.instanceSecrets[instanceId] ?? {};
   return testServiceConnection(serviceId, {

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -22,17 +22,22 @@ const DEFAULT_TIMEOUT = 15000;
  * existing away→remote URL resolution already keeps the LAN URL out of those
  * requests when auto-switch is on.
  *
- * An active VPN voids the premise entirely: WireGuard/OpenVPN/Tailscale
- * subnet routes carry the private ranges into the tunnel, so the LAN URL may
- * be reachable from anywhere (#185). Stand down and let the bounded timeout
- * handle the genuinely-unreachable case.
+ * An active VPN the user opted to trust as home (`treatVpnAsHome`) voids the
+ * premise: WireGuard/OpenVPN/Tailscale subnet routes carry the private ranges
+ * into the tunnel, so the LAN URL may be reachable from anywhere (#185). Stand
+ * down for that case and let the bounded timeout handle a genuinely-unreachable
+ * server. A VPN WITHOUT the opt-in is NOT trusted to reach home, so the guard
+ * stays up — otherwise any tunnel (even to a hostile network) would silently
+ * make the private URL "work" off Wi-Fi, contradicting the opt-in. This keeps
+ * the guard aligned with `getActiveUrl`/`evaluateHomeNetwork`, which only treat
+ * a VPN as home when `treatVpnAsHome` is on.
  */
 function lanUnreachableOffWifi(url: string): boolean {
   const store = useConfigStore.getState();
   // Demo mode never hits the network (probes return canned data), so don't let
   // the guard short-circuit demo services to offline when testing on cellular.
   if (store.demoMode) return false;
-  if (store.isVpnActive) return false;
+  if (store.isVpnActive && store.treatVpnAsHome) return false;
   return store.isOnWifi === false && isPrivateUrl(url);
 }
 

--- a/lib/network.test.ts
+++ b/lib/network.test.ts
@@ -15,6 +15,12 @@ jest.mock("@/store/config-store", () => ({
   useConfigStore: { getState: () => mockGetState() },
 }));
 
+// Native VPN detection (lib/vpn.ts requires an Expo native module).
+const mockDetectVpnActive = jest.fn();
+jest.mock("@/lib/vpn", () => ({
+  detectVpnActive: () => mockDetectVpnActive(),
+}));
+
 import {
   isHomeNetwork,
   evaluateHomeNetwork,
@@ -28,6 +34,7 @@ const cellular = () => ({ type: "cellular", isConnected: true, details: {} }) as
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockDetectVpnActive.mockReturnValue(false);
 });
 
 describe("isHomeNetwork", () => {
@@ -69,12 +76,14 @@ describe("evaluateHomeNetwork", () => {
     return {
       demoMode: false,
       autoSwitchNetwork: true,
+      treatVpnAsHome: false,
       homeNetworks: [{ id: "1", ssid: "Home", bssid: "" }],
       // No dashboards by default → resolveEffectiveHomeNetworks falls back to
       // the global list, so the pre-v29 cases below keep exercising it.
       dashboards: [],
       activeDashboardId: "",
       setNetworkAwayFromHome: jest.fn(),
+      setIsVpnActive: jest.fn(),
       ...over,
     };
   }
@@ -197,6 +206,73 @@ describe("evaluateHomeNetwork", () => {
     await evaluateHomeNetwork();
 
     expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  // --- v32: opt-in "treat VPN as home" (#185) ---
+
+  it("always refreshes the isVpnActive flag, even when auto-switch is off", async () => {
+    const store = fakeStore({ autoSwitchNetwork: false });
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(true);
+
+    await evaluateHomeNetwork();
+
+    expect(store.setIsVpnActive).toHaveBeenCalledWith(true);
+    expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+
+  it("sets away=false when treatVpnAsHome is on and a VPN is up (no SSID needed)", async () => {
+    const store = fakeStore({ treatVpnAsHome: true });
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(true);
+
+    await evaluateHomeNetwork();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("falls back to the SSID match when treatVpnAsHome is on but no VPN is up", async () => {
+    const store = fakeStore({ treatVpnAsHome: true });
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(false);
+    mockFetch.mockResolvedValue(wifi("Home"));
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("counts a VPN as home even with zero configured home networks", async () => {
+    const store = fakeStore({ treatVpnAsHome: true, homeNetworks: [] });
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(true);
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("actively flips back to away when the VPN drops with zero configured home networks", async () => {
+    const store = fakeStore({ treatVpnAsHome: true, homeNetworks: [] });
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(false);
+
+    await evaluateHomeNetwork();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+  });
+
+  it("does not treat a VPN as home without the opt-in (the pinned safe default)", async () => {
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(true);
+    mockFetch.mockResolvedValue(vpn());
+
+    await evaluateHomeNetwork();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
   });
 });
 

--- a/lib/network.test.ts
+++ b/lib/network.test.ts
@@ -274,6 +274,37 @@ describe("evaluateHomeNetwork", () => {
 
     expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
   });
+
+  // --- re-runnable in-flight gate (#185 flakiness) ---
+
+  it("re-runs with a fresh store snapshot when called again while in-flight", async () => {
+    // First pass: opt-in off, so it reaches the awaited NetInfo.fetch and parks
+    // there (held open by a deferred promise) — the gate is now in-flight.
+    const before = fakeStore();
+    mockGetState.mockReturnValue(before);
+    let resolveFetch!: (v: any) => void;
+    mockFetch.mockReturnValue(
+      new Promise((r) => {
+        resolveFetch = r;
+      }),
+    );
+
+    const inFlight = evaluateHomeNetwork();
+
+    // Mid-flight, the user enables "treat VPN as home" and a VPN is up. A naive
+    // gate would DROP this call; the re-runnable gate must queue it.
+    const after = fakeStore({ treatVpnAsHome: true });
+    mockGetState.mockReturnValue(after);
+    mockDetectVpnActive.mockReturnValue(true);
+    await evaluateHomeNetwork(); // queued, returns immediately
+
+    resolveFetch(wifi("Cafe")); // first pass settles: not home → away=true
+    await inFlight;
+
+    // The queued re-run read the FRESH snapshot (opt-in on + VPN) → away=false.
+    expect(before.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+    expect(after.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
 });
 
 describe("resolveEffectiveHomeNetworks", () => {

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -2,16 +2,19 @@ import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
 import type { Dashboard, HomeNetwork } from "@/store/config-store";
 import { detectWifi } from "@/lib/wifi";
+import { detectVpnActive } from "@/lib/vpn";
 
 /**
  * Home-network detection — the single signal behind local/remote URL switching.
  *
- * SSID matching is the only "am I home?" signal we trust, deliberately: the
+ * SSID matching is the primary "am I home?" signal we trust, deliberately: the
  * local URL is a private address (192.168.x / 10.x / mDNS name) that is only
  * meaningful and safe on your actual home LAN. We never use it on a network we
  * can't confirm is home, because a stranger's device at the same private address
  * (airport/cafe WiFi) would receive the API key the app sends. So:
  *   - confirmed home network → local URL.
+ *   - an active VPN with the opt-in `treatVpnAsHome` setting → counts as home
+ *     (the tunnel routes private ranges to the user's own LAN, #185).
  *   - anything else (away / cellular / other WiFi / VPN that masks the SSID / no
  *     home networks configured) → remote URL only; never the local URL.
  *
@@ -77,18 +80,38 @@ let evalInFlight = false;
  * call unconditionally — early-returns when auto-switch is off, in demo mode, or
  * no home networks are configured (in which case the flag stays at its default
  * `true`, i.e. away → remote, so we never use the private local URL off-home).
+ *
+ * Always refreshes the ephemeral `isVpnActive` flag first, even when the
+ * away-flag evaluation early-returns: the off-WiFi LAN guard reads it
+ * regardless of auto-switch, and this runs on app resume — the one moment a
+ * VPN toggled while the JS runtime was suspended (no NetInfo event) gets
+ * noticed (#185).
  */
 export async function evaluateHomeNetwork(): Promise<void> {
   if (evalInFlight) return;
   evalInFlight = true;
   try {
     const store = useConfigStore.getState();
+    const vpnActive = detectVpnActive();
+    store.setIsVpnActive(vpnActive);
+    if (store.demoMode || !store.autoSwitchNetwork) return;
+    // Opt-in "VPN connected counts as home" (#185): the tunnel routes the
+    // private ranges to the user's own LAN, so local URLs are safe. Checked
+    // before the SSID match — under a VPN the SSID is often masked anyway.
+    if (store.treatVpnAsHome && vpnActive) {
+      store.setNetworkAwayFromHome(false);
+      return;
+    }
     const effective = resolveEffectiveHomeNetworks(
       store.dashboards,
       store.activeDashboardId,
       store.homeNetworks,
     );
-    if (store.demoMode || !store.autoSwitchNetwork || effective.length === 0) {
+    if (effective.length === 0) {
+      // No SSIDs to match. With treatVpnAsHome on, a VPN drop must actively
+      // flip us back to away; otherwise keep the historical no-op (the flag
+      // already sits at its safe default and use-network forces it).
+      if (store.treatVpnAsHome) store.setNetworkAwayFromHome(true);
       return;
     }
     const state = await NetInfo.fetch();
@@ -119,7 +142,12 @@ export async function reevaluateHomeNetworkAfterImport(): Promise<void> {
     store.activeDashboardId,
     store.homeNetworks,
   );
-  if (effective.length === 0) return;
+  if (effective.length === 0) {
+    // No SSIDs to match — but an imported treatVpnAsHome can still clear the
+    // away flag via the VPN check, which needs no permission prompt.
+    if (store.treatVpnAsHome) await evaluateHomeNetwork();
+    return;
+  }
   // Prompt for Location now; if granted, the subsequent evaluate reads the real
   // SSID and clears the away flag when we're home. If denied, we stay safely
   // "away" (remote-only) — the honest result.

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -73,7 +73,14 @@ export function resolveEffectiveHomeNetworks(
 }
 
 // Shared in-flight gate so startup / NetInfo-change / resume callers don't race.
+// `evalQueued` makes the gate RE-RUNNABLE: a call that arrives while one is in
+// flight isn't dropped — it sets the flag, and the running pass loops once more
+// when it finishes. Without this, toggling `treatVpnAsHome` (or a VPN drop)
+// while a slow `NetInfo.fetch()` is pending would be silently lost, leaving the
+// away flag stale — the flaky "the toggle did nothing" report (#185). The
+// re-run re-reads `getState()`, so it always sees the latest settings.
 let evalInFlight = false;
+let evalQueued = false;
 
 /**
  * Recompute whether we're on a home network and store the away flag. Safe to
@@ -88,37 +95,49 @@ let evalInFlight = false;
  * noticed (#185).
  */
 export async function evaluateHomeNetwork(): Promise<void> {
-  if (evalInFlight) return;
+  if (evalInFlight) {
+    evalQueued = true;
+    return;
+  }
   evalInFlight = true;
   try {
-    const store = useConfigStore.getState();
-    const vpnActive = detectVpnActive();
-    store.setIsVpnActive(vpnActive);
-    if (store.demoMode || !store.autoSwitchNetwork) return;
-    // Opt-in "VPN connected counts as home" (#185): the tunnel routes the
-    // private ranges to the user's own LAN, so local URLs are safe. Checked
-    // before the SSID match — under a VPN the SSID is often masked anyway.
-    if (store.treatVpnAsHome && vpnActive) {
-      store.setNetworkAwayFromHome(false);
-      return;
-    }
-    const effective = resolveEffectiveHomeNetworks(
-      store.dashboards,
-      store.activeDashboardId,
-      store.homeNetworks,
-    );
-    if (effective.length === 0) {
-      // No SSIDs to match. With treatVpnAsHome on, a VPN drop must actively
-      // flip us back to away; otherwise keep the historical no-op (the flag
-      // already sits at its safe default and use-network forces it).
-      if (store.treatVpnAsHome) store.setNetworkAwayFromHome(true);
-      return;
-    }
-    const state = await NetInfo.fetch();
-    store.setNetworkAwayFromHome(!isHomeNetwork(state, effective));
+    do {
+      evalQueued = false;
+      await evaluateHomeNetworkOnce();
+    } while (evalQueued);
   } finally {
     evalInFlight = false;
   }
+}
+
+// One evaluation pass. Reads a fresh store snapshot each call so a re-run
+// triggered by `evalQueued` picks up settings changed mid-flight.
+async function evaluateHomeNetworkOnce(): Promise<void> {
+  const store = useConfigStore.getState();
+  const vpnActive = detectVpnActive();
+  store.setIsVpnActive(vpnActive);
+  if (store.demoMode || !store.autoSwitchNetwork) return;
+  // Opt-in "VPN connected counts as home" (#185): the tunnel routes the
+  // private ranges to the user's own LAN, so local URLs are safe. Checked
+  // before the SSID match — under a VPN the SSID is often masked anyway.
+  if (store.treatVpnAsHome && vpnActive) {
+    store.setNetworkAwayFromHome(false);
+    return;
+  }
+  const effective = resolveEffectiveHomeNetworks(
+    store.dashboards,
+    store.activeDashboardId,
+    store.homeNetworks,
+  );
+  if (effective.length === 0) {
+    // No SSIDs to match. With treatVpnAsHome on, a VPN drop must actively
+    // flip us back to away; otherwise keep the historical no-op (the flag
+    // already sits at its safe default and use-network forces it).
+    if (store.treatVpnAsHome) store.setNetworkAwayFromHome(true);
+    return;
+  }
+  const state = await NetInfo.fetch();
+  store.setNetworkAwayFromHome(!isHomeNetwork(state, effective));
 }
 
 /**

--- a/lib/vpn.ts
+++ b/lib/vpn.ts
@@ -22,3 +22,14 @@ export function detectVpnActive(): boolean {
     return false;
   }
 }
+
+/**
+ * Whether the native VpnStatus module is present in the running binary. False
+ * when the JS bundle was hot-reloaded onto an app built before the module
+ * existed (an OTA update, or `expo start` on a stale dev client) — in that case
+ * `detectVpnActive` can only ever return false, so "Treat VPN as home" silently
+ * does nothing until a fresh native build. Used by the Home Networks diagnostics.
+ */
+export function isVpnModuleAvailable(): boolean {
+  return VpnStatus != null;
+}

--- a/lib/vpn.ts
+++ b/lib/vpn.ts
@@ -1,0 +1,24 @@
+import { requireOptionalNativeModule } from "expo";
+
+/**
+ * Native VPN detection (modules/vpn-status). NetInfo cannot report this:
+ * on iOS its SCNetworkReachability backend has no VPN branch at all, and on
+ * Android it checks TRANSPORT_VPN only after the underlying wifi/cellular
+ * transport that the OS merges into the VPN network's capabilities — so a
+ * VPN over WiFi/cellular reports as plain "wifi"/"cellular" (#185).
+ *
+ * Optional require: binaries shipped before the module existed (OTA updates
+ * land on them) resolve to null and `detectVpnActive` reports false, which is
+ * exactly the pre-VPN-awareness behavior.
+ */
+const VpnStatus = requireOptionalNativeModule<{ isVpnActive(): boolean }>(
+  "VpnStatus",
+);
+
+export function detectVpnActive(): boolean {
+  try {
+    return VpnStatus?.isVpnActive() === true;
+  } catch {
+    return false;
+  }
+}

--- a/modules/vpn-status/android/build.gradle
+++ b/modules/vpn-status/android/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'com.android.library'
+
+group = 'expo.modules.vpnstatus'
+version = '1.0.0'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+buildscript {
+  // Simple helper that allows the root project to override versions declared by this library.
+  ext.safeExtGet = { prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+}
+project.android {
+  compileSdkVersion safeExtGet("compileSdkVersion", 36)
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 24)
+    targetSdkVersion safeExtGet("targetSdkVersion", 36)
+  }
+}
+
+android {
+  namespace "expo.modules.vpnstatus"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/modules/vpn-status/android/src/main/AndroidManifest.xml
+++ b/modules/vpn-status/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/vpn-status/android/src/main/java/expo/modules/vpnstatus/VpnStatusModule.kt
+++ b/modules/vpn-status/android/src/main/java/expo/modules/vpnstatus/VpnStatusModule.kt
@@ -1,0 +1,28 @@
+package expo.modules.vpnstatus
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+// Reports whether the active network runs through a VPN tunnel. NetInfo can't
+// tell us this: it checks TRANSPORT_VPN only after the underlying
+// wifi/cellular transport (which Android merges into the VPN network's
+// capabilities), so a VPN over WiFi/cellular reports as plain wifi/cellular.
+class VpnStatusModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("VpnStatus")
+
+    Function("isVpnActive") {
+      val context = appContext.reactContext ?: return@Function false
+      val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+          ?: return@Function false
+      val network = connectivityManager.activeNetwork ?: return@Function false
+      val capabilities =
+        connectivityManager.getNetworkCapabilities(network) ?: return@Function false
+      capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+    }
+  }
+}

--- a/modules/vpn-status/expo-module.config.json
+++ b/modules/vpn-status/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["VpnStatusModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.vpnstatus.VpnStatusModule"]
+  }
+}

--- a/modules/vpn-status/ios/VpnStatus.podspec
+++ b/modules/vpn-status/ios/VpnStatus.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'VpnStatus'
+  s.version        = '1.0.0'
+  s.summary        = 'Reports whether a VPN tunnel is currently active'
+  s.description    = 'Reports whether a VPN tunnel is currently active'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/vpn-status/ios/VpnStatusModule.swift
+++ b/modules/vpn-status/ios/VpnStatusModule.swift
@@ -1,0 +1,26 @@
+import ExpoModulesCore
+
+public class VpnStatusModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("VpnStatus")
+
+    // iOS has no public "is a VPN up" API; the de facto check is whether the
+    // system's scoped proxy settings list a tunnel interface. Detects
+    // NEPacketTunnelProvider-based VPNs (WireGuard, Tailscale, OpenVPN
+    // Connect, IKEv2 profiles). Reads __SCOPED__ rather than getifaddrs —
+    // iOS always has idle system utun interfaces, but only interfaces with
+    // active scoped routes appear here.
+    Function("isVpnActive") { () -> Bool in
+      guard
+        let proxySettings = CFNetworkCopySystemProxySettings()?.takeRetainedValue() as? [String: Any],
+        let scoped = proxySettings["__SCOPED__"] as? [String: Any]
+      else {
+        return false
+      }
+      let tunnelPrefixes = ["utun", "tun", "tap", "ppp", "ipsec"]
+      return scoped.keys.contains { key in
+        tunnelPrefixes.contains { key.hasPrefix($0) }
+      }
+    }
+  }
+}

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -123,8 +123,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         stamp — coerceNotificationSettings treats them as optional keys, so
  *         older exports without them validate and the missing entries fall back
  *         to DEFAULT_NOTIFICATION_SETTINGS at hydrate time.
+ *   v32 — optional top-level `treatVpnAsHome` boolean: opt-in "VPN connected
+ *         counts as home" (#185). Pure version stamp — absent means false on
+ *         import.
  */
-export const CURRENT_CONFIG_VERSION = 31;
+export const CURRENT_CONFIG_VERSION = 32;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -612,6 +615,7 @@ const migrations: Record<number, (payload: any) => any> = {
   // treats them as optional keys, so older exports without them validate and the
   // missing entries fall back to DEFAULT_NOTIFICATION_SETTINGS at hydrate time.
   30: (payload) => ({ ...payload, version: 31 }),
+  31: (payload) => ({ ...payload, version: 32 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -1076,6 +1076,27 @@ describe("validateExportPayload — hapticsEnabled", () => {
   });
 });
 
+describe("validateExportPayload — treatVpnAsHome (v32, #185)", () => {
+  it("accepts a boolean", () => {
+    expect(
+      validateExportPayload({ ...baseValid(), treatVpnAsHome: true }).treatVpnAsHome,
+    ).toBe(true);
+    expect(
+      validateExportPayload({ ...baseValid(), treatVpnAsHome: false }).treatVpnAsHome,
+    ).toBe(false);
+  });
+
+  it("rejects a non-boolean treatVpnAsHome", () => {
+    expect(() =>
+      validateExportPayload({ ...baseValid(), treatVpnAsHome: "yes" as any }),
+    ).toThrow(/treatVpnAsHome/);
+  });
+
+  it("omits treatVpnAsHome from the result when absent (pre-v32 exports)", () => {
+    expect(validateExportPayload(baseValid()).treatVpnAsHome).toBeUndefined();
+  });
+});
+
 describe("validateExportPayload — service customHeaders", () => {
   // Each test pairs a single-instance services entry with secrets keyed by
   // that instance's UUID, mirroring the v13 storage shape.

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -468,6 +468,11 @@ export function validateExportPayload(raw: unknown): ExportPayload {
     payload.hapticsEnabled = raw.hapticsEnabled;
   }
 
+  if (raw.treatVpnAsHome !== undefined) {
+    if (typeof raw.treatVpnAsHome !== "boolean") throw new Error("Config treatVpnAsHome is invalid");
+    payload.treatVpnAsHome = raw.treatVpnAsHome;
+  }
+
   if (raw.globalCustomHeaders !== undefined && raw.globalCustomHeaders !== null) {
     const headers = coerceHeaderMap(raw.globalCustomHeaders);
     if (!headers) throw new Error("Config globalCustomHeaders is invalid");

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -298,6 +298,19 @@ interface ConfigState {
   // cellular, so probing it there just hangs and (because the health grid awaits
   // the whole probe batch) freezes every dot red — the Glances/#106 report.
   isOnWifi: boolean | null;
+  // EPHEMERAL (never persisted). Whether a VPN tunnel is currently active
+  // (native check — see lib/vpn.ts; NetInfo can't report this). Tracked
+  // alongside isOnWifi and refreshed by evaluateHomeNetwork() on resume. A VPN
+  // can route private ranges to the home LAN, so the off-WiFi LAN guard stands
+  // down while one is up, and the opt-in `treatVpnAsHome` setting counts it as
+  // a confirmed home network (#185).
+  isVpnActive: boolean;
+  // While a VPN is connected, behave as if on a confirmed home network: local
+  // URLs are used and the away→remote-only rule is suspended. Off by default —
+  // the device can only detect that *some* VPN is up, not which one, so the
+  // user must opt in (same caveat as Home Assistant Companion's "VPN connected"
+  // home-network option). Only consulted when autoSwitchNetwork is on (#185).
+  treatVpnAsHome: boolean;
   homeNetworks: HomeNetwork[];
   // v17: per-user display order for the Services tab. Unknown ids are skipped
   // at render time; any SERVICE_IDS missing from the list fall in at the end
@@ -351,6 +364,8 @@ export interface ExportPayload {
   uiScale?: UiScale;
   // v17 — user-defined Services tab tile order.
   servicesOrder?: ServiceId[];
+  // v32 — opt-in "VPN connected counts as home" (#185).
+  treatVpnAsHome?: boolean;
 }
 
 export type ExportStage = "preparing" | "encrypting" | "finalizing";
@@ -398,6 +413,10 @@ interface ConfigActions {
   // Set by useNetworkAutoSwitch on every NetInfo change (and eagerly at start).
   // EPHEMERAL — never persisted.
   setIsOnWifi: (onWifi: boolean | null) => void;
+  // Set by useNetworkAutoSwitch / evaluateHomeNetwork from lib/vpn.ts.
+  // EPHEMERAL — never persisted.
+  setIsVpnActive: (active: boolean) => void;
+  setTreatVpnAsHome: (enabled: boolean) => void;
   addHomeNetwork: (network: Omit<HomeNetwork, "id">) => HomeNetwork;
   updateHomeNetwork: (id: string, patch: Partial<Omit<HomeNetwork, "id">>) => void;
   removeHomeNetwork: (id: string) => void;
@@ -870,6 +889,8 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   autoSwitchNetwork: false,
   networkAwayFromHome: true,
   isOnWifi: null,
+  isVpnActive: false,
+  treatVpnAsHome: false,
   homeNetworks: [],
   servicesOrder: [],
   dashboards: initialDashboards,
@@ -1053,6 +1074,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     // Stash the legacy value and apply after the dashboards array exists.
 
     const autoSwitchNetwork = getBoolean(STORAGE_KEYS.autoSwitchNetwork);
+    const treatVpnAsHome = getBoolean(STORAGE_KEYS.treatVpnAsHome);
     // Purge the orphaned persisted flag from older builds. networkAwayFromHome is
     // now ephemeral runtime state, recomputed fresh each launch by
     // evaluateHomeNetwork() (lib/network.ts) — persisting a live network
@@ -1400,6 +1422,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       services,
       secrets,
       autoSwitchNetwork,
+      treatVpnAsHome,
       homeNetworks,
       servicesOrder,
       dashboards,
@@ -1734,6 +1757,20 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     if (get().isOnWifi === onWifi) return;
     set({ isOnWifi: onWifi });
     void queryClient.invalidateQueries();
+  },
+
+  setIsVpnActive: (active) => {
+    // Same shape as setIsOnWifi: a VPN coming up makes LAN URLs reachable
+    // (the off-WiFi guard stands down); it dropping takes them away again.
+    if (get().isVpnActive === active) return;
+    set({ isVpnActive: active });
+    void queryClient.invalidateQueries();
+  },
+
+  setTreatVpnAsHome: (enabled) => {
+    setBoolean(STORAGE_KEYS.treatVpnAsHome, enabled);
+    set({ treatVpnAsHome: enabled });
+    // useNetworkAutoSwitch subscribes to this and re-evaluates home/away.
   },
 
   addHomeNetwork: (network) => {
@@ -2470,6 +2507,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       serviceInstances,
       instanceSecrets,
       autoSwitchNetwork,
+      treatVpnAsHome,
       homeNetworks,
       servicesOrder,
       dashboards,
@@ -2490,6 +2528,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       // v22: activeInstance is now per-dashboard, serialized inside the
       // `dashboards` array — no top-level field.
       autoSwitchNetwork,
+      treatVpnAsHome,
       homeNetworks,
       servicesOrder,
       dashboards,
@@ -2629,6 +2668,8 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
 
     // Restore app settings
     setBoolean(STORAGE_KEYS.autoSwitchNetwork, payload.autoSwitchNetwork ?? false);
+    const importedTreatVpnAsHome = payload.treatVpnAsHome ?? false;
+    setBoolean(STORAGE_KEYS.treatVpnAsHome, importedTreatVpnAsHome);
     const importedHomeNetworks = payload.homeNetworks ?? [];
     setJSON(STORAGE_KEYS.homeNetworks, importedHomeNetworks);
 
@@ -2700,6 +2741,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       services: derivedServices,
       secrets: derivedSecrets,
       autoSwitchNetwork: payload.autoSwitchNetwork ?? false,
+      treatVpnAsHome: importedTreatVpnAsHome,
       homeNetworks: importedHomeNetworks,
       servicesOrder: importedServicesOrder,
       dashboards: importedDashboards,


### PR DESCRIPTION
## Summary
Fixes the v1.10.0 regression where the off-WiFi LAN guard blocked private addresses even when a VPN (WireGuard / OpenVPN / Tailscale subnet router) made them reachable (Refs #185).

- New local Expo module `modules/vpn-status`: `isVpnActive()` via `TRANSPORT_VPN` on Android and the scoped-proxy utun check on iOS. NetInfo cannot report VPN on either platform (iOS has no VPN branch at all; Android checks it after the merged underlying transport).
- The LAN guard stands down while a VPN is up, so private addresses are attempted again (bounded timeouts cover genuinely unreachable hosts). Guard message is now slot-neutral: "private LAN address not reachable off Wi-Fi (no VPN detected)".
- New opt-in **Settings → Treat VPN as home** (default off, shown when auto-switch is on): while any VPN is connected the app behaves as on home WiFi, so local URLs work. SSID matching stays the primary home signal; config export bumped v31→v32 with migration.
- 15s VPN liveness re-check: iOS emits no NetInfo event when a tunnel silently drops over WiFi, which would otherwise leave stale home state.
- Health probes re-key on VPN state; README VPN section updated.

Requires a native build for the new module; the JS falls back gracefully on older binaries via `requireOptionalNativeModule` (OTA-safe).

## Test plan
- `tsc --noEmit` clean; 581 jest tests pass (new: guard VPN bypass incl. the forced-remote LAN-address path from the issue, treat-VPN-as-home evaluation, schema v32, health-probe re-key)
- To verify on device: VPN over cellular → LAN-address services load; toggling "Treat VPN as home" flips local/remote resolution; VPN drop returns to remote-only

---

## Follow-up (06241f0): bugfixes found on a real WireGuard device

- **An untrusted VPN no longer exposes local URLs.** The off-Wi-Fi LAN guard stood down for *any* active VPN; it now stands down only when **Treat VPN as home** is on — matching `getActiveUrl` / `evaluateHomeNetwork`, so all three mechanisms agree on what a VPN means.
- **Toggling the opt-in is reliable.** `evaluateHomeNetwork`'s in-flight gate is now re-runnable, so a toggle (or a VPN drop) mid-evaluation can't be silently dropped, and the re-run reads fresh state. The health query also re-keys on `treatVpnAsHome`.
- **Stale data is now obvious.** New `CachedDataBanner` on offline service screens (wired into Glances) so cached values aren't mistaken for live ones; a collapsible, default-closed **Network diagnostics** panel was added to Home Networks as a screenshot aid for bug reports.

`tsc --noEmit` clean; **584** jest tests pass (added: untrusted-VPN-still-blocks guard test, re-runnable-gate concurrency test, opt-in re-key signature test).
