### PR TITLE
feat(services): spinner + "checking" dots while health is determined (Refs #196)

### DIFF
--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -8,6 +8,8 @@ import Sortable, {
 import { useRouter } from "expo-router";
 import { Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { Spinner } from "@/components/ui/spinner";
+import { StatusDot } from "@/components/ui/status-dot";
 import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { useConfigStore } from "@/store/config-store";
@@ -19,14 +21,6 @@ import type { ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
 import type { HealthStatusKind } from "@/lib/types";
-
-// Same dot palette as the dashboard service-health card — kept in sync so the
-// user sees green/orange/red mean the same thing across surfaces.
-const DOT_BG: Record<HealthStatusKind, string> = {
-  ok: "bg-success",
-  auth_failed: "bg-warning",
-  offline: "bg-danger",
-};
 
 // Bottom breathing room below the last grid row. The tab-bar clearance itself
 // is handled by ScreenWrapper (safe-area inset / floating glass tab-bar
@@ -43,7 +37,11 @@ export default function ServicesScreen() {
   );
   const activeDashboard = useActiveDashboard();
   const attachedKinds = useAttachedKinds();
-  const { data: health } = useServiceHealth();
+  const { data: health, isPending, isPlaceholderData } = useServiceHealth();
+  // "Determining": first probe batch (no data yet) or a re-keyed refetch in
+  // flight after a network/dashboard change (stale verdict kept visible). A
+  // routine 30s background poll is neither — see service-health-card.tsx.
+  const determining = isPending || isPlaceholderData;
   const uiScale = useUiScale();
   // Grid gap scales with the UI scale setting so spacing tracks the tiles.
   const tileGap = 12 * uiScale;
@@ -122,6 +120,7 @@ export default function ServicesScreen() {
   const renderTile = ({ item: id }: SortableGridRenderItemInfo<ServiceId>) => {
     const service = services[id];
     const status = health?.find((h) => h.id === id);
+    const checking = determining && !status;
     const healthStatus: HealthStatusKind = status?.status ?? "offline";
     const online = healthStatus !== "offline";
     // Surface WHY a tile isn't green (timeout, wrong key, off-WiFi LAN, …) so a
@@ -143,9 +142,7 @@ export default function ServicesScreen() {
           <View className="bg-surface-light rounded-xl p-3">
             <ServiceLogo id={id} size={28} online={online} />
           </View>
-          <View
-            className={`absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-surface ${DOT_BG[healthStatus]}`}
-          />
+          <StatusDot state={checking ? "checking" : healthStatus} overlay />
         </View>
         <Text className="text-zinc-100 text-sm font-medium">{service.name}</Text>
         {detail && (
@@ -164,7 +161,10 @@ export default function ServicesScreen() {
     <ScreenWrapper scrollable={false}>
       <View className="flex-row items-center justify-between mb-4 pt-2">
         <View className="flex-1 pr-3">
-          <Text className="text-zinc-100 text-2xl font-bold">Services</Text>
+          <View className="flex-row items-center gap-2">
+            <Text className="text-zinc-100 text-2xl font-bold">Services</Text>
+            {determining ? <Spinner size={18} color="#71717a" /> : null}
+          </View>
           {canReorder && (
             <Text className="text-zinc-500 text-xs mt-0.5">
               Long-press a tile to reorder

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -25,6 +25,7 @@ import GithubLogo from "@/assets/services/github.svg";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { Icon } from "@/components/ui/icon";
 import { ServiceLogo } from "@/components/ui/service-logo";
+import { StatusDot } from "@/components/ui/status-dot";
 import { BackendStatusPill } from "@/components/ui/backend-status-pill";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { Card } from "@/components/ui/card";
@@ -42,15 +43,6 @@ import { BackHeader } from "@/components/common/back-header";
 import { testServiceConnection } from "@/lib/http-client";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import type { HealthStatusKind } from "@/lib/types";
-
-// Same green/orange/red palette as the dashboard service-health card and the
-// Services tab — kept in sync so the indicator means the same thing across
-// every surface that shows a per-instance status dot.
-const DOT_BG: Record<HealthStatusKind, string> = {
-  ok: "bg-success",
-  auth_failed: "bg-warning",
-  offline: "bg-danger",
-};
 import { qbClearSession } from "@/services/qbittorrent-api";
 import { SERVICE_IDS, SERVICE_DEFAULTS } from "@/lib/constants";
 import type { ServiceId } from "@/lib/constants";
@@ -385,9 +377,7 @@ export default function SettingsScreen() {
         subtitle={subtitle}
         onPress={() => setViewingService(id)}
         right={
-          kindHealth ? (
-            <View className={`w-2 h-2 rounded-full ${DOT_BG[kindHealth]}`} />
-          ) : null
+          kindHealth ? <StatusDot state={kindHealth} size="sm" /> : null
         }
       />
     );
@@ -859,9 +849,7 @@ function InstanceList({
                     : null}
                 </View>
                 {instanceStatus ? (
-                  <View
-                    className={`w-2 h-2 rounded-full mr-2 ${DOT_BG[instanceStatus]}`}
-                  />
+                  <StatusDot state={instanceStatus} size="sm" className="mr-2" />
                 ) : null}
               </Pressable>
               {instances.length > 1 ? (

--- a/components/common/service-header.tsx
+++ b/components/common/service-header.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { View, Text, Platform, Pressable } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { ChevronDown, Server, Check } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { StatusDot } from "@/components/ui/status-dot";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { useActiveInstance } from "@/hooks/use-active-instance";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -39,23 +40,9 @@ export function ServiceHeader({
         // or unreachable active instances show red even when a sibling is up.
         <ActiveInstanceStatusDot serviceId={serviceId} fallback={online} />
       ) : online !== undefined ? (
-        <StatusDot online={online} />
+        <StatusDot state={online ? "ok" : "offline"} size="md" shadow />
       ) : null}
     </View>
-  );
-}
-
-function StatusDot({ online }: { online: boolean }) {
-  return (
-    <View
-      className={`w-2.5 h-2.5 rounded-full ${online ? "bg-success" : "bg-danger"}`}
-      style={Platform.OS === "ios" ? {
-        shadowColor: online ? "#22c55e" : "#ef4444",
-        shadowRadius: 6,
-        shadowOpacity: 0.6,
-        shadowOffset: { width: 0, height: 0 },
-      } : undefined}
-    />
   );
 }
 
@@ -76,7 +63,7 @@ function ActiveInstanceStatusDot({
   // doesn't flicker red on first paint.
   const online = instance?.online ?? fallback;
   if (online === undefined) return null;
-  return <StatusDot online={online} />;
+  return <StatusDot state={online ? "ok" : "offline"} size="md" shadow />;
 }
 
 // Inline instance picker: renders nothing for kinds with 0–1 enabled instances,

--- a/components/dashboard/prowlarr-stats-card.tsx
+++ b/components/dashboard/prowlarr-stats-card.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "expo-router";
 import { AlertTriangle } from "lucide-react-native";
 import { useQueries } from "@tanstack/react-query";
 import { Icon } from "@/components/ui/icon";
+import { StatusDot } from "@/components/ui/status-dot";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -95,11 +96,9 @@ export function ProwlarrStatsCard({ slotId }: WidgetComponentProps) {
                   isFailed ? "bg-red-600/10" : "bg-surface-light"
                 }`}
               >
-                <View
-                  className={`w-1.5 h-1.5 rounded-full ${
-                    isFailed ? "bg-danger" : "bg-success"
-                  }`}
-                />
+                {/* Indexer up/down maps onto the shared dot's ok/offline
+                    colors (green/red) — same visual, one source of truth. */}
+                <StatusDot state={isFailed ? "offline" : "ok"} size="xs" />
                 <Text className="text-zinc-400 text-xs">{indexer.name}</Text>
                 {isFailed && <Icon icon={AlertTriangle} size={10} color="#ef4444" />}
               </View>

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -1,9 +1,11 @@
-import { View, Text, Pressable, Platform } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import Animated, { LinearTransition } from "react-native-reanimated";
 import { useRouter } from "expo-router";
 import { WifiOff } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ServiceLogo, hasServiceLogo } from "@/components/ui/service-logo";
+import { Spinner } from "@/components/ui/spinner";
+import { StatusDot } from "@/components/ui/status-dot";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
@@ -46,21 +48,10 @@ interface RenderEntry {
   // (away from home / workspace pinned remote) but has no remote URL set — the
   // #168 case. Drives the away badge, which takes the L/R badge's corner.
   awayBlocked: boolean;
+  // True while the health batch is still settling and we have no verdict yet
+  // for this instance — render the dot as "checking" instead of red (#196).
+  checking: boolean;
 }
-
-// Tailwind class + iOS shadow color for the small corner dot, by tri-state.
-// Centralized so the Services tab and the Settings instance list use the
-// same palette — keeps "green/orange/red" consistent across the app.
-const DOT_BG: Record<HealthStatusKind, string> = {
-  ok: "bg-success",
-  auth_failed: "bg-warning",
-  offline: "bg-danger",
-};
-const DOT_SHADOW: Record<HealthStatusKind, string> = {
-  ok: "#22c55e",
-  auth_failed: "#f59e0b",
-  offline: "#ef4444",
-};
 
 // L/R corner badge palette — deliberately hues NOT used by the status dot
 // (green/amber/red) so the two corners read as different signals at a glance.
@@ -74,7 +65,12 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
     slotId,
     SERVICE_HEALTH_DEFAULT_SETTINGS,
   );
-  const { data: services } = useServiceHealth();
+  const { data: services, isPending, isPlaceholderData } = useServiceHealth();
+  // "Determining": either the first-ever probe batch (no data yet) or a re-keyed
+  // refetch in flight after a network/dashboard change (keepPreviousData keeps
+  // the stale verdict visible, flagged by isPlaceholderData). A routine 30s
+  // background poll is neither, so the spinner doesn't blink every interval.
+  const determining = isPending || isPlaceholderData;
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
   const servicesOrder = useConfigStore((s) => s.servicesOrder);
   const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
@@ -139,6 +135,12 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
     if (bound.length === 0) continue;
     for (const inst of bound) {
       const health = healthByInstance.get(`${kindId}:${inst.id}`);
+      const awayBlocked = isRemoteOnlyOffline(
+        inst,
+        autoSwitchNetwork,
+        networkAwayFromHome,
+        workspaceForcesRemote,
+      );
       entries.push({
         kindId,
         instanceId: inst.id,
@@ -153,12 +155,11 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
           networkAwayFromHome,
           workspaceForcesRemote,
         ),
-        awayBlocked: isRemoteOnlyOffline(
-          inst,
-          autoSwitchNetwork,
-          networkAwayFromHome,
-          workspaceForcesRemote,
-        ),
+        awayBlocked,
+        // Away-blocked instances are deterministically offline-by-config (no
+        // remote URL while remote-only), so they keep their red dot + away
+        // badge rather than a misleading "checking" pulse.
+        checking: determining && !health && !awayBlocked,
       });
     }
   }
@@ -168,7 +169,10 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Services</CardTitle>
+        <View className="flex-row items-center gap-2">
+          <CardTitle>Services</CardTitle>
+          {determining ? <Spinner size={14} color="#71717a" /> : null}
+        </View>
       </CardHeader>
       <View className="flex-row flex-wrap gap-4">
         {entries.map((entry) => {
@@ -225,14 +229,10 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
                     </Text>
                   </View>
                 ) : null}
-                <View
-                  className={`absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-surface ${DOT_BG[entry.status]}`}
-                  style={Platform.OS === "ios" ? {
-                    shadowColor: DOT_SHADOW[entry.status],
-                    shadowRadius: 6,
-                    shadowOpacity: 0.6,
-                    shadowOffset: { width: 0, height: 0 },
-                  } : undefined}
+                <StatusDot
+                  state={entry.checking ? "checking" : entry.status}
+                  overlay
+                  shadow
                 />
               </View>
               <Text className="text-zinc-500 text-xs" numberOfLines={1}>

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  Easing,
+  cancelAnimation,
+} from "react-native-reanimated";
+import { Loader2 } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+
+interface SpinnerProps {
+  size?: number;
+  color?: string;
+  strokeWidth?: number;
+}
+
+// Small inline spinner — a continuously rotating Loader2. Same rotation timing
+// as ProgressModal's spinner so loading motion feels consistent app-wide, but
+// scoped to an inline glyph (next to a title, in a row) rather than a modal.
+// Sizes through the Icon wrapper so it respects the global UI scale setting.
+export function Spinner({
+  size = 16,
+  color = "#a1a1aa",
+  strokeWidth = 2.25,
+}: SpinnerProps) {
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, { duration: 1100, easing: Easing.linear }),
+      -1,
+      false,
+    );
+    return () => cancelAnimation(rotation);
+  }, [rotation]);
+
+  const style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <Animated.View style={style}>
+      <Icon icon={Loader2} size={size} color={color} strokeWidth={strokeWidth} />
+    </Animated.View>
+  );
+}

--- a/components/ui/status-dot.tsx
+++ b/components/ui/status-dot.tsx
@@ -1,0 +1,120 @@
+import { useEffect } from "react";
+import { Platform } from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withSequence,
+  withTiming,
+  Easing,
+  cancelAnimation,
+} from "react-native-reanimated";
+import type { HealthStatusKind } from "@/lib/types";
+
+// The one status dot used across every surface that shows service health —
+// the dashboard Services widget, the Services tab, the service-screen header,
+// the Settings instance list, and the Prowlarr indexer chips. Keeps
+// "green/orange/red" meaning the same thing everywhere instead of each surface
+// hand-rolling its own copy of the palette + circle.
+//
+// Adds a "checking" state on top of the tri-state health kind: a pulsing
+// neutral dot shown while the health probe batch is still settling, so a cold
+// start reads as "determining" instead of a wall of red that looks like an
+// outage (#196).
+export type StatusDotState = HealthStatusKind | "checking";
+
+const DOT_BG: Record<StatusDotState, string> = {
+  ok: "bg-success",
+  auth_failed: "bg-warning",
+  offline: "bg-danger",
+  checking: "bg-zinc-500",
+};
+
+// iOS glow color per settled state — the checking state pulses instead of
+// glowing, so it isn't keyed here.
+const DOT_SHADOW: Record<HealthStatusKind, string> = {
+  ok: "#22c55e",
+  auth_failed: "#f59e0b",
+  offline: "#ef4444",
+};
+
+// Standard Tailwind size tokens (rem-based, so they scale with the UI scale
+// setting). Matches the four sizes the surfaces use today.
+type StatusDotSize = "xs" | "sm" | "md" | "lg";
+const DOT_SIZE: Record<StatusDotSize, string> = {
+  xs: "w-1.5 h-1.5",
+  sm: "w-2 h-2",
+  md: "w-2.5 h-2.5",
+  lg: "w-3 h-3",
+};
+
+interface StatusDotProps {
+  state: StatusDotState;
+  // Dot diameter. Defaults to "lg" (the dashboard/Services-grid size).
+  size?: StatusDotSize;
+  // Render as an absolutely-positioned top-right corner badge with a
+  // surface-colored ring — for dots overlaid on a service logo (the grids).
+  // Inline dots (headers, list rows) leave this off.
+  overlay?: boolean;
+  // iOS glow halo behind the dot. Never applied to the checking state.
+  shadow?: boolean;
+  // Extra classes for layout-specific spacing (e.g. "mr-2").
+  className?: string;
+}
+
+export function StatusDot({
+  state,
+  size = "lg",
+  overlay = false,
+  shadow = false,
+  className = "",
+}: StatusDotProps) {
+  const pulse = useSharedValue(1);
+
+  useEffect(() => {
+    if (state === "checking") {
+      pulse.value = withRepeat(
+        withSequence(
+          withTiming(0.35, { duration: 650, easing: Easing.inOut(Easing.quad) }),
+          withTiming(1, { duration: 650, easing: Easing.inOut(Easing.quad) }),
+        ),
+        -1,
+        false,
+      );
+    } else {
+      cancelAnimation(pulse);
+      pulse.value = 1;
+    }
+    return () => cancelAnimation(pulse);
+  }, [state, pulse]);
+
+  const pulseStyle = useAnimatedStyle(() => ({ opacity: pulse.value }));
+
+  const classes = [
+    "rounded-full",
+    DOT_SIZE[size],
+    DOT_BG[state],
+    overlay ? "absolute -top-0.5 -right-0.5 border-2 border-surface" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      className={classes}
+      style={[
+        state === "checking" ? pulseStyle : undefined,
+        shadow && state !== "checking" && Platform.OS === "ios"
+          ? {
+              shadowColor: DOT_SHADOW[state],
+              shadowRadius: 6,
+              shadowOpacity: 0.6,
+              shadowOffset: { width: 0, height: 0 },
+            }
+          : undefined,
+      ]}
+    />
+  );
+}


### PR DESCRIPTION
Adds a loading indicator to the services status widget so the ~15s after cold start / VPN toggle / dashboard switch reads as "checking" instead of a wall of red that looks like an outage (Refs #196).

## What
- New `Spinner` (rotating Loader2) and `StatusDot` UI primitives.
- A title spinner + pulsing neutral "checking" dots show while the health probe batch is still settling, keyed on `isPending || isPlaceholderData` (so a routine 30s background poll does not blink it). No change to the `useServiceHealth` hook.
- DRY pass: every status dot (dashboard widget, Services tab, service header, Settings list, Prowlarr chips) now uses the one `StatusDot`. Existing green/amber/red looks are unchanged; only a new "checking" state was added.

## Test plan
- `tsc --noEmit` clean; full jest suite passes (656 tests).
- Cold start / JS reload: spinner + gray pulsing dots, then settle to colors.
- VPN toggle / dashboard switch: spinner shows while previous colors stay (no flash to gray).
- Idle past 30s: spinner does not reappear on the background poll.
- Settled dots on every surface look identical to before.