### PR TITLE
fix: purple downloading indicator across all *arr surfaces (Refs #207)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -20,8 +20,14 @@ import { FilterChip } from "@/components/ui/filter-chip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { ICON, POLLING_INTERVALS, SERVICE_DEFAULTS } from "@/lib/constants";
-import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
-import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
+import {
+  getCalendar as getSonarrCalendar,
+  getQueue as getSonarrQueue,
+} from "@/services/sonarr-api";
+import {
+  getCalendar as getRadarrCalendar,
+  getQueue as getRadarrQueue,
+} from "@/services/radarr-api";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
@@ -225,6 +231,46 @@ export default function CalendarScreen() {
       refetchInterval: POLLING_INTERVALS.calendar,
     })),
   });
+
+  // Per-instance download queues, so an episode/movie currently grabbing reads
+  // purple in the day list — same indicator as the poster grid and the detail
+  // screens (issue #207). Reuses the shared ["sonarr"/"radarr", id, "queue"]
+  // cache key, so this rides whatever the rest of the app already polls.
+  const sonarrQueueQueries = useQueries({
+    queries: sonarrInstances.map((inst) => ({
+      queryKey: ["sonarr", inst.id, "queue"] as const,
+      queryFn: () => getSonarrQueue(1, 20, true, true, inst.id),
+      refetchInterval: POLLING_INTERVALS.queue,
+    })),
+  });
+  const radarrQueueQueries = useQueries({
+    queries: radarrInstances.map((inst) => ({
+      queryKey: ["radarr", inst.id, "queue"] as const,
+      queryFn: () => getRadarrQueue(1, 20, true, inst.id),
+      refetchInterval: POLLING_INTERVALS.queue,
+    })),
+  });
+
+  // Keyed by `instanceId:episodeId` / `instanceId:movieId` because ids aren't
+  // globally unique across instances.
+  const downloadingKeys = useMemo(() => {
+    const keys = new Set<string>();
+    sonarrQueueQueries.forEach((q, i) => {
+      const instanceId = sonarrInstances[i]?.id;
+      if (!instanceId) return;
+      (q.data?.records ?? []).forEach((r) =>
+        keys.add(`${instanceId}:${r.episodeId}`),
+      );
+    });
+    radarrQueueQueries.forEach((q, i) => {
+      const instanceId = radarrInstances[i]?.id;
+      if (!instanceId) return;
+      (q.data?.records ?? []).forEach((r) =>
+        keys.add(`${instanceId}:${r.movieId}`),
+      );
+    });
+    return keys;
+  }, [sonarrQueueQueries, radarrQueueQueries, sonarrInstances, radarrInstances]);
 
   // Tag each calendar entry with the source instance so navigation can route
   // detail-screen queries to the correct Sonarr/Radarr (ids aren't globally
@@ -578,14 +624,23 @@ export default function CalendarScreen() {
         ) : selectedItems.length === 0 ? (
           <EmptyState title="Nothing on this day" />
         ) : (
-          <SelectedDayList items={selectedItems} />
+          <SelectedDayList
+            items={selectedItems}
+            downloadingKeys={downloadingKeys}
+          />
         )}
       </View>
     </ScreenWrapper>
   );
 }
 
-function SelectedDayList({ items }: { items: CalendarItem[] }) {
+function SelectedDayList({
+  items,
+  downloadingKeys,
+}: {
+  items: CalendarItem[];
+  downloadingKeys: Set<string>;
+}) {
   const router = useRouter();
 
   return (
@@ -595,6 +650,7 @@ function SelectedDayList({ items }: { items: CalendarItem[] }) {
           <EpisodeRow
             key={`ep-${item.instanceId}-${item.data.id}`}
             episode={item.data}
+            downloading={downloadingKeys.has(`${item.instanceId}:${item.data.id}`)}
             onPress={() =>
               router.push(
                 `/series/${item.data.seriesId}?instanceId=${item.instanceId}`,
@@ -605,6 +661,7 @@ function SelectedDayList({ items }: { items: CalendarItem[] }) {
           <MovieRow
             key={`mov-${item.instanceId}-${item.data.id}`}
             movie={item.data}
+            downloading={downloadingKeys.has(`${item.instanceId}:${item.data.id}`)}
             onPress={() =>
               router.push(`/movie/${item.data.id}?instanceId=${item.instanceId}`)
             }
@@ -617,9 +674,11 @@ function SelectedDayList({ items }: { items: CalendarItem[] }) {
 
 function EpisodeRow({
   episode,
+  downloading,
   onPress,
 }: {
   episode: SonarrCalendarEntry;
+  downloading: boolean;
   onPress: () => void;
 }) {
   return (
@@ -629,6 +688,7 @@ function EpisodeRow({
       title={episode.series.title}
       subtitle={`${formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} — ${episode.title}`}
       hasFile={episode.hasFile}
+      downloading={downloading}
       onPress={onPress}
     />
   );
@@ -636,9 +696,11 @@ function EpisodeRow({
 
 function MovieRow({
   movie,
+  downloading,
   onPress,
 }: {
   movie: RadarrMovie;
+  downloading: boolean;
   onPress: () => void;
 }) {
   return (
@@ -648,6 +710,7 @@ function MovieRow({
       title={movie.title}
       subtitle={`${movie.year} — ${getMovieReleaseType(movie)}`}
       hasFile={movie.hasFile}
+      downloading={downloading}
       onPress={onPress}
     />
   );

--- a/app/album/[id].tsx
+++ b/app/album/[id].tsx
@@ -17,12 +17,17 @@ import { Badge } from "@/components/ui/badge";
 import {
   useLidarrAlbum,
   useLidarrTracks,
+  useLidarrQueue,
   useToggleAlbumMonitored,
   useSearchAlbums,
 } from "@/hooks/use-lidarr";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { getLidarrArtistFanart } from "@/services/lidarr-api";
 import { formatBytes } from "@/lib/utils";
+import {
+  downloadIndicator,
+  DOWNLOAD_INDICATOR_COLOR,
+} from "@/lib/arr-poster-status";
 import type { LidarrAlbum, LidarrTrack } from "@/lib/types";
 
 export default function AlbumDetailScreen() {
@@ -33,6 +38,7 @@ export default function AlbumDetailScreen() {
   const router = useRouter();
   const { data: album, isLoading, error } = useLidarrAlbum(Number(id), instanceId);
   const { data: tracks } = useLidarrTracks(Number(id), instanceId);
+  const { data: queue } = useLidarrQueue(instanceId);
   const toggleAlbum = useToggleAlbumMonitored(instanceId);
   const searchAlbum = useSearchAlbums(instanceId);
 
@@ -62,6 +68,11 @@ export default function AlbumDetailScreen() {
 
   const stats = album.statistics;
   const hasFiles = (stats?.trackFileCount ?? 0) > 0;
+  // Lidarr queues a whole album/release, not individual tracks, so a queued
+  // album turns every still-missing track purple (issue #207).
+  const albumDownloading = (queue?.records ?? []).some(
+    (r) => r.albumId === album.id,
+  );
 
   const actions: MediaActionItem[] = [
     {
@@ -110,8 +121,20 @@ export default function AlbumDetailScreen() {
         badges={
           <>
             <Badge
-              label={hasFiles ? "Downloaded" : "Missing"}
-              variant={hasFiles ? "success" : "missing"}
+              label={
+                albumDownloading
+                  ? "Downloading"
+                  : hasFiles
+                    ? "Downloaded"
+                    : "Missing"
+              }
+              variant={
+                albumDownloading
+                  ? "grabbing"
+                  : hasFiles
+                    ? "success"
+                    : "missing"
+              }
             />
             {album.albumType ? <Badge label={album.albumType} variant="default" /> : null}
           </>
@@ -153,7 +176,11 @@ export default function AlbumDetailScreen() {
                 .slice()
                 .sort((a, b) => trackOrder(a) - trackOrder(b))
                 .map((track) => (
-                  <TrackRow key={track.id} track={track} />
+                  <TrackRow
+                    key={track.id}
+                    track={track}
+                    albumDownloading={albumDownloading}
+                  />
                 ))}
             </View>
           </View>
@@ -218,12 +245,25 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-function TrackRow({ track }: { track: LidarrTrack }) {
+function TrackRow({
+  track,
+  albumDownloading,
+}: {
+  track: LidarrTrack;
+  albumDownloading: boolean;
+}) {
   const duration = formatTrackDuration(track.duration);
+  // A downloaded track stays green even while the album re-grabs; only the
+  // still-missing tracks read purple.
+  const indicator = downloadIndicator(
+    track.hasFile,
+    albumDownloading && !track.hasFile,
+  );
   return (
     <View className="flex-row items-center px-4 py-2.5 border-b border-border/30 last:border-b-0">
       <View
-        className={`w-1.5 h-6 rounded-full mr-3 ${track.hasFile ? "bg-success" : "bg-zinc-600"}`}
+        className="w-1.5 h-6 rounded-full mr-3"
+        style={{ backgroundColor: DOWNLOAD_INDICATOR_COLOR[indicator] }}
       />
       <Text className="text-zinc-500 text-xs w-6">{track.trackNumber ?? ""}</Text>
       <Text className="text-zinc-200 text-sm flex-1" numberOfLines={1}>

--- a/app/artist/[id].tsx
+++ b/app/artist/[id].tsx
@@ -35,6 +35,7 @@ import { ConfirmModal } from "@/components/common/confirm-modal";
 import {
   useLidarrArtist,
   useLidarrAlbums,
+  useLidarrQueue,
   useToggleArtistMonitored,
   useToggleAlbumMonitored,
   useSearchArtist,
@@ -49,6 +50,7 @@ import { useServiceImage } from "@/hooks/use-service-image";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import { getLidarrAlbumCover } from "@/services/lidarr-api";
 import { formatBytes } from "@/lib/utils";
+import { BAR_KIND_COLOR } from "@/lib/arr-poster-status";
 import type { LidarrArtist, LidarrAlbum } from "@/lib/types";
 
 type DeleteMode = "keep" | "withFiles";
@@ -60,6 +62,7 @@ export default function ArtistDetailScreen() {
   }>();
   const { data: artist, isLoading, error } = useLidarrArtist(Number(id), instanceId);
   const { data: albums } = useLidarrAlbums(Number(id), instanceId);
+  const { data: queue } = useLidarrQueue(instanceId);
   const toggleArtist = useToggleArtistMonitored(instanceId);
   const searchArtist = useSearchArtist(instanceId);
   const deleteArtist = useDeleteArtist(instanceId);
@@ -159,6 +162,19 @@ export default function ArtistDetailScreen() {
 
   const stats = buildArtistStats(artist);
 
+  // Albums of this artist currently grabbing → purple, mirroring the series
+  // screen and the poster grid (issue #207). Lidarr queues per album/release;
+  // the queue is global, so the per-album set (ids are unique) drives the album
+  // rows while the artist-level flag filters by artistId.
+  const downloadingAlbumIds = new Set(
+    (queue?.records ?? [])
+      .map((r) => r.albumId)
+      .filter((aId): aId is number => aId != null),
+  );
+  const artistDownloading = (queue?.records ?? []).some(
+    (r) => r.artistId === artist.id,
+  );
+
   return (
     <>
       <ScreenWrapper edgeToEdge>
@@ -183,7 +199,10 @@ export default function ArtistDetailScreen() {
 
           <MediaStatsStrip stats={stats} className="mb-5" />
 
-          <TrackProgressBlock artist={artist} />
+          <TrackProgressBlock
+            artist={artist}
+            downloading={artistDownloading}
+          />
 
           <AboutBlock
             artist={artist}
@@ -227,6 +246,7 @@ export default function ArtistDetailScreen() {
                     key={album.id}
                     album={album}
                     instanceId={instanceId}
+                    downloading={downloadingAlbumIds.has(album.id)}
                   />
                 ))}
             </View>
@@ -399,18 +419,31 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-function TrackProgressBlock({ artist }: { artist: LidarrArtist }) {
+function TrackProgressBlock({
+  artist,
+  downloading,
+}: {
+  artist: LidarrArtist;
+  downloading: boolean;
+}) {
   const have = artist.statistics?.trackFileCount ?? 0;
   const total = artist.statistics?.totalTrackCount ?? artist.statistics?.trackCount ?? 0;
   if (!total) return null;
   const ratio = total > 0 ? have / total : 0;
   const missing = total - have;
   const allDownloaded = missing === 0;
+  // Purple while grabbing, mirroring the series Progress block and poster bar.
+  // Inline hex keeps the status color out of the Tailwind build (issue #207).
+  const accent = downloading
+    ? BAR_KIND_COLOR.purple
+    : allDownloaded
+      ? BAR_KIND_COLOR.success
+      : BAR_KIND_COLOR.primary;
   return (
     <View className="mb-5">
       <SectionLabel>Progress</SectionLabel>
       <View className="rounded-2xl bg-surface border border-border overflow-hidden flex-row">
-        <View className={`w-1 ${allDownloaded ? "bg-success" : "bg-primary"}`} />
+        <View className="w-1" style={{ backgroundColor: accent }} />
         <View className="flex-1 p-4">
           <View className="flex-row items-end justify-between mb-2.5">
             <Text className="text-zinc-100 text-2xl font-bold">
@@ -418,23 +451,24 @@ function TrackProgressBlock({ artist }: { artist: LidarrArtist }) {
               <Text className="text-zinc-500 text-base font-medium"> / {total}</Text>
             </Text>
             <Text
-              className={`text-sm font-semibold ${
-                allDownloaded ? "text-success" : "text-primary"
-              }`}
+              className="text-sm font-semibold"
+              style={{ color: accent }}
             >
               {Math.round(ratio * 100)}%
             </Text>
           </View>
-          <ProgressBar
-            progress={ratio}
-            color={allDownloaded ? "bg-success" : "bg-primary"}
-          />
+          <ProgressBar progress={ratio} fillColor={accent} />
           <Text
-            className={`text-xs mt-2.5 ${allDownloaded ? "text-success" : "text-zinc-500"}`}
+            className="text-xs mt-2.5"
+            style={{
+              color: downloading || allDownloaded ? accent : "#71717a",
+            }}
           >
-            {allDownloaded
-              ? "All tracks downloaded"
-              : `${missing} track${missing !== 1 ? "s" : ""} missing`}
+            {downloading
+              ? "Downloading…"
+              : allDownloaded
+                ? "All tracks downloaded"
+                : `${missing} track${missing !== 1 ? "s" : ""} missing`}
           </Text>
         </View>
       </View>
@@ -505,9 +539,11 @@ function AboutRow({
 function AlbumRow({
   album,
   instanceId,
+  downloading,
 }: {
   album: LidarrAlbum;
   instanceId?: string;
+  downloading: boolean;
 }) {
   const router = useRouter();
   const toggleAlbum = useToggleAlbumMonitored(instanceId);
@@ -552,7 +588,13 @@ function AlbumRow({
           <Text className="text-zinc-500 text-xs">
             {[album.albumType, year ? String(year) : null].filter(Boolean).join(" · ")}
           </Text>
-          {total > 0 ? <ProgressBar progress={ratio} className="mt-1.5" /> : null}
+          {total > 0 ? (
+            <ProgressBar
+              progress={ratio}
+              fillColor={downloading ? BAR_KIND_COLOR.purple : undefined}
+              className="mt-1.5"
+            />
+          ) : null}
         </View>
         <View className="flex-row items-center gap-1">
           <Pressable

--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -30,6 +30,7 @@ import { ActionSheet } from "@/components/ui/action-sheet";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import {
   useRadarrMovie,
+  useRadarrQueue,
   useDeleteMovie,
   useToggleMovieMonitored,
   useRadarrQualityProfiles,
@@ -56,6 +57,7 @@ export default function MovieDetailScreen() {
   }>();
   const router = useRouter();
   const { data: movie, isLoading, error } = useRadarrMovie(Number(id), instanceId);
+  const { data: queue } = useRadarrQueue(instanceId);
   const deleteMutation = useDeleteMovie(instanceId);
   const toggleMonitored = useToggleMovieMonitored(instanceId);
   const { data: qualityProfiles } = useRadarrQualityProfiles(instanceId);
@@ -106,6 +108,12 @@ export default function MovieDetailScreen() {
       </ScreenWrapper>
     );
   }
+
+  // A grab in flight wins over the downloaded/missing badge — mirrors the
+  // poster grid's purple bar and Radarr's "downloading" state (issue #207).
+  const isDownloading = (queue?.records ?? []).some(
+    (r) => r.movieId === movie.id,
+  );
 
   const qualityProfileName = qualityProfiles?.find(
     (p) => p.id === movie.qualityProfileId,
@@ -206,8 +214,20 @@ export default function MovieDetailScreen() {
           badges={
             <>
               <Badge
-                label={movie.hasFile ? "Downloaded" : "Missing"}
-                variant={movie.hasFile ? "success" : "missing"}
+                label={
+                  isDownloading
+                    ? "Downloading"
+                    : movie.hasFile
+                      ? "Downloaded"
+                      : "Missing"
+                }
+                variant={
+                  isDownloading
+                    ? "grabbing"
+                    : movie.hasFile
+                      ? "success"
+                      : "missing"
+                }
               />
               {movie.certification ? (
                 <Badge label={movie.certification} variant="default" />

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -41,6 +41,7 @@ import {
   useSonarrSeriesById,
   useSonarrEpisodes,
   useSonarrEpisodeFiles,
+  useSonarrQueue,
   useToggleEpisodeMonitored,
   useDeleteEpisodeFile,
   useSearchForEpisodes,
@@ -65,6 +66,11 @@ import {
 } from "@/lib/utils";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useModalFlow } from "@/hooks/use-modal-flow";
+import {
+  downloadIndicator,
+  DOWNLOAD_INDICATOR_COLOR,
+  BAR_KIND_COLOR,
+} from "@/lib/arr-poster-status";
 import type {
   SonarrEpisode,
   SonarrEpisodeFile,
@@ -86,6 +92,7 @@ export default function SeriesDetailScreen() {
   } = useSonarrSeriesById(Number(id), instanceId);
   const { data: episodes } = useSonarrEpisodes(Number(id), instanceId);
   const { data: episodeFiles } = useSonarrEpisodeFiles(Number(id), instanceId);
+  const { data: queue } = useSonarrQueue(instanceId);
   const toggleSeries = useToggleSeriesMonitored(instanceId);
   const searchSeries = useSearchForSeries(instanceId);
   const deleteSeries = useDeleteSeries(instanceId);
@@ -113,6 +120,20 @@ export default function SeriesDetailScreen() {
     episodeFiles?.forEach((f) => map.set(f.id, f));
     return map;
   }, [episodeFiles]);
+
+  // Episodes currently grabbing/downloading, so the per-episode spine, the
+  // season bars and the series Progress block can read purple — mirroring the
+  // poster grid (issue #207). The queue is the shared global query (≤20 records,
+  // same cache the TV list uses); episode ids are unique so the per-episode
+  // lookup is exact, and the series-level flag filters by seriesId.
+  const downloadingEpisodeIds = useMemo(
+    () => new Set((queue?.records ?? []).map((r) => r.episodeId)),
+    [queue],
+  );
+  const seriesDownloading = useMemo(
+    () => (queue?.records ?? []).some((r) => r.seriesId === Number(id)),
+    [queue, id],
+  );
 
   const poster = series?.images.find((i) => i.coverType === "poster");
   const fanart = series?.images.find((i) => i.coverType === "fanart");
@@ -250,7 +271,10 @@ export default function SeriesDetailScreen() {
 
           <MediaStatsStrip stats={stats} className="mb-5" />
 
-          <EpisodeProgressBlock series={series} />
+          <EpisodeProgressBlock
+            series={series}
+            downloading={seriesDownloading}
+          />
 
           <AboutBlock
             series={series}
@@ -318,6 +342,7 @@ export default function SeriesDetailScreen() {
                       (ep) => ep.seasonNumber === season.seasonNumber,
                     )}
                     episodeFileMap={episodeFileMap}
+                    downloadingEpisodeIds={downloadingEpisodeIds}
                   />
                 ))}
             </View>
@@ -512,20 +537,33 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-function EpisodeProgressBlock({ series }: { series: SonarrSeries }) {
+function EpisodeProgressBlock({
+  series,
+  downloading,
+}: {
+  series: SonarrSeries;
+  downloading: boolean;
+}) {
   const have = series.episodeFileCount;
   const total = series.totalEpisodeCount;
   if (!total) return null;
   const ratio = total > 0 ? have / total : 0;
   const missing = total - have;
   const allDownloaded = missing === 0;
+  // Purple wins while a grab is in flight, exactly like the poster bar; the
+  // proportional fill still tracks downloaded/total so progress stays readable.
+  // Inline hex (not Tailwind classes) so the status color can't be dropped by
+  // the build and stays in lockstep with every other indicator (issue #207).
+  const accent = downloading
+    ? BAR_KIND_COLOR.purple
+    : allDownloaded
+      ? BAR_KIND_COLOR.success
+      : BAR_KIND_COLOR.primary;
   return (
     <View className="mb-5">
       <SectionLabel>Progress</SectionLabel>
       <View className="rounded-2xl bg-surface border border-border overflow-hidden flex-row">
-        <View
-          className={`w-1 ${allDownloaded ? "bg-success" : "bg-primary"}`}
-        />
+        <View className="w-1" style={{ backgroundColor: accent }} />
         <View className="flex-1 p-4">
           <View className="flex-row items-end justify-between mb-2.5">
             <Text className="text-zinc-100 text-2xl font-bold">
@@ -536,25 +574,24 @@ function EpisodeProgressBlock({ series }: { series: SonarrSeries }) {
               </Text>
             </Text>
             <Text
-              className={`text-sm font-semibold ${
-                allDownloaded ? "text-success" : "text-primary"
-              }`}
+              className="text-sm font-semibold"
+              style={{ color: accent }}
             >
               {Math.round(ratio * 100)}%
             </Text>
           </View>
-          <ProgressBar
-            progress={ratio}
-            color={allDownloaded ? "bg-success" : "bg-primary"}
-          />
+          <ProgressBar progress={ratio} fillColor={accent} />
           <Text
-            className={`text-xs mt-2.5 ${
-              allDownloaded ? "text-success" : "text-zinc-500"
-            }`}
+            className="text-xs mt-2.5"
+            style={{
+              color: downloading || allDownloaded ? accent : "#71717a",
+            }}
           >
-            {allDownloaded
-              ? "All episodes downloaded"
-              : `${missing} episode${missing !== 1 ? "s" : ""} missing`}
+            {downloading
+              ? "Downloading…"
+              : allDownloaded
+                ? "All episodes downloaded"
+                : `${missing} episode${missing !== 1 ? "s" : ""} missing`}
           </Text>
         </View>
       </View>
@@ -691,12 +728,14 @@ function SeasonAccordion({
   season,
   episodes,
   episodeFileMap,
+  downloadingEpisodeIds,
 }: {
   seriesId: number;
   instanceId?: string;
   season: SonarrSeason;
   episodes?: SonarrEpisode[];
   episodeFileMap: Map<number, SonarrEpisodeFile>;
+  downloadingEpisodeIds: Set<number>;
 }) {
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
@@ -704,6 +743,10 @@ function SeasonAccordion({
   const searchSeason = useSearchForSeason(instanceId);
   const stats = season.statistics;
   const progress = stats ? stats.percentOfEpisodes / 100 : 0;
+  // Any episode of this season currently grabbing turns the season bar purple.
+  const seasonDownloading = (episodes ?? []).some((ep) =>
+    downloadingEpisodeIds.has(ep.id),
+  );
 
   const seasonLabel =
     season.seasonNumber === 0 ? "Specials" : `Season ${season.seasonNumber}`;
@@ -766,7 +809,13 @@ function SeasonAccordion({
         </View>
       </View>
 
-      {stats && <ProgressBar progress={progress} className="mt-2" />}
+      {stats && (
+        <ProgressBar
+          progress={progress}
+          fillColor={seasonDownloading ? BAR_KIND_COLOR.purple : undefined}
+          className="mt-2"
+        />
+      )}
 
       {expanded && episodes && (
         <View className="mt-3 gap-1">
@@ -784,6 +833,7 @@ function SeasonAccordion({
                     ? episodeFileMap.get(ep.episodeFileId)
                     : undefined
                 }
+                isDownloading={downloadingEpisodeIds.has(ep.id)}
               />
             ))}
         </View>
@@ -803,11 +853,13 @@ function EpisodeRow({
   instanceId,
   episode,
   episodeFile,
+  isDownloading,
 }: {
   seriesId: number;
   instanceId?: string;
   episode: SonarrEpisode;
   episodeFile?: SonarrEpisodeFile;
+  isDownloading: boolean;
 }) {
   const router = useRouter();
   const toggleMonitored = useToggleEpisodeMonitored(instanceId);
@@ -854,9 +906,13 @@ function EpisodeRow({
     <>
       <View className="flex-row items-center py-1.5 border-b border-border/30">
         <View
-          className={`w-1.5 h-6 rounded-full mr-2 ${
-            episode.hasFile ? "bg-success" : "bg-zinc-600"
-          }`}
+          className="w-1.5 h-6 rounded-full mr-2"
+          style={{
+            backgroundColor:
+              DOWNLOAD_INDICATOR_COLOR[
+                downloadIndicator(episode.hasFile, isDownloading)
+              ],
+          }}
         />
         <View className="flex-1">
           <Text className="text-zinc-300 text-xs" numberOfLines={1}>

--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -5,6 +5,10 @@ import { Tv, Film, Check, Download, type LucideIcon } from "lucide-react-native"
 import { Icon } from "@/components/ui/icon";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useUiScale } from "@/hooks/use-ui-scale";
+import {
+  downloadIndicator,
+  DOWNLOAD_INDICATOR_COLOR,
+} from "@/lib/arr-poster-status";
 
 interface PosterImage {
   coverType: string;
@@ -18,10 +22,19 @@ const ROW_HEIGHT = 64;
 const POSTER_W = 44;
 const POSTER_H = 56;
 
-// Downloaded vs not-yet-downloaded. The calendar lists *upcoming* releases, so
-// "not downloaded" is expected (not an error) — keep it neutral, not alarming.
-const DOWNLOADED = "#22c55e";
-const PENDING = "#52525b";
+// Downloaded vs downloading vs not-yet-downloaded. The calendar lists *upcoming*
+// releases, so "not downloaded" is expected (not an error) — keep it neutral,
+// not alarming. A grab in flight reads purple, mirroring the *arr poster grid
+// and the detail screens (issue #207).
+const DOWNLOADED = DOWNLOAD_INDICATOR_COLOR.downloaded; // green
+const DOWNLOADING = DOWNLOAD_INDICATOR_COLOR.downloading; // purple
+
+// Trailing status pill tint per indicator (icon + translucent background).
+const BADGE_STYLE = {
+  downloading: { bg: "rgba(168, 85, 247, 0.2)", icon: Download, color: DOWNLOADING },
+  downloaded: { bg: "rgba(34, 197, 94, 0.2)", icon: Check, color: DOWNLOADED },
+  pending: { bg: "rgba(255, 255, 255, 0.12)", icon: Download, color: "#d4d4d8" },
+} as const;
 
 const SERVICE_FALLBACK: Record<"sonarr" | "radarr", LucideIcon> = {
   sonarr: Tv,
@@ -35,6 +48,11 @@ export interface CalendarEventRowProps {
   subtitle: string;
   /** Drives the status indicators: green when downloaded, gray when missing. */
   hasFile: boolean;
+  /**
+   * Whether the episode/movie is currently in the *arr download queue. Takes
+   * priority over `hasFile` and turns the spine + badge purple (issue #207).
+   */
+  downloading?: boolean;
   onPress: () => void;
   /** Optional long-press (e.g. the TV calendar opens an episode action sheet). */
   onLongPress?: () => void;
@@ -60,6 +78,7 @@ export function CalendarEventRow({
   title,
   subtitle,
   hasFile,
+  downloading = false,
   onPress,
   onLongPress,
   action,
@@ -75,7 +94,9 @@ export function CalendarEventRow({
   const { src: backdropSrc, onError: onBackdropError } = useServiceImage(fanart, service);
 
   const FallbackIcon = SERVICE_FALLBACK[service];
-  const statusColor = hasFile ? DOWNLOADED : PENDING;
+  const indicator = downloadIndicator(hasFile, downloading);
+  const statusColor = DOWNLOAD_INDICATOR_COLOR[indicator];
+  const badge = BADGE_STYLE[indicator];
 
   return (
     <Pressable
@@ -159,20 +180,12 @@ export function CalendarEventRow({
             )}
           </Pressable>
         ) : (
-          /* Status badge — explicit downloaded / not-yet state. */
+          /* Status badge — explicit downloading / downloaded / not-yet state. */
           <View
             className="w-7 h-7 rounded-full items-center justify-center"
-            style={{
-              backgroundColor: hasFile
-                ? "rgba(34, 197, 94, 0.2)"
-                : "rgba(255, 255, 255, 0.12)",
-            }}
+            style={{ backgroundColor: badge.bg }}
           >
-            <Icon
-              icon={hasFile ? Check : Download}
-              size={14}
-              color={hasFile ? DOWNLOADED : "#d4d4d8"}
-            />
+            <Icon icon={badge.icon} size={14} color={badge.color} />
           </View>
         )}
       </View>

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -24,8 +24,14 @@ import {
   localDateKey,
   releaseDateKey,
 } from "@/lib/utils";
-import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
-import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
+import {
+  getCalendar as getSonarrCalendar,
+  getQueue as getSonarrQueue,
+} from "@/services/sonarr-api";
+import {
+  getCalendar as getRadarrCalendar,
+  getQueue as getRadarrQueue,
+} from "@/services/radarr-api";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
 import type { SonarrCalendarEntry, RadarrMovie } from "@/lib/types";
@@ -113,6 +119,44 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
           refetchInterval: POLLING_INTERVALS.calendar,
         }))
       : [],
+  });
+
+  // Download queues per instance, so a release already grabbing reads purple —
+  // same indicator as the poster grid, detail screens and Calendar tab (#207).
+  // Shares the ["sonarr"/"radarr", id, "queue"] cache the rest of the app polls.
+  const sonarrQueueQueries = useQueries({
+    queries: showSonarr
+      ? sonarrInstances.map((inst) => ({
+          queryKey: ["sonarr", inst.id, "queue"] as const,
+          queryFn: () => getSonarrQueue(1, 20, true, true, inst.id),
+          refetchInterval: POLLING_INTERVALS.queue,
+        }))
+      : [],
+  });
+  const radarrQueueQueries = useQueries({
+    queries: showRadarr
+      ? radarrInstances.map((inst) => ({
+          queryKey: ["radarr", inst.id, "queue"] as const,
+          queryFn: () => getRadarrQueue(1, 20, true, inst.id),
+          refetchInterval: POLLING_INTERVALS.queue,
+        }))
+      : [],
+  });
+
+  // Keyed by `instanceId:episodeId` / `instanceId:movieId` (ids aren't unique
+  // across instances).
+  const downloadingKeys = new Set<string>();
+  sonarrQueueQueries.forEach((q, i) => {
+    const instanceId = sonarrInstances[i]?.id;
+    if (!instanceId) return;
+    for (const r of q.data?.records ?? [])
+      downloadingKeys.add(`${instanceId}:${r.episodeId}`);
+  });
+  radarrQueueQueries.forEach((q, i) => {
+    const instanceId = radarrInstances[i]?.id;
+    if (!instanceId) return;
+    for (const r of q.data?.records ?? [])
+      downloadingKeys.add(`${instanceId}:${r.movieId}`);
   });
 
   // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton
@@ -217,6 +261,9 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
                     <EpisodeRow
                       key={`ep-${item.instanceId}-${item.entry.id}`}
                       entry={item.entry}
+                      downloading={downloadingKeys.has(
+                        `${item.instanceId}:${item.entry.id}`,
+                      )}
                       onPress={() =>
                         router.push(
                           `/series/${item.entry.seriesId}?instanceId=${item.instanceId}`,
@@ -227,6 +274,9 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
                     <MovieRow
                       key={`mv-${item.instanceId}-${item.movie.id}`}
                       movie={item.movie}
+                      downloading={downloadingKeys.has(
+                        `${item.instanceId}:${item.movie.id}`,
+                      )}
                       onPress={() =>
                         router.push(
                           `/movie/${item.movie.id}?instanceId=${item.instanceId}`,
@@ -285,9 +335,11 @@ function titleOf(item: CalendarItem): string {
 
 function EpisodeRow({
   entry,
+  downloading,
   onPress,
 }: {
   entry: SonarrCalendarEntry;
+  downloading: boolean;
   onPress: () => void;
 }) {
   return (
@@ -297,6 +349,7 @@ function EpisodeRow({
       title={entry.series.title}
       subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
       hasFile={entry.hasFile}
+      downloading={downloading}
       onPress={onPress}
     />
   );
@@ -304,9 +357,11 @@ function EpisodeRow({
 
 function MovieRow({
   movie,
+  downloading,
   onPress,
 }: {
   movie: RadarrMovie;
+  downloading: boolean;
   onPress: () => void;
 }) {
   return (
@@ -316,6 +371,7 @@ function MovieRow({
       title={movie.title}
       subtitle={movie.year ? `${movie.year} • Movie` : "Movie"}
       hasFile={movie.hasFile}
+      downloading={downloading}
       onPress={onPress}
     />
   );

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -23,8 +23,14 @@ import {
   getDateOffset,
   localDateKey,
 } from "@/lib/utils";
-import { getWantedMissing as getSonarrWantedMissing } from "@/services/sonarr-api";
-import { getAllWantedMissing as getRadarrWantedMissing } from "@/services/radarr-api";
+import {
+  getWantedMissing as getSonarrWantedMissing,
+  getQueue as getSonarrQueue,
+} from "@/services/sonarr-api";
+import {
+  getAllWantedMissing as getRadarrWantedMissing,
+  getQueue as getRadarrQueue,
+} from "@/services/radarr-api";
 import { radarrReleaseTime } from "@/lib/radarr-release-date";
 import { useSearchForMovie } from "@/hooks/use-radarr";
 import { useSearchForEpisodes } from "@/hooks/use-sonarr";
@@ -80,6 +86,44 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
           refetchInterval: POLLING_INTERVALS.calendar,
         }))
       : [],
+  });
+
+  // Download queues per instance: an overdue item that's already grabbing reads
+  // purple instead of the neutral "pending" spine — same indicator as the rest
+  // of the app (issue #207). Shares the ["sonarr"/"radarr", id, "queue"] cache.
+  const sonarrQueueQueries = useQueries({
+    queries: showSonarr
+      ? sonarrInstances.map((inst) => ({
+          queryKey: ["sonarr", inst.id, "queue"] as const,
+          queryFn: () => getSonarrQueue(1, 20, true, true, inst.id),
+          refetchInterval: POLLING_INTERVALS.queue,
+        }))
+      : [],
+  });
+  const radarrQueueQueries = useQueries({
+    queries: showRadarr
+      ? radarrInstances.map((inst) => ({
+          queryKey: ["radarr", inst.id, "queue"] as const,
+          queryFn: () => getRadarrQueue(1, 20, true, inst.id),
+          refetchInterval: POLLING_INTERVALS.queue,
+        }))
+      : [],
+  });
+
+  // Keyed by `instanceId:episodeId` / `instanceId:movieId` (ids aren't unique
+  // across instances).
+  const downloadingKeys = new Set<string>();
+  sonarrQueueQueries.forEach((q, i) => {
+    const instanceId = sonarrInstances[i]?.id;
+    if (!instanceId) return;
+    for (const r of q.data?.records ?? [])
+      downloadingKeys.add(`${instanceId}:${r.episodeId}`);
+  });
+  radarrQueueQueries.forEach((q, i) => {
+    const instanceId = radarrInstances[i]?.id;
+    if (!instanceId) return;
+    for (const r of q.data?.records ?? [])
+      downloadingKeys.add(`${instanceId}:${r.movieId}`);
   });
 
   // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton
@@ -195,6 +239,9 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
                       key={`ep-${item.instanceId}-${item.entry.id}`}
                       entry={item.entry}
                       instanceId={item.instanceId}
+                      downloading={downloadingKeys.has(
+                        `${item.instanceId}:${item.entry.id}`,
+                      )}
                       onPress={() =>
                         router.push(
                           `/series/${item.entry.seriesId}?instanceId=${item.instanceId}`,
@@ -206,6 +253,9 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
                       key={`mv-${item.instanceId}-${item.movie.id}`}
                       movie={item.movie}
                       instanceId={item.instanceId}
+                      downloading={downloadingKeys.has(
+                        `${item.instanceId}:${item.movie.id}`,
+                      )}
                       onPress={() =>
                         router.push(
                           `/movie/${item.movie.id}?instanceId=${item.instanceId}`,
@@ -268,10 +318,12 @@ function titleOf(item: PendingItem): string {
 function PendingEpisodeRow({
   entry,
   instanceId,
+  downloading,
   onPress,
 }: {
   entry: SonarrEpisode;
   instanceId: string;
+  downloading: boolean;
   onPress: () => void;
 }) {
   const search = useSearchForEpisodes(instanceId);
@@ -282,6 +334,7 @@ function PendingEpisodeRow({
       title={entry.series?.title ?? "Unknown series"}
       subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
       hasFile={false}
+      downloading={downloading}
       onPress={onPress}
       action={{
         icon: Search,
@@ -295,10 +348,12 @@ function PendingEpisodeRow({
 function PendingMovieRow({
   movie,
   instanceId,
+  downloading,
   onPress,
 }: {
   movie: RadarrMovie;
   instanceId: string;
+  downloading: boolean;
   onPress: () => void;
 }) {
   const search = useSearchForMovie(instanceId);
@@ -309,6 +364,7 @@ function PendingMovieRow({
       title={movie.title}
       subtitle={movie.year ? `${movie.year} • Movie` : "Movie"}
       hasFile={false}
+      downloading={downloading}
       onPress={onPress}
       action={{
         icon: Search,

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -517,7 +517,13 @@ function CalendarView({
   onLongPress: (ep: SonarrCalendarEntry) => void;
 }) {
   const { data: episodes, isLoading, error } = useSonarrCalendar();
+  const { data: queue } = useSonarrQueue();
   const router = useRouter();
+
+  const downloadingEpisodeIds = useMemo(
+    () => new Set((queue?.records ?? []).map((r) => r.episodeId)),
+    [queue],
+  );
 
   if (isLoading) return <SkeletonCardContent rows={4} />;
   if (error) {
@@ -568,6 +574,7 @@ function CalendarView({
                   title={ep.series.title}
                   subtitle={`${formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} — ${ep.title}`}
                   hasFile={ep.hasFile}
+                  downloading={downloadingEpisodeIds.has(ep.id)}
                   onPress={() => router.push(`/series/${ep.seriesId}`)}
                   onLongPress={() => onLongPress(ep)}
                 />

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,10 +1,14 @@
 import { View, Text } from "react-native";
 
-type BadgeVariant = "default" | "downloading" | "seeding" | "paused" | "missing" | "wanted" | "warning" | "error" | "success" | "info";
+type BadgeVariant = "default" | "downloading" | "grabbing" | "seeding" | "paused" | "missing" | "wanted" | "warning" | "error" | "success" | "info";
 
 const VARIANT_CLASSES: Record<BadgeVariant, string> = {
   default: "bg-zinc-700",
   downloading: "bg-blue-600",
+  // `grabbing` = an *arr item currently in the download queue. Purple mirrors
+  // Sonarr/Radarr (and the poster grid's purple bar); distinct from the
+  // blue `downloading` used for qBittorrent/indexer protocol chips.
+  grabbing: "bg-purple-600",
   seeding: "bg-green-600",
   paused: "bg-yellow-600",
   warning: "bg-yellow-600",

--- a/components/ui/progress-bar.tsx
+++ b/components/ui/progress-bar.tsx
@@ -3,7 +3,14 @@ import { View, Text } from "react-native";
 interface ProgressBarProps {
   progress: number; // 0-1
   showLabel?: boolean;
+  /** Tailwind class for the fill (e.g. "bg-primary"). Ignored when `fillColor` is set. */
   color?: string;
+  /**
+   * Explicit fill color as a hex/rgb string. Use this for status colors derived
+   * at runtime (e.g. the purple downloading indicator) so the fill never depends
+   * on a Tailwind class being present in the build. Overrides `color`.
+   */
+  fillColor?: string;
   className?: string;
 }
 
@@ -11,6 +18,7 @@ export function ProgressBar({
   progress,
   showLabel = false,
   color = "bg-primary",
+  fillColor,
   className = "",
 }: ProgressBarProps) {
   const clampedProgress = Math.min(Math.max(progress, 0), 1);
@@ -20,8 +28,11 @@ export function ProgressBar({
     <View className={`flex-row items-center gap-2 ${className}`}>
       <View className="flex-1 h-2 bg-zinc-700 rounded-full overflow-hidden">
         <View
-          className={`h-full rounded-full ${color}`}
-          style={{ width: `${percentage}%` }}
+          className={`h-full rounded-full ${fillColor ? "" : color}`}
+          style={{
+            width: `${percentage}%`,
+            ...(fillColor ? { backgroundColor: fillColor } : null),
+          }}
         />
       </View>
       {showLabel && (

--- a/lib/arr-poster-status.test.ts
+++ b/lib/arr-poster-status.test.ts
@@ -3,6 +3,9 @@ import {
   sonarrBarKind,
   sonarrBarProgress,
   cornerColorFor,
+  downloadIndicator,
+  DOWNLOAD_INDICATOR_COLOR,
+  BAR_KIND_COLOR,
 } from "@/lib/arr-poster-status";
 import type { RadarrMovie, SonarrSeries } from "@/lib/types";
 
@@ -25,6 +28,28 @@ function movie(over: Partial<RadarrMovie>): RadarrMovie {
     ...over,
   } as RadarrMovie;
 }
+
+describe("downloadIndicator", () => {
+  it("downloading wins over hasFile (issue #207)", () => {
+    expect(downloadIndicator(false, true)).toBe("downloading");
+    expect(downloadIndicator(true, true)).toBe("downloading");
+  });
+
+  it("hasFile and not downloading → downloaded", () => {
+    expect(downloadIndicator(true, false)).toBe("downloaded");
+  });
+
+  it("neither → pending", () => {
+    expect(downloadIndicator(false, false)).toBe("pending");
+  });
+
+  it("downloading reuses the exact poster-bar purple", () => {
+    // Guards the promise that a single item reads the same color in the grid
+    // and on the detail/calendar row.
+    expect(DOWNLOAD_INDICATOR_COLOR.downloading).toBe(BAR_KIND_COLOR.purple);
+    expect(DOWNLOAD_INDICATOR_COLOR.downloaded).toBe(BAR_KIND_COLOR.success);
+  });
+});
 
 describe("sonarrBarKind", () => {
   it("downloading wins over everything", () => {

--- a/lib/arr-poster-status.ts
+++ b/lib/arr-poster-status.ts
@@ -38,6 +38,42 @@ export const BAR_KIND_COLOR: Record<PosterBarKind, string> = {
  */
 export const BAR_TRACK_COLOR = "#3f3f46"; // zinc-700
 
+/**
+ * Per-item download indicator (issue #207). A single episode / movie / track /
+ * calendar row reads the SAME color everywhere it appears — the poster grid, the
+ * detail-screen spine bar, and the calendar row — so the app's status cues stay
+ * consistent and mirror Sonarr/Radarr:
+ *   - downloading (in the *arr queue) → purple  (same purple as the poster bar)
+ *   - downloaded  (hasFile)           → green
+ *   - pending     (neither)           → neutral gray
+ *
+ * Before #207 the detail/calendar indicators only knew green/gray and never
+ * turned purple while a grab was in progress, unlike the poster grid which has
+ * always shown purple via the bar-kind logic above.
+ */
+export type DownloadIndicator = "downloading" | "downloaded" | "pending";
+
+export function downloadIndicator(
+  hasFile: boolean,
+  isDownloading: boolean,
+): DownloadIndicator {
+  if (isDownloading) return "downloading";
+  if (hasFile) return "downloaded";
+  return "pending";
+}
+
+/**
+ * Indicator → hex, for the inline-styled spine bars. `downloading` reuses the
+ * exact poster-bar purple so the grid poster and the detail spine match; the
+ * `bg-purple-500` / `bg-purple-600` Tailwind tokens used for className-based
+ * consumers (ProgressBar fill, Badge) resolve to the same #a855f7 family.
+ */
+export const DOWNLOAD_INDICATOR_COLOR: Record<DownloadIndicator, string> = {
+  downloading: BAR_KIND_COLOR.purple, // #a855f7
+  downloaded: BAR_KIND_COLOR.success, // #22c55e
+  pending: "#52525b", // zinc-600 — the long-standing "no file yet" neutral
+};
+
 const CORNER_ENDED = "#ef4444"; // danger
 const CORNER_DELETED = "#71717a"; // gray
 


### PR DESCRIPTION
Episode/movie/album/track indicators stayed green/gray and never turned purple while a grab was in flight — only the poster grids showed it. This routes every per-item indicator through one shared helper (`lib/arr-poster-status.ts`) so a downloading item reads the same purple everywhere, mirroring Sonarr/Radarr.

**Surfaces unified** (purple=downloading, green=downloaded, gray=pending):
- Series detail: episode spines, season bars, Progress block
- Movie/Album detail: hero badge gains a purple "Downloading" state
- Album/Artist detail: track spines, Progress block, per-album bars
- Calendar tab + dashboard "Releasing Soon" / "Still Pending" + TV-tab calendar (per-instance queues)
- Poster grids already correct (unchanged)

Adds a `grabbing` Badge variant and an optional `ProgressBar` `fillColor`.

Refs #207

## Test plan
- `tsc --noEmit` clean
- `jest` — 660/660 pass (added 4 `downloadIndicator` cases)
- Verify an episode/movie/album currently in the *arr queue shows purple on its detail spine/badge, its season/artist progress bar, and its calendar row; reverts to green once the file lands.