### PR TITLE
fix(tracearr): honor per-instance notification overrides without ?instance= (Refs #200)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1516,9 +1516,10 @@ function WebhookInstanceIdCard({
       </Text>
       <Text className="text-zinc-400 text-xs leading-5">
         Append <Text className="text-zinc-200">?instance=&lt;id&gt;</Text> to your
-        backend webhook URL in this service's notification settings so push
-        notifications can be tagged with this instance's name. Optional —
-        without it, pushes still arrive but aren't attributed.
+        backend webhook URL in this service's notification settings to tag pushes
+        with this instance's name and apply its per-instance notification
+        settings. Only needed when you run more than one instance of this service
+        — with a single instance, both apply automatically.
       </Text>
       <Pressable
         onPress={() => void handleCopy()}

--- a/backend/dashboarr-backend/src/db/repos/service-instance.ts
+++ b/backend/dashboarr-backend/src/db/repos/service-instance.ts
@@ -127,6 +127,22 @@ export function getServiceInstance(id: string): StoredServiceInstance | null {
 }
 
 /**
+ * Returns the sole enabled instance of a kind, or null when there are 0 or >1.
+ * Used by the webhook resolver to attribute (and apply per-instance notification
+ * overrides for) an inbound event when the URL carries no `?instance=` — with a
+ * single instance there's no ambiguity about which one sent it.
+ */
+export function getSoleEnabledInstanceByKind(kind: ServiceId): StoredServiceInstance | null {
+  const rows = getDb()
+    .prepare<[string], ServiceInstanceRow>(
+      "SELECT * FROM service_instance WHERE enabled = 1 AND service_id = ?",
+    )
+    .all(kind);
+  const [first] = rows;
+  return rows.length === 1 && first ? mapRow(first) : null;
+}
+
+/**
  * Used by the offline-push attribution path: we only want to disambiguate the
  * push body when a kind has more than one enabled instance.
  */

--- a/backend/dashboarr-backend/src/routes/webhooks/shared.ts
+++ b/backend/dashboarr-backend/src/routes/webhooks/shared.ts
@@ -4,6 +4,7 @@ import { getWebhookSecret } from "../../db/repos/settings.js";
 import {
   countEnabledInstancesByKind,
   getServiceInstance,
+  getSoleEnabledInstanceByKind,
   type StoredServiceInstance,
 } from "../../db/repos/service-instance.js";
 import type { ServiceId } from "../../types.js";
@@ -49,16 +50,23 @@ export async function checkWebhookSecret(
 }
 
 /**
- * Resolve the optional `?instance=<uuid>` query param to the matching
- * service_instance row, scoped to a service kind. Used by per-service webhook
- * handlers to attribute the inbound event to a specific instance ("Radarr
- * Seedbox: Movie X downloaded" instead of "Radarr: Movie X downloaded").
+ * Resolve the inbound webhook to a specific service_instance, scoped to a kind.
+ * Used by per-service webhook handlers to attribute the event ("Radarr Seedbox:
+ * Movie X downloaded" instead of "Radarr: Movie X downloaded") AND to make the
+ * dispatcher apply that instance's per-instance notification overrides.
  *
- * Returns null in two cases — both treated as "kind-only attribution":
- *  - The query param is absent (legacy webhook URL).
- *  - The param is present but doesn't match any enabled instance of `kind`
- *    (stale URL after the user deleted the instance, or kind mismatch from a
- *    misconfigured webhook URL pasted into the wrong service).
+ * Resolution order:
+ *  1. `?instance=<uuid>` — when present and it matches an enabled instance of
+ *     `kind`, use it. A stale/mismatched id falls through to step 2.
+ *  2. Sole-instance fallback — when there's exactly one enabled instance of
+ *     `kind`, attribute to it. With a single instance there's no ambiguity about
+ *     which one sent the event, and it lets per-instance notification overrides
+ *     apply without the user appending `?instance=` to the webhook URL. This is
+ *     essential for Tracearr, whose categories are per-instance-only and several
+ *     of which default off — without it a user's "Always notify" never takes
+ *     effect on the common single-instance, no-`?instance=` setup (issue #200).
+ *  3. Otherwise null ("kind-only attribution") — 0 or >1 enabled instances and
+ *     no usable `?instance=`.
  *
  * We deliberately don't 4xx on a missing/unknown instance — the secret has
  * already been verified, the upstream service won't retry on a 4xx anyway,
@@ -69,12 +77,12 @@ export function resolveWebhookInstance(
   kind: ServiceId,
 ): StoredServiceInstance | null {
   const id = request.query.instance;
-  if (!id) return null;
-  const inst = getServiceInstance(id);
-  if (!inst) return null;
-  if (inst.serviceId !== kind) return null;
-  if (!inst.enabled) return null;
-  return inst;
+  if (id) {
+    const inst = getServiceInstance(id);
+    if (inst && inst.serviceId === kind && inst.enabled) return inst;
+    // Stale / kind-mismatched id — fall through to the sole-instance fallback.
+  }
+  return getSoleEnabledInstanceByKind(kind);
 }
 
 /**


### PR DESCRIPTION
## Summary
Tracearr `stream_started`/`stopped` pushes were silently dropped. Those categories have no global toggle and are controlled only per-instance, but the dispatcher only consults the per-instance override when the webhook URL carries `?instance=<id>` — which the default URL omits, so it fell back to the global default (off). The test webhook works because it bypasses the category gate.

The webhook resolver now falls back to the **sole enabled instance** of a kind when no usable `?instance=` is present, so a single instance's "Always notify" applies automatically. Multi-instance is unchanged (still needs `?instance=`). Also fixes the misleading in-app webhook-attribution copy.

## Test plan
- Backend + app `tsc --noEmit` clean.
- Local `app.inject()` smoke test over a seeded DB, asserted via `seen_state` dedupe rows (written only after the gate passes): sole-instance + override → sent; sole-instance no override → dropped; 2 instances no `?instance=` → dropped; 2 instances + `?instance=` → sent; bad secret → 401. Reverting just the resolver flips only the first case.

Refs #200