### PR TITLE
fix(services): spinner freeze under Reduce Motion + spinner on pull-to-refresh (Refs #196)

### DIFF
--- a/components/common/progress-modal.tsx
+++ b/components/common/progress-modal.tsx
@@ -9,6 +9,7 @@ import Animated, {
   Easing,
   cancelAnimation,
   FadeIn,
+  ReduceMotion,
 } from "react-native-reanimated";
 import { Loader2 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -25,19 +26,39 @@ export function ProgressModal({ visible, title, subtitle }: ProgressModalProps) 
 
   useEffect(() => {
     if (visible) {
+      // ReduceMotion.Never on both loops: a progress spinner/halo must keep
+      // moving even with the OS "Reduce Motion" setting on, or it freezes and
+      // looks like the operation hung. The 5th withRepeat arg governs whether
+      // the infinite repeat starts (same root cause as #196).
       rotation.value = 0;
       rotation.value = withRepeat(
-        withTiming(360, { duration: 1100, easing: Easing.linear }),
+        withTiming(360, {
+          duration: 1100,
+          easing: Easing.linear,
+          reduceMotion: ReduceMotion.Never,
+        }),
         -1,
         false,
+        undefined,
+        ReduceMotion.Never,
       );
       pulse.value = withRepeat(
         withSequence(
-          withTiming(1.15, { duration: 900, easing: Easing.inOut(Easing.quad) }),
-          withTiming(1, { duration: 900, easing: Easing.inOut(Easing.quad) }),
+          withTiming(1.15, {
+            duration: 900,
+            easing: Easing.inOut(Easing.quad),
+            reduceMotion: ReduceMotion.Never,
+          }),
+          withTiming(1, {
+            duration: 900,
+            easing: Easing.inOut(Easing.quad),
+            reduceMotion: ReduceMotion.Never,
+          }),
         ),
         -1,
         false,
+        undefined,
+        ReduceMotion.Never,
       );
     } else {
       cancelAnimation(rotation);

--- a/components/common/pull-to-refresh.tsx
+++ b/components/common/pull-to-refresh.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useFocusEffect } from "expo-router";
 import { lightHaptic } from "@/lib/haptics";
+import { useManualRefresh } from "@/store/manual-refresh-store";
 
 // The iOS UIRefreshControl (New Architecture / Fabric) retracts only when the
 // native side observes a clean `refreshing: true -> false` transition — see
@@ -37,6 +38,17 @@ export function useRefreshSpinner(doRefresh: () => Promise<unknown>) {
   const mounted = useRef(true);
   const running = useRef(false);
   const endTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks whether THIS hook instance currently holds a manual-refresh count, so
+  // stop() decrements exactly once per pull. stop() also fires on blur/unmount
+  // with no pull in flight, and a balanced begin/end keeps the global counter
+  // honest no matter which teardown path runs first.
+  const heldManualRefresh = useRef(false);
+
+  const releaseManualRefresh = useCallback(() => {
+    if (!heldManualRefresh.current) return;
+    heldManualRefresh.current = false;
+    useManualRefresh.getState().end();
+  }, []);
 
   const stop = useCallback(() => {
     if (endTimer.current) {
@@ -44,16 +56,19 @@ export function useRefreshSpinner(doRefresh: () => Promise<unknown>) {
       endTimer.current = null;
     }
     running.current = false;
+    releaseManualRefresh();
     if (mounted.current) setRefreshing(false);
-  }, []);
+  }, [releaseManualRefresh]);
 
   useEffect(() => {
     mounted.current = true;
     return () => {
       mounted.current = false;
       if (endTimer.current) clearTimeout(endTimer.current);
+      // Backstop: if the screen unmounts before stop() runs, don't leak a count.
+      releaseManualRefresh();
     };
-  }, []);
+  }, [releaseManualRefresh]);
 
   // iOS: react-native-screens detaches a blurred tab screen. Clearing the
   // spinner (and any pending end-timer) on blur dismisses the native control
@@ -67,6 +82,13 @@ export function useRefreshSpinner(doRefresh: () => Promise<unknown>) {
   const onRefresh = useCallback(async () => {
     if (running.current) return; // ignore re-pulls while one is already in flight
     running.current = true;
+    // Mark a user-initiated refresh in flight so widgets (the dashboard Services
+    // tile) can show their own spinner during the pull but stay quiet on the 30s
+    // background poll. Released in stop() / on teardown via releaseManualRefresh.
+    if (!heldManualRefresh.current) {
+      heldManualRefresh.current = true;
+      useManualRefresh.getState().begin();
+    }
     lightHaptic();
     setRefreshing(true);
     const startedAt = Date.now();

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -9,6 +9,7 @@ import { StatusDot } from "@/components/ui/status-dot";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useManualRefresh } from "@/store/manual-refresh-store";
 import { ICON, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
@@ -65,12 +66,25 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
     slotId,
     SERVICE_HEALTH_DEFAULT_SETTINGS,
   );
-  const { data: services, isPending, isPlaceholderData } = useServiceHealth();
-  // "Determining": either the first-ever probe batch (no data yet) or a re-keyed
-  // refetch in flight after a network/dashboard change (keepPreviousData keeps
-  // the stale verdict visible, flagged by isPlaceholderData). A routine 30s
-  // background poll is neither, so the spinner doesn't blink every interval.
-  const determining = isPending || isPlaceholderData;
+  const {
+    data: services,
+    isPending,
+    isPlaceholderData,
+    isFetching,
+  } = useServiceHealth();
+  // True while the user is actively pulling-to-refresh somewhere (set by
+  // useRefreshSpinner). A same-key invalidate refetch flips only isFetching —
+  // not isPending/isPlaceholderData — so without this the title spinner never
+  // appeared on a Home pull-to-refresh (#196 follow-up). Gating on the manual
+  // flag keeps the 30s background poll (which also sets isFetching) silent.
+  const manualRefreshing = useManualRefresh((s) => s.count > 0);
+  // "Determining": the first-ever probe batch (no data yet), a re-keyed refetch
+  // in flight after a network/dashboard change (keepPreviousData keeps the stale
+  // verdict visible, flagged by isPlaceholderData), or an in-flight user pull.
+  // A routine 30s background poll is none of these, so the spinner doesn't blink
+  // every interval.
+  const determining =
+    isPending || isPlaceholderData || (manualRefreshing && isFetching);
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
   const servicesOrder = useConfigStore((s) => s.servicesOrder);
   const setActiveInstance = useConfigStore((s) => s.setActiveInstance);

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -6,6 +6,7 @@ import Animated, {
   withRepeat,
   withTiming,
   Easing,
+  ReduceMotion,
 } from "react-native-reanimated";
 
 interface SkeletonProps {
@@ -24,9 +25,20 @@ export function Skeleton({
   const translateX = useSharedValue(-1);
 
   useEffect(() => {
+    // ReduceMotion.Never: the shimmer is a loading affordance, so keep it moving
+    // even with the OS "Reduce Motion" setting on (otherwise it sits as a static
+    // bar). The 5th withRepeat arg governs whether the infinite repeat starts, so
+    // the explicit reverse/callback slots are required to position it (#196).
     translateX.value = withRepeat(
-      withTiming(1, { duration: 1200, easing: Easing.inOut(Easing.ease) }),
+      withTiming(1, {
+        duration: 1200,
+        easing: Easing.inOut(Easing.ease),
+        reduceMotion: ReduceMotion.Never,
+      }),
       -1,
+      false,
+      undefined,
+      ReduceMotion.Never,
     );
   }, [translateX]);
 

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -6,6 +6,7 @@ import Animated, {
   withTiming,
   Easing,
   cancelAnimation,
+  ReduceMotion,
 } from "react-native-reanimated";
 import { Loader2 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -28,10 +29,22 @@ export function Spinner({
   const rotation = useSharedValue(0);
 
   useEffect(() => {
+    // ReduceMotion.Never: this is a functional "loading" indicator, not
+    // decoration, so it must keep spinning even when the OS "Reduce Motion"
+    // accessibility setting is on. Under the default ReduceMotion.System an
+    // infinite withRepeat doesn't start at all, leaving the glyph frozen (#196).
+    // The 5th withRepeat arg is the one that governs whether the repeat runs;
+    // setting it on the inner withTiming too is belt-and-suspenders.
     rotation.value = withRepeat(
-      withTiming(360, { duration: 1100, easing: Easing.linear }),
+      withTiming(360, {
+        duration: 1100,
+        easing: Easing.linear,
+        reduceMotion: ReduceMotion.Never,
+      }),
       -1,
       false,
+      undefined,
+      ReduceMotion.Never,
     );
     return () => cancelAnimation(rotation);
   }, [rotation]);

--- a/components/ui/status-dot.tsx
+++ b/components/ui/status-dot.tsx
@@ -8,6 +8,7 @@ import Animated, {
   withTiming,
   Easing,
   cancelAnimation,
+  ReduceMotion,
 } from "react-native-reanimated";
 import type { HealthStatusKind } from "@/lib/types";
 
@@ -73,13 +74,27 @@ export function StatusDot({
 
   useEffect(() => {
     if (state === "checking") {
+      // ReduceMotion.Never: the pulse is the "still determining" signal, so it
+      // must animate even with the OS "Reduce Motion" setting on — otherwise the
+      // dot sits frozen at full opacity and reads as a settled state (#196). The
+      // 5th withRepeat arg governs whether the infinite repeat starts.
       pulse.value = withRepeat(
         withSequence(
-          withTiming(0.35, { duration: 650, easing: Easing.inOut(Easing.quad) }),
-          withTiming(1, { duration: 650, easing: Easing.inOut(Easing.quad) }),
+          withTiming(0.35, {
+            duration: 650,
+            easing: Easing.inOut(Easing.quad),
+            reduceMotion: ReduceMotion.Never,
+          }),
+          withTiming(1, {
+            duration: 650,
+            easing: Easing.inOut(Easing.quad),
+            reduceMotion: ReduceMotion.Never,
+          }),
         ),
         -1,
         false,
+        undefined,
+        ReduceMotion.Never,
       );
     } else {
       cancelAnimation(pulse);

--- a/store/manual-refresh-store.ts
+++ b/store/manual-refresh-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+// Ephemeral (never persisted) count of in-flight manual pull-to-refreshes.
+// `useRefreshSpinner` bumps it when the user pulls and drops it when the spinner
+// settles, so widgets can show a "refreshing" affordance during a user-initiated
+// refresh WITHOUT also reacting to background polls — a routine 30s TanStack
+// poll never touches this store, so it can't blink the indicator every interval.
+//
+// A counter (not a boolean): if two refresh-driving screens are briefly alive at
+// once, one screen's teardown can't clear the gate the other is still holding.
+// `end` floors at 0 so a stray decrement can never strand it negative.
+//
+// Used by the dashboard "Services" widget so its title spinner appears on a Home
+// pull-to-refresh — the #196 follow-up where `isPending || isPlaceholderData`
+// never flips on a same-key invalidate refetch (only `isFetching` does).
+interface ManualRefreshState {
+  count: number;
+  begin: () => void;
+  end: () => void;
+}
+
+export const useManualRefresh = create<ManualRefreshState>((set) => ({
+  count: 0,
+  begin: () => set((s) => ({ count: s.count + 1 })),
+  end: () => set((s) => ({ count: Math.max(0, s.count - 1) })),
+}));


### PR DESCRIPTION
Two follow-up bugs reported on #196.

## Frozen spinner
reanimated defaults to `ReduceMotion.System`, so with the OS "Reduce Motion" setting on, an infinite `withRepeat` never starts and the loader sits frozen (fine for users without the setting). Fixed by setting `ReduceMotion.Never` on the functional loaders (`spinner`, `status-dot` checking pulse, `progress-modal`, `skeleton`). Decorative transitions keep respecting the user preference.

## No spinner on Home pull-to-refresh
A same-key invalidate refetch flips only `isFetching`, which the widget deliberately excluded to avoid blinking on the 30s poll. Added an ephemeral manual-refresh counter (set by `useRefreshSpinner`) and gate the spinner on `manualRefreshing && isFetching`, so it shows on user pulls but not background polls.

## Test plan
- `tsc --noEmit` clean
- `jest` 656/656 pass
- With OS Reduce Motion on: spinner spins, checking dot pulses
- Home pull-to-refresh: Services title spinner appears; dots keep their colors; no blink on the 30s poll