### PR TITLE
feat(dashboard): Still Pending widget for overdue movies/episodes (Refs #134)

### DIFF
--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable } from "react-native";
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
 import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 import { Tv, Film, Check, Download, type LucideIcon } from "lucide-react-native";
@@ -38,6 +38,12 @@ export interface CalendarEventRowProps {
   onPress: () => void;
   /** Optional long-press (e.g. the TV calendar opens an episode action sheet). */
   onLongPress?: () => void;
+  /**
+   * Optional trailing action button. When set it replaces the static status
+   * badge (e.g. the Still Pending widget puts a per-row search trigger there —
+   * every row is missing, so the badge would be redundant).
+   */
+  action?: { icon: LucideIcon; onPress: () => void; loading?: boolean };
 }
 
 /**
@@ -56,6 +62,7 @@ export function CalendarEventRow({
   hasFile,
   onPress,
   onLongPress,
+  action,
 }: CalendarEventRowProps) {
   const scale = useUiScale();
   const rowHeight = Math.round(ROW_HEIGHT * scale);
@@ -138,21 +145,36 @@ export function CalendarEventRow({
           </Text>
         </View>
 
-        {/* Status badge — explicit downloaded / not-yet state. */}
-        <View
-          className="w-7 h-7 rounded-full items-center justify-center"
-          style={{
-            backgroundColor: hasFile
-              ? "rgba(34, 197, 94, 0.2)"
-              : "rgba(255, 255, 255, 0.12)",
-          }}
-        >
-          <Icon
-            icon={hasFile ? Check : Download}
-            size={14}
-            color={hasFile ? DOWNLOADED : "#d4d4d8"}
-          />
-        </View>
+        {action ? (
+          <Pressable
+            onPress={action.loading ? undefined : action.onPress}
+            hitSlop={8}
+            className="w-7 h-7 rounded-full items-center justify-center active:opacity-70"
+            style={{ backgroundColor: "rgba(255, 255, 255, 0.12)" }}
+          >
+            {action.loading ? (
+              <ActivityIndicator size="small" color="#d4d4d8" />
+            ) : (
+              <Icon icon={action.icon} size={14} color="#d4d4d8" />
+            )}
+          </Pressable>
+        ) : (
+          /* Status badge — explicit downloaded / not-yet state. */
+          <View
+            className="w-7 h-7 rounded-full items-center justify-center"
+            style={{
+              backgroundColor: hasFile
+                ? "rgba(34, 197, 94, 0.2)"
+                : "rgba(255, 255, 255, 0.12)",
+            }}
+          >
+            <Icon
+              icon={hasFile ? Check : Download}
+              size={14}
+              color={hasFile ? DOWNLOADED : "#d4d4d8"}
+            />
+          </View>
+        )}
       </View>
     </Pressable>
   );

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -36,7 +36,9 @@ type PendingItem =
   | { kind: "movie"; date: string; movie: RadarrMovie; instanceId: string };
 
 // The calendar widget owns today and the future; this widget lists what's
-// strictly overdue, so an item never appears on both cards.
+// strictly overdue, so by default an item never appears on both cards. The
+// "Include today" setting opts into already-aired/released same-day items at
+// the cost of them showing on both cards.
 export function StillPendingCard({ slotId }: WidgetComponentProps) {
   const router = useRouter();
   const { settings } = useWidgetSettings<StillPendingSettingsValue>(
@@ -101,7 +103,15 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
         // cheap guard. Undated episodes (unaired specials) are skipped.
         if (ep.hasFile || !ep.monitored || !ep.series) continue;
         const date = ep.airDate ?? ep.airDateUtc?.slice(0, 10);
-        if (!date || date < cutoffIso || date >= todayIso) continue;
+        if (!date || date < cutoffIso || date > todayIso) continue;
+        if (date === todayIso) {
+          if (!settings.includeToday) continue;
+          // Today is hour-granular: only count an episode once its air time
+          // has actually passed, so a primetime slot isn't "overdue" at 9am.
+          const airedAt = ep.airDateUtc ? new Date(ep.airDateUtc).getTime() : null;
+          if (airedAt === null || !Number.isFinite(airedAt) || airedAt > Date.now())
+            continue;
+        }
         items.push({ kind: "episode", date, entry: ep, instanceId });
       }
     });
@@ -116,7 +126,10 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
         const t = radarrReleaseTime(movie);
         if (t === null) continue;
         const date = localDateKey(new Date(t));
-        if (date < cutoffIso || date >= todayIso) continue;
+        if (date < cutoffIso || date > todayIso) continue;
+        // Movie release dates are day-granular — no air time to wait for, so
+        // a today-dated movie is included outright when the toggle is on.
+        if (date === todayIso && !settings.includeToday) continue;
         items.push({ kind: "movie", date, movie, instanceId });
       }
     });
@@ -167,7 +180,11 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
         <View className="gap-4">
           {grouped.map(({ date, entries }) => (
             <View key={date} className="gap-2">
-              <Text className="text-xs font-semibold text-zinc-500">
+              <Text
+                className={`text-xs font-semibold ${
+                  date === todayIso ? "text-primary" : "text-zinc-500"
+                }`}
+              >
                 {relativeDate(date)}
               </Text>
               <View className="gap-2">

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -1,0 +1,302 @@
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import { Hourglass, Search } from "lucide-react-native";
+import { useQueries } from "@tanstack/react-query";
+import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useConfigStore } from "@/store/config-store";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
+import { POLLING_INTERVALS } from "@/lib/constants";
+import {
+  STILL_PENDING_DEFAULT_SETTINGS,
+  type StillPendingSettingsValue,
+} from "@/components/dashboard/widget-settings/still-pending-settings";
+import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
+import {
+  formatEpisodeCode,
+  relativeDate,
+  getDateOffset,
+  localDateKey,
+} from "@/lib/utils";
+import { getWantedMissing as getSonarrWantedMissing } from "@/services/sonarr-api";
+import { getAllWantedMissing as getRadarrWantedMissing } from "@/services/radarr-api";
+import { radarrReleaseTime } from "@/lib/radarr-release-date";
+import { useSearchForMovie } from "@/hooks/use-radarr";
+import { useSearchForEpisodes } from "@/hooks/use-sonarr";
+import { CalendarEventRow } from "@/components/common/calendar-event-row";
+import { CardHeaderLink } from "@/components/dashboard/card-header-link";
+import type { SonarrEpisode, RadarrMovie } from "@/lib/types";
+
+type PendingItem =
+  | { kind: "episode"; date: string; entry: SonarrEpisode; instanceId: string }
+  | { kind: "movie"; date: string; movie: RadarrMovie; instanceId: string };
+
+// The calendar widget owns today and the future; this widget lists what's
+// strictly overdue, so an item never appears on both cards.
+export function StillPendingCard({ slotId }: WidgetComponentProps) {
+  const router = useRouter();
+  const { settings } = useWidgetSettings<StillPendingSettingsValue>(
+    slotId,
+    STILL_PENDING_DEFAULT_SETTINGS,
+  );
+  const sonarrEnabled = useConfigStore((s) => s.services.sonarr.enabled);
+  const radarrEnabled = useConfigStore((s) => s.services.radarr.enabled);
+
+  const showSonarr = settings.includeSonarr && sonarrEnabled;
+  const showRadarr = settings.includeRadarr && radarrEnabled;
+
+  const sonarrInstances = useWorkspaceScopedInstances(
+    "sonarr",
+    settings.sonarrInstanceIds,
+  );
+  const radarrInstances = useWorkspaceScopedInstances(
+    "radarr",
+    settings.radarrInstanceIds,
+  );
+
+  const sonarrQueries = useQueries({
+    queries: showSonarr
+      ? sonarrInstances.map((inst) => ({
+          queryKey: ["sonarr", inst.id, "wanted", "recent"] as const,
+          queryFn: () => getSonarrWantedMissing(1, 100, inst.id),
+          refetchInterval: POLLING_INTERVALS.calendar,
+        }))
+      : [],
+  });
+  // Same key as the Movies Wanted tab's useWantedMissing so the dashboard and
+  // the tab share one cache entry instead of double-fetching the full walk.
+  const radarrQueries = useQueries({
+    queries: showRadarr
+      ? radarrInstances.map((inst) => ({
+          queryKey: ["radarr", inst.id, "wanted", "all"] as const,
+          queryFn: () => getRadarrWantedMissing(inst.id),
+          refetchInterval: POLLING_INTERVALS.calendar,
+        }))
+      : [],
+  });
+
+  // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton
+  // shows only while we're truly cold across both kinds; a single failing
+  // instance just contributes nothing to the merged list.
+  const sonarrState = aggregateMultiInstanceState(sonarrQueries);
+  const radarrState = aggregateMultiInstanceState(radarrQueries);
+  const isLoading =
+    (showSonarr && !sonarrState.hasAnyData && sonarrState.isInitialLoading) ||
+    (showRadarr && !radarrState.hasAnyData && radarrState.isInitialLoading);
+
+  const todayIso = localDateKey();
+  const cutoffIso = getDateOffset(-settings.lookbackDays);
+
+  const items: PendingItem[] = [];
+  if (showSonarr) {
+    sonarrQueries.forEach((q, i) => {
+      const instanceId = sonarrInstances[i]?.id;
+      if (!instanceId) return;
+      for (const ep of q.data?.records ?? []) {
+        // monitored=true is requested server-side; the client check is a
+        // cheap guard. Undated episodes (unaired specials) are skipped.
+        if (ep.hasFile || !ep.monitored || !ep.series) continue;
+        const date = ep.airDate ?? ep.airDateUtc?.slice(0, 10);
+        if (!date || date < cutoffIso || date >= todayIso) continue;
+        items.push({ kind: "episode", date, entry: ep, instanceId });
+      }
+    });
+  }
+  if (showRadarr) {
+    radarrQueries.forEach((q, i) => {
+      const instanceId = radarrInstances[i]?.id;
+      if (!instanceId) return;
+      for (const movie of q.data?.records ?? []) {
+        // wanted/missing records are monitored + missing by contract; the
+        // effective release date replicates Radarr's own computation (#135).
+        const t = radarrReleaseTime(movie);
+        if (t === null) continue;
+        const date = localDateKey(new Date(t));
+        if (date < cutoffIso || date >= todayIso) continue;
+        items.push({ kind: "movie", date, movie, instanceId });
+      }
+    });
+  }
+
+  // Newest-due first; alphabetical within a day. Slice after merging so the
+  // cap applies across both services, then group the visible slice by day.
+  items.sort(
+    (a, b) => b.date.localeCompare(a.date) || titleOf(a).localeCompare(titleOf(b)),
+  );
+  const totalCount = items.length;
+  const grouped = groupByDate(items.slice(0, settings.maxItems));
+
+  const noSources = !showSonarr && !showRadarr;
+  const noServicesEnabled = !sonarrEnabled && !radarrEnabled;
+
+  return (
+    <Card>
+      <CardHeaderLink
+        title="Still Pending"
+        trailing={
+          !noSources && totalCount > 0 ? (
+            <Text className="text-zinc-500 text-sm">
+              {totalCount} overdue
+            </Text>
+          ) : null
+        }
+      />
+
+      {noSources ? (
+        <EmptyState
+          icon={<Icon icon={Hourglass} size={32} color="#71717a" />}
+          title="No pending sources"
+          message={
+            noServicesEnabled
+              ? "Configure Sonarr or Radarr in app settings to track overdue releases."
+              : "Enable Sonarr or Radarr in the widget settings."
+          }
+        />
+      ) : isLoading ? (
+        <StillPendingSkeleton />
+      ) : grouped.length === 0 ? (
+        <EmptyState
+          compact
+          title={`Nothing overdue in the last ${settings.lookbackDays} days`}
+        />
+      ) : (
+        <View className="gap-4">
+          {grouped.map(({ date, entries }) => (
+            <View key={date} className="gap-2">
+              <Text className="text-xs font-semibold text-zinc-500">
+                {relativeDate(date)}
+              </Text>
+              <View className="gap-2">
+                {entries.map((item) =>
+                  item.kind === "episode" ? (
+                    <PendingEpisodeRow
+                      key={`ep-${item.instanceId}-${item.entry.id}`}
+                      entry={item.entry}
+                      instanceId={item.instanceId}
+                      onPress={() =>
+                        router.push(
+                          `/series/${item.entry.seriesId}?instanceId=${item.instanceId}`,
+                        )
+                      }
+                    />
+                  ) : (
+                    <PendingMovieRow
+                      key={`mv-${item.instanceId}-${item.movie.id}`}
+                      movie={item.movie}
+                      instanceId={item.instanceId}
+                      onPress={() =>
+                        router.push(
+                          `/movie/${item.movie.id}?instanceId=${item.instanceId}`,
+                        )
+                      }
+                    />
+                  ),
+                )}
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+    </Card>
+  );
+}
+
+function StillPendingSkeleton() {
+  return (
+    <View className="gap-4">
+      {Array.from({ length: 2 }).map((_, groupIdx) => (
+        <View key={groupIdx} className="gap-2">
+          <Skeleton width={80} height={12} borderRadius={4} />
+          <View className="gap-2">
+            {Array.from({ length: 2 }).map((_, rowIdx) => (
+              <Skeleton key={rowIdx} width="100%" height={72} borderRadius={12} />
+            ))}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function groupByDate(
+  items: PendingItem[],
+): { date: string; entries: PendingItem[] }[] {
+  // Items arrive sorted date-descending, so Map insertion order already
+  // yields newest-due groups first.
+  const groups = new Map<string, PendingItem[]>();
+  for (const item of items) {
+    const list = groups.get(item.date);
+    if (list) list.push(item);
+    else groups.set(item.date, [item]);
+  }
+  return Array.from(groups.entries()).map(([date, entries]) => ({
+    date,
+    entries,
+  }));
+}
+
+function titleOf(item: PendingItem): string {
+  return item.kind === "episode"
+    ? (item.entry.series?.title ?? "")
+    : item.movie.title;
+}
+
+// Per-row search mutations are owned by the row components so each row scopes
+// its command to the instance it came from (download-card TorrentTile pattern).
+function PendingEpisodeRow({
+  entry,
+  instanceId,
+  onPress,
+}: {
+  entry: SonarrEpisode;
+  instanceId: string;
+  onPress: () => void;
+}) {
+  const search = useSearchForEpisodes(instanceId);
+  return (
+    <CalendarEventRow
+      images={entry.series?.images ?? []}
+      service="sonarr"
+      title={entry.series?.title ?? "Unknown series"}
+      subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
+      hasFile={false}
+      onPress={onPress}
+      action={{
+        icon: Search,
+        onPress: () => search.mutate([entry.id]),
+        loading: search.isPending,
+      }}
+    />
+  );
+}
+
+function PendingMovieRow({
+  movie,
+  instanceId,
+  onPress,
+}: {
+  movie: RadarrMovie;
+  instanceId: string;
+  onPress: () => void;
+}) {
+  const search = useSearchForMovie(instanceId);
+  return (
+    <CalendarEventRow
+      images={movie.images}
+      service="radarr"
+      title={movie.title}
+      subtitle={movie.year ? `${movie.year} • Movie` : "Movie"}
+      hasFile={false}
+      onPress={onPress}
+      action={{
+        icon: Search,
+        onPress: () => search.mutate(movie.id),
+        loading: search.isPending,
+      }}
+    />
+  );
+}

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -10,6 +10,7 @@ import {
   Gauge,
   HardDrive,
   HeartPulse,
+  Hourglass,
   Inbox,
   Disc3,
   MonitorPlay,
@@ -32,6 +33,7 @@ import { RadarrQueueCard } from "@/components/dashboard/radarr-queue-card";
 import { LidarrQueueCard } from "@/components/dashboard/lidarr-queue-card";
 import { RecentlyDownloadedCard } from "@/components/dashboard/recently-downloaded-card";
 import { CalendarCard } from "@/components/dashboard/calendar-card";
+import { StillPendingCard } from "@/components/dashboard/still-pending-card";
 import { StreamMonitorCard } from "@/components/dashboard/stream-monitor-card";
 import { StreamingBandwidthCard } from "@/components/dashboard/streaming-bandwidth-card";
 import { OverseerrRequestsCard } from "@/components/dashboard/overseerr-requests-card";
@@ -58,6 +60,11 @@ import {
   CALENDAR_DEFAULT_SETTINGS,
   type CalendarSettingsValue,
 } from "@/components/dashboard/widget-settings/calendar-settings";
+import {
+  StillPendingSettings,
+  STILL_PENDING_DEFAULT_SETTINGS,
+  type StillPendingSettingsValue,
+} from "@/components/dashboard/widget-settings/still-pending-settings";
 import {
   DownloadsSettings,
   DOWNLOADS_DEFAULT_SETTINGS,
@@ -319,6 +326,16 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     settingsComponent: CalendarSettings,
     defaultSettings: CALENDAR_DEFAULT_SETTINGS,
   },
+  "still-pending": {
+    id: "still-pending",
+    label: "Still Pending",
+    description: "Overdue movies and episodes that haven't downloaded yet",
+    icon: Hourglass,
+    service: ["sonarr", "radarr"],
+    component: StillPendingCard,
+    settingsComponent: StillPendingSettings,
+    defaultSettings: STILL_PENDING_DEFAULT_SETTINGS,
+  },
   "stream-monitor": {
     id: "stream-monitor",
     label: "Stream Activity",
@@ -441,6 +458,7 @@ export type {
   ServerStatsSettingsValue,
   ServiceHealthSettingsValue,
   CalendarSettingsValue,
+  StillPendingSettingsValue,
   DownloadsSettingsValue,
   SabnzbdQueueSettingsValue,
   NzbgetQueueSettingsValue,

--- a/components/dashboard/widget-settings/still-pending-settings.tsx
+++ b/components/dashboard/widget-settings/still-pending-settings.tsx
@@ -23,6 +23,10 @@ export interface StillPendingSettingsValue extends Record<string, unknown> {
   includeRadarr: boolean;
   lookbackDays: number;
   maxItems: number;
+  // When on, items dated today that have already aired/released are included
+  // too (they also appear under "Today" in the Releasing Soon widget). Off by
+  // default so the two cards never list the same item.
+  includeToday: boolean;
 }
 
 export const STILL_PENDING_DEFAULT_SETTINGS: StillPendingSettingsValue = {
@@ -34,6 +38,7 @@ export const STILL_PENDING_DEFAULT_SETTINGS: StillPendingSettingsValue = {
   // Movies Wanted tab; this widget is about catching what just slipped by.
   lookbackDays: 14,
   maxItems: 5,
+  includeToday: false,
 };
 
 const LOOKBACK_OPTIONS: { value: number; label: string }[] = [
@@ -109,6 +114,17 @@ export function StillPendingSettings({ slotId }: WidgetSettingsComponentProps) {
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
       />
+
+      <SettingsSection label="Options">
+        <ToggleCard>
+          <Toggle
+            label="Include today"
+            description="Also show items already aired or released today — these are listed in Releasing Soon too"
+            value={settings.includeToday}
+            onValueChange={(includeToday) => update({ includeToday })}
+          />
+        </ToggleCard>
+      </SettingsSection>
     </View>
   );
 }

--- a/components/dashboard/widget-settings/still-pending-settings.tsx
+++ b/components/dashboard/widget-settings/still-pending-settings.tsx
@@ -1,0 +1,114 @@
+import { View } from "react-native";
+import { Toggle } from "@/components/ui/toggle";
+import { useConfigStore } from "@/store/config-store";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+import {
+  InstancePickerRow,
+  INSTANCE_BINDING_ALL,
+  type InstanceBindingValue,
+} from "@/components/dashboard/widget-settings/instance-picker-row";
+import {
+  ChipGroup,
+  MaxItemsSelector,
+  SettingsSection,
+  ToggleCard,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
+
+export interface StillPendingSettingsValue extends Record<string, unknown> {
+  // Independent per-service bindings, same shape as the calendar widget.
+  sonarrInstanceIds: InstanceBindingValue;
+  radarrInstanceIds: InstanceBindingValue;
+  includeSonarr: boolean;
+  includeRadarr: boolean;
+  lookbackDays: number;
+  maxItems: number;
+}
+
+export const STILL_PENDING_DEFAULT_SETTINGS: StillPendingSettingsValue = {
+  sonarrInstanceIds: INSTANCE_BINDING_ALL,
+  radarrInstanceIds: INSTANCE_BINDING_ALL,
+  includeSonarr: true,
+  includeRadarr: true,
+  // "Recently due" window — the full missing backlog already lives in the
+  // Movies Wanted tab; this widget is about catching what just slipped by.
+  lookbackDays: 14,
+  maxItems: 5,
+};
+
+const LOOKBACK_OPTIONS: { value: number; label: string }[] = [
+  { value: 7, label: "7 days" },
+  { value: 14, label: "14 days" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+];
+
+export function StillPendingSettings({ slotId }: WidgetSettingsComponentProps) {
+  const sonarrEnabled = useConfigStore((s) => s.services.sonarr.enabled);
+  const radarrEnabled = useConfigStore((s) => s.services.radarr.enabled);
+  const { settings, update } = useWidgetSettings<StillPendingSettingsValue>(
+    slotId,
+    STILL_PENDING_DEFAULT_SETTINGS,
+  );
+
+  return (
+    <View className="px-4 py-2 gap-5">
+      <SettingsSection label="Sources">
+        <ToggleCard>
+          <Toggle
+            label="Sonarr (TV episodes)"
+            description={
+              sonarrEnabled
+                ? "Show aired episodes that haven't downloaded"
+                : "Enable Sonarr in Settings to use this source"
+            }
+            value={settings.includeSonarr && sonarrEnabled}
+            onValueChange={(includeSonarr) => update({ includeSonarr })}
+            disabled={!sonarrEnabled}
+          />
+          <Toggle
+            label="Radarr (movies)"
+            description={
+              radarrEnabled
+                ? "Show released movies that haven't downloaded"
+                : "Enable Radarr in Settings to use this source"
+            }
+            value={settings.includeRadarr && radarrEnabled}
+            onValueChange={(includeRadarr) => update({ includeRadarr })}
+            disabled={!radarrEnabled}
+          />
+        </ToggleCard>
+      </SettingsSection>
+
+      {settings.includeSonarr && sonarrEnabled && (
+        <InstancePickerRow
+          serviceId="sonarr"
+          label="Sonarr instance"
+          value={settings.sonarrInstanceIds}
+          onChange={(sonarrInstanceIds) => update({ sonarrInstanceIds })}
+        />
+      )}
+
+      {settings.includeRadarr && radarrEnabled && (
+        <InstancePickerRow
+          serviceId="radarr"
+          label="Radarr instance"
+          value={settings.radarrInstanceIds}
+          onChange={(radarrInstanceIds) => update({ radarrInstanceIds })}
+        />
+      )}
+
+      <ChipGroup
+        label="Look back"
+        options={LOOKBACK_OPTIONS}
+        value={settings.lookbackDays}
+        onChange={(lookbackDays) => update({ lookbackDays })}
+      />
+
+      <MaxItemsSelector
+        value={settings.maxItems}
+        onChange={(maxItems) => update({ maxItems })}
+      />
+    </View>
+  );
+}

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -44,6 +44,7 @@ import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { mediumHaptic } from "@/lib/haptics";
 import { BAR_KIND_COLOR, cornerColorFor, radarrBarKind } from "@/lib/arr-poster-status";
+import { radarrReleaseTime } from "@/lib/radarr-release-date";
 import type { RadarrMovie, RadarrQueueItem } from "@/lib/types";
 
 type MovieSheetTarget =
@@ -64,35 +65,6 @@ const SORT_OPTIONS: { key: MoviesSortKey; label: string }[] = [
   { key: "release-asc", label: "Release Date: Oldest First" },
   { key: "size-desc", label: "Size: Largest First" },
 ];
-
-function parseTime(d?: string): number | null {
-  if (!d) return null;
-  const t = new Date(d).getTime();
-  return Number.isFinite(t) ? t : null;
-}
-
-// Must sort identically to Radarr's own "Release Date" option, which uses the
-// server-computed `releaseDate` (Movie.GetReleaseDate(), keyed off
-// minimumAvailability). The local computation below replicates it for Radarr
-// servers older than 5.10 that don't send `releaseDate`.
-function releaseTime(m: RadarrMovie): number | null {
-  const fromServer = parseTime(m.releaseDate);
-  if (fromServer !== null) return fromServer;
-
-  const cinema = parseTime(m.inCinemas);
-  if (m.minimumAvailability === "tba" || m.minimumAvailability === "announced") {
-    const all = [cinema, parseTime(m.digitalRelease), parseTime(m.physicalRelease)].filter(
-      (t): t is number => t !== null,
-    );
-    return all.length ? Math.min(...all) : null;
-  }
-  if (m.minimumAvailability === "inCinemas" && cinema !== null) return cinema;
-  const home = [parseTime(m.digitalRelease), parseTime(m.physicalRelease)].filter(
-    (t): t is number => t !== null,
-  );
-  if (home.length) return Math.min(...home);
-  return cinema !== null ? cinema + 90 * 24 * 60 * 60 * 1000 : null;
-}
 
 function nextReleaseTime(m: RadarrMovie): number | null {
   const times = [m.inCinemas, m.digitalRelease, m.physicalRelease]
@@ -120,8 +92,8 @@ function compareMovies(a: RadarrMovie, b: RadarrMovie, sort: MoviesSortKey): num
       return a.year - b.year;
     case "release-desc":
     case "release-asc": {
-      const aT = releaseTime(a);
-      const bT = releaseTime(b);
+      const aT = radarrReleaseTime(a);
+      const bT = radarrReleaseTime(b);
       if (aT === null && bT === null)
         return (a.sortTitle || a.title).localeCompare(b.sortTitle || b.title);
       if (aT === null) return 1;

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -80,8 +80,10 @@ export function useRadarrHistory(instanceId?: string, active = true) {
   });
 }
 
-// Fetches the complete wanted/missing list (all pages). Only mounted by the
-// Movies "Wanted" tab, so the full walk doesn't run while the user is elsewhere.
+// Fetches the complete wanted/missing list (all pages). Mounted by the Movies
+// "Wanted" tab; the Still Pending widget subscribes to the same
+// ["radarr", id, "wanted", "all"] key (via useQueries) so the two share one
+// cache entry instead of double-fetching the full walk.
 // The key is namespaced with "all" so it never aliases the count-only
 // ["radarr", id, "wanted"] entry the dashboard's RadarrQueueCard owns — sharing
 // a key would let its 1-record badge fetch clobber the full list (and vice

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -107,6 +107,7 @@ export const DASHBOARD_WIDGET_IDS = [
   "lidarr-queue",
   "recently-downloaded",
   "calendar",
+  "still-pending",
   "stream-monitor",
   "streaming-bandwidth",
   "overseerr-requests",

--- a/lib/radarr-release-date.ts
+++ b/lib/radarr-release-date.ts
@@ -1,0 +1,33 @@
+import type { RadarrMovie } from "@/lib/types";
+
+export function parseReleaseTime(d?: string): number | null {
+  if (!d) return null;
+  const t = new Date(d).getTime();
+  return Number.isFinite(t) ? t : null;
+}
+
+// Must sort identically to Radarr's own "Release Date" option, which uses the
+// server-computed `releaseDate` (Movie.GetReleaseDate(), keyed off
+// minimumAvailability). The local computation below replicates it for Radarr
+// servers older than 5.10 that don't send `releaseDate`.
+export function radarrReleaseTime(m: RadarrMovie): number | null {
+  const fromServer = parseReleaseTime(m.releaseDate);
+  if (fromServer !== null) return fromServer;
+
+  const cinema = parseReleaseTime(m.inCinemas);
+  if (m.minimumAvailability === "tba" || m.minimumAvailability === "announced") {
+    const all = [
+      cinema,
+      parseReleaseTime(m.digitalRelease),
+      parseReleaseTime(m.physicalRelease),
+    ].filter((t): t is number => t !== null);
+    return all.length ? Math.min(...all) : null;
+  }
+  if (m.minimumAvailability === "inCinemas" && cinema !== null) return cinema;
+  const home = [
+    parseReleaseTime(m.digitalRelease),
+    parseReleaseTime(m.physicalRelease),
+  ].filter((t): t is number => t !== null);
+  if (home.length) return Math.min(...home);
+  return cinema !== null ? cinema + 90 * 24 * 60 * 60 * 1000 : null;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -619,6 +619,15 @@ export interface SonarrQueue {
   records: SonarrQueueItem[];
 }
 
+// Paged /wanted/missing response — aired, monitored episodes without a file.
+// Fetched with includeSeries=true so each record carries its series.
+export interface SonarrWantedMissing {
+  page: number;
+  pageSize: number;
+  totalRecords: number;
+  records: SonarrEpisode[];
+}
+
 export interface SonarrHistoryRecord {
   id: number;
   eventType: string;

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -131,7 +131,7 @@ export function getWantedMissing(
     params: {
       page,
       pageSize,
-      sortKey: "airDateUtc",
+      sortKey: "episodes.airDateUtc",
       sortDirection: "descending",
       includeSeries: true,
       monitored: true,

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -10,6 +10,7 @@ import type {
   SonarrSeriesType,
   SonarrImage,
   SonarrRelease,
+  SonarrWantedMissing,
 } from "@/lib/types";
 
 const INTERACTIVE_SEARCH_TIMEOUT = 90_000;
@@ -111,6 +112,29 @@ export function getCalendar(
       end: endDate,
       includeSeries: true,
       unmonitored: options.unmonitored ?? false,
+    },
+    instanceId,
+  });
+}
+
+// --- Wanted / Missing ---
+
+// Aired, monitored episodes without a file, newest first. One page of 100
+// covers any dashboard lookback window unless more than 100 episodes went
+// missing inside it — an acceptable cap for a widget surface.
+export function getWantedMissing(
+  page = 1,
+  pageSize = 100,
+  instanceId?: string,
+): Promise<SonarrWantedMissing> {
+  return serviceRequest<SonarrWantedMissing>("sonarr", "/wanted/missing", {
+    params: {
+      page,
+      pageSize,
+      sortKey: "airDateUtc",
+      sortDirection: "descending",
+      includeSeries: true,
+      monitored: true,
     },
     instanceId,
   });


### PR DESCRIPTION
## Summary
- New "Still Pending" dashboard widget: monitored movies (Radarr) and episodes (Sonarr) whose release/air date passed without a download, grouped by day newest-first. Per-row button triggers an automatic search; tapping opens the detail screen for interactive search. Refs #134
- Settings mirror the calendar widget: source toggles, per-service instance bindings, look-back window (7/14/30/90 days), max items
- Sonarr: new `getWantedMissing()` against `/api/v3/wanted/missing`; Radarr reuses `getAllWantedMissing()` under the Wanted tab's query key (shared cache)
- Extracted the #135 release-date logic into shared `lib/radarr-release-date.ts`
- `CalendarEventRow` gains an optional `action` prop (additive; calendar surfaces unchanged)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Widget appears in Add Widget picker only with Sonarr/Radarr attached
- [ ] Item due today shows only in Releasing Soon; yesterday's only in Still Pending
- [ ] Per-row search shows spinner + "Search started" toast; row tap lands on detail with correct instance
- [ ] Movies → Wanted tab still sorts by release date identically