### PR TITLE
fix: make all Sonarr/Radarr status indicators consistent (Refs #217)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -33,6 +33,11 @@ import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import {
+  radarrBarKind,
+  sonarrEpisodeBarKind,
+  BAR_KIND_COLOR,
+} from "@/lib/arr-poster-status";
+import {
   airDateKey,
   formatEpisodeCode,
   localDateKey,
@@ -689,6 +694,7 @@ function EpisodeRow({
       subtitle={`${formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} — ${episode.title}`}
       hasFile={episode.hasFile}
       downloading={downloading}
+      barColor={BAR_KIND_COLOR[sonarrEpisodeBarKind(episode, downloading)]}
       onPress={onPress}
     />
   );
@@ -711,6 +717,7 @@ function MovieRow({
       subtitle={`${movie.year} — ${getMovieReleaseType(movie)}`}
       hasFile={movie.hasFile}
       downloading={downloading}
+      barColor={BAR_KIND_COLOR[radarrBarKind(movie, downloading)]}
       onPress={onPress}
     />
   );

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -67,8 +67,7 @@ import {
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import {
-  downloadIndicator,
-  DOWNLOAD_INDICATOR_COLOR,
+  sonarrEpisodeBarKind,
   BAR_KIND_COLOR,
 } from "@/lib/arr-poster-status";
 import type {
@@ -909,9 +908,7 @@ function EpisodeRow({
           className="w-1.5 h-6 rounded-full mr-2"
           style={{
             backgroundColor:
-              DOWNLOAD_INDICATOR_COLOR[
-                downloadIndicator(episode.hasFile, isDownloading)
-              ],
+              BAR_KIND_COLOR[sonarrEpisodeBarKind(episode, isDownloading)],
           }}
         />
         <View className="flex-1">

--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -50,9 +50,16 @@ export interface CalendarEventRowProps {
   hasFile: boolean;
   /**
    * Whether the episode/movie is currently in the *arr download queue. Takes
-   * priority over `hasFile` and turns the spine + badge purple (issue #207).
+   * priority over `hasFile` and turns the badge purple (issue #207).
    */
   downloading?: boolean;
+  /**
+   * Explicit left-spine color, so the row matches the poster grid's bar for the
+   * same item (red = missing, blue = upcoming, etc. via radarr/sonarr bar kinds
+   * — issue #217). When omitted the spine falls back to the green/purple/gray
+   * download indicator.
+   */
+  barColor?: string;
   onPress: () => void;
   /** Optional long-press (e.g. the TV calendar opens an episode action sheet). */
   onLongPress?: () => void;
@@ -79,6 +86,7 @@ export function CalendarEventRow({
   subtitle,
   hasFile,
   downloading = false,
+  barColor,
   onPress,
   onLongPress,
   action,
@@ -95,7 +103,9 @@ export function CalendarEventRow({
 
   const FallbackIcon = SERVICE_FALLBACK[service];
   const indicator = downloadIndicator(hasFile, downloading);
-  const statusColor = DOWNLOAD_INDICATOR_COLOR[indicator];
+  // Spine mirrors the poster grid's bar (issue #217) when the caller passes a
+  // kind color; otherwise it falls back to the 3-state download indicator.
+  const statusColor = barColor ?? DOWNLOAD_INDICATOR_COLOR[indicator];
   const badge = BADGE_STYLE[indicator];
 
   return (

--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -22,20 +22,6 @@ const ROW_HEIGHT = 64;
 const POSTER_W = 44;
 const POSTER_H = 56;
 
-// Downloaded vs downloading vs not-yet-downloaded. The calendar lists *upcoming*
-// releases, so "not downloaded" is expected (not an error) — keep it neutral,
-// not alarming. A grab in flight reads purple, mirroring the *arr poster grid
-// and the detail screens (issue #207).
-const DOWNLOADED = DOWNLOAD_INDICATOR_COLOR.downloaded; // green
-const DOWNLOADING = DOWNLOAD_INDICATOR_COLOR.downloading; // purple
-
-// Trailing status pill tint per indicator (icon + translucent background).
-const BADGE_STYLE = {
-  downloading: { bg: "rgba(168, 85, 247, 0.2)", icon: Download, color: DOWNLOADING },
-  downloaded: { bg: "rgba(34, 197, 94, 0.2)", icon: Check, color: DOWNLOADED },
-  pending: { bg: "rgba(255, 255, 255, 0.12)", icon: Download, color: "#d4d4d8" },
-} as const;
-
 const SERVICE_FALLBACK: Record<"sonarr" | "radarr", LucideIcon> = {
   sonarr: Tv,
   radarr: Film,
@@ -106,7 +92,10 @@ export function CalendarEventRow({
   // Spine mirrors the poster grid's bar (issue #217) when the caller passes a
   // kind color; otherwise it falls back to the 3-state download indicator.
   const statusColor = barColor ?? DOWNLOAD_INDICATOR_COLOR[indicator];
-  const badge = BADGE_STYLE[indicator];
+  // Trailing badge tracks the SAME color as the spine (a missing item now reads
+  // red on both, not red spine + gray badge). Check when downloaded, download
+  // glyph otherwise. `+ "33"` = ~20% alpha (8-digit hex) for the tinted pill.
+  const BadgeIcon = hasFile ? Check : Download;
 
   return (
     <Pressable
@@ -190,12 +179,12 @@ export function CalendarEventRow({
             )}
           </Pressable>
         ) : (
-          /* Status badge — explicit downloading / downloaded / not-yet state. */
+          /* Status badge — same color as the spine; check when downloaded. */
           <View
             className="w-7 h-7 rounded-full items-center justify-center"
-            style={{ backgroundColor: badge.bg }}
+            style={{ backgroundColor: statusColor + "33" }}
           >
-            <Icon icon={badge.icon} size={14} color={badge.color} />
+            <Icon icon={BadgeIcon} size={14} color={statusColor} />
           </View>
         )}
       </View>

--- a/components/dashboard/arr-queue-card.tsx
+++ b/components/dashboard/arr-queue-card.tsx
@@ -19,6 +19,7 @@ import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
 import { PosterProgressStrip } from "@/components/dashboard/poster-progress-strip";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
 import { ViewAllTile } from "@/components/dashboard/view-all-tile";
+import { DOWNLOAD_INDICATOR_COLOR } from "@/lib/arr-poster-status";
 
 interface Props extends WidgetComponentProps {
   adapter: ArrQueueAdapter;
@@ -112,7 +113,12 @@ export function ArrQueueCard({ slotId, adapter }: Props) {
                 label: item.qualityLabel,
                 color: adapter.badgeColor,
               }}
-              bottomOverlay={<PosterProgressStrip progress={item.progress} />}
+              bottomOverlay={
+                <PosterProgressStrip
+                  progress={item.progress}
+                  color={DOWNLOAD_INDICATOR_COLOR.downloading}
+                />
+              }
               onPress={() => item.detailPath && router.push(item.detailPath)}
             />
           ))}

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -34,6 +34,11 @@ import {
 } from "@/services/radarr-api";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
+import {
+  radarrBarKind,
+  sonarrEpisodeBarKind,
+  BAR_KIND_COLOR,
+} from "@/lib/arr-poster-status";
 import type { SonarrCalendarEntry, RadarrMovie } from "@/lib/types";
 
 type CalendarItem =
@@ -350,6 +355,7 @@ function EpisodeRow({
       subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
       hasFile={entry.hasFile}
       downloading={downloading}
+      barColor={BAR_KIND_COLOR[sonarrEpisodeBarKind(entry, downloading)]}
       onPress={onPress}
     />
   );
@@ -372,6 +378,7 @@ function MovieRow({
       subtitle={movie.year ? `${movie.year} • Movie` : "Movie"}
       hasFile={movie.hasFile}
       downloading={downloading}
+      barColor={BAR_KIND_COLOR[radarrBarKind(movie, downloading)]}
       onPress={onPress}
     />
   );

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -36,6 +36,11 @@ import { useSearchForMovie } from "@/hooks/use-radarr";
 import { useSearchForEpisodes } from "@/hooks/use-sonarr";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
+import {
+  radarrBarKind,
+  sonarrEpisodeBarKind,
+  BAR_KIND_COLOR,
+} from "@/lib/arr-poster-status";
 import type { SonarrEpisode, RadarrMovie } from "@/lib/types";
 
 type PendingItem =
@@ -335,6 +340,7 @@ function PendingEpisodeRow({
       subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
       hasFile={false}
       downloading={downloading}
+      barColor={BAR_KIND_COLOR[sonarrEpisodeBarKind(entry, downloading)]}
       onPress={onPress}
       action={{
         icon: Search,
@@ -365,6 +371,7 @@ function PendingMovieRow({
       subtitle={movie.year ? `${movie.year} • Movie` : "Movie"}
       hasFile={false}
       downloading={downloading}
+      barColor={BAR_KIND_COLOR[radarrBarKind(movie, downloading)]}
       onPress={onPress}
       action={{
         icon: Search,

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -44,7 +44,13 @@ import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import { mediumHaptic } from "@/lib/haptics";
-import { BAR_KIND_COLOR, cornerColorFor, radarrBarKind } from "@/lib/arr-poster-status";
+import {
+  BAR_KIND_COLOR,
+  cornerColorFor,
+  radarrBarKind,
+  DOWNLOAD_INDICATOR_COLOR,
+} from "@/lib/arr-poster-status";
+import { ProgressBar } from "@/components/ui/progress-bar";
 import { radarrReleaseTime } from "@/lib/radarr-release-date";
 import type { RadarrMovie, RadarrQueueItem } from "@/lib/types";
 
@@ -479,23 +485,39 @@ function MovieQueue({ onLongPress }: { onLongPress: (item: RadarrQueueItem) => v
 
   return (
     <View className="gap-2">
-      {queue.records.map((item) => (
-        <Card
-          key={item.id}
-          onPress={() => item.movie && router.push(`/movie/${item.movie.id}`)}
-          onLongPress={item.movie ? () => onLongPress(item) : undefined}
-        >
-          <View className="flex-row items-center justify-between">
-            <Text className="text-zinc-200 text-sm flex-1" numberOfLines={1}>
-              {item.title}
-            </Text>
-            <Badge label={item.quality.quality.name} />
-          </View>
-          {item.timeleft && (
-            <Text className="text-zinc-500 text-xs mt-1">ETA {item.timeleft}</Text>
-          )}
-        </Card>
-      ))}
+      {queue.records.map((item) => {
+        // Downloaded fraction; queue items carry size + sizeleft.
+        const progress =
+          item.size > 0 ? (item.size - item.sizeleft) / item.size : 0;
+        // Colour the bar by tracked status, mirroring Sonarr/Radarr: a stalled
+        // grab warns amber, a failed one reads red, everything else is the
+        // app's purple "downloading" (issue #207 consistency).
+        const tracked = (item.trackedDownloadStatus ?? "").toLowerCase();
+        const barColor =
+          tracked === "error"
+            ? BAR_KIND_COLOR.danger
+            : tracked === "warning"
+              ? BAR_KIND_COLOR.warning
+              : DOWNLOAD_INDICATOR_COLOR.downloading;
+        return (
+          <Card
+            key={item.id}
+            onPress={() => item.movie && router.push(`/movie/${item.movie.id}`)}
+            onLongPress={item.movie ? () => onLongPress(item) : undefined}
+          >
+            <View className="flex-row items-center justify-between">
+              <Text className="text-zinc-200 text-sm flex-1" numberOfLines={1}>
+                {item.title}
+              </Text>
+              <Badge label={item.quality.quality.name} />
+            </View>
+            <ProgressBar progress={progress} fillColor={barColor} className="mt-2" />
+            {item.timeleft && (
+              <Text className="text-zinc-500 text-xs mt-1">ETA {item.timeleft}</Text>
+            )}
+          </Card>
+        );
+      })}
     </View>
   );
 }

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -60,6 +60,7 @@ import {
   cornerColorFor,
   sonarrBarKind,
   sonarrBarProgress,
+  sonarrEpisodeBarKind,
 } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
@@ -575,6 +576,11 @@ function CalendarView({
                   subtitle={`${formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} — ${ep.title}`}
                   hasFile={ep.hasFile}
                   downloading={downloadingEpisodeIds.has(ep.id)}
+                  barColor={
+                    BAR_KIND_COLOR[
+                      sonarrEpisodeBarKind(ep, downloadingEpisodeIds.has(ep.id))
+                    ]
+                  }
                   onPress={() => router.push(`/series/${ep.seriesId}`)}
                   onLongPress={() => onLongPress(ep)}
                 />

--- a/lib/arr-poster-status.test.ts
+++ b/lib/arr-poster-status.test.ts
@@ -1,6 +1,7 @@
 import {
   radarrBarKind,
   sonarrBarKind,
+  sonarrEpisodeBarKind,
   sonarrBarProgress,
   cornerColorFor,
   downloadIndicator,
@@ -48,6 +49,48 @@ describe("downloadIndicator", () => {
     // and on the detail/calendar row.
     expect(DOWNLOAD_INDICATOR_COLOR.downloading).toBe(BAR_KIND_COLOR.purple);
     expect(DOWNLOAD_INDICATOR_COLOR.downloaded).toBe(BAR_KIND_COLOR.success);
+  });
+});
+
+describe("sonarrEpisodeBarKind", () => {
+  const NOW = Date.parse("2026-06-19T00:00:00Z");
+  const PAST = "2026-06-01T00:00:00Z";
+  const FUTURE = "2026-07-01T00:00:00Z";
+
+  it("downloading wins over everything (issue #207/#217)", () => {
+    expect(
+      sonarrEpisodeBarKind({ hasFile: false, monitored: true, airDateUtc: PAST }, true, NOW),
+    ).toBe("purple");
+  });
+
+  it("has file → green", () => {
+    expect(
+      sonarrEpisodeBarKind({ hasFile: true, monitored: true, airDateUtc: PAST }, false, NOW),
+    ).toBe("success");
+  });
+
+  it("monitored + aired + missing → red (matches the grid; fixes #217)", () => {
+    expect(
+      sonarrEpisodeBarKind({ hasFile: false, monitored: true, airDateUtc: PAST }, false, NOW),
+    ).toBe("danger");
+  });
+
+  it("monitored + not yet aired → blue (upcoming, not alarming)", () => {
+    expect(
+      sonarrEpisodeBarKind({ hasFile: false, monitored: true, airDateUtc: FUTURE }, false, NOW),
+    ).toBe("primary");
+  });
+
+  it("unmonitored + missing → gray", () => {
+    expect(
+      sonarrEpisodeBarKind({ hasFile: false, monitored: false, airDateUtc: PAST }, false, NOW),
+    ).toBe("default");
+  });
+
+  it("no air date → treated as not aired (blue)", () => {
+    expect(
+      sonarrEpisodeBarKind({ hasFile: false, monitored: true }, false, NOW),
+    ).toBe("primary");
   });
 });
 

--- a/lib/arr-poster-status.ts
+++ b/lib/arr-poster-status.ts
@@ -108,6 +108,30 @@ export function sonarrBarKind(series: SonarrSeries, isDownloading: boolean): Pos
 }
 
 /**
+ * Per-episode bar kind (issue #217). A single episode reads the same color
+ * wherever it appears — the calendar, the Still Pending card, the series detail
+ * list — using the same kind→color mapping the series poster uses in the grid,
+ * so the "color bars should match" complaint goes away. Mirrors the *arr
+ * episode-status semantics; structured like radarrBarKind (first match wins):
+ *   downloading → purple, has file → green, unmonitored & missing → gray,
+ *   monitored & aired & missing → red (danger), monitored & not yet aired → blue.
+ * `now` is injectable for deterministic tests (defaults to the current time).
+ */
+export function sonarrEpisodeBarKind(
+  episode: { hasFile: boolean; monitored: boolean; airDateUtc?: string },
+  isDownloading: boolean,
+  now: number = Date.now(),
+): PosterBarKind {
+  if (isDownloading) return "purple";
+  if (episode.hasFile) return "success";
+  if (!episode.monitored) return "default";
+  const aired = episode.airDateUtc
+    ? Date.parse(episode.airDateUtc) <= now
+    : false;
+  return aired ? "danger" : "primary";
+}
+
+/**
  * Port of Radarr's getProgressBarKind(status, monitored, hasFile, isAvailable,
  * isDownloading). Branches are evaluated in order; first match wins.
  */


### PR DESCRIPTION
Brings every Sonarr/Radarr color/status indicator in line so the same item reads the same color everywhere — closing the gap that made #207/#217 resurface.

### #217 — row bars match the poster grid
Per-item row spines now run the same bar-kind logic as the posters (`radarrBarKind` / new `sonarrEpisodeBarKind` → `BAR_KIND_COLOR`):
- 🔴 missing (monitored, released/aired) · 🔵 upcoming · 🟢 downloaded · 🟣 downloading · ⚪ unmonitored
- Surfaces: calendar tab, dashboard "Releasing Soon" + "Still Pending", series detail episode rows
- A monitored-missing movie (e.g. "Busboys") is now red in the grid AND in Still Pending.

### Full-audit follow-ups
An exhaustive audit of every Sonarr/Radarr indicator surfaced three more:
- Calendar/queue row **trailing badge** now matches its spine color (was red spine + gray badge).
- Dashboard **\*arr queue card** progress strip → purple (downloading), was blue.
- **Movies queue** rows gain a status-colored progress bar (purple downloading / amber on tracked-warning / red on tracked-error).

`CalendarEventRow` gains a `barColor` spine override; `PosterProgressStrip` color is now set per-use.

Scope is Sonarr + Radarr (the issue's scope). Deliberately unchanged: search "already added" check (means *in library*, not download status), the series hero (uses the X/Y Progress block, not a binary badge), and the calendar month-grid dots (TV-vs-movie category markers). Lidarr detail rows still use the simpler indicator — easy follow-up.

Refs #217

## Test plan
- `tsc --noEmit` clean
- `jest` — 666/666 pass (incl. 6 new `sonarrEpisodeBarKind` cases)
- Same item shows the same bar color in the grid, calendar rows, Still Pending, and detail; queue items read purple (or amber/red when stalled/failed).