### PR TITLE
fix(calendar): show releases on the viewer-local day (Refs #86)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -26,7 +26,12 @@ import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
-import { formatEpisodeCode, localDateKey } from "@/lib/utils";
+import {
+  airDateKey,
+  formatEpisodeCode,
+  localDateKey,
+  releaseDateKey,
+} from "@/lib/utils";
 import { lightHaptic } from "@/lib/haptics";
 import { getBoolean, setBoolean, getString, setString } from "@/store/storage";
 import type { ServiceId } from "@/lib/constants";
@@ -65,9 +70,16 @@ const MONTH_NAMES = [
   "July", "August", "September", "October", "November", "December",
 ];
 
-function getMonthRange(year: number, month: number) {
-  const start = new Date(year, month, 1);
-  const end = new Date(year, month + 1, 0);
+// Fetch the full visible grid (incl. prev/next-month padding cells) padded
+// ±1 day, mirroring Sonarr's web UI. The padding keeps boundary episodes
+// whose UTC day differs from the local day inside the server-side range
+// filter; the extra day on `end` also matters because the *arr APIs treat a
+// date-only end as midnight (exclusive of that day's airings).
+function getFetchRange(year: number, month: number) {
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+  const start = new Date(year, month, 1 - first.getDay() - 1);
+  const end = new Date(year, month, last.getDate() + (6 - last.getDay()) + 1);
   return {
     start: localDateKey(start),
     end: localDateKey(end),
@@ -176,7 +188,7 @@ export default function CalendarScreen() {
     [radarrAll, radarrFilter],
   );
 
-  const { start, end } = getMonthRange(year, month);
+  const { start, end } = getFetchRange(year, month);
 
   // Fan out the calendar query across every selected Sonarr/Radarr instance.
   // Each instance contributes its own slice of dates; we flatten and dedupe
@@ -283,16 +295,18 @@ export default function CalendarScreen() {
     if (filter !== "movies") {
       for (const { data: ep, instanceId } of taggedEpisodes) {
         if (!instanceId) continue;
+        const key = airDateKey(ep);
+        if (!key) continue;
         const item: CalendarItem = {
           type: "episode",
-          date: ep.airDate,
+          date: key,
           data: ep,
           instanceId,
         };
         all.push(item);
-        const list = map.get(ep.airDate) ?? [];
+        const list = map.get(key) ?? [];
         list.push(item);
-        map.set(ep.airDate, list);
+        map.set(key, list);
       }
     }
 
@@ -710,9 +724,9 @@ function InstanceScopePicker({
 // --- Helpers ---
 
 function getMovieReleaseDate(movie: RadarrMovie): string | null {
-  const date =
-    movie.digitalRelease ?? movie.physicalRelease ?? movie.inCinemas;
-  return date ? date.split("T")[0] : null;
+  return releaseDateKey(
+    movie.digitalRelease ?? movie.physicalRelease ?? movie.inCinemas,
+  );
 }
 
 function getMovieReleaseType(movie: RadarrMovie): string {

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -57,6 +57,7 @@ import {
 import { SERIES_TYPE_OPTIONS } from "@/components/sonarr/add-series-sheet";
 import { SeriesOptionsSheet } from "@/components/sonarr/series-options-sheet";
 import {
+  airDateKey,
   formatEpisodeCode,
   formatBytes,
   formatAudioChannels,
@@ -844,6 +845,8 @@ function EpisodeRow({
   // present a second modal while the first is dismissing).
   const wantDeleteFile = useRef(false);
   const mediaInfo = episodeFile?.mediaInfo;
+  // Local day of airDateUtc, matching Sonarr web's episode list (issue #86).
+  const airLabel = airDateKey(episode);
 
   // Search/delete live in the "⋯" sheet so the row stays uncluttered and the
   // automatic-vs-interactive search distinction reads clearly as labeled rows.
@@ -899,8 +902,8 @@ function EpisodeRow({
                 ? ` · ${mediaInfo.videoDynamicRangeType}`
                 : ""}
             </Text>
-          ) : episode.airDate ? (
-            <Text className="text-zinc-600 text-xs">{episode.airDate}</Text>
+          ) : airLabel ? (
+            <Text className="text-zinc-600 text-xs">{airLabel}</Text>
           ) : null}
         </View>
         <View className="flex-row items-center gap-1">

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -17,10 +17,12 @@ import {
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import {
+  airDateKey,
   formatEpisodeCode,
   relativeDate,
   getDateOffset,
   localDateKey,
+  releaseDateKey,
 } from "@/lib/utils";
 import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
 import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
@@ -61,10 +63,6 @@ function pickRadarrDate(
   }
 }
 
-function isoDate(value: string): string {
-  return value.slice(0, 10);
-}
-
 function isToday(dateString: string): boolean {
   return dateString === localDateKey();
 }
@@ -93,8 +91,11 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   // Fan out the calendar fetch across each resolved instance per kind. The
   // instance id is folded into the query key so two Sonarrs don't trample
   // each other's cached calendar.
-  const start = getDateOffset(0);
-  const end = getDateOffset(settings.daysAhead);
+  // Padded ±1 day so boundary episodes whose UTC day differs from the local
+  // day survive the server-side range filter; the [todayIso, horizonIso]
+  // client filter below keeps the display window exact.
+  const start = getDateOffset(-1);
+  const end = getDateOffset(settings.daysAhead + 1);
   const sonarrQueries = useQueries({
     queries: showSonarr
       ? sonarrInstances.map((inst) => ({
@@ -135,8 +136,8 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
       const instanceId = sonarrInstances[i]?.id;
       if (!instanceId) return;
       for (const ep of q.data ?? []) {
-        const date = isoDate(ep.airDate);
-        if (date < todayIso || date > horizonIso) continue;
+        const date = airDateKey(ep);
+        if (!date || date < todayIso || date > horizonIso) continue;
         // No air-time filter: the Calendar tab shows every episode that
         // airs on a given day regardless of clock, and this widget must
         // stay in lockstep with it (otherwise "Today" disappears from the
@@ -151,10 +152,10 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
       const instanceId = radarrInstances[i]?.id;
       if (!instanceId) return;
       for (const movie of q.data ?? []) {
-        const raw = pickRadarrDate(movie, settings.radarrReleaseType);
-        if (!raw) continue;
-        const date = isoDate(raw);
-        if (date < todayIso || date > horizonIso) continue;
+        const date = releaseDateKey(
+          pickRadarrDate(movie, settings.radarrReleaseType),
+        );
+        if (!date || date < todayIso || date > horizonIso) continue;
         items.push({ kind: "movie", date, movie, instanceId });
       }
     });

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -17,6 +17,7 @@ import {
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import {
+  airDateKey,
   formatEpisodeCode,
   relativeDate,
   getDateOffset,
@@ -102,7 +103,7 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
         // monitored=true is requested server-side; the client check is a
         // cheap guard. Undated episodes (unaired specials) are skipped.
         if (ep.hasFile || !ep.monitored || !ep.series) continue;
-        const date = ep.airDate ?? ep.airDateUtc?.slice(0, 10);
+        const date = airDateKey(ep);
         if (!date || date < cutoffIso || date > todayIso) continue;
         if (date === todayIso) {
           if (!settings.includeToday) continue;

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -65,7 +65,13 @@ import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { useUiScale } from "@/hooks/use-ui-scale";
-import { formatEpisodeCode, relativeDate, localDateKey } from "@/lib/utils";
+import {
+  airDateKey,
+  formatEpisodeCode,
+  getDateOffset,
+  relativeDate,
+  localDateKey,
+} from "@/lib/utils";
 import { mediumHaptic } from "@/lib/haptics";
 import type { SonarrSeries, SonarrCalendarEntry } from "@/lib/types";
 
@@ -533,15 +539,23 @@ function CalendarView({
   if (error) {
     return <ErrorBanner error={error} title="Failed to load calendar" />;
   }
-  if (!episodes?.length) {
-    return <EmptyState title="Nothing airing this week" />;
+
+  // Group by the local day of airDateUtc (parity with the Calendar tab and
+  // Sonarr's web UI), bounded back to the visible week — the hook fetches a
+  // day extra on each side for timezone boundary airings.
+  const todayKey = getDateOffset(0);
+  const horizonKey = getDateOffset(7);
+  const grouped = new Map<string, SonarrCalendarEntry[]>();
+  for (const ep of episodes ?? []) {
+    const key = airDateKey(ep);
+    if (!key || key < todayKey || key > horizonKey) continue;
+    const list = grouped.get(key) ?? [];
+    list.push(ep);
+    grouped.set(key, list);
   }
 
-  const grouped = new Map<string, SonarrCalendarEntry[]>();
-  for (const ep of episodes) {
-    const list = grouped.get(ep.airDate) ?? [];
-    list.push(ep);
-    grouped.set(ep.airDate, list);
+  if (grouped.size === 0) {
+    return <EmptyState title="Nothing airing this week" />;
   }
 
   const sortedDates = Array.from(grouped.keys()).sort();

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -75,8 +75,11 @@ export function useSonarrCalendar(days = 7, instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "calendar", days],
+    // Padded ±1 day: episodes are placed on the local day of airDateUtc, so a
+    // boundary airing whose UTC day differs from the local day would fall
+    // outside the server-side range filter. Consumers re-bound to [0, days].
     queryFn: () =>
-      getCalendar(getDateOffset(0), getDateOffset(days), {}, id ?? undefined),
+      getCalendar(getDateOffset(-1), getDateOffset(days + 1), {}, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.calendar,
     enabled: enabled && !!id,
   });

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,9 +1,10 @@
 import type { ServiceId } from "@/lib/constants";
+import { getDateOffset } from "@/lib/utils";
 
+// Local day, not toISOString()'s UTC day — date-only demo dates flow through
+// releaseDateKey verbatim and must land on the viewer's calendar day.
 function daysFromNow(days: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() + days);
-  return d.toISOString().split("T")[0]!;
+  return getDateOffset(days);
 }
 
 function daysFromNowFull(days: number): string {

--- a/lib/utils.timezone.test.ts
+++ b/lib/utils.timezone.test.ts
@@ -1,0 +1,71 @@
+import { airDateKey, releaseDateKey } from "./utils";
+
+// Instants below are built from LOCAL components (new Date(y, m, d, h)) so
+// these tests are deterministic in any host timezone. Runtime process.env.TZ
+// changes are NOT honored by V8's cached timezone inside Jest workers, so we
+// can't pin a named zone per-suite; pin one for the whole run from the CLI
+// instead (e.g. `TZ=Asia/Tokyo pnpm test`).
+
+describe("airDateKey", () => {
+  it("places an episode on the local day of airDateUtc, not the network airDate", () => {
+    // Regression for issue #86: a show airing 01:00 local on Jan 7 carries
+    // the previous day's network airDate for viewers east of the network
+    // (e.g. a European or Asian viewer of a US show). Sonarr web shows
+    // Jan 7; grouping by airDate showed Jan 6 — one day early.
+    const airsEarlyLocal = new Date(2026, 0, 7, 1, 0, 0);
+    expect(
+      airDateKey({
+        airDate: "2026-01-06",
+        airDateUtc: airsEarlyLocal.toISOString(),
+      }),
+    ).toBe("2026-01-07");
+  });
+
+  it("keeps an episode on the airDate day when it airs within that local day", () => {
+    // Parity with the #77/#100/#103 behavior for viewers in the network's
+    // timezone (e.g. US viewer + US show): Tuesday evening stays Tuesday.
+    const airsSameLocalDay = new Date(2026, 0, 6, 23, 0, 0);
+    expect(
+      airDateKey({
+        airDate: "2026-01-06",
+        airDateUtc: airsSameLocalDay.toISOString(),
+      }),
+    ).toBe("2026-01-06");
+  });
+
+  it("falls back to airDate when airDateUtc is missing", () => {
+    expect(airDateKey({ airDate: "2026-01-06" })).toBe("2026-01-06");
+  });
+
+  it("falls back to airDate when airDateUtc is unparsable", () => {
+    expect(
+      airDateKey({ airDate: "2026-01-06", airDateUtc: "not-a-date" }),
+    ).toBe("2026-01-06");
+  });
+
+  it("returns null when neither field is usable", () => {
+    expect(airDateKey({})).toBeNull();
+    expect(airDateKey({ airDateUtc: "garbage" })).toBeNull();
+  });
+});
+
+describe("releaseDateKey", () => {
+  it("returns the local day of an ISO datetime", () => {
+    // For any non-UTC host at least one of these crosses the UTC day
+    // boundary, where the old `.split("T")[0]` returned the wrong day.
+    const lateEvening = new Date(2026, 0, 6, 23, 0, 0);
+    expect(releaseDateKey(lateEvening.toISOString())).toBe("2026-01-06");
+    const earlyMorning = new Date(2026, 0, 7, 1, 0, 0);
+    expect(releaseDateKey(earlyMorning.toISOString())).toBe("2026-01-07");
+  });
+
+  it("returns date-only strings verbatim", () => {
+    expect(releaseDateKey("2026-01-06")).toBe("2026-01-06");
+  });
+
+  it("returns null for missing or unparsable input", () => {
+    expect(releaseDateKey(undefined)).toBeNull();
+    expect(releaseDateKey(null)).toBeNull();
+    expect(releaseDateKey("garbage")).toBeNull();
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -128,6 +128,38 @@ export function getDateOffset(days: number): string {
 }
 
 /**
+ * Calendar-day key for a Sonarr episode, matching Sonarr's web UI: the
+ * device-local day of the UTC airing instant (airDateUtc), NOT the network's
+ * airDate. A Tuesday-evening US airing is Wednesday for viewers east of the
+ * US; Sonarr web shows Wednesday, so we must too (issue #86). Falls back to
+ * airDate when airDateUtc is missing/unparsable (TBA entries); null if neither.
+ */
+export function airDateKey(ep: {
+  airDate?: string;
+  airDateUtc?: string;
+}): string | null {
+  if (ep.airDateUtc) {
+    const d = new Date(ep.airDateUtc);
+    if (!Number.isNaN(d.getTime())) return localDateKey(d);
+  }
+  return ep.airDate ?? null;
+}
+
+/**
+ * Calendar-day key for a Radarr release datetime (inCinemas/digitalRelease/
+ * physicalRelease), matching Radarr's web UI: the device-local day of the UTC
+ * instant — never `.split("T")[0]` (the UTC day). Date-only strings are
+ * returned verbatim (new Date("YYYY-MM-DD") parses as UTC midnight and would
+ * shift the day west of UTC). Null for missing/unparsable input.
+ */
+export function releaseDateKey(value?: string | null): string | null {
+  if (!value) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : localDateKey(d);
+}
+
+/**
  * Format audio channels number to label (e.g. 7.1, 5.1, 2.0)
  */
 export function formatAudioChannels(channels: number): string {


### PR DESCRIPTION
Sonarr/Radarr web UIs place calendar events on the local day of the UTC instant (`moment(airDateUtc)` / `moment(digitalRelease)`); the app grouped by `airDate` (the network's date) and the UTC date, showing releases a day early for viewers east of the show's network (Refs #86).

- New `airDateKey` / `releaseDateKey` helpers in `lib/utils.ts`; applied across the Calendar tab, Releasing Soon widget, TV-tab week view, Still Pending widget, and series detail air-date label so all surfaces stay in lockstep.
- Fetch ranges padded ±1 day (and the Calendar tab now fetches the full visible grid, like Sonarr web) so boundary airings survive the server-side range filter.
- Demo data uses local dates instead of UTC.

## Test plan
- `pnpm test` (601 passing), plus pinned runs under `TZ=Asia/Tokyo`, `TZ=America/Los_Angeles`, `TZ=UTC`.
- New `lib/utils.timezone.test.ts` pins the east-of-UTC regression and same-timezone-viewer parity (the #77/#100/#103 behavior).
- `npx tsc --noEmit` clean.