### PR TITLE
feat(sonarr): edit series type, season folders & monitor new seasons (Refs #184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 
 ---
 
+## Supporters
+
+A huge thank you to everyone who has supported Dashboarr's development on Ko-fi. Your generosity helps keep the project alive!
+
+<a href="https://ko-fi.com/renzobeux"><img src="https://img.shields.io/badge/Ko--fi-Support%20on%20Ko--fi-FF5E5B?logo=ko-fi&logoColor=white&style=for-the-badge" alt="Support on Ko-fi" height="40" /></a>
+
 ## Contributors
 
 Thanks to everyone who has contributed to Dashboarr!

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -48,11 +48,12 @@ import {
   useToggleSeriesMonitored,
   useDeleteSeries,
   useSonarrQualityProfiles,
-  useUpdateSeriesQualityProfile,
+  useUpdateSeriesFields,
   useSonarrRootFolders,
   useUpdateSeriesRootFolder,
   useSonarrTags,
 } from "@/hooks/use-sonarr";
+import { SERIES_TYPE_OPTIONS } from "@/components/sonarr/add-series-sheet";
 import {
   formatEpisodeCode,
   formatBytes,
@@ -87,7 +88,8 @@ export default function SeriesDetailScreen() {
   const searchSeries = useSearchForSeries(instanceId);
   const deleteSeries = useDeleteSeries(instanceId);
   const { data: qualityProfiles } = useSonarrQualityProfiles(instanceId);
-  const updateProfile = useUpdateSeriesQualityProfile(instanceId);
+  const updateProfile = useUpdateSeriesFields(instanceId);
+  const updateOptions = useUpdateSeriesFields(instanceId);
   const { data: rootFolders } = useSonarrRootFolders(instanceId);
   const updateRootFolder = useUpdateSeriesRootFolder(instanceId);
   const { data: tags } = useSonarrTags(instanceId);
@@ -95,6 +97,9 @@ export default function SeriesDetailScreen() {
   const [actionsVisible, setActionsVisible] = useState(false);
   const [pendingSeriesSearch, setPendingSeriesSearch] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
+  const [optionSheet, setOptionSheet] = useState<
+    "type" | "seasonFolder" | "newSeasons" | null
+  >(null);
   const [rootFolderVisible, setRootFolderVisible] = useState(false);
   const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(
     null,
@@ -167,6 +172,9 @@ export default function SeriesDetailScreen() {
   const handleToggleMonitor = () => {
     toggleSeries.mutate({ seriesId: series.id, monitored: !series.monitored });
   };
+
+  const setSeriesField = (fields: Partial<SonarrSeries>, errorLabel: string) =>
+    updateOptions.mutate({ seriesId: series.id, fields, errorLabel });
 
   const confirmDelete = () => {
     if (!pendingDelete) return;
@@ -261,6 +269,8 @@ export default function SeriesDetailScreen() {
                 : undefined
             }
           />
+
+          <OptionsBlock series={series} onPress={setOptionSheet} />
 
           {series.overview ? (
             <View className="mb-5">
@@ -369,8 +379,108 @@ export default function SeriesDetailScreen() {
             if (p.id === series.qualityProfileId) return;
             updateProfile.mutate({
               seriesId: series.id,
-              qualityProfileId: p.id,
+              fields: { qualityProfileId: p.id },
+              errorLabel: "Failed to update quality profile",
             });
+          },
+        }))}
+      />
+
+      <ActionSheet
+        visible={optionSheet === "type"}
+        onClose={() => setOptionSheet(null)}
+        title="Series Type"
+        subtitle={series.title}
+        actions={SERIES_TYPE_OPTIONS.map((opt) => ({
+          label: opt.label,
+          description: opt.description,
+          icon: (
+            <Icon
+              icon={opt.value === series.seriesType ? Check : Circle}
+              size={18}
+              color={opt.value === series.seriesType ? "#60a5fa" : "#71717a"}
+            />
+          ),
+          onPress: () => {
+            if (opt.value === series.seriesType) return;
+            setSeriesField(
+              { seriesType: opt.value },
+              "Failed to update series type",
+            );
+          },
+        }))}
+      />
+
+      <ActionSheet
+        visible={optionSheet === "seasonFolder"}
+        onClose={() => setOptionSheet(null)}
+        title="Season Folders"
+        subtitle={series.title}
+        actions={[
+          {
+            value: true,
+            label: "Use Season Folders",
+            description: "Sort episodes into season folders",
+          },
+          {
+            value: false,
+            label: "No Season Folders",
+            description: "Keep episodes directly in the series folder",
+          },
+        ].map((opt) => ({
+          label: opt.label,
+          description: opt.description,
+          icon: (
+            <Icon
+              icon={opt.value === series.seasonFolder ? Check : Circle}
+              size={18}
+              color={opt.value === series.seasonFolder ? "#60a5fa" : "#71717a"}
+            />
+          ),
+          onPress: () => {
+            if (opt.value === series.seasonFolder) return;
+            setSeriesField(
+              { seasonFolder: opt.value },
+              "Failed to update season folders",
+            );
+          },
+        }))}
+      />
+
+      <ActionSheet
+        visible={optionSheet === "newSeasons"}
+        onClose={() => setOptionSheet(null)}
+        title="Monitor New Seasons"
+        subtitle={series.title}
+        actions={[
+          {
+            value: "all" as const,
+            label: "All Seasons",
+            description: "Monitor new seasons automatically",
+          },
+          {
+            value: "none" as const,
+            label: "None",
+            description: "Don't monitor new seasons",
+          },
+        ].map((opt) => ({
+          label: opt.label,
+          description: opt.description,
+          icon: (
+            <Icon
+              icon={opt.value === series.monitorNewItems ? Check : Circle}
+              size={18}
+              color={
+                opt.value === series.monitorNewItems ? "#60a5fa" : "#71717a"
+              }
+            />
+          ),
+          onPress: () => {
+            if (opt.value === series.monitorNewItems) return;
+            setSeriesField(
+              { monitorNewItems: opt.value },
+              "Failed to update new season monitoring",
+            );
           },
         }))}
       />
@@ -637,6 +747,69 @@ function AboutRow({
   }
 
   return <View className="flex-row items-center">{content}</View>;
+}
+
+// Editable Sonarr series options (issue #184): series type, season folders,
+// monitor-new-seasons. Each row opens an ActionSheet picker.
+function OptionsBlock({
+  series,
+  onPress,
+}: {
+  series: SonarrSeries;
+  onPress: (sheet: "type" | "seasonFolder" | "newSeasons") => void;
+}) {
+  const typeLabel =
+    SERIES_TYPE_OPTIONS.find((o) => o.value === series.seriesType)?.label ??
+    capitalize(series.seriesType);
+  return (
+    <View className="mb-5">
+      <SectionLabel>Options</SectionLabel>
+      <View className="rounded-2xl bg-surface border border-border p-4 gap-2.5">
+        <OptionRow
+          label="Series Type"
+          value={typeLabel}
+          onPress={() => onPress("type")}
+        />
+        <OptionRow
+          label="Season Folders"
+          value={series.seasonFolder ? "Yes" : "No"}
+          onPress={() => onPress("seasonFolder")}
+        />
+        {/* "Monitor New Seasons" only exists on Sonarr v4+ — hide otherwise. */}
+        {series.monitorNewItems != null ? (
+          <OptionRow
+            label="Monitor New Seasons"
+            value={series.monitorNewItems === "all" ? "All Seasons" : "None"}
+            onPress={() => onPress("newSeasons")}
+          />
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function OptionRow({
+  label,
+  value,
+  onPress,
+}: {
+  label: string;
+  value: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center active:opacity-60"
+      hitSlop={6}
+    >
+      <Text className="text-zinc-500 text-[0.65rem] uppercase font-semibold tracking-wider flex-1">
+        {label}
+      </Text>
+      <Text className="text-zinc-300 text-xs ml-2 mr-1">{value}</Text>
+      <Icon icon={ChevronRight} size={14} color="#71717a" />
+    </Pressable>
+  );
 }
 
 function SeasonAccordion({

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -14,6 +14,7 @@ import {
   Tv,
   Circle,
   FolderTree,
+  Pencil,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { toastError } from "@/components/ui/toast";
@@ -54,6 +55,7 @@ import {
   useSonarrTags,
 } from "@/hooks/use-sonarr";
 import { SERIES_TYPE_OPTIONS } from "@/components/sonarr/add-series-sheet";
+import { SeriesOptionsSheet } from "@/components/sonarr/series-options-sheet";
 import {
   formatEpisodeCode,
   formatBytes,
@@ -89,7 +91,6 @@ export default function SeriesDetailScreen() {
   const deleteSeries = useDeleteSeries(instanceId);
   const { data: qualityProfiles } = useSonarrQualityProfiles(instanceId);
   const updateProfile = useUpdateSeriesFields(instanceId);
-  const updateOptions = useUpdateSeriesFields(instanceId);
   const { data: rootFolders } = useSonarrRootFolders(instanceId);
   const updateRootFolder = useUpdateSeriesRootFolder(instanceId);
   const { data: tags } = useSonarrTags(instanceId);
@@ -97,9 +98,7 @@ export default function SeriesDetailScreen() {
   const [actionsVisible, setActionsVisible] = useState(false);
   const [pendingSeriesSearch, setPendingSeriesSearch] = useState(false);
   const [qualityVisible, setQualityVisible] = useState(false);
-  const [optionSheet, setOptionSheet] = useState<
-    "type" | "seasonFolder" | "newSeasons" | null
-  >(null);
+  const [optionsVisible, setOptionsVisible] = useState(false);
   const [rootFolderVisible, setRootFolderVisible] = useState(false);
   const [pendingRootFolder, setPendingRootFolder] = useState<string | null>(
     null,
@@ -172,9 +171,6 @@ export default function SeriesDetailScreen() {
   const handleToggleMonitor = () => {
     toggleSeries.mutate({ seriesId: series.id, monitored: !series.monitored });
   };
-
-  const setSeriesField = (fields: Partial<SonarrSeries>, errorLabel: string) =>
-    updateOptions.mutate({ seriesId: series.id, fields, errorLabel });
 
   const confirmDelete = () => {
     if (!pendingDelete) return;
@@ -270,7 +266,10 @@ export default function SeriesDetailScreen() {
             }
           />
 
-          <OptionsBlock series={series} onPress={setOptionSheet} />
+          <OptionsBlock
+            series={series}
+            onPress={() => setOptionsVisible(true)}
+          />
 
           {series.overview ? (
             <View className="mb-5">
@@ -386,103 +385,11 @@ export default function SeriesDetailScreen() {
         }))}
       />
 
-      <ActionSheet
-        visible={optionSheet === "type"}
-        onClose={() => setOptionSheet(null)}
-        title="Series Type"
-        subtitle={series.title}
-        actions={SERIES_TYPE_OPTIONS.map((opt) => ({
-          label: opt.label,
-          description: opt.description,
-          icon: (
-            <Icon
-              icon={opt.value === series.seriesType ? Check : Circle}
-              size={18}
-              color={opt.value === series.seriesType ? "#60a5fa" : "#71717a"}
-            />
-          ),
-          onPress: () => {
-            if (opt.value === series.seriesType) return;
-            setSeriesField(
-              { seriesType: opt.value },
-              "Failed to update series type",
-            );
-          },
-        }))}
-      />
-
-      <ActionSheet
-        visible={optionSheet === "seasonFolder"}
-        onClose={() => setOptionSheet(null)}
-        title="Season Folders"
-        subtitle={series.title}
-        actions={[
-          {
-            value: true,
-            label: "Use Season Folders",
-            description: "Sort episodes into season folders",
-          },
-          {
-            value: false,
-            label: "No Season Folders",
-            description: "Keep episodes directly in the series folder",
-          },
-        ].map((opt) => ({
-          label: opt.label,
-          description: opt.description,
-          icon: (
-            <Icon
-              icon={opt.value === series.seasonFolder ? Check : Circle}
-              size={18}
-              color={opt.value === series.seasonFolder ? "#60a5fa" : "#71717a"}
-            />
-          ),
-          onPress: () => {
-            if (opt.value === series.seasonFolder) return;
-            setSeriesField(
-              { seasonFolder: opt.value },
-              "Failed to update season folders",
-            );
-          },
-        }))}
-      />
-
-      <ActionSheet
-        visible={optionSheet === "newSeasons"}
-        onClose={() => setOptionSheet(null)}
-        title="Monitor New Seasons"
-        subtitle={series.title}
-        actions={[
-          {
-            value: "all" as const,
-            label: "All Seasons",
-            description: "Monitor new seasons automatically",
-          },
-          {
-            value: "none" as const,
-            label: "None",
-            description: "Don't monitor new seasons",
-          },
-        ].map((opt) => ({
-          label: opt.label,
-          description: opt.description,
-          icon: (
-            <Icon
-              icon={opt.value === series.monitorNewItems ? Check : Circle}
-              size={18}
-              color={
-                opt.value === series.monitorNewItems ? "#60a5fa" : "#71717a"
-              }
-            />
-          ),
-          onPress: () => {
-            if (opt.value === series.monitorNewItems) return;
-            setSeriesField(
-              { monitorNewItems: opt.value },
-              "Failed to update new season monitoring",
-            );
-          },
-        }))}
+      <SeriesOptionsSheet
+        visible={optionsVisible}
+        onClose={() => setOptionsVisible(false)}
+        series={series}
+        instanceId={instanceId}
       />
 
       <ActionSheet
@@ -749,14 +656,15 @@ function AboutRow({
   return <View className="flex-row items-center">{content}</View>;
 }
 
-// Editable Sonarr series options (issue #184): series type, season folders,
-// monitor-new-seasons. Each row opens an ActionSheet picker.
+// Sonarr series options (issue #184): series type, season folders,
+// monitor-new-seasons. The whole card is one tap target — small per-row
+// targets are fiddly on phones — and opens the SeriesOptionsSheet editor.
 function OptionsBlock({
   series,
   onPress,
 }: {
   series: SonarrSeries;
-  onPress: (sheet: "type" | "seasonFolder" | "newSeasons") => void;
+  onPress: () => void;
 }) {
   const typeLabel =
     SERIES_TYPE_OPTIONS.find((o) => o.value === series.seriesType)?.label ??
@@ -764,51 +672,42 @@ function OptionsBlock({
   return (
     <View className="mb-5">
       <SectionLabel>Options</SectionLabel>
-      <View className="rounded-2xl bg-surface border border-border p-4 gap-2.5">
-        <OptionRow
-          label="Series Type"
-          value={typeLabel}
-          onPress={() => onPress("type")}
-        />
-        <OptionRow
-          label="Season Folders"
-          value={series.seasonFolder ? "Yes" : "No"}
-          onPress={() => onPress("seasonFolder")}
-        />
-        {/* "Monitor New Seasons" only exists on Sonarr v4+ — hide otherwise. */}
-        {series.monitorNewItems != null ? (
+      <Pressable
+        onPress={onPress}
+        className="rounded-2xl bg-surface border border-border p-4 flex-row items-center active:opacity-70"
+        accessibilityRole="button"
+        accessibilityLabel="Edit series options"
+      >
+        <View className="flex-1 gap-2.5">
+          <OptionRow label="Series Type" value={typeLabel} />
           <OptionRow
-            label="Monitor New Seasons"
-            value={series.monitorNewItems === "all" ? "All Seasons" : "None"}
-            onPress={() => onPress("newSeasons")}
+            label="Season Folders"
+            value={series.seasonFolder ? "Yes" : "No"}
           />
-        ) : null}
-      </View>
+          {/* "Monitor New Seasons" only exists on Sonarr v4+ — hide otherwise. */}
+          {series.monitorNewItems != null ? (
+            <OptionRow
+              label="Monitor New Seasons"
+              value={series.monitorNewItems === "all" ? "All Seasons" : "None"}
+            />
+          ) : null}
+        </View>
+        <View className="ml-3 w-9 h-9 rounded-full bg-surface-light items-center justify-center">
+          <Icon icon={Pencil} size={16} color="#a1a1aa" />
+        </View>
+      </Pressable>
     </View>
   );
 }
 
-function OptionRow({
-  label,
-  value,
-  onPress,
-}: {
-  label: string;
-  value: string;
-  onPress: () => void;
-}) {
+function OptionRow({ label, value }: { label: string; value: string }) {
   return (
-    <Pressable
-      onPress={onPress}
-      className="flex-row items-center active:opacity-60"
-      hitSlop={6}
-    >
+    <View className="flex-row items-center">
       <Text className="text-zinc-500 text-[0.65rem] uppercase font-semibold tracking-wider flex-1">
         {label}
       </Text>
-      <Text className="text-zinc-300 text-xs ml-2 mr-1">{value}</Text>
-      <Icon icon={ChevronRight} size={14} color="#71717a" />
-    </Pressable>
+      <Text className="text-zinc-300 text-xs ml-2">{value}</Text>
+    </View>
   );
 }
 

--- a/components/sonarr/add-series-sheet.tsx
+++ b/components/sonarr/add-series-sheet.tsx
@@ -10,11 +10,8 @@ import {
   useSonarrRootFolders,
   useSonarrTags,
 } from "@/hooks/use-sonarr";
-import type {
-  SonarrMonitorOption,
-  SonarrSeriesType,
-} from "@/services/sonarr-api";
-import type { SonarrSearchResult } from "@/lib/types";
+import type { SonarrMonitorOption } from "@/services/sonarr-api";
+import type { SonarrSearchResult, SonarrSeriesType } from "@/lib/types";
 
 interface AddSeriesSheetProps {
   result: SonarrSearchResult | null;
@@ -38,7 +35,8 @@ const MONITOR_OPTIONS: {
   { value: "none", label: "None", description: "Don't monitor any episodes" },
 ];
 
-const SERIES_TYPE_OPTIONS: {
+// Shared with the series detail screen's Series Type picker.
+export const SERIES_TYPE_OPTIONS: {
   value: SonarrSeriesType;
   label: string;
   description: string;

--- a/components/sonarr/series-options-sheet.tsx
+++ b/components/sonarr/series-options-sheet.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { Modal, ScrollView, View } from "react-native";
+import { Select } from "@/components/ui/select";
+import { Toggle } from "@/components/ui/toggle";
+import { Button } from "@/components/ui/button";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { SERIES_TYPE_OPTIONS } from "@/components/sonarr/add-series-sheet";
+import { useUpdateSeriesFields } from "@/hooks/use-sonarr";
+import type { SonarrSeries, SonarrSeriesType } from "@/lib/types";
+
+const NEW_SEASONS_OPTIONS: {
+  value: "all" | "none";
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "all",
+    label: "All Seasons",
+    description: "Monitor new seasons automatically",
+  },
+  { value: "none", label: "None", description: "Don't monitor new seasons" },
+];
+
+interface SeriesOptionsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  series: SonarrSeries;
+  instanceId?: string;
+}
+
+// Editable Sonarr series options (issue #184). A dedicated sheet with
+// full-size Select/Toggle controls instead of small tappable rows; Save sends
+// all changed fields in a single PUT.
+export function SeriesOptionsSheet({
+  visible,
+  onClose,
+  series,
+  instanceId,
+}: SeriesOptionsSheetProps) {
+  const updateFields = useUpdateSeriesFields(instanceId);
+
+  const [seriesType, setSeriesType] = useState<SonarrSeriesType>(
+    series.seriesType,
+  );
+  const [seasonFolder, setSeasonFolder] = useState(series.seasonFolder);
+  const [monitorNewItems, setMonitorNewItems] = useState(
+    series.monitorNewItems,
+  );
+
+  // Re-seed from the server values whenever the sheet opens.
+  useEffect(() => {
+    if (!visible) return;
+    setSeriesType(series.seriesType);
+    setSeasonFolder(series.seasonFolder);
+    setMonitorNewItems(series.monitorNewItems);
+  }, [visible, series]);
+
+  const fields: Partial<SonarrSeries> = {};
+  if (seriesType !== series.seriesType) fields.seriesType = seriesType;
+  if (seasonFolder !== series.seasonFolder) fields.seasonFolder = seasonFolder;
+  if (monitorNewItems != null && monitorNewItems !== series.monitorNewItems) {
+    fields.monitorNewItems = monitorNewItems;
+  }
+  const dirty = Object.keys(fields).length > 0;
+
+  const handleSave = () => {
+    if (!dirty) return;
+    // Optimistic update keeps the Options card in sync immediately; on error
+    // the hook rolls the caches back and shows a toast.
+    updateFields.mutate({
+      seriesId: series.id,
+      fields,
+      errorLabel: "Failed to update series options",
+    });
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Series Options" onClose={onClose} />
+
+        <ScrollView contentContainerClassName="px-4 py-4 pb-8">
+          {/* "Monitor New Seasons" only exists on Sonarr v4+ — hide otherwise. */}
+          {series.monitorNewItems != null ? (
+            <Select
+              label="Monitor New Seasons"
+              value={monitorNewItems}
+              options={NEW_SEASONS_OPTIONS}
+              onChange={setMonitorNewItems}
+              containerClassName="mb-4"
+            />
+          ) : null}
+
+          <Select
+            label="Series Type"
+            value={seriesType}
+            options={SERIES_TYPE_OPTIONS}
+            onChange={setSeriesType}
+            containerClassName="mb-2"
+          />
+
+          <Toggle
+            label="Season Folder"
+            description="Organize episodes into season subfolders"
+            value={seasonFolder}
+            onValueChange={setSeasonFolder}
+            className="mb-4"
+          />
+
+          <Button label="Save" onPress={handleSave} disabled={!dirty} />
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/components/ui/action-sheet.tsx
+++ b/components/ui/action-sheet.tsx
@@ -38,8 +38,6 @@ export type ActionSheetVariant = "default" | "danger";
 
 export interface ActionSheetAction {
   label: string;
-  /** Optional helper text rendered under the label. */
-  description?: string;
   icon?: React.ReactNode;
   variant?: ActionSheetVariant;
   disabled?: boolean;
@@ -250,23 +248,16 @@ function ActionRow({ action, onPress }: ActionRowProps) {
             {action.icon}
           </View>
         )}
-        <View className="flex-1">
-          <Text
-            className={`text-base ${
-              isDanger
-                ? "text-danger font-semibold"
-                : "text-zinc-100 font-medium"
-            }`}
-            numberOfLines={1}
-          >
-            {action.label}
-          </Text>
-          {action.description ? (
-            <Text className="text-zinc-500 text-xs mt-0.5" numberOfLines={2}>
-              {action.description}
-            </Text>
-          ) : null}
-        </View>
+        <Text
+          className={`flex-1 text-base ${
+            isDanger
+              ? "text-danger font-semibold"
+              : "text-zinc-100 font-medium"
+          }`}
+          numberOfLines={1}
+        >
+          {action.label}
+        </Text>
       </Pressable>
     </Animated.View>
   );

--- a/components/ui/action-sheet.tsx
+++ b/components/ui/action-sheet.tsx
@@ -38,6 +38,8 @@ export type ActionSheetVariant = "default" | "danger";
 
 export interface ActionSheetAction {
   label: string;
+  /** Optional helper text rendered under the label. */
+  description?: string;
   icon?: React.ReactNode;
   variant?: ActionSheetVariant;
   disabled?: boolean;
@@ -248,16 +250,23 @@ function ActionRow({ action, onPress }: ActionRowProps) {
             {action.icon}
           </View>
         )}
-        <Text
-          className={`flex-1 text-base ${
-            isDanger
-              ? "text-danger font-semibold"
-              : "text-zinc-100 font-medium"
-          }`}
-          numberOfLines={1}
-        >
-          {action.label}
-        </Text>
+        <View className="flex-1">
+          <Text
+            className={`text-base ${
+              isDanger
+                ? "text-danger font-semibold"
+                : "text-zinc-100 font-medium"
+            }`}
+            numberOfLines={1}
+          >
+            {action.label}
+          </Text>
+          {action.description ? (
+            <Text className="text-zinc-500 text-xs mt-0.5" numberOfLines={2}>
+              {action.description}
+            </Text>
+          ) : null}
+        </View>
       </Pressable>
     </Animated.View>
   );

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -285,16 +285,20 @@ export function useToggleSeriesMonitored(instanceId?: string) {
   });
 }
 
-export function useUpdateSeriesQualityProfile(instanceId?: string) {
+// Generic series field update (quality profile, series type, season folder,
+// monitor-new-seasons, …): forwards the cached series with `fields` overridden
+// via full PUT and mirrors the change optimistically into both caches.
+export function useUpdateSeriesFields(instanceId?: string) {
   const queryClient = useQueryClient();
   const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
   return useMutation({
     mutationFn: ({
       seriesId,
-      qualityProfileId,
+      fields,
     }: {
       seriesId: number;
-      qualityProfileId: number;
+      fields: Partial<SonarrSeries>;
+      errorLabel?: string;
     }) => {
       const cached = queryClient.getQueryData<SonarrSeries>([
         "sonarr",
@@ -303,9 +307,9 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
         seriesId,
       ]);
       if (!cached) throw new Error("Series not loaded");
-      return updateSeries({ ...cached, qualityProfileId }, id ?? undefined);
+      return updateSeries({ ...cached, ...fields }, id ?? undefined);
     },
-    onMutate: async ({ seriesId, qualityProfileId }) => {
+    onMutate: async ({ seriesId, fields }) => {
       await queryClient.cancelQueries({
         queryKey: ["sonarr", id, "series", seriesId],
       });
@@ -326,21 +330,19 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
       if (prevDetail) {
         queryClient.setQueryData<SonarrSeries>(
           ["sonarr", id, "series", seriesId],
-          { ...prevDetail, qualityProfileId },
+          { ...prevDetail, ...fields },
         );
       }
       if (prevList) {
         queryClient.setQueryData<SonarrSeries[]>(
           ["sonarr", id, "series"],
-          prevList.map((s) =>
-            s.id === seriesId ? { ...s, qualityProfileId } : s,
-          ),
+          prevList.map((s) => (s.id === seriesId ? { ...s, ...fields } : s)),
         );
       }
 
       return { prevDetail, prevList };
     },
-    onError: (err, { seriesId }, context) => {
+    onError: (err, { seriesId, errorLabel }, context) => {
       if (context?.prevDetail) {
         queryClient.setQueryData(
           ["sonarr", id, "series", seriesId],
@@ -350,7 +352,7 @@ export function useUpdateSeriesQualityProfile(instanceId?: string) {
       if (context?.prevList) {
         queryClient.setQueryData(["sonarr", id, "series"], context.prevList);
       }
-      toastError("Failed to update quality profile", err);
+      toastError(errorLabel ?? "Failed to update series", err);
     },
     onSettled: (_data, _err, { seriesId }) => {
       queryClient.invalidateQueries({

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -488,6 +488,8 @@ export interface ArrDiskSpace {
 
 // --- Sonarr Types ---
 
+export type SonarrSeriesType = "standard" | "daily" | "anime";
+
 export interface SonarrSeries {
   id: number;
   title: string;
@@ -509,6 +511,10 @@ export interface SonarrSeries {
   seasons: SonarrSeason[];
   qualityProfileId: number;
   rootFolderPath: string;
+  seriesType: SonarrSeriesType;
+  seasonFolder: boolean;
+  // "Monitor New Seasons" — Sonarr v4+; absent on older v3 servers.
+  monitorNewItems?: "all" | "none";
   ratings?: RatingsBundle;
   genres?: string[];
   tags?: number[];

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -7,6 +7,7 @@ import type {
   SonarrQueue,
   SonarrHistory,
   SonarrSearchResult,
+  SonarrSeriesType,
   SonarrImage,
   SonarrRelease,
 } from "@/lib/types";
@@ -163,8 +164,6 @@ export function searchSeries(
 }
 
 // --- Add Series ---
-
-export type SonarrSeriesType = "standard" | "daily" | "anime";
 
 export type SonarrMonitorOption =
   | "all"


### PR DESCRIPTION
Adds the remaining Sonarr edit options to the series detail page (Refs #184): an **Options** card (Series Type, Season Folders, Monitor New Seasons) where the whole card is a single tap target opening a **Series Options** sheet — full-size Select/Toggle controls (same primitives as Add Series) with a Save button that sends all changed fields in one PUT.

- `monitorNewItems` is Sonarr v4+; control and row hidden when the server doesn't return it
- Generalized `useUpdateSeriesQualityProfile` into `useUpdateSeriesFields` (one optimistic full-PUT mutation for all field edits)
- Field names/enums verified against Sonarr's OpenAPI spec (`monitorNewItems: all|none`, `seriesType: standard|daily|anime`, `seasonFolder: boolean`)

Test plan: tsc clean, 593 jest tests pass; verify on device — edit each option, save, confirm values persist in Sonarr web UI and after pull-to-refresh.