### PR TITLE
fix(search): stay on release list after grabbing (Refs #199)

### DIFF
--- a/components/common/release-detail-sheet.tsx
+++ b/components/common/release-detail-sheet.tsx
@@ -43,7 +43,6 @@ interface ReleaseDetailSheetProps {
   service: "radarr" | "sonarr";
   instanceId?: string;
   onClose: () => void;
-  onGrabbed?: () => void;
   /**
    * Fired once the sheet's native `<Modal>` is fully gone — the safe point to
    * navigate on iOS (see `useModalClosed`).
@@ -56,7 +55,6 @@ export function ReleaseDetailSheet({
   service,
   instanceId,
   onClose,
-  onGrabbed,
   onClosed,
 }: ReleaseDetailSheetProps) {
   const insets = useSafeAreaInsets();
@@ -118,7 +116,6 @@ export function ReleaseDetailSheet({
       {
         onSuccess: () => {
           onClose();
-          onGrabbed?.();
         },
       },
     );

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -514,13 +514,6 @@ export function ReleasesPicker({
         service={service}
         instanceId={instanceId}
         onClose={flow.close}
-        onGrabbed={() => {
-          // After a grab succeeds, pop back to the detail screen so the user
-          // sees their queue update in context — flow.back() pops only once
-          // the sheet has fully dismissed (navigating mid-dismiss hangs
-          // iOS/Fabric). Never reintroduce a fixed setTimeout here.
-          flow.back();
-        }}
         onClosed={flow.onClosed}
       />
     </View>


### PR DESCRIPTION
Refs #199

Interactive search now keeps you on the release list after a grab instead of bouncing back to the episode/movie list, so you can grab more without re-searching.

The release list is a route and the detail is a modal over it. On grab success, `onClose()` already closes the sheet (returning to the list); the extra `onGrabbed` → `flow.back()` then ran `router.back()`, popping the whole route. Dropped it (and the dead `onGrabbed` plumbing). Applies to both Sonarr and Radarr via the shared `ReleasesPicker`.

## Test plan
- Series → episode ⋯ → Interactive Search → tap release → Grab: toast shows, sheet closes, you stay on the list; grab another immediately.
- Movie → Search → Grab: stay on the list.
- Back gesture still returns to series/movie detail.
- `tsc --noEmit` clean.