### PR TITLE
fix(home-network): recover from stuck 'away' after config import (Refs #168)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -300,9 +300,20 @@ export default function SettingsScreen() {
         // Import resets the away flag to its safe default, so local-only
         // services start "remote-only" until home is re-confirmed. Prompt for
         // Location + re-evaluate now so they come back online on the home WiFi
-        // without the user hunting for a permission (#168). Fire-and-forget —
-        // the import already succeeded; this just resolves home/away.
-        void reevaluateHomeNetworkAfterImport();
+        // without the user hunting for a permission (#168). The import already
+        // succeeded, so this runs detached — but if we're STILL away once it
+        // settles (permission denied, no home network configured, or genuinely
+        // away), tell the user why their services are on remote URLs and where
+        // to fix it, instead of leaving every service silently stuck on remote.
+        void reevaluateHomeNetworkAfterImport().then(() => {
+          const st = useConfigStore.getState();
+          if (st.autoSwitchNetwork && st.networkAwayFromHome) {
+            toast(
+              "Services are using remote URLs until your home WiFi is confirmed. Open Settings → Home Networks to finish setup.",
+              "info",
+            );
+          }
+        });
       }
     } catch (e) {
       toastError("Invalid config file", e);

--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
-import { View, Text, Pressable, ActivityIndicator, Platform } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { View, Text, Pressable, ActivityIndicator, Platform, Linking, AppState } from "react-native";
 import Animated, { FadeIn } from "react-native-reanimated";
-import { Wifi, Plus, Pencil, Trash2, Activity, ChevronDown, ChevronUp } from "lucide-react-native";
+import { Wifi, WifiOff, MapPin, Plus, Pencil, Trash2, Activity, ChevronDown, ChevronUp } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { lightHaptic } from "@/lib/haptics";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -12,7 +12,14 @@ import { TextInput } from "@/components/ui/text-input";
 import { toast } from "@/components/ui/toast";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useConfigStore } from "@/store/config-store";
-import { detectWifi, validateHomeNetworkInput } from "@/lib/wifi";
+import {
+  detectWifi,
+  validateHomeNetworkInput,
+  ensureWifiPermission,
+  getWifiPermissionStatus,
+  type WifiPermissionState,
+} from "@/lib/wifi";
+import { evaluateHomeNetwork } from "@/lib/network";
 import { detectVpnActive, isVpnModuleAvailable } from "@/lib/vpn";
 import type { HomeNetwork } from "@/store/config-store";
 import { MAX_HOME_NETWORKS } from "@/lib/constants";
@@ -89,6 +96,55 @@ export default function HomeNetworksScreen() {
   const [bssid, setBssid] = useState("");
   const [detecting, setDetecting] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<HomeNetwork | null>(null);
+
+  // Location-permission state for the "away" recovery card (#168). Read without
+  // prompting on mount AND on every app-resume: tapping "Open Settings" sends the
+  // user to the system Settings app (Linking.openSettings backgrounds us rather
+  // than changing navigation focus), so a permission they grant there must be
+  // picked up when we foreground again — otherwise the card stays stale on "Open
+  // Settings". The Grant button also refreshes it directly.
+  const [wifiPerm, setWifiPerm] = useState<WifiPermissionState | null>(null);
+  const [grantingLocation, setGrantingLocation] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    const read = () => {
+      void getWifiPermissionStatus().then((p) => {
+        if (alive) setWifiPerm(p);
+      });
+    };
+    read();
+    const sub = AppState.addEventListener("change", (s) => {
+      if (s === "active") read();
+    });
+    return () => {
+      alive = false;
+      sub.remove();
+    };
+  }, []);
+
+  const handleGrantLocation = async () => {
+    setGrantingLocation(true);
+    try {
+      const result = await ensureWifiPermission();
+      setWifiPerm(result);
+      if (result.granted) {
+        // Re-confirm home now that we can read the SSID; the away flag (and so
+        // this card) updates through the store if we're actually home.
+        await evaluateHomeNetwork();
+      } else if (!result.canAskAgain) {
+        // iOS won't show the prompt again — the only way back is system Settings.
+        toast(
+          "Enable Location for Dashboarr in Settings to use your home WiFi.",
+          "info",
+        );
+        await Linking.openSettings();
+      }
+    } catch {
+      toast("Couldn't request Location permission", "error");
+    } finally {
+      setGrantingLocation(false);
+    }
+  };
 
   const resetForm = () => {
     setSsid("");
@@ -317,6 +373,66 @@ export default function HomeNetworksScreen() {
           </Animated.View>
         ) : null}
       </Card>
+
+      {/* Recovery card (#168): we have home networks but are stuck "away" while
+          on WiFi — almost always missing Location permission on a freshly set-up
+          device, or this WiFi isn't a saved network. Hidden on cellular, where
+          remote-only is the correct, expected state. */}
+      {autoSwitchNetwork &&
+      networkAwayFromHome &&
+      homeNetworks.length > 0 &&
+      isOnWifi !== false ? (
+        <Card className="mb-4 gap-3 border border-amber-500/30 bg-amber-500/5">
+          <View className="flex-row items-center gap-2">
+            <Icon icon={WifiOff} size={18} color="#f59e0b" />
+            <Text className="text-amber-300 text-sm font-semibold">
+              Using remote URLs
+            </Text>
+          </View>
+          {/* Three-way: while the permission read is still in flight (null) we
+              show only the explanation, never a wrong action button that would
+              flip once it resolves. */}
+          {wifiPerm === null ? (
+            <Text className="text-zinc-400 text-xs leading-5">
+              The app is using your remote URLs because it hasn't confirmed
+              you're on a home network yet.
+            </Text>
+          ) : !wifiPerm.granted ? (
+            <>
+              <Text className="text-zinc-400 text-xs leading-5">
+                The app needs Location permission to read your WiFi name and
+                confirm you're home — until then it uses your remote URLs
+                everywhere. It's only used on-device to match your home networks.
+              </Text>
+              <Button
+                label={
+                  wifiPerm.canAskAgain
+                    ? "Grant Location permission"
+                    : "Open Settings"
+                }
+                onPress={handleGrantLocation}
+                loading={grantingLocation}
+                icon={<Icon icon={MapPin} size={14} color="#fff" />}
+                size="sm"
+              />
+            </>
+          ) : (
+            <>
+              <Text className="text-zinc-400 text-xs leading-5">
+                This WiFi isn't one of your saved home networks, so the app is
+                using your remote URLs. Add it to use local URLs here.
+              </Text>
+              <Button
+                label="Add current WiFi"
+                onPress={handleDetect}
+                loading={detecting}
+                icon={<Icon icon={Wifi} size={14} color="#fff" />}
+                size="sm"
+              />
+            </>
+          )}
+        </Card>
+      ) : null}
 
       {!homeNetworks.length ? (
         <View className="items-center justify-center py-20 gap-3">

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -181,6 +181,14 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
             >
             <Pressable
               onPress={() => {
+                // Offline purely because we're remote-only with no remote URL
+                // (#168) — send the user to Home Networks, where they can
+                // confirm home / grant Location, instead of a service screen
+                // that can't load while away.
+                if (entry.awayBlocked) {
+                  router.push("/home-networks");
+                  return;
+                }
                 if (!route) return;
                 // Switch the active instance to the one tapped so the
                 // destination tab opens against this server, not whichever

--- a/lib/wifi.test.ts
+++ b/lib/wifi.test.ts
@@ -1,0 +1,91 @@
+// expo-location and NetInfo are native; mock them so importing wifi.ts (which
+// calls NetInfo.configure at module load) pulls in nothing native.
+const mockGetPerm = jest.fn();
+const mockReqPerm = jest.fn();
+jest.mock("expo-location", () => ({
+  getForegroundPermissionsAsync: (...a: any[]) => mockGetPerm(...a),
+  requestForegroundPermissionsAsync: (...a: any[]) => mockReqPerm(...a),
+}));
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: {
+    configure: jest.fn(),
+    fetch: jest.fn(),
+    addEventListener: jest.fn(() => jest.fn()),
+  },
+}));
+
+import { Platform } from "react-native";
+import { ensureWifiPermission, getWifiPermissionStatus } from "./wifi";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (Platform as any).OS = "ios";
+});
+
+describe("ensureWifiPermission", () => {
+  it("returns granted without prompting when already granted", async () => {
+    mockGetPerm.mockResolvedValue({ status: "granted", canAskAgain: false });
+
+    const result = await ensureWifiPermission();
+
+    expect(result).toEqual({ granted: true, canAskAgain: false });
+    expect(mockReqPerm).not.toHaveBeenCalled();
+  });
+
+  it("prompts once when undetermined and the OS still allows it", async () => {
+    mockGetPerm.mockResolvedValue({ status: "undetermined", canAskAgain: true });
+    mockReqPerm.mockResolvedValue({ status: "granted", canAskAgain: false });
+
+    const result = await ensureWifiPermission();
+
+    expect(mockReqPerm).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ granted: true, canAskAgain: false });
+  });
+
+  it("does NOT prompt when hard-denied (canAskAgain false) — avoids a silent no-op loop", async () => {
+    mockGetPerm.mockResolvedValue({ status: "denied", canAskAgain: false });
+
+    const result = await ensureWifiPermission();
+
+    expect(mockReqPerm).not.toHaveBeenCalled();
+    expect(result).toEqual({ granted: false, canAskAgain: false });
+  });
+
+  it("reports still-denied after a declined prompt", async () => {
+    mockGetPerm.mockResolvedValue({ status: "undetermined", canAskAgain: true });
+    mockReqPerm.mockResolvedValue({ status: "denied", canAskAgain: false });
+
+    const result = await ensureWifiPermission();
+
+    expect(result).toEqual({ granted: false, canAskAgain: false });
+  });
+
+  it("treats non-native platforms as granted (no Location needed)", async () => {
+    (Platform as any).OS = "web";
+
+    const result = await ensureWifiPermission();
+
+    expect(mockGetPerm).not.toHaveBeenCalled();
+    expect(result).toEqual({ granted: true, canAskAgain: false });
+  });
+});
+
+describe("getWifiPermissionStatus", () => {
+  it("reports the granted state without ever prompting", async () => {
+    mockGetPerm.mockResolvedValue({ status: "granted", canAskAgain: false });
+
+    const result = await getWifiPermissionStatus();
+
+    expect(result.granted).toBe(true);
+    expect(mockReqPerm).not.toHaveBeenCalled();
+  });
+
+  it("reports a denied state with canAskAgain so the UI can offer Settings", async () => {
+    mockGetPerm.mockResolvedValue({ status: "denied", canAskAgain: false });
+
+    const result = await getWifiPermissionStatus();
+
+    expect(result).toEqual({ granted: false, canAskAgain: false });
+  });
+});

--- a/lib/wifi.ts
+++ b/lib/wifi.ts
@@ -38,6 +38,46 @@ export async function detectSSID(): Promise<string | null> {
   return wifi?.ssid ?? null;
 }
 
+export interface WifiPermissionState {
+  /** Location permission is granted, so SSID/BSSID reads will work. */
+  granted: boolean;
+  /** False once the OS will no longer surface the permission prompt (on iOS,
+   *  after the user denies it the first time). The UI uses this to offer "Open
+   *  Settings" instead of a re-request that would silently resolve to denied. */
+  canAskAgain: boolean;
+}
+
+/** Current Location-permission state, read WITHOUT prompting. */
+export async function getWifiPermissionStatus(): Promise<WifiPermissionState> {
+  if (Platform.OS !== "android" && Platform.OS !== "ios") {
+    return { granted: true, canAskAgain: false };
+  }
+  const { status, canAskAgain } =
+    await Location.getForegroundPermissionsAsync();
+  return { granted: status === "granted", canAskAgain };
+}
+
+/**
+ * Ensure Location permission (needed to read the WiFi SSID for home-network
+ * detection). Prompts once if the OS still allows it; never loops. Returns the
+ * resulting state so callers can fall back to opening system Settings when the
+ * OS has hard-denied — the #168 recovery path: a freshly set-up device that
+ * dismissed the one-shot post-import prompt otherwise has no way to confirm home
+ * (and thus no way back to local URLs) short of reinstalling.
+ */
+export async function ensureWifiPermission(): Promise<WifiPermissionState> {
+  if (Platform.OS !== "android" && Platform.OS !== "ios") {
+    return { granted: true, canAskAgain: false };
+  }
+  const current = await Location.getForegroundPermissionsAsync();
+  if (current.status === "granted") {
+    return { granted: true, canAskAgain: false };
+  }
+  if (!current.canAskAgain) return { granted: false, canAskAgain: false };
+  const next = await Location.requestForegroundPermissionsAsync();
+  return { granted: next.status === "granted", canAskAgain: next.canAskAgain };
+}
+
 export function normalizeBssid(value: string): string {
   return value.trim().toLowerCase();
 }

--- a/store/config-store.test.ts
+++ b/store/config-store.test.ts
@@ -21,7 +21,11 @@ jest.mock("expo-secure-store", () => ({
   deleteItemAsync: jest.fn(async () => {}),
 }));
 
-import { useConfigStore } from "./config-store";
+import {
+  useConfigStore,
+  stripImportedBssids,
+  repairOrphanedHomeNetworkSelection,
+} from "./config-store";
 import { setJSON } from "./storage";
 import { STORAGE_KEYS } from "@/lib/constants";
 import { queryClient } from "@/lib/query-client";
@@ -957,5 +961,66 @@ describe("setActiveDashboard — superset switch stays home (#14)", () => {
     } as Partial<ReturnType<typeof useConfigStore.getState>>);
     useConfigStore.getState().setActiveDashboard("B");
     expect(useConfigStore.getState().networkAwayFromHome).toBe(false);
+  });
+});
+
+// #168: a BSSID pinned on the source device won't match on the importing
+// device (different AP/band, or iOS hides it) → isHomeNetwork fails closed →
+// stuck "away" → remote-only on the real home WiFi. Strip pins on import so
+// matching is SSID-only; the SSID still has to match, so the invariant holds.
+describe("stripImportedBssids (#168)", () => {
+  it("clears pinned BSSIDs so imported networks match by SSID on a new device", () => {
+    expect(
+      stripImportedBssids([
+        { id: "1", ssid: "Home", bssid: "aa:bb:cc:dd:ee:ff" },
+        { id: "2", ssid: "Cabin", bssid: "" },
+      ]),
+    ).toEqual([
+      { id: "1", ssid: "Home", bssid: "" },
+      { id: "2", ssid: "Cabin", bssid: "" },
+    ]);
+  });
+
+  it("returns the same object reference for an unpinned entry (no needless copy)", () => {
+    const net = { id: "2", ssid: "Cabin", bssid: "" };
+    expect(stripImportedBssids([net])[0]).toBe(net);
+  });
+
+  it("handles an empty list", () => {
+    expect(stripImportedBssids([])).toEqual([]);
+  });
+});
+
+// #168: a non-empty home-network selection whose ids are ALL stale resolves to
+// an empty effective set, which getActiveUrl treats as "always remote" — local
+// URLs silently break with no recovery. Revert that to "use all networks".
+describe("repairOrphanedHomeNetworkSelection (#168)", () => {
+  const nets = [{ id: "home", ssid: "Home", bssid: "" }];
+  const dash = (homeNetworkIds?: any) =>
+    ({
+      id: "d1",
+      name: "D",
+      widgets: [],
+      ...(homeNetworkIds !== undefined ? { homeNetworkIds } : {}),
+    }) as any;
+
+  it("reverts a fully-orphaned selection to 'use all networks' (undefined)", () => {
+    const [d] = repairOrphanedHomeNetworkSelection([dash(["gone1", "gone2"])], nets);
+    expect("homeNetworkIds" in d).toBe(false);
+  });
+
+  it("keeps an explicit empty selection ([] = deliberate always-remote)", () => {
+    const [d] = repairOrphanedHomeNetworkSelection([dash([])], nets);
+    expect(d.homeNetworkIds).toEqual([]);
+  });
+
+  it("keeps a selection that still has at least one live id", () => {
+    const [d] = repairOrphanedHomeNetworkSelection([dash(["home", "gone"])], nets);
+    expect(d.homeNetworkIds).toEqual(["home", "gone"]);
+  });
+
+  it("leaves 'use all' (undefined) untouched", () => {
+    const [d] = repairOrphanedHomeNetworkSelection([dash(undefined)], nets);
+    expect("homeNetworkIds" in d).toBe(false);
   });
 });

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -684,6 +684,47 @@ function switchInvalidatesAwayFlag(
   return false;
 }
 
+/**
+ * Drop BSSID pins from imported home networks (#168). A pinned BSSID is the
+ * access-point radio MAC the source device recorded; on the importing device it
+ * often won't match — with mesh/multiple APs or 2.4-vs-5GHz the device can
+ * associate with a different radio (different BSSID), and iOS frequently doesn't
+ * surface a BSSID at all — and `isHomeNetwork` fails closed in those cases, so
+ * the device is stuck "away" → remote-only even on the real home WiFi (the two
+ * reports on #168). Stripping to SSID-only matching makes the transfer robust
+ * cross-device; the user can re-pin locally if they want the rogue-AP guard.
+ * The security invariant is intact — the SSID must still match before any local
+ * URL is used.
+ */
+export function stripImportedBssids(networks: HomeNetwork[]): HomeNetwork[] {
+  return networks.map((n) => (n.bssid ? { ...n, bssid: "" } : n));
+}
+
+/**
+ * Repair dashboards' home-network selections after import (#168). A selection
+ * that is a NON-EMPTY array but whose ids are ALL absent from the imported
+ * global list is corruption — a clean export/import keeps the two consistent —
+ * and it resolves to an empty effective set, which `getActiveUrl` treats as
+ * "always remote", silently breaking local URLs with no way for the user to
+ * recover. Revert those to `undefined` ("use all networks"). An explicit empty
+ * `[]` is left untouched (that's the user's deliberate "always remote" choice,
+ * not corruption), as are selections with at least one live id
+ * (`resolveEffectiveHomeNetworks` already ignores the stale ones).
+ */
+export function repairOrphanedHomeNetworkSelection(
+  dashboards: Dashboard[],
+  homeNetworks: HomeNetwork[],
+): Dashboard[] {
+  const validIds = new Set(homeNetworks.map((n) => n.id));
+  return dashboards.map((d) => {
+    const ids = d.homeNetworkIds;
+    if (!Array.isArray(ids) || ids.length === 0) return d;
+    if (ids.some((id) => validIds.has(id))) return d;
+    const { homeNetworkIds: _orphaned, ...rest } = d;
+    return rest as Dashboard;
+  });
+}
+
 function emptyLegacySecrets(): Record<ServiceId, ServiceSecrets> {
   const secrets = {} as Record<ServiceId, ServiceSecrets>;
   for (const id of SERVICE_IDS) {
@@ -2670,17 +2711,24 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     setBoolean(STORAGE_KEYS.autoSwitchNetwork, payload.autoSwitchNetwork ?? false);
     const importedTreatVpnAsHome = payload.treatVpnAsHome ?? false;
     setBoolean(STORAGE_KEYS.treatVpnAsHome, importedTreatVpnAsHome);
-    const importedHomeNetworks = payload.homeNetworks ?? [];
+    // Strip BSSID pins so imported networks match by SSID on this device (#168
+    // — a source-device AP MAC won't match here and would wedge us "away").
+    const importedHomeNetworks = stripImportedBssids(payload.homeNetworks ?? []);
     setJSON(STORAGE_KEYS.homeNetworks, importedHomeNetworks);
 
     // Dashboards (v14): trust the migrated payload — the migration chain has
     // already folded any legacy widgetSettings/dashboardWidgets into a single
     // Default dashboard. If the post-migration payload is somehow empty we
     // seed a fresh Default so the dashboard screen always has something.
-    const importedDashboards: Dashboard[] =
+    // Repair any fully-orphaned home-network selection (#168) so a dashboard
+    // whose ids all went stale reverts to "use all networks" instead of being
+    // silently pinned to "always remote".
+    const importedDashboards: Dashboard[] = repairOrphanedHomeNetworkSelection(
       Array.isArray(payload.dashboards) && payload.dashboards.length > 0
         ? payload.dashboards
-        : defaultDashboards();
+        : defaultDashboards(),
+      importedHomeNetworks,
+    );
     const importedActiveDashboardId =
       typeof payload.activeDashboardId === "string" &&
       importedDashboards.some((d) => d.id === payload.activeDashboardId)


### PR DESCRIPTION
## Summary
After importing a config, local-only services could stay stuck on remote URLs with no obvious way back. This adds recovery paths for the away state.

- Strip BSSID pins on import so home networks match by SSID on the new device (source-device AP MAC won't match; iOS often hides BSSID).
- Revert fully-orphaned dashboard `homeNetworkIds` selections to "use all networks" (an all-stale non-empty selection silently meant always-remote).
- Home Networks: recovery card when on WiFi but stuck away — prompts for Location permission (or routes to system Settings when hard-denied), re-reads permission on app resume.
- Post-import toast and away-blocked service tap both point the user to Home Networks.

The local-URL security invariant holds: SSID must still match before any local URL is used.

## Test plan
- `npx jest lib/wifi.test.ts store/config-store.test.ts` — 65 passing (new coverage for `ensureWifiPermission`/`getWifiPermissionStatus`, `stripImportedBssids`, `repairOrphanedHomeNetworkSelection`).