### PR TITLE
fix(releases): persist interactive-search filters (Refs #198)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import { useConfigStore } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
 import { useSortStore } from "@/store/sort-store";
 import { useGlancesUiStore } from "@/store/glances-ui-store";
+import { useReleaseFilterStore } from "@/store/releases-filter-store";
 import { useIntroStore } from "@/store/intro-store";
 import { queryClient } from "@/lib/query-client";
 import { configureNotifications } from "@/lib/notifications";
@@ -249,6 +250,7 @@ export default function RootLayout() {
   const hydrateBackend = useBackendStore((s) => s.hydrate);
   const hydrateSort = useSortStore((s) => s.hydrate);
   const hydrateGlancesUi = useGlancesUiStore((s) => s.hydrate);
+  const hydrateReleaseFilters = useReleaseFilterStore((s) => s.hydrate);
   const hydrateIntro = useIntroStore((s) => s.hydrate);
   const introHydrated = useIntroStore((s) => s.hydrated);
   const introSeen = useIntroStore((s) => s.workspaceIntroSeen);
@@ -267,9 +269,16 @@ export default function RootLayout() {
     if (hydrated) {
       hydrateSort();
       hydrateGlancesUi();
+      hydrateReleaseFilters();
       hydrateIntro();
     }
-  }, [hydrated, hydrateSort, hydrateGlancesUi, hydrateIntro]);
+  }, [
+    hydrated,
+    hydrateSort,
+    hydrateGlancesUi,
+    hydrateReleaseFilters,
+    hydrateIntro,
+  ]);
 
   // Intro overlay visibility: never auto-open during Demo Mode (user is
   // exploring fake data; an overlay on top would be noise). Re-mounts when

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -25,6 +25,11 @@ import { lightHaptic } from "@/lib/haptics";
 import { getHttpErrorMessage } from "@/lib/http-client";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import { useSortStore, type ReleasesSortKey } from "@/store/sort-store";
+import {
+  useReleaseFilterStore,
+  RELEASE_FILTER_DEFAULTS,
+  type ProtocolFilter,
+} from "@/store/releases-filter-store";
 import { useArrCustomFilters } from "@/hooks/use-arr-custom-filters";
 import { applyArrCustomFilter } from "@/lib/arr-custom-filters";
 
@@ -64,8 +69,6 @@ const SORT_SUMMARY: Record<ReleasesSortKey, string> = {
   "score-desc": "Score",
   "title-asc": "Title",
 };
-
-type ProtocolFilter = "all" | "torrent" | "usenet";
 
 function sortReleases(list: Release[], key: ReleasesSortKey): Release[] {
   const copy = [...list];
@@ -188,12 +191,27 @@ export function ReleasesPicker({
   const sortKey = useSortStore((s) => s.releases);
   const setSortKey = useSortStore((s) => s.setReleases);
 
-  const [hideRejected, setHideRejected] = useState(true);
+  // Filters persist across searches (#198) so they don't reset every time the
+  // picker remounts. Quality persists by NAME (stable cross-search), protocol
+  // and the rejected toggle are stable preferences too. The saved *arr filter
+  // (selectedFilterId) stays local — its id is per-instance, so persisting it
+  // could apply the wrong server-side filter across services/instances.
+  const prefHideRejected = useReleaseFilterStore((s) => s.hideRejected);
+  const setPrefHideRejected = useReleaseFilterStore((s) => s.setHideRejected);
+  const protocolFilter = useReleaseFilterStore((s) => s.protocol);
+  const setProtocolFilter = useReleaseFilterStore((s) => s.setProtocol);
+  const qualityFilter = useReleaseFilterStore((s) => s.quality);
+  const setQualityFilter = useReleaseFilterStore((s) => s.setQuality);
+  const resetFilters = useReleaseFilterStore((s) => s.reset);
+
   const [autoFlippedRejected, setAutoFlippedRejected] = useState(false);
-  const [protocolFilter, setProtocolFilter] = useState<ProtocolFilter>("all");
-  const [qualityFilter, setQualityFilter] = useState<string | null>(null);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
   const [selectedFilterId, setSelectedFilterId] = useState<number | null>(null);
+
+  // Effective rejected state: the saved preference, transiently overridden by a
+  // one-shot auto-flip when every result was rejected (below). The auto-flip is
+  // never written back to the store, so it can't corrupt the saved preference.
+  const hideRejected = prefHideRejected && !autoFlippedRejected;
 
   // Saved interactive-search filters configured in the *arr web UI. Only the
   // "releases" section is relevant here; the control is hidden when there are
@@ -277,16 +295,17 @@ export function ReleasesPicker({
   useEffect(() => {
     if (
       !flippedOnceRef.current &&
-      hideRejected &&
+      prefHideRejected &&
       data &&
       data.length > 0 &&
       data.every((r) => r.rejected)
     ) {
       flippedOnceRef.current = true;
-      setHideRejected(false);
+      // Transient override only — never written back to the store, so the
+      // saved "Accepted only" preference survives for the next search.
       setAutoFlippedRejected(true);
     }
-  }, [data, hideRejected]);
+  }, [data, prefHideRejected]);
 
   function handleRefresh() {
     if (isFetching) return;
@@ -296,9 +315,11 @@ export function ReleasesPicker({
 
   function handleClearFilters() {
     lightHaptic();
-    setHideRejected(false);
-    setProtocolFilter("all");
-    setQualityFilter(null);
+    // Reset the persisted filters to their defaults (not "show everything"),
+    // so clearing doesn't permanently flip the saved Show pref or leave the
+    // filter pill stuck highlighted. selectedFilterId is local/ephemeral.
+    resetFilters();
+    setAutoFlippedRejected(false);
     setSelectedFilterId(null);
   }
 
@@ -306,9 +327,9 @@ export function ReleasesPicker({
   // one is active, otherwise the rejection state; the dot/highlight signals any
   // additional protocol/quality filtering.
   const filterSortActive =
-    !hideRejected ||
-    protocolFilter !== "all" ||
-    qualityFilter !== null ||
+    hideRejected !== RELEASE_FILTER_DEFAULTS.hideRejected ||
+    protocolFilter !== RELEASE_FILTER_DEFAULTS.protocol ||
+    qualityFilter !== RELEASE_FILTER_DEFAULTS.quality ||
     selectedFilter !== null ||
     sortKey !== "seeders-desc";
   const filterSummary = selectedFilter
@@ -476,7 +497,7 @@ export function ReleasesPicker({
         ]}
         filterValue={hideRejected ? "hide" : "all"}
         onFilterChange={(v) => {
-          setHideRejected(v === "hide");
+          setPrefHideRejected(v === "hide");
           setAutoFlippedRejected(false);
         }}
         extraSections={extraSections}

--- a/store/releases-filter-store.test.ts
+++ b/store/releases-filter-store.test.ts
@@ -1,0 +1,107 @@
+// Mock the storage layer before importing the store — releases-filter-store
+// imports storage.ts at module load, which pulls in AsyncStorage/SecureStore.
+// Both are native modules unavailable in the jest-expo node environment, so we
+// replace them with no-op shims. setJSON/getJSON round-trip through storage.ts's
+// in-memory cache (synchronous), so persistence is still observable in tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  useReleaseFilterStore,
+  RELEASE_FILTER_DEFAULTS,
+  type ProtocolFilter,
+} from "./releases-filter-store";
+import { getJSON, setJSON, deleteKey } from "./storage";
+
+const STORAGE_KEY = "ui.releaseFilters";
+
+beforeEach(() => {
+  // Storage cache and the zustand store are module singletons shared across
+  // tests, so reset both to a clean slate.
+  deleteKey(STORAGE_KEY);
+  useReleaseFilterStore.setState(RELEASE_FILTER_DEFAULTS);
+});
+
+describe("useReleaseFilterStore (#198)", () => {
+  it("starts at the documented defaults", () => {
+    const { hideRejected, protocol, quality } =
+      useReleaseFilterStore.getState();
+    expect({ hideRejected, protocol, quality }).toEqual(RELEASE_FILTER_DEFAULTS);
+    expect(RELEASE_FILTER_DEFAULTS).toEqual({
+      hideRejected: true,
+      protocol: "all",
+      quality: null,
+    });
+  });
+
+  it("each setter updates state AND write-through persists", () => {
+    useReleaseFilterStore.getState().setHideRejected(false);
+    useReleaseFilterStore.getState().setProtocol("torrent");
+    useReleaseFilterStore.getState().setQuality("WEBDL-1080p");
+
+    const { hideRejected, protocol, quality } =
+      useReleaseFilterStore.getState();
+    expect({ hideRejected, protocol, quality }).toEqual({
+      hideRejected: false,
+      protocol: "torrent",
+      quality: "WEBDL-1080p",
+    });
+    // Only the three persisted fields land in storage — not the methods.
+    expect(getJSON(STORAGE_KEY)).toEqual({
+      hideRejected: false,
+      protocol: "torrent",
+      quality: "WEBDL-1080p",
+    });
+  });
+
+  it("hydrate() merges a partial stored blob over defaults", () => {
+    // Forward-compat: an older/partial persisted blob (only protocol) must keep
+    // the other fields at their current defaults rather than turning them
+    // undefined.
+    setJSON(STORAGE_KEY, { protocol: "usenet" as ProtocolFilter });
+
+    useReleaseFilterStore.getState().hydrate();
+
+    const { hideRejected, protocol, quality } =
+      useReleaseFilterStore.getState();
+    expect(protocol).toBe("usenet");
+    expect(hideRejected).toBe(RELEASE_FILTER_DEFAULTS.hideRejected);
+    expect(quality).toBe(RELEASE_FILTER_DEFAULTS.quality);
+  });
+
+  it("hydrate() with nothing stored keeps defaults (no throw)", () => {
+    expect(() => useReleaseFilterStore.getState().hydrate()).not.toThrow();
+    const { hideRejected, protocol, quality } =
+      useReleaseFilterStore.getState();
+    expect({ hideRejected, protocol, quality }).toEqual(RELEASE_FILTER_DEFAULTS);
+  });
+
+  it("reset() returns state to defaults and persists them", () => {
+    const s = useReleaseFilterStore.getState();
+    s.setHideRejected(false);
+    s.setProtocol("usenet");
+    s.setQuality("Bluray-2160p");
+
+    useReleaseFilterStore.getState().reset();
+
+    const { hideRejected, protocol, quality } =
+      useReleaseFilterStore.getState();
+    expect({ hideRejected, protocol, quality }).toEqual(RELEASE_FILTER_DEFAULTS);
+    expect(getJSON(STORAGE_KEY)).toEqual(RELEASE_FILTER_DEFAULTS);
+  });
+});

--- a/store/releases-filter-store.ts
+++ b/store/releases-filter-store.ts
@@ -1,0 +1,75 @@
+import { create } from "zustand";
+import { getJSON, setJSON } from "@/store/storage";
+
+const STORAGE_KEY = "ui.releaseFilters";
+
+// Quick interactive-search release filters. Persisted so they survive the
+// picker remounting on every new search (issue #198) — the sort key already
+// persists via sort-store, which is why sort stuck but these didn't. Shared
+// across Radarr and Sonarr (one global blob), matching how the `releases`
+// sort key is already shared.
+//
+// Notably NOT persisted: the saved *arr custom filter selection. Its id is a
+// per-instance auto-increment integer (Radarr #3 ≠ Sonarr #3), so a global id
+// would risk applying the wrong server-side filter; it stays per-search.
+export type ProtocolFilter = "all" | "torrent" | "usenet";
+
+interface ReleaseFilterPrefs {
+  /** Hide rejected releases ("Accepted only"). */
+  hideRejected: boolean;
+  protocol: ProtocolFilter;
+  /** Quality NAME (e.g. "WEBDL-1080p"), not an id — names are stable across
+   *  searches, unlike *arr filter ids. null = all qualities. */
+  quality: string | null;
+}
+
+export const RELEASE_FILTER_DEFAULTS: ReleaseFilterPrefs = {
+  hideRejected: true,
+  protocol: "all",
+  quality: null,
+};
+
+interface ReleaseFilterStore extends ReleaseFilterPrefs {
+  hydrate: () => void;
+  setHideRejected: (v: boolean) => void;
+  setProtocol: (v: ProtocolFilter) => void;
+  setQuality: (v: string | null) => void;
+  /** Reset every filter to its default (the "Clear filters" path). */
+  reset: () => void;
+}
+
+function snapshot(state: ReleaseFilterPrefs): ReleaseFilterPrefs {
+  return {
+    hideRejected: state.hideRejected,
+    protocol: state.protocol,
+    quality: state.quality,
+  };
+}
+
+export const useReleaseFilterStore = create<ReleaseFilterStore>((set, get) => ({
+  ...RELEASE_FILTER_DEFAULTS,
+
+  // Reads from the storage cache, populated by useConfigStore.hydrate(). Must
+  // be called after that; safe to call multiple times.
+  hydrate: () => {
+    const stored = getJSON<Partial<ReleaseFilterPrefs>>(STORAGE_KEY);
+    if (stored) set({ ...RELEASE_FILTER_DEFAULTS, ...stored });
+  },
+
+  setHideRejected: (hideRejected) => {
+    set({ hideRejected });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), hideRejected }));
+  },
+  setProtocol: (protocol) => {
+    set({ protocol });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), protocol }));
+  },
+  setQuality: (quality) => {
+    set({ quality });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), quality }));
+  },
+  reset: () => {
+    set(RELEASE_FILTER_DEFAULTS);
+    setJSON(STORAGE_KEY, snapshot(RELEASE_FILTER_DEFAULTS));
+  },
+}));


### PR DESCRIPTION
## Summary
Interactive-search filters reset to defaults on every new search because the picker held them in component-local state and remounts per search; only the sort key persisted. Now Show / Protocol / Quality persist (new `ui.releaseFilters` store mirroring `sort-store`), shared across Radarr+Sonarr.

The saved *arr custom filter stays per-search — its per-instance id could otherwise apply the wrong filter across services/instances. The all-rejected auto-flip is kept as a transient override (`hideRejected = pref && !autoFlipped`) so it can't overwrite the saved preference.

Refs #198

## Test plan
- `npx tsc --noEmit` clean; `pnpm jest store/ lib/` → 559 passed (incl. 5 new store tests).
- Manual: set Show=All / Protocol=Torrent / Quality=X on one episode search → reopen a different search → filters persist. All-rejected search still auto-flips without changing the saved Show pref.