### PR TITLE
fix(backend): try https first when pairing a public host (Refs #218)

### DIFF
--- a/app/backend.tsx
+++ b/app/backend.tsx
@@ -84,7 +84,10 @@ export default function BackendScreen() {
         }
         const platform: "ios" | "android" = Platform.OS === "ios" ? "ios" : "android";
         const result = await pairClaim(trimmedUrl, token, expoPushToken, platform);
-        await pair({ url: trimmedUrl, sharedSecret: result.sharedSecret, deviceId: result.deviceId });
+        // Persist the URL that actually answered. pairClaim may have upgraded a
+        // public http:// host to https:// to dodge the edge redirect that breaks
+        // pairing (#218); persisting it keeps later calls off that downgrade.
+        await pair({ url: result.baseUrl, sharedSecret: result.sharedSecret, deviceId: result.deviceId });
         // Kick a health check and an initial config sync immediately.
         try {
           await getBackendHealth();
@@ -279,6 +282,9 @@ export default function BackendScreen() {
                   keyboardType="url"
                   autoCapitalize="none"
                 />
+                <Text className="text-zinc-500 text-xs mt-2">
+                  Behind Cloudflare Tunnel or a reverse proxy? Enter the full https:// URL.
+                </Text>
               </Card>
 
               <Pressable

--- a/backend/dashboarr-backend/README.md
+++ b/backend/dashboarr-backend/README.md
@@ -333,6 +333,14 @@ This backend does **not** terminate TLS. Options:
 - **Caddy / Traefik / Nginx Proxy Manager:** put a reverse proxy in front of it
   and terminate TLS there. Set `PUBLIC_URL` to the HTTPS URL so the pairing
   QR encodes the full connection info for single-scan setup.
+- **Cloudflare Tunnel:** set `PUBLIC_URL` to your `https://` tunnel hostname so
+  the QR pairs in a single scan. If you enter the URL by hand in the app instead,
+  type the full `https://` URL. A bare hostname or an `http://` URL gets a
+  301/302 redirect to `https://` at the Cloudflare edge, and following that
+  redirect rewrites the pairing `POST /pair/claim` into a `GET` (request method
+  is downgraded on 301/302), so the backend logs `GET /pair/claim` → 404 and
+  pairing fails. The app upgrades a public `http://` host to `https://`
+  automatically, but setting `PUBLIC_URL` is the clean fix.
 
 ### Caddy snippet
 

--- a/services/backend-api.ts
+++ b/services/backend-api.ts
@@ -1,6 +1,7 @@
 import { useBackendStore } from "@/store/backend-store";
 import { useConfigStore } from "@/store/config-store";
 import { SERVICE_IDS } from "@/lib/constants";
+import { isPrivateHost } from "@/lib/url-validation";
 
 const DEFAULT_TIMEOUT = 10000;
 
@@ -33,7 +34,16 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
       signal: controller.signal,
     });
     if (!res.ok) {
-      throw new Error(`Backend ${path} HTTP ${res.status}`);
+      // Tag the status so callers can tell a real HTTP response (the endpoint
+      // answered) apart from a connection-level failure (fetch rejects with no
+      // `.status`). `pairClaim` relies on this to decide whether to retry a
+      // different scheme. Existing catch sites only read `.message`, so this is
+      // backwards-compatible.
+      const err = new Error(`Backend ${path} HTTP ${res.status}`) as Error & {
+        status?: number;
+      };
+      err.status = res.status;
+      throw err;
     }
     const ct = res.headers.get("content-type");
     if (ct?.includes("application/json")) {
@@ -75,21 +85,70 @@ export function getBackendHealth(): Promise<BackendHealth> {
 interface PairClaimResult {
   deviceId: string;
   sharedSecret: string;
+  /**
+   * The base URL that actually answered. May differ from the one passed in:
+   * for a public host typed as http:// we try https:// first (see
+   * `pairingBaseCandidates`). The caller must persist this so later calls use
+   * the same origin and don't hit the redirect that breaks pairing (#218).
+   */
+  baseUrl: string;
 }
 
-export function pairClaim(
+/**
+ * Candidate base URLs to try when claiming, most-correct first.
+ *
+ * A backend behind Cloudflare/a reverse proxy is usually HTTPS-only. If the
+ * user types a bare hostname, `normalizeServiceUrl` defaults it to http://, and
+ * the edge answers our POST with a 301/302 to https://. React Native's fetch
+ * follows that redirect by downgrading POST→GET and dropping the body (per the
+ * WHATWG Fetch spec; only 307/308 preserve the method), so the backend receives
+ * `GET /pair/claim` and 404s (#218). 301/302 leave GET/HEAD untouched, so
+ * `res.url`/`res.redirected` are unreliable for detecting this in RN — instead
+ * we avoid the redirect entirely by trying https:// first for PUBLIC http hosts.
+ * Private/LAN hosts (192.168.x, 10.x, *.local, localhost) legitimately run plain
+ * http with no TLS, so they are never upgraded.
+ */
+function pairingBaseCandidates(normalizedUrl: string): string[] {
+  try {
+    const u = new URL(normalizedUrl);
+    if (u.protocol === "http:" && !isPrivateHost(u.hostname)) {
+      return [normalizedUrl.replace(/^http:\/\//i, "https://"), normalizedUrl];
+    }
+  } catch {
+    // unparseable — fall through to the single-candidate path
+  }
+  return [normalizedUrl];
+}
+
+export async function pairClaim(
   baseUrl: string,
   token: string,
   expoPushToken: string,
   platform: "ios" | "android",
   appVersion?: string,
 ): Promise<PairClaimResult> {
-  return request<PairClaimResult>("/pair/claim", {
-    baseUrl,
-    sharedSecret: null,
-    method: "POST",
-    body: JSON.stringify({ token, expoPushToken, platform, appVersion }),
-  });
+  const candidates = pairingBaseCandidates(baseUrl.replace(/\/$/, ""));
+  const body = JSON.stringify({ token, expoPushToken, platform, appVersion });
+  let lastErr: unknown;
+  for (const candidate of candidates) {
+    try {
+      const data = await request<Omit<PairClaimResult, "baseUrl">>("/pair/claim", {
+        baseUrl: candidate,
+        sharedSecret: null,
+        method: "POST",
+        body,
+      });
+      return { ...data, baseUrl: candidate };
+    } catch (err) {
+      // A numeric `.status` means the endpoint answered (e.g. 401 invalid token,
+      // 400 bad payload) — a real result, not a wrong-scheme guess — so surface
+      // it. Only fall through to the next candidate on a connection-level
+      // failure (TLS/DNS/refused/timeout), where https simply wasn't reachable.
+      if (typeof (err as { status?: number } | null)?.status === "number") throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr;
 }
 
 export function registerDevice(expoPushToken: string, platform: "ios" | "android"): Promise<void> {


### PR DESCRIPTION
## Summary

Pairing fails behind a Cloudflare Tunnel / HTTPS-only reverse proxy: the backend logs `GET /pair/claim` → 404 even though the app only sends `POST`.

Cause: with `PUBLIC_URL` unset the user types the URL by hand, `normalizeServiceUrl` defaults a bare host to `http://`, and the edge answers the `http` POST with a 301/302 to `https`. RN's fetch follows the redirect and downgrades `POST`→`GET` (dropping the body) per the Fetch spec, so the backend sees a bodyless `GET`.

Fix:
- `services/backend-api.ts`: for a **public** host typed as `http://`, `pairClaim` tries `https://` first (avoiding the redirect entirely), falls back to `http://` only if https can't connect, and returns the URL that answered. Gated by `isPrivateHost`, so LAN `http://192.168.x:4000` is untouched. `request()` tags HTTP errors with `.status` so a real response (e.g. 401) isn't mistaken for an unreachable scheme.
- `app/backend.tsx`: persists the canonical URL so later calls (`/health`, `/config`) skip the same downgrade; adds an https hint under the URL field.
- `README.md`: documents the Cloudflare Tunnel gotcha and the `PUBLIC_URL=https://…` recommendation.

## Test plan
- [x] `tsc --noEmit` clean; `url-validation` suite green (covers the `isPrivateHost` gate)
- [ ] Behind a Cloudflare Tunnel (`PUBLIC_URL` unset): enter the bare host, pair → backend logs `POST /pair/claim` 200, summary shows the `https://` URL
- [ ] LAN regression: pair `http://192.168.x:4000` → stays http, no https probe
- [ ] Manual `https://` entry pairs directly