### PR TITLE
fix(home-network): refresh NetInfo so SSID surfaces after permission grant (Refs #168)

### DIFF
--- a/app/home-networks.tsx
+++ b/app/home-networks.tsx
@@ -13,7 +13,8 @@ import { toast } from "@/components/ui/toast";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useConfigStore } from "@/store/config-store";
 import {
-  detectWifi,
+  detectWifiWithRefresh,
+  refreshWifiIdentity,
   validateHomeNetworkInput,
   ensureWifiPermission,
   getWifiPermissionStatus,
@@ -105,6 +106,11 @@ export default function HomeNetworksScreen() {
   // Settings". The Grant button also refreshes it directly.
   const [wifiPerm, setWifiPerm] = useState<WifiPermissionState | null>(null);
   const [grantingLocation, setGrantingLocation] = useState(false);
+  // Permission granted + on WiFi, but the SSID still won't surface after a
+  // refresh+retry (#168) — e.g. Precise Location off, or the WiFi hasn't
+  // re-associated. Distinct from "this WiFi isn't saved" so the card can offer
+  // a real next step (retry / toggle WiFi) instead of the wrong "add it" copy.
+  const [ssidUnreadable, setSsidUnreadable] = useState(false);
   useEffect(() => {
     let alive = true;
     const read = () => {
@@ -128,6 +134,13 @@ export default function HomeNetworksScreen() {
       const result = await ensureWifiPermission();
       setWifiPerm(result);
       if (result.granted) {
+        // Warm NetInfo's singleton (refresh+retry) so the just-authorized SSID
+        // surfaces before we evaluate (#168). If it never does while we're on
+        // WiFi, flag it so the card offers a retry instead of "add this WiFi".
+        const id = await refreshWifiIdentity();
+        setSsidUnreadable(
+          id === null && useConfigStore.getState().isOnWifi === true,
+        );
         // Re-confirm home now that we can read the SSID; the away flag (and so
         // this card) updates through the store if we're actually home.
         await evaluateHomeNetwork();
@@ -141,6 +154,28 @@ export default function HomeNetworksScreen() {
       }
     } catch {
       toast("Couldn't request Location permission", "error");
+    } finally {
+      setGrantingLocation(false);
+    }
+  };
+
+  // "Retry detection" for the SSID-unreadable card state (#168): re-runs the
+  // refresh+retry warm-up and re-evaluates. Permission is already granted here
+  // (this state only shows then), so refreshWifiIdentity won't prompt.
+  const handleRetryDetection = async () => {
+    setGrantingLocation(true);
+    try {
+      const id = await refreshWifiIdentity();
+      setSsidUnreadable(id === null);
+      await evaluateHomeNetwork();
+      if (id === null) {
+        toast(
+          "Still can't read your WiFi name. Toggle WiFi off/on, and make sure Precise Location is enabled for Dashboarr.",
+          "info",
+        );
+      }
+    } catch {
+      toast("Failed to detect WiFi name", "error");
     } finally {
       setGrantingLocation(false);
     }
@@ -171,7 +206,9 @@ export default function HomeNetworksScreen() {
   const handleDetect = async () => {
     setDetecting(true);
     try {
-      const wifi = await detectWifi();
+      // Refresh+retry so a freshly-granted device surfaces the SSID (#168);
+      // user-initiated and one-shot, so the brief retry budget is fine here.
+      const wifi = await detectWifiWithRefresh();
       if (!wifi) {
         toast(
           "Could not detect WiFi name. Check that you're on WiFi and location is allowed.",
@@ -413,6 +450,22 @@ export default function HomeNetworksScreen() {
                 onPress={handleGrantLocation}
                 loading={grantingLocation}
                 icon={<Icon icon={MapPin} size={14} color="#fff" />}
+                size="sm"
+              />
+            </>
+          ) : ssidUnreadable ? (
+            <>
+              <Text className="text-zinc-400 text-xs leading-5">
+                Location is allowed and you're on WiFi, but the app still can't
+                read the network name, so it's using your remote URLs. This
+                usually clears by toggling WiFi off and on, or enabling Precise
+                Location for Dashboarr in iOS Settings.
+              </Text>
+              <Button
+                label="Retry detection"
+                onPress={handleRetryDetection}
+                loading={grantingLocation}
+                icon={<Icon icon={Wifi} size={14} color="#fff" />}
                 size="sm"
               />
             </>

--- a/lib/network.test.ts
+++ b/lib/network.test.ts
@@ -1,13 +1,24 @@
 // Mock NetInfo (native) and the config store so importing network.ts pulls in
 // no native modules and the store is fully controllable.
 const mockFetch = jest.fn();
+const mockRefresh = jest.fn();
 jest.mock("@react-native-community/netinfo", () => ({
   __esModule: true,
   default: {
     configure: jest.fn(),
     fetch: (...args: any[]) => mockFetch(...args),
+    refresh: (...args: any[]) => mockRefresh(...args),
     addEventListener: jest.fn(() => jest.fn()),
   },
+}));
+
+// network.ts pulls in lib/wifi.ts (via detectWifiWithRefresh), which imports
+// expo-location — mock it so the import is native-free and the permission
+// prompt is controllable.
+const mockReqPerm = jest.fn();
+jest.mock("expo-location", () => ({
+  getForegroundPermissionsAsync: jest.fn(),
+  requestForegroundPermissionsAsync: (...a: any[]) => mockReqPerm(...a),
 }));
 
 const mockGetState = jest.fn();
@@ -21,10 +32,12 @@ jest.mock("@/lib/vpn", () => ({
   detectVpnActive: () => mockDetectVpnActive(),
 }));
 
+import { Platform } from "react-native";
 import {
   isHomeNetwork,
   evaluateHomeNetwork,
   resolveEffectiveHomeNetworks,
+  reevaluateHomeNetworkAfterImport,
 } from "./network";
 
 const wifi = (ssid: string | null, bssid: string | null = null) =>
@@ -304,6 +317,89 @@ describe("evaluateHomeNetwork", () => {
     // The queued re-run read the FRESH snapshot (opt-in on + VPN) → away=false.
     expect(before.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
     expect(after.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("reevaluateHomeNetworkAfterImport", () => {
+  function fakeStore(over: Record<string, any> = {}) {
+    return {
+      demoMode: false,
+      autoSwitchNetwork: true,
+      treatVpnAsHome: false,
+      homeNetworks: [{ id: "1", ssid: "Home", bssid: "" }],
+      dashboards: [],
+      activeDashboardId: "",
+      setNetworkAwayFromHome: jest.fn(),
+      setIsVpnActive: jest.fn(),
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    // detectWifiWithRefresh only prompts/refreshes on a native platform.
+    (Platform as any).OS = "ios";
+  });
+
+  it("prompts for Location, warms the SSID, then clears away on the home WiFi", async () => {
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockReqPerm.mockResolvedValue({ status: "granted" });
+    mockRefresh.mockResolvedValue(wifi("Home")); // surfaces on first refresh
+    mockFetch.mockResolvedValue(wifi("Home"));
+
+    await reevaluateHomeNetworkAfterImport();
+
+    expect(mockReqPerm).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenLastCalledWith(false);
+  });
+
+  it("stays away when the confirmed WiFi isn't a home network", async () => {
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockReqPerm.mockResolvedValue({ status: "granted" });
+    mockRefresh.mockResolvedValue(wifi("Cafe"));
+    mockFetch.mockResolvedValue(wifi("Cafe"));
+
+    await reevaluateHomeNetworkAfterImport();
+
+    expect(store.setNetworkAwayFromHome).toHaveBeenLastCalledWith(true);
+  });
+
+  it("stays away (honest result) when Location is denied — never refreshes", async () => {
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockReqPerm.mockResolvedValue({ status: "denied" });
+    mockFetch.mockResolvedValue(wifi(null));
+
+    await reevaluateHomeNetworkAfterImport();
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenLastCalledWith(true);
+  });
+
+  it("is a full no-op with no home networks and no treatVpnAsHome (no prompt)", async () => {
+    const store = fakeStore({ homeNetworks: [] });
+    mockGetState.mockReturnValue(store);
+
+    await reevaluateHomeNetworkAfterImport();
+
+    expect(mockReqPerm).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).not.toHaveBeenCalled();
+  });
+
+  it("clears away via the VPN check with zero networks — without a permission prompt", async () => {
+    const store = fakeStore({ homeNetworks: [], treatVpnAsHome: true });
+    mockGetState.mockReturnValue(store);
+    mockDetectVpnActive.mockReturnValue(true);
+
+    await reevaluateHomeNetworkAfterImport();
+
+    expect(mockReqPerm).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
   });
 });
 

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -1,7 +1,7 @@
 import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
 import type { Dashboard, HomeNetwork } from "@/store/config-store";
-import { detectWifi } from "@/lib/wifi";
+import { detectWifiWithRefresh } from "@/lib/wifi";
 import { detectVpnActive } from "@/lib/vpn";
 
 /**
@@ -148,10 +148,11 @@ async function evaluateHomeNetworkOnce(): Promise<void> {
  * device almost certainly hasn't granted yet — so local-only services stay stuck
  * "invalid URL" until the user stumbles onto the permission.
  *
- * This requests the permission (via detectWifi, which also ensures NetInfo is
- * configured to surface the SSID on iOS) *while the user is actively setting the
- * device up*, then evaluates. No-op when auto-switch is off or no home networks
- * are configured — in those cases the SSID is never needed, so we don't prompt.
+ * This requests the permission (via detectWifiWithRefresh, which also force-
+ * refreshes NetInfo so the just-authorized SSID surfaces on iOS) *while the user
+ * is actively setting the device up*, then evaluates. No-op when auto-switch is
+ * off or no home networks are configured — in those cases the SSID is never
+ * needed, so we don't prompt.
  */
 export async function reevaluateHomeNetworkAfterImport(): Promise<void> {
   const store = useConfigStore.getState();
@@ -167,9 +168,11 @@ export async function reevaluateHomeNetworkAfterImport(): Promise<void> {
     if (store.treatVpnAsHome) await evaluateHomeNetwork();
     return;
   }
-  // Prompt for Location now; if granted, the subsequent evaluate reads the real
-  // SSID and clears the away flag when we're home. If denied, we stay safely
-  // "away" (remote-only) — the honest result.
-  await detectWifi();
+  // Prompt for Location now; refresh+retry so the SSID is readable on a device
+  // granting permission for the FIRST time (netinfo iOS null-SSID bug, #168) —
+  // this also warms NetInfo's singleton, so the evaluateHomeNetwork() fetch below
+  // reads the surfaced SSID and clears the away flag when we're home. If denied,
+  // we stay safely "away" (remote-only) — the honest result.
+  await detectWifiWithRefresh();
   await evaluateHomeNetwork();
 }

--- a/lib/wifi.test.ts
+++ b/lib/wifi.test.ts
@@ -6,17 +6,30 @@ jest.mock("expo-location", () => ({
   getForegroundPermissionsAsync: (...a: any[]) => mockGetPerm(...a),
   requestForegroundPermissionsAsync: (...a: any[]) => mockReqPerm(...a),
 }));
+const mockRefresh = jest.fn();
 jest.mock("@react-native-community/netinfo", () => ({
   __esModule: true,
   default: {
     configure: jest.fn(),
     fetch: jest.fn(),
+    refresh: (...a: any[]) => mockRefresh(...a),
     addEventListener: jest.fn(() => jest.fn()),
   },
 }));
 
 import { Platform } from "react-native";
-import { ensureWifiPermission, getWifiPermissionStatus } from "./wifi";
+import {
+  ensureWifiPermission,
+  getWifiPermissionStatus,
+  refreshWifiIdentity,
+  detectWifiWithRefresh,
+} from "./wifi";
+
+// Never wait real time in the refresh+retry loop.
+const noSleep = async () => {};
+const wifiState = (ssid: string | null, bssid: string | null = null) =>
+  ({ type: "wifi", details: { ssid, bssid } }) as any;
+const cellularState = () => ({ type: "cellular", details: {} }) as any;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -87,5 +100,78 @@ describe("getWifiPermissionStatus", () => {
     const result = await getWifiPermissionStatus();
 
     expect(result).toEqual({ granted: false, canAskAgain: false });
+  });
+});
+
+describe("refreshWifiIdentity", () => {
+  it("returns the identity on the first refresh, lowercasing the BSSID", async () => {
+    mockRefresh.mockResolvedValueOnce(wifiState("Home", "AA:BB:CC"));
+
+    const result = await refreshWifiIdentity(noSleep);
+
+    expect(result).toEqual({ ssid: "Home", bssid: "aa:bb:cc" });
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries until the SSID surfaces — the post-grant null-SSID bug (#168)", async () => {
+    // iOS: first read after the permission grant has no SSID yet; the next does.
+    mockRefresh
+      .mockResolvedValueOnce(wifiState(null))
+      .mockResolvedValueOnce(wifiState("Home"));
+
+    const result = await refreshWifiIdentity(noSleep);
+
+    expect(result).toEqual({ ssid: "Home", bssid: "" });
+    expect(mockRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up (null) after the retry budget when the SSID never surfaces", async () => {
+    mockRefresh.mockResolvedValue(wifiState(null));
+
+    const result = await refreshWifiIdentity(noSleep);
+
+    expect(result).toBeNull();
+    expect(mockRefresh).toHaveBeenCalledTimes(4); // WIFI_REFRESH_ATTEMPTS
+  });
+
+  it("bails immediately when not on WiFi (no point retrying)", async () => {
+    mockRefresh.mockResolvedValue(cellularState());
+
+    const result = await refreshWifiIdentity(noSleep);
+
+    expect(result).toBeNull();
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null without refreshing on non-native platforms", async () => {
+    (Platform as any).OS = "web";
+
+    const result = await refreshWifiIdentity(noSleep);
+
+    expect(result).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectWifiWithRefresh", () => {
+  it("prompts for Location, then warms until the SSID surfaces", async () => {
+    mockReqPerm.mockResolvedValue({ status: "granted" });
+    mockRefresh
+      .mockResolvedValueOnce(wifiState(null))
+      .mockResolvedValueOnce(wifiState("Home", "aa:bb"));
+
+    const result = await detectWifiWithRefresh(noSleep);
+
+    expect(mockReqPerm).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ssid: "Home", bssid: "aa:bb" });
+  });
+
+  it("returns null without refreshing when Location is denied", async () => {
+    mockReqPerm.mockResolvedValue({ status: "denied" });
+
+    const result = await detectWifiWithRefresh(noSleep);
+
+    expect(result).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 });

--- a/lib/wifi.ts
+++ b/lib/wifi.ts
@@ -15,6 +15,19 @@ export interface WifiIdentity {
   bssid: string;
 }
 
+// Warm-up tuning for the iOS netinfo SSID-null-after-grant bug (#168): right
+// after Location permission is FIRST granted, the next NetInfo.fetch() returns a
+// null SSID until the WiFi re-associates or the app restarts. NetInfo.refresh()
+// force-refreshes the singleton; a few retries outlast the brief window where
+// the OS hasn't surfaced the SSID yet. User-initiated/one-shot, so ~1.2s worst
+// case is fine — the steady-state poll never runs this.
+const WIFI_REFRESH_ATTEMPTS = 4;
+const WIFI_REFRESH_DELAY_MS = 400;
+
+/** Injectable so tests pass a no-op instead of waiting real time. */
+type Sleep = (ms: number) => Promise<void>;
+const realSleep: Sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 export async function detectWifi(): Promise<WifiIdentity | null> {
   // Both Android and iOS require Location permission to read WiFi SSID/BSSID.
   // On iOS this also needs the `com.apple.developer.networking.wifi-info`
@@ -36,6 +49,59 @@ export async function detectWifi(): Promise<WifiIdentity | null> {
 export async function detectSSID(): Promise<string | null> {
   const wifi = await detectWifi();
   return wifi?.ssid ?? null;
+}
+
+/**
+ * Force-refresh NetInfo's global singleton and poll until the WiFi SSID is
+ * readable, working around the netinfo iOS bug where the SSID stays null on the
+ * first read right after Location permission is first granted, until the WiFi
+ * re-associates or the app restarts (#168). Returns the identity once the SSID
+ * surfaces, or null if it never does within the budget (caller stays "away" →
+ * remote, the honest result). Assumes Location permission is already granted —
+ * does NOT prompt (callers prompt first via detectWifi / ensureWifiPermission).
+ *
+ * Side effect: leaves the singleton warm, so a subsequent NetInfo.fetch()
+ * elsewhere (evaluateHomeNetwork's own fetch) reads the surfaced SSID too.
+ */
+export async function refreshWifiIdentity(
+  sleep: Sleep = realSleep,
+): Promise<WifiIdentity | null> {
+  if (Platform.OS !== "android" && Platform.OS !== "ios") return null;
+  for (let attempt = 0; attempt < WIFI_REFRESH_ATTEMPTS; attempt++) {
+    // refresh() resolves with the same state the next fetch() would return, so
+    // read it directly and skip a redundant native round-trip per attempt.
+    const state = await NetInfo.refresh();
+    if (state.type === "wifi" && state.details?.ssid) {
+      return {
+        ssid: state.details.ssid,
+        bssid:
+          typeof state.details.bssid === "string"
+            ? state.details.bssid.toLowerCase()
+            : "",
+      };
+    }
+    // Not on WiFi at all → no amount of retrying surfaces an SSID; bail fast so
+    // cellular/away callers don't wait out the whole budget.
+    if (state.type !== "wifi") return null;
+    if (attempt < WIFI_REFRESH_ATTEMPTS - 1) await sleep(WIFI_REFRESH_DELAY_MS);
+  }
+  return null;
+}
+
+/**
+ * Like `detectWifi`, but works around the post-grant null-SSID bug (#168):
+ * prompts for Location, then refresh+retries until the SSID surfaces. Use on
+ * user-initiated recovery paths (config import, manual "detect", grant). The
+ * cheap single-fetch `detectWifi` stays for the steady-state poll.
+ */
+export async function detectWifiWithRefresh(
+  sleep?: Sleep,
+): Promise<WifiIdentity | null> {
+  if (Platform.OS === "android" || Platform.OS === "ios") {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== "granted") return null;
+  }
+  return refreshWifiIdentity(sleep);
 }
 
 export interface WifiPermissionState {


### PR DESCRIPTION
## Summary
After a config import on a fresh second phone, local-only services stayed stuck on remote URLs even on the home WiFi. Cause: every WiFi read used `NetInfo.fetch()`, which on iOS returns a null SSID on the first read right after Location permission is first granted (until WiFi re-associates or the app restarts). The import recovery flow read that null SSID and stayed "away". `NetInfo.refresh()` surfaces the just-authorized SSID.

- Add `refreshWifiIdentity` + `detectWifiWithRefresh` (`NetInfo.refresh` + bounded retry) in `lib/wifi.ts`.
- Warm the singleton on the import re-eval (`lib/network.ts`) and the Home Networks grant/detect handlers.
- Add a "Retry detection" recovery-card state for the residual granted-but-SSID-unreadable case (e.g. Precise Location off).

Security invariant unchanged: the SSID must still match before any local URL is used.

## Test plan
- `pnpm jest lib/wifi.test.ts lib/network.test.ts` — new coverage for the warm-up (null-then-SSID retry, give-up, off-WiFi bail, non-native) and `reevaluateHomeNetworkAfterImport`. Full suite 656/656 pass.
- `pnpm exec tsc --noEmit` — 0 app-scope errors.
- On-device: second iOS phone with no prior Location grant, import on the home WiFi, grant the prompt → services flip to Local within ~1-2s, no restart.