### PR TITLE
fix(layout): drop redundant bottom safe-area inset on tab screens (Refs #212)

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -15,7 +15,7 @@ import Animated, {
   type SharedValue,
 } from "react-native-reanimated";
 import { useLocalSearchParams } from "expo-router";
-import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { ScreenWrapper, useScreenSafeAreaEdges } from "@/components/common/screen-wrapper";
 import { DemoBanner } from "@/components/common/demo-banner";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LibrarySwipeHint } from "@/components/onboarding/library-swipe-hint";
@@ -107,6 +107,7 @@ function LibraryPager({
   onChange: (next: LibrarySection) => void;
 }) {
   const { width } = useWindowDimensions();
+  const safeAreaEdges = useScreenSafeAreaEdges();
   const activeIndex = sections.indexOf(activeSection);
   const scrollRef = useRef<React.ComponentRef<typeof Animated.ScrollView>>(null);
   // Live horizontal scroll position (0..(n-1)*width), used to drive the
@@ -182,7 +183,7 @@ function LibraryPager({
   };
 
   return (
-    <SafeAreaView edges={["top", "left", "right"]} className="flex-1 bg-background">
+    <SafeAreaView edges={safeAreaEdges} className="flex-1 bg-background">
       <DemoBanner />
       <View className="px-4">
         <LibrarySegmentedControl

--- a/components/common/screen-wrapper.tsx
+++ b/components/common/screen-wrapper.tsx
@@ -15,6 +15,8 @@ cssInterop(KeyboardAwareScrollView, {
 
 const SCROLL_BOTTOM_PADDING = 24;
 
+type Edge = "top" | "left" | "right" | "bottom";
+
 /**
  * Bottom padding (in dp) that a screen-level scroll container needs so its
  * content clears the tab bar. Matches the value ScreenWrapper uses
@@ -26,6 +28,23 @@ export function useScreenBottomPadding(): number {
   const tabBarHeight = useContext(BottomTabBarHeightContext);
   const usesFloatingTabBar = HAS_GLASS_TAB_BAR && tabBarHeight !== undefined;
   return SCROLL_BOTTOM_PADDING + (usesFloatingTabBar ? tabBarHeight : 0);
+}
+
+/**
+ * Safe-area edges for a screen-level SafeAreaView. The bottom edge is dropped
+ * whenever the screen is inside a tab navigator — the tab bar (non-absolute on
+ * Android / absolute glass on iOS 26) already consumes the bottom inset, so
+ * re-applying it here leaves a dead gap above the bar (#212). Pushed/non-tab
+ * screens (no BottomTabBarHeightContext) keep the bottom edge. Use this from
+ * any custom scene-level SafeAreaView so the behavior stays in one place.
+ */
+export function useScreenSafeAreaEdges(edgeToEdge = false): readonly Edge[] {
+  const tabBarHeight = useContext(BottomTabBarHeightContext);
+  const insideTabNavigator = tabBarHeight !== undefined;
+  if (edgeToEdge) return ["left", "right"];
+  return insideTabNavigator
+    ? ["top", "left", "right"]
+    : ["top", "left", "right", "bottom"];
 }
 
 interface ScreenWrapperProps extends ViewProps {
@@ -52,13 +71,11 @@ export function ScreenWrapper({
   // Compensate by extending content past the bottom inset (handled by the
   // tab bar itself) and padding the scroll view by the full tab bar height.
   const tabBarHeight = useContext(BottomTabBarHeightContext);
+  // Padding keys on the floating glass bar (content scrolls *behind* it, so it
+  // needs +tabBarHeight); the bottom *edge* keys on being inside a tab
+  // navigator at all (the bar already owns that inset — see hook).
   const usesFloatingTabBar = HAS_GLASS_TAB_BAR && tabBarHeight !== undefined;
-  const baseEdges: ReadonlyArray<"top" | "left" | "right" | "bottom"> = edgeToEdge
-    ? ["left", "right"]
-    : usesFloatingTabBar
-      ? ["top", "left", "right"]
-      : ["top", "left", "right", "bottom"];
-  const safeAreaEdges = baseEdges as readonly ("top" | "left" | "right" | "bottom")[];
+  const safeAreaEdges = useScreenSafeAreaEdges(edgeToEdge);
   const scrollPaddingBottom = useScreenBottomPadding();
 
   if (scrollable) {

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -40,6 +40,7 @@ import { ActionSheet } from "@/components/ui/action-sheet";
 import { CategorySheet } from "@/components/qbittorrent/category-sheet";
 import { errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
+import { useScreenSafeAreaEdges } from "@/components/common/screen-wrapper";
 import {
   useSortStore,
   SORT_DEFAULTS,
@@ -132,13 +133,13 @@ export function TorrentDownloadsView({
   const caveat = adapter.capabilities.deleteWithDataCaveat ?? false;
   const SpeedLimitsControl = adapter.SpeedLimitsControl;
 
-  // Tab-bar offset so the last list item clears the floating glass tab bar
-  // (iOS 26+). On other platforms the safe-area inset already handles it.
+  // Extra list padding so the last item clears the floating glass tab bar
+  // (iOS 26+), which content scrolls behind. Otherwise the bar sits below the
+  // scene, so only breathing room (24) is needed and the bottom safe-area edge
+  // is dropped via useScreenSafeAreaEdges (the bar owns that inset — #212).
   const tabBarHeight = useContext(BottomTabBarHeightContext);
   const usesFloatingTabBar = HAS_GLASS_TAB_BAR && tabBarHeight !== undefined;
-  const safeAreaEdges = usesFloatingTabBar
-    ? (["top", "left", "right"] as const)
-    : (["top", "left", "right", "bottom"] as const);
+  const safeAreaEdges = useScreenSafeAreaEdges();
   const listBottomPadding = 24 + (usesFloatingTabBar ? tabBarHeight : 0);
 
   // Hand-rolled refresh (custom qBittorrent refetch instead of a query-key


### PR DESCRIPTION
## Summary
Fixes the persistent empty band above the bottom tab bar on every screen (#212, Poco F5).

Tab screens sit above the non-absolute tab bar, which already consumes the bottom safe-area inset (`52 + bottom`). `ScreenWrapper` was *also* adding the `"bottom"` safe-area edge on Android / non-glass iOS, re-applying `insets.bottom` (~48dp) as dead space.

New shared hook `useScreenSafeAreaEdges` drops the bottom edge whenever inside a tab navigator (`tabBarHeight !== undefined`) and keeps it for pushed/non-tab screens. Applied in `ScreenWrapper`, `TorrentDownloadsView`, and `LibraryPager` (last hand-rolled copy). iOS-26 glass behavior unchanged; content padding untouched.

## Test plan
- `tsc --noEmit` clean.
- Android (3-button + gesture nav): no gap above the tab bar on Dashboard/Downloads/Services/Library/Plex/Movies/Jellyfin/Calendar/Settings; last row keeps ~24dp breathing room.
- iOS-26 glass: no visual change (content scrolls behind bar, last item not hidden).
- Pushed screens (`/movie/[id]`, settings sub-routes) + sheets: bottom inset still applied.

Refs #212