### PR TITLE
feat(dashboard): Disk Space widget from *arr diskspace (Refs #63, #181)

### DIFF
--- a/components/dashboard/add-widget-sheet.tsx
+++ b/components/dashboard/add-widget-sheet.tsx
@@ -239,39 +239,42 @@ function EnabledRow({ widget, index, onAdd }: EnabledRowProps) {
     transform: [{ scale: scale.value }],
   }));
 
+  // The entering layout animation and the press-scale transform live on
+  // separate views — FadeInDown writes `transform` too, so sharing one view
+  // lets the layout animation clobber the scale (Reanimated warns about it).
+  // Same split as ActionSheet's rows.
   return (
-    <Animated.View
-      entering={FadeInDown.delay(index * 35).duration(260)}
-      style={style}
-    >
-      <Pressable
-        onPressIn={() => {
-          scale.value = withSpring(0.97, { damping: 18, stiffness: 320 });
-        }}
-        onPressOut={() => {
-          scale.value = withSpring(1, { damping: 18, stiffness: 320 });
-        }}
-        onPress={onAdd}
-        className="flex-row items-center gap-3 bg-surface-light rounded-2xl px-3 py-3 border border-border/70"
-      >
-        <View className="w-10 h-10 rounded-xl bg-primary/15 items-center justify-center">
-          <Icon icon={WidgetIcon} size={ICON.MD} color="#60a5fa" />
-        </View>
-        <View className="flex-1">
-          <Text className="text-zinc-100 text-sm font-semibold">
-            {widget.label}
-          </Text>
-          <Text
-            className="text-zinc-500 text-xs mt-0.5"
-            numberOfLines={1}
-          >
-            {widget.description}
-          </Text>
-        </View>
-        <View className="w-7 h-7 rounded-full bg-primary/20 items-center justify-center">
-          <Icon icon={Plus} size={ICON.SM} color="#60a5fa" />
-        </View>
-      </Pressable>
+    <Animated.View entering={FadeInDown.delay(index * 35).duration(260)}>
+      <Animated.View style={style}>
+        <Pressable
+          onPressIn={() => {
+            scale.value = withSpring(0.97, { damping: 18, stiffness: 320 });
+          }}
+          onPressOut={() => {
+            scale.value = withSpring(1, { damping: 18, stiffness: 320 });
+          }}
+          onPress={onAdd}
+          className="flex-row items-center gap-3 bg-surface-light rounded-2xl px-3 py-3 border border-border/70"
+        >
+          <View className="w-10 h-10 rounded-xl bg-primary/15 items-center justify-center">
+            <Icon icon={WidgetIcon} size={ICON.MD} color="#60a5fa" />
+          </View>
+          <View className="flex-1">
+            <Text className="text-zinc-100 text-sm font-semibold">
+              {widget.label}
+            </Text>
+            <Text
+              className="text-zinc-500 text-xs mt-0.5"
+              numberOfLines={1}
+            >
+              {widget.description}
+            </Text>
+          </View>
+          <View className="w-7 h-7 rounded-full bg-primary/20 items-center justify-center">
+            <Icon icon={Plus} size={ICON.SM} color="#60a5fa" />
+          </View>
+        </Pressable>
+      </Animated.View>
     </Animated.View>
   );
 }

--- a/components/dashboard/disk-space-card.tsx
+++ b/components/dashboard/disk-space-card.tsx
@@ -1,0 +1,160 @@
+import { View, Text } from "react-native";
+import { ServerCrash } from "lucide-react-native";
+import { useQueries } from "@tanstack/react-query";
+import { Icon } from "@/components/ui/icon";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { SkeletonCardContent } from "@/components/ui/skeleton";
+import { DiskUsageRow } from "@/components/dashboard/disk-usage-row";
+import { getArrDiskSpace, selectDiskSpace } from "@/services/arr-diskspace";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import {
+  useAttachedEnabledInstances,
+  useWorkspaceScopedInstances,
+} from "@/hooks/use-workspace-instances";
+import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import { POLLING_INTERVALS, SERVICE_DEFAULTS } from "@/lib/constants";
+import {
+  DISK_SPACE_DEFAULT_SETTINGS,
+  resolveDiskSpaceSource,
+  diskSpaceBindingFor,
+  type DiskSpaceSettingsValue,
+} from "@/components/dashboard/widget-settings/disk-space-settings";
+import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
+
+export function DiskSpaceCard({ slotId }: WidgetComponentProps) {
+  const { settings } = useWidgetSettings<DiskSpaceSettingsValue>(
+    slotId,
+    DISK_SPACE_DEFAULT_SETTINGS,
+  );
+
+  // Workspace-scoped availability drives the source-forcing decision so a
+  // Sonarr-only dashboard renders Sonarr disks without the user ever opening
+  // the settings (#148 pattern; mirrors speed-stats).
+  const wsRadarr = useAttachedEnabledInstances("radarr");
+  const wsSonarr = useAttachedEnabledInstances("sonarr");
+  const wsLidarr = useAttachedEnabledInstances("lidarr");
+  const source = resolveDiskSpaceSource(settings.source, {
+    radarr: wsRadarr.length > 0,
+    sonarr: wsSonarr.length > 0,
+    lidarr: wsLidarr.length > 0,
+  });
+  const sourceName = SERVICE_DEFAULTS[source].name;
+
+  const instances = useWorkspaceScopedInstances(
+    source,
+    diskSpaceBindingFor(settings, source),
+  );
+
+  // Fan out across the bound instances; each keeps its own cache slot via the
+  // [serviceId, instanceId, endpoint] key shape (shared with the path picker).
+  const queries = useQueries({
+    queries: instances.map((inst) => ({
+      queryKey: [source, inst.id, "diskspace"] as const,
+      queryFn: () => getArrDiskSpace(source, inst.id),
+      refetchInterval: POLLING_INTERVALS.diskSpace,
+    })),
+  });
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState(queries);
+
+  // Unlike speed-stats' self-explanatory pills, a bare mount list needs
+  // context — always render a header.
+  const title = settings.title.trim() || "Disk Space";
+  const header = (
+    <CardHeader>
+      <CardTitle>{title}</CardTitle>
+    </CardHeader>
+  );
+
+  if (instances.length === 0) {
+    return (
+      <Card>
+        {header}
+        <View className="flex-row items-center gap-2 py-1">
+          <Icon icon={ServerCrash} size={16} color="#71717a" />
+          <Text className="text-zinc-500 text-sm">
+            No {sourceName} instances enabled
+          </Text>
+        </View>
+      </Card>
+    );
+  }
+
+  // Every bound instance errored without ever returning data — surface that
+  // instead of an empty card that reads as "no disks".
+  if (isAllErrored) {
+    return (
+      <Card>
+        {header}
+        <View className="flex-row items-center gap-2 py-1">
+          <Icon icon={ServerCrash} size={16} color="#71717a" />
+          <Text className="text-zinc-500 text-sm">
+            Could not reach {sourceName}
+          </Text>
+        </View>
+      </Card>
+    );
+  }
+
+  if (isInitialLoading) {
+    return (
+      <Card>
+        {header}
+        <SkeletonCardContent rows={2} />
+      </Card>
+    );
+  }
+
+  const sections = instances.map((inst, i) => {
+    const q = queries[i];
+    const disks = selectDiskSpace(q?.data, settings.paths);
+    return { inst, q, disks };
+  });
+  const allFilteredOut =
+    sections.every((s) => s.disks.length === 0) &&
+    sections.some((s) => (s.q?.data?.length ?? 0) > 0);
+
+  return (
+    <Card>
+      {header}
+      {allFilteredOut ? (
+        <Text className="text-zinc-500 text-sm py-1">
+          All mounts hidden — adjust paths in the widget settings.
+        </Text>
+      ) : (
+        <View className="gap-4">
+          {sections.map(({ inst, q, disks }) => (
+            <View key={inst.id} className="gap-2">
+              {instances.length > 1 && (
+                <Text className="text-zinc-400 text-xs uppercase tracking-wider">
+                  {inst.name}
+                </Text>
+              )}
+              {q?.isError && !q.data ? (
+                <View className="flex-row items-center gap-2">
+                  <Icon icon={ServerCrash} size={16} color="#71717a" />
+                  <Text className="text-zinc-500 text-sm">
+                    Could not reach {inst.name}
+                  </Text>
+                </View>
+              ) : (
+                disks.map((disk) => (
+                  <DiskUsageRow
+                    key={disk.path}
+                    label={disk.label?.trim() || disk.path}
+                    percent={
+                      disk.totalSpace > 0
+                        ? ((disk.totalSpace - disk.freeSpace) / disk.totalSpace) * 100
+                        : 0
+                    }
+                    used={Math.max(disk.totalSpace - disk.freeSpace, 0)}
+                    total={disk.totalSpace}
+                  />
+                ))
+              )}
+            </View>
+          ))}
+        </View>
+      )}
+    </Card>
+  );
+}

--- a/components/dashboard/disk-usage-row.tsx
+++ b/components/dashboard/disk-usage-row.tsx
@@ -1,0 +1,65 @@
+import { memo } from "react";
+import { View, Text } from "react-native";
+import { HardDrive } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { formatBytes } from "@/lib/utils";
+
+// Extracted from server-stats-card's DiskRow so the Glances Server Stats
+// widget and the *arr-backed Disk Space widget render mounts identically.
+// Percent is caller-owned: Glances reports its own `percent`, the *arr
+// /diskspace payload derives it from (total - free) / total.
+
+export function diskBarColor(percent: number): string {
+  if (percent >= 85) return "bg-red-500";
+  if (percent >= 70) return "bg-amber-500";
+  return "bg-success";
+}
+
+export function diskTextColor(percent: number): string {
+  if (percent >= 85) return "text-red-400";
+  if (percent >= 70) return "text-amber-400";
+  return "text-success";
+}
+
+interface DiskUsageRowProps {
+  label: string; // mount label/path
+  percent: number; // 0–100 usage
+  used: number; // bytes
+  total: number; // bytes
+}
+
+export const DiskUsageRow = memo(function DiskUsageRow({
+  label,
+  percent,
+  used,
+  total,
+}: DiskUsageRowProps) {
+  const pct = Math.min(Math.max(percent, 0), 100);
+  return (
+    <View className="gap-1">
+      <View className="flex-row justify-between items-center gap-2">
+        <View className="flex-row items-center gap-1.5 flex-1 min-w-0">
+          <Icon icon={HardDrive} size={11} color="#a1a1aa" />
+          <Text
+            className="text-zinc-300 text-xs font-medium"
+            numberOfLines={1}
+          >
+            {label}
+          </Text>
+        </View>
+        <Text className="text-zinc-500 text-[0.7rem]">
+          {formatBytes(used)} / {formatBytes(total)}
+        </Text>
+        <Text className={`text-xs font-semibold w-10 text-right ${diskTextColor(pct)}`}>
+          {pct.toFixed(0)}%
+        </Text>
+      </View>
+      <View className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+        <View
+          className={`h-full rounded-full ${diskBarColor(pct)}`}
+          style={{ width: `${pct}%` }}
+        />
+      </View>
+    </View>
+  );
+});

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -5,7 +5,6 @@ import {
   Cpu as CpuIcon,
   MemoryStick,
   Gpu as GpuIconSvg,
-  HardDrive,
   Network,
   Gauge,
   Activity,
@@ -16,6 +15,7 @@ import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
+import { DiskUsageRow } from "@/components/dashboard/disk-usage-row";
 import { getCpu, getMem, getFs, getGpu, getNet, getLoad, selectInterfaces, type GlancesNetRate } from "@/services/glances-api";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
@@ -26,7 +26,7 @@ import {
 } from "@/components/dashboard/widget-settings/server-stats-settings";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { formatBytes, formatSpeed } from "@/lib/utils";
-import type { GlancesFsItem, GlancesGpuItem, GlancesLoad } from "@/lib/types";
+import type { GlancesGpuItem, GlancesLoad } from "@/lib/types";
 import type { ServiceInstance } from "@/store/config-store";
 
 const RING_BASE = 60;
@@ -37,18 +37,6 @@ function ringColor(percent: number): string {
   if (percent >= 85) return "#ef4444";
   if (percent >= 70) return "#f59e0b";
   return "#22c55e";
-}
-
-function diskBarColor(percent: number): string {
-  if (percent >= 85) return "bg-red-500";
-  if (percent >= 70) return "bg-amber-500";
-  return "bg-success";
-}
-
-function diskTextColor(percent: number): string {
-  if (percent >= 85) return "text-red-400";
-  if (percent >= 70) return "text-amber-400";
-  return "text-success";
 }
 
 interface MetricRingProps {
@@ -337,7 +325,15 @@ function InstanceBlock({ instance, settings, showName }: InstanceBlockProps) {
           {hasDisks && (
             <View className="gap-2">
               {fs.map((disk) => (
-                <DiskRow key={disk.mnt_point} disk={disk} />
+                <DiskUsageRow
+                  key={disk.mnt_point}
+                  // Strip the Glances-in-Docker /host prefix at the call site —
+                  // it's Glances-specific, not part of the shared row.
+                  label={disk.mnt_point.replace(/^\/host/, "") || "/"}
+                  percent={disk.percent}
+                  used={disk.used}
+                  total={disk.size}
+                />
               ))}
             </View>
           )}
@@ -452,34 +448,3 @@ function shortenGpuName(name: string): string {
     .trim();
 }
 
-const DiskRow = memo(function DiskRow({ disk }: { disk: GlancesFsItem }) {
-  const mount = disk.mnt_point.replace(/^\/host/, "") || "/";
-  const pct = Math.min(Math.max(disk.percent, 0), 100);
-  return (
-    <View className="gap-1">
-      <View className="flex-row justify-between items-center gap-2">
-        <View className="flex-row items-center gap-1.5 flex-1 min-w-0">
-          <Icon icon={HardDrive} size={11} color="#a1a1aa" />
-          <Text
-            className="text-zinc-300 text-xs font-medium"
-            numberOfLines={1}
-          >
-            {mount}
-          </Text>
-        </View>
-        <Text className="text-zinc-500 text-[0.7rem]">
-          {formatBytes(disk.used)} / {formatBytes(disk.size)}
-        </Text>
-        <Text className={`text-xs font-semibold w-10 text-right ${diskTextColor(pct)}`}>
-          {pct.toFixed(0)}%
-        </Text>
-      </View>
-      <View className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
-        <View
-          className={`h-full rounded-full ${diskBarColor(pct)}`}
-          style={{ width: `${pct}%` }}
-        />
-      </View>
-    </View>
-  );
-});

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -8,6 +8,7 @@ import {
   Download,
   Film,
   Gauge,
+  HardDrive,
   HeartPulse,
   Inbox,
   Disc3,
@@ -41,6 +42,7 @@ import { CombinedNowPlayingCard } from "@/components/dashboard/combined-now-play
 import { ProwlarrStatsCard } from "@/components/dashboard/prowlarr-stats-card";
 import { BazarrWantedCard } from "@/components/dashboard/bazarr-wanted-card";
 import { WolDevicesCard } from "@/components/dashboard/wol-devices-card";
+import { DiskSpaceCard } from "@/components/dashboard/disk-space-card";
 import {
   ServerStatsSettings,
   SERVER_STATS_DEFAULT_SETTINGS,
@@ -136,6 +138,11 @@ import {
   BAZARR_WANTED_DEFAULT_SETTINGS,
   type BazarrWantedSettingsValue,
 } from "@/components/dashboard/widget-settings/bazarr-wanted-settings";
+import {
+  DiskSpaceSettings,
+  DISK_SPACE_DEFAULT_SETTINGS,
+  type DiskSpaceSettingsValue,
+} from "@/components/dashboard/widget-settings/disk-space-settings";
 import { DASHBOARD_WIDGET_IDS, type ServiceId, type WidgetId } from "@/lib/constants";
 
 // Every widget component receives the id of its slot in the active dashboard.
@@ -410,6 +417,16 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     service: null,
     component: WolDevicesCard,
   },
+  "disk-space": {
+    id: "disk-space",
+    label: "Disk Space",
+    description: "Mount usage from Radarr, Sonarr or Lidarr — no Glances needed",
+    icon: HardDrive,
+    service: ["radarr", "sonarr", "lidarr"],
+    component: DiskSpaceCard,
+    settingsComponent: DiskSpaceSettings,
+    defaultSettings: DISK_SPACE_DEFAULT_SETTINGS,
+  },
 };
 
 // Lists widgets the user can still add. With per-slot dashboards a user can
@@ -440,4 +457,5 @@ export type {
   RecentlyDownloadedSettingsValue,
   ProwlarrStatsSettingsValue,
   BazarrWantedSettingsValue,
+  DiskSpaceSettingsValue,
 };

--- a/components/dashboard/widget-settings/disk-path-picker-row.tsx
+++ b/components/dashboard/widget-settings/disk-path-picker-row.tsx
@@ -1,0 +1,125 @@
+import { View, Text } from "react-native";
+import { useQueries } from "@tanstack/react-query";
+import {
+  getArrDiskSpace,
+  DISK_PATHS_ALL,
+  type ArrDiskSpaceService,
+  type DiskPathsValue,
+} from "@/services/arr-diskspace";
+import { useEnabledInstances } from "@/hooks/use-instance-target";
+import {
+  resolveBoundInstances,
+  type InstanceBindingValue,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+import { SelectRow } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import { POLLING_INTERVALS } from "@/lib/constants";
+import { formatBytes } from "@/lib/utils";
+import type { ArrDiskSpace } from "@/lib/types";
+
+// Re-exported so settings panels can keep importing the value contract from
+// the picker they render. Source of truth lives in services/arr-diskspace.
+export { DISK_PATHS_ALL, type DiskPathsValue };
+
+interface DiskPathPickerRowProps {
+  // Which *arr kind + instances the widget is bound to — candidate mounts are
+  // gathered from these hosts.
+  source: ArrDiskSpaceService;
+  instanceIds: InstanceBindingValue;
+  value: DiskPathsValue;
+  onChange: (value: DiskPathsValue) => void;
+}
+
+/**
+ * Lets the Disk Space widget restrict its list to specific mounts, or show
+ * every mount the source reports. Candidates are fetched live from the bound
+ * instance(s) — *arr's /diskspace often includes docker overlays and system
+ * mounts the user doesn't care about — and rendered as a checklist with an
+ * "All mounts" default. Selections are stored by path string and applied
+ * per-instance.
+ */
+export function DiskPathPickerRow({
+  source,
+  instanceIds,
+  value,
+  onChange,
+}: DiskPathPickerRowProps) {
+  const allInstances = useEnabledInstances(source);
+  const instances = resolveBoundInstances(instanceIds, allInstances);
+
+  // Reuse the same query key the card polls on, so candidates appear
+  // instantly when data is already cached.
+  const queries = useQueries({
+    queries: instances.map((inst) => ({
+      queryKey: [source, inst.id, "diskspace"] as const,
+      queryFn: () => getArrDiskSpace(source, inst.id),
+      refetchInterval: POLLING_INTERVALS.diskSpace,
+    })),
+  });
+
+  // Merge mounts across bound hosts by path (first label wins), sorted by
+  // path for a stable order under the user's finger.
+  const byPath = new Map<string, ArrDiskSpace>();
+  for (const q of queries) {
+    if (!q.data) continue;
+    for (const disk of q.data) {
+      if (!byPath.has(disk.path)) byPath.set(disk.path, disk);
+    }
+  }
+  const merged = Array.from(byPath.values()).sort((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+
+  const isAll = value === DISK_PATHS_ALL;
+  const selectedSet = new Set<string>(isAll ? [] : value);
+
+  const toggle = (path: string) => {
+    if (isAll) {
+      // From "all" → start a fresh explicit subset with just this mount.
+      onChange([path]);
+      return;
+    }
+    if (selectedSet.has(path)) {
+      const next = (value as string[]).filter((v) => v !== path);
+      onChange(next.length === 0 ? DISK_PATHS_ALL : next);
+    } else {
+      onChange([...(value as string[]), path]);
+    }
+  };
+
+  return (
+    <View>
+      <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-2">
+        Mounts
+      </Text>
+      <View className="bg-surface-light rounded-2xl border border-border divide-y divide-border/60 overflow-hidden">
+        <SelectRow
+          label="All mounts"
+          caption="Every mount the server reports — new ones auto-included"
+          selected={isAll}
+          onPress={() => onChange(DISK_PATHS_ALL)}
+        />
+        {merged.map((disk) => (
+          <SelectRow
+            key={disk.path}
+            label={disk.label?.trim() || disk.path}
+            caption={usageCaption(disk)}
+            selected={!isAll && selectedSet.has(disk.path)}
+            onPress={() => toggle(disk.path)}
+          />
+        ))}
+      </View>
+      {merged.length === 0 ? (
+        <Text className="text-zinc-600 text-xs mt-2">
+          No mounts reported yet.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function usageCaption(disk: ArrDiskSpace): string {
+  const used = Math.max(disk.totalSpace - disk.freeSpace, 0);
+  if (disk.totalSpace <= 0) return formatBytes(disk.freeSpace) + " free";
+  const pct = Math.round((used / disk.totalSpace) * 100);
+  return `${formatBytes(used)} / ${formatBytes(disk.totalSpace)} · ${pct}%`;
+}

--- a/components/dashboard/widget-settings/disk-space-settings.test.ts
+++ b/components/dashboard/widget-settings/disk-space-settings.test.ts
@@ -1,0 +1,65 @@
+// Mock native storage before importing — disk-space-settings pulls in
+// use-widget-settings → config-store → AsyncStorage/SecureStore at module
+// load. The functions under test are pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  resolveDiskSpaceSource,
+  diskSpaceBindingFor,
+  DISK_SPACE_DEFAULT_SETTINGS,
+  type DiskSpaceSettingsValue,
+} from "./disk-space-settings";
+
+describe("resolveDiskSpaceSource", () => {
+  it("keeps the stored source when that kind is available", () => {
+    expect(
+      resolveDiskSpaceSource("sonarr", { radarr: true, sonarr: true, lidarr: false }),
+    ).toBe("sonarr");
+  });
+
+  it("falls back to the first configured kind in radarr → sonarr → lidarr order", () => {
+    expect(
+      resolveDiskSpaceSource("radarr", { radarr: false, sonarr: true, lidarr: true }),
+    ).toBe("sonarr");
+    expect(
+      resolveDiskSpaceSource("sonarr", { radarr: false, sonarr: false, lidarr: true }),
+    ).toBe("lidarr");
+  });
+
+  it("returns the stored source when nothing is configured", () => {
+    expect(
+      resolveDiskSpaceSource("lidarr", { radarr: false, sonarr: false, lidarr: false }),
+    ).toBe("lidarr");
+  });
+});
+
+describe("diskSpaceBindingFor", () => {
+  const settings: DiskSpaceSettingsValue = {
+    ...DISK_SPACE_DEFAULT_SETTINGS,
+    radarrInstanceIds: ["r1"],
+    sonarrInstanceIds: ["s1"],
+    lidarrInstanceIds: ["l1"],
+  };
+
+  it("returns the binding field matching the source", () => {
+    expect(diskSpaceBindingFor(settings, "radarr")).toEqual(["r1"]);
+    expect(diskSpaceBindingFor(settings, "sonarr")).toEqual(["s1"]);
+    expect(diskSpaceBindingFor(settings, "lidarr")).toEqual(["l1"]);
+  });
+});

--- a/components/dashboard/widget-settings/disk-space-settings.tsx
+++ b/components/dashboard/widget-settings/disk-space-settings.tsx
@@ -1,0 +1,161 @@
+import { View } from "react-native";
+import { TextInput } from "@/components/ui/text-input";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useAttachedEnabledInstances } from "@/hooks/use-workspace-instances";
+import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+import {
+  InstancePickerRow,
+  INSTANCE_BINDING_ALL,
+  type InstanceBindingValue,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  DiskPathPickerRow,
+  DISK_PATHS_ALL,
+  type DiskPathsValue,
+} from "@/components/dashboard/widget-settings/disk-path-picker-row";
+import {
+  ChipGroup,
+  SettingsSection,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import { SERVICE_DEFAULTS } from "@/lib/constants";
+
+// A widget shows ONE source service at a time — Radarr and Sonarr on the same
+// box report the same mounts, so merging sources would duplicate disks (or
+// need fragile path dedupe). Place several widgets for several servers.
+export type DiskSpaceSource = "radarr" | "sonarr" | "lidarr";
+
+const DISK_SPACE_SOURCES: readonly DiskSpaceSource[] = [
+  "radarr",
+  "sonarr",
+  "lidarr",
+];
+
+const SOURCE_OPTIONS: readonly { value: DiskSpaceSource; label: string }[] =
+  DISK_SPACE_SOURCES.map((value) => ({
+    value,
+    label: SERVICE_DEFAULTS[value].name,
+  }));
+
+export interface DiskSpaceSettingsValue extends Record<string, unknown> {
+  // Optional header override. Empty = "Disk Space". Lets a user place several
+  // widgets for different servers ("Media NAS", "Seedbox", …).
+  title: string;
+  // Which single source service the widget reads /diskspace from.
+  source: DiskSpaceSource;
+  // Per-source bindings (speed-stats precedent: separate instanceIds fields
+  // per kind) so flipping the source chip never leaves foreign UUIDs in the
+  // active binding.
+  radarrInstanceIds: InstanceBindingValue;
+  sonarrInstanceIds: InstanceBindingValue;
+  lidarrInstanceIds: InstanceBindingValue;
+  // Which mounts to show. "all" = every reported mount; an array of path
+  // strings restricts the list, applied per-instance.
+  paths: DiskPathsValue;
+}
+
+export const DISK_SPACE_DEFAULT_SETTINGS: DiskSpaceSettingsValue = {
+  title: "",
+  source: "radarr",
+  radarrInstanceIds: INSTANCE_BINDING_ALL,
+  sonarrInstanceIds: INSTANCE_BINDING_ALL,
+  lidarrInstanceIds: INSTANCE_BINDING_ALL,
+  paths: DISK_PATHS_ALL,
+};
+
+/**
+ * The source actually used, given what's configured on this workspace. The
+ * stored choice wins when that kind is available; otherwise it's forced to the
+ * first configured kind (radarr → sonarr → lidarr). Shared by the card and the
+ * settings panel so they never disagree — mirrors resolveSpeedStatsSource.
+ */
+export function resolveDiskSpaceSource(
+  source: DiskSpaceSource,
+  available: Record<DiskSpaceSource, boolean>,
+): DiskSpaceSource {
+  if (available[source]) return source;
+  return DISK_SPACE_SOURCES.find((s) => available[s]) ?? source;
+}
+
+/** The instance binding field matching the given source. */
+export function diskSpaceBindingFor(
+  settings: DiskSpaceSettingsValue,
+  source: DiskSpaceSource,
+): InstanceBindingValue {
+  switch (source) {
+    case "radarr":
+      return settings.radarrInstanceIds;
+    case "sonarr":
+      return settings.sonarrInstanceIds;
+    case "lidarr":
+      return settings.lidarrInstanceIds;
+  }
+}
+
+const BINDING_FIELD: Record<
+  DiskSpaceSource,
+  "radarrInstanceIds" | "sonarrInstanceIds" | "lidarrInstanceIds"
+> = {
+  radarr: "radarrInstanceIds",
+  sonarr: "sonarrInstanceIds",
+  lidarr: "lidarrInstanceIds",
+};
+
+export function DiskSpaceSettings({ slotId }: WidgetSettingsComponentProps) {
+  const { settings, update } = useWidgetSettings<DiskSpaceSettingsValue>(
+    slotId,
+    DISK_SPACE_DEFAULT_SETTINGS,
+  );
+  // Scoped to the active workspace so the source chips and pickers match what
+  // the card actually renders (#148 pattern).
+  const radarrInstances = useAttachedEnabledInstances("radarr");
+  const sonarrInstances = useAttachedEnabledInstances("sonarr");
+  const lidarrInstances = useAttachedEnabledInstances("lidarr");
+  const available: Record<DiskSpaceSource, boolean> = {
+    radarr: radarrInstances.length > 0,
+    sonarr: sonarrInstances.length > 0,
+    lidarr: lidarrInstances.length > 0,
+  };
+  const source = resolveDiskSpaceSource(settings.source, available);
+  const configuredKinds = DISK_SPACE_SOURCES.filter((s) => available[s]);
+
+  return (
+    <View className="px-4 py-2 gap-5">
+      <SettingsSection label="Title">
+        <TextInput
+          placeholder="e.g. Media NAS"
+          value={settings.title}
+          onChangeText={(title) => update({ title })}
+          maxLength={24}
+          returnKeyType="done"
+        />
+      </SettingsSection>
+
+      {configuredKinds.length > 1 && (
+        <ChipGroup
+          label="Source"
+          options={SOURCE_OPTIONS.filter((o) => available[o.value])}
+          value={source}
+          // The stored paths belong to the previous server's mounts — reset to
+          // "all" so switching source never shows an empty, mystery-filtered card.
+          onChange={(next) => update({ source: next, paths: DISK_PATHS_ALL })}
+        />
+      )}
+
+      {available[source] && (
+        <>
+          <InstancePickerRow
+            serviceId={source}
+            value={diskSpaceBindingFor(settings, source)}
+            onChange={(binding) => update({ [BINDING_FIELD[source]]: binding })}
+          />
+          <DiskPathPickerRow
+            source={source}
+            instanceIds={diskSpaceBindingFor(settings, source)}
+            value={settings.paths}
+            onChange={(paths) => update({ paths })}
+          />
+        </>
+      )}
+    </View>
+  );
+}

--- a/components/dashboard/widget-settings/network-interface-picker-row.tsx
+++ b/components/dashboard/widget-settings/network-interface-picker-row.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { View, Text, Pressable } from "react-native";
-import { Check, ChevronDown, ChevronUp } from "lucide-react-native";
+import { ChevronDown, ChevronUp } from "lucide-react-native";
 import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
 import {
@@ -16,6 +16,7 @@ import {
   resolveBoundInstances,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { SelectRow } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 import { formatSpeed } from "@/lib/utils";
 
 // Re-exported so settings panels can keep importing the value contract from the
@@ -165,43 +166,4 @@ export function NetworkInterfacePickerRow({
 function rateCaption(iface: GlancesNetRate): string {
   if (iface.rx + iface.tx <= 0) return "idle";
   return `↓ ${formatSpeed(iface.rx)}   ↑ ${formatSpeed(iface.tx)}`;
-}
-
-function SelectRow({
-  label,
-  caption,
-  selected,
-  onPress,
-}: {
-  label: string;
-  caption?: string;
-  selected: boolean;
-  onPress: () => void;
-}) {
-  return (
-    <Pressable
-      onPress={onPress}
-      className={`flex-row items-center gap-3 px-3 py-2.5 active:opacity-70 ${
-        selected ? "bg-primary/10" : ""
-      }`}
-    >
-      <View
-        className={`w-5 h-5 rounded-md items-center justify-center border ${
-          selected ? "bg-primary border-primary" : "border-zinc-600"
-        }`}
-      >
-        {selected ? <Icon icon={Check} size={14} color="#fff" /> : null}
-      </View>
-      <View className="flex-1 min-w-0">
-        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
-          {label}
-        </Text>
-        {caption ? (
-          <Text className="text-zinc-500 text-[0.7rem]" numberOfLines={1}>
-            {caption}
-          </Text>
-        ) : null}
-      </View>
-    </Pressable>
-  );
 }

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
-import { View, Text } from "react-native";
+import { View, Text, Pressable } from "react-native";
+import { Check } from "lucide-react-native";
 import { FilterChip } from "@/components/ui/filter-chip";
+import { Icon } from "@/components/ui/icon";
 
 /**
  * Section header + body wrapper used by every widget-settings panel. Keeps
@@ -72,6 +74,49 @@ const DEFAULT_MAX_OPTIONS: readonly { value: number; label: string }[] = [
   { value: 10, label: "10" },
   { value: 20, label: "20" },
 ];
+
+/**
+ * Checkbox row for grouped checklists (interface picker, disk path picker).
+ * Render inside a `bg-surface-light rounded-2xl … divide-y` container.
+ */
+export function SelectRow({
+  label,
+  caption,
+  selected,
+  onPress,
+}: {
+  label: string;
+  caption?: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`flex-row items-center gap-3 px-3 py-2.5 active:opacity-70 ${
+        selected ? "bg-primary/10" : ""
+      }`}
+    >
+      <View
+        className={`w-5 h-5 rounded-md items-center justify-center border ${
+          selected ? "bg-primary border-primary" : "border-zinc-600"
+        }`}
+      >
+        {selected ? <Icon icon={Check} size={14} color="#fff" /> : null}
+      </View>
+      <View className="flex-1 min-w-0">
+        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
+          {label}
+        </Text>
+        {caption ? (
+          <Text className="text-zinc-500 text-[0.7rem]" numberOfLines={1}>
+            {caption}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
 
 /**
  * "Max items" chip selector. Defaults to 3/5/10/20; pass `options` to override

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -93,6 +93,7 @@ export const POLLING_INTERVALS = {
   serviceHealth: 30000,
   queue: 30000,
   calendar: 60000,
+  diskSpace: 60000,
 } as const;
 
 export const DASHBOARD_WIDGET_IDS = [
@@ -116,6 +117,7 @@ export const DASHBOARD_WIDGET_IDS = [
   "prowlarr-stats",
   "bazarr-wanted",
   "wol-devices",
+  "disk-space",
 ] as const;
 
 export type WidgetId = (typeof DASHBOARD_WIDGET_IDS)[number];

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1348,6 +1348,14 @@ const DEMO_RTORRENT_OK_XML = rtResponse(
 // Single-value response for load.start (add torrent).
 const DEMO_RTORRENT_SCALAR_OK_XML = rtResponse(`<value><i4>0</i4></value>`);
 
+// Shared across radarr/sonarr/lidarr — the /diskspace payload is identical on
+// all three. Percentages chosen to exercise the amber (≥70%) and red (≥85%)
+// bar thresholds in demo screenshots.
+const DEMO_ARR_DISKSPACE = [
+  { path: "/", label: "/", freeSpace: 48_000_000_000, totalSpace: 250_000_000_000 }, // ~81% used → amber
+  { path: "/data", label: "/data", freeSpace: 2_400_000_000_000, totalSpace: 16_000_000_000_000 }, // ~85% used → red
+];
+
 export function getDemoResponse(
   serviceId: ServiceId,
   path: string,
@@ -1366,6 +1374,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/calendar")) return DEMO_RADARR_CALENDAR;
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "HD-1080p" }, { id: 2, name: "Ultra-HD" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/movies", freeSpace: 2199023255552 }];
+      if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;
       if (normalized.startsWith("/tag")) return [];
       if (normalized.startsWith("/customfilter")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
@@ -1379,6 +1388,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/queue")) return DEMO_SONARR_QUEUE;
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "Any" }, { id: 2, name: "HD-1080p" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/tv", freeSpace: 2199023255552 }];
+      if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;
       if (normalized.startsWith("/tag")) return [];
       if (normalized.startsWith("/customfilter")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
@@ -1414,6 +1424,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "Lossless" }, { id: 2, name: "Standard" }];
       if (normalized.startsWith("/metadataprofile")) return [{ id: 1, name: "Standard" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/music", freeSpace: 2199023255552 }];
+      if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;
       if (normalized.startsWith("/tag")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
       return undefined;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -475,6 +475,17 @@ export interface ArrCustomFilter {
   filters: ArrFilterClause[];
 }
 
+// --- *arr disk space (identical payload on Radarr v3, Sonarr v3, Lidarr v1) ---
+
+// `GET /diskspace` returns one entry per mount the *arr process can see — the
+// System → Status disk table. Powers the Disk Space dashboard widget.
+export interface ArrDiskSpace {
+  path: string; // mount path, e.g. "/data"
+  label: string; // display label; often equals path, may be "" on some platforms
+  freeSpace: number; // bytes
+  totalSpace: number; // bytes
+}
+
 // --- Sonarr Types ---
 
 export interface SonarrSeries {

--- a/services/arr-diskspace.test.ts
+++ b/services/arr-diskspace.test.ts
@@ -1,0 +1,64 @@
+// Mock native storage before importing — arr-diskspace pulls in http-client →
+// config-store → AsyncStorage/SecureStore at module load. The functions under
+// test are pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { selectDiskSpace, DISK_PATHS_ALL } from "@/services/arr-diskspace";
+import type { ArrDiskSpace } from "@/lib/types";
+
+function disk(path: string, freeSpace = 100, totalSpace = 1000): ArrDiskSpace {
+  return { path, label: path, freeSpace, totalSpace };
+}
+
+describe("selectDiskSpace", () => {
+  it("returns [] for undefined input", () => {
+    expect(selectDiskSpace(undefined, DISK_PATHS_ALL)).toEqual([]);
+    expect(selectDiskSpace(undefined, ["/data"])).toEqual([]);
+  });
+
+  it('"all" returns every mount sorted by path', () => {
+    const disks = [disk("/media"), disk("/"), disk("/data")];
+    expect(selectDiskSpace(disks, DISK_PATHS_ALL).map((d) => d.path)).toEqual([
+      "/",
+      "/data",
+      "/media",
+    ]);
+  });
+
+  it("an explicit subset filters by exact path, still sorted", () => {
+    const disks = [disk("/media"), disk("/"), disk("/data")];
+    expect(selectDiskSpace(disks, ["/media", "/data"]).map((d) => d.path)).toEqual([
+      "/data",
+      "/media",
+    ]);
+  });
+
+  it("selection naming a vanished mount just omits it", () => {
+    const disks = [disk("/data")];
+    expect(selectDiskSpace(disks, ["/gone", "/data"]).map((d) => d.path)).toEqual([
+      "/data",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const disks = [disk("/media"), disk("/")];
+    selectDiskSpace(disks, DISK_PATHS_ALL);
+    expect(disks.map((d) => d.path)).toEqual(["/media", "/"]);
+  });
+});

--- a/services/arr-diskspace.ts
+++ b/services/arr-diskspace.ts
@@ -1,0 +1,37 @@
+import { serviceRequest } from "@/lib/http-client";
+import type { ArrDiskSpace } from "@/lib/types";
+
+// Radarr, Sonarr and Lidarr all expose the System → Status disk table at
+// /diskspace with X-Api-Key auth and an identical payload, so one function
+// serves all three (SERVICE_DEFAULTS already routes each kind's API base path).
+export type ArrDiskSpaceService = "radarr" | "sonarr" | "lidarr";
+
+export function getArrDiskSpace(
+  service: ArrDiskSpaceService,
+  instanceId?: string,
+): Promise<ArrDiskSpace[]> {
+  return serviceRequest<ArrDiskSpace[]>(service, "/diskspace", { instanceId });
+}
+
+// Special sentinel used in widget settings to mean "show every mount the
+// source reports". Stored as a string (not null) so it survives JSON
+// export/import, and so mounts that appear later are auto-included — mirrors
+// INSTANCE_BINDING_ALL / NETWORK_INTERFACES_ALL.
+export const DISK_PATHS_ALL = "all" as const;
+export type DiskPathsValue = string[] | typeof DISK_PATHS_ALL;
+
+/**
+ * Apply a widget's path selection to a /diskspace payload. Always sorts by
+ * path — the API order is arbitrary and would shuffle rows between polls.
+ * "all" returns everything; an array restricts to those exact path strings.
+ */
+export function selectDiskSpace(
+  disks: ArrDiskSpace[] | undefined,
+  selection: DiskPathsValue,
+): ArrDiskSpace[] {
+  if (!disks) return [];
+  const sorted = [...disks].sort((a, b) => a.path.localeCompare(b.path));
+  if (selection === DISK_PATHS_ALL) return sorted;
+  const allowed = new Set(selection);
+  return sorted.filter((d) => allowed.has(d.path));
+}


### PR DESCRIPTION
## Summary
- New **Disk Space** dashboard widget: per-mount usage bars (free/total, amber ≥70% / red ≥85%) from Radarr/Sonarr/Lidarr `/diskspace` — no Glances needed (Refs #63, #181)
- Settings: title, one source per widget (auto-forced when only one kind configured), per-source instance bindings, mount/path picker (default all)
- Extracted shared `DiskUsageRow` from server-stats and `SelectRow` from the network interface picker (no visual change)
- Demo-mode fixtures; fixed pre-existing Reanimated warning in add-widget sheet rows (entering animation + press-scale transform shared one view)

## Test plan
- `tsc --noEmit` clean, jest 24 suites / 593 tests pass (2 new suites)
- Manual: widget appears in Add Widget with *arr attached; source chips only with 2+ kinds; path picker hides mounts; per-instance sections with 2 bound instances; server down shows "Could not reach …"; Server Stats disks render unchanged