### PR TITLE
fix: purple downloading bar in download widgets to match Sonarr/Radarr (Refs #208)

### DIFF
--- a/components/dashboard/download-card.tsx
+++ b/components/dashboard/download-card.tsx
@@ -40,6 +40,7 @@ import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
 import { PosterProgressStrip } from "@/components/dashboard/poster-progress-strip";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
 import { ViewAllTile } from "@/components/dashboard/view-all-tile";
+import { downloadStatusColor } from "@/lib/download-status";
 
 type StateGroup = "downloading" | "seeding" | "paused" | "errored" | "other";
 
@@ -387,7 +388,12 @@ function TorrentTile({
           : "rgba(245, 158, 11, 0.9)",
         onPress: handleToggle,
       }}
-      bottomOverlay={<PosterProgressStrip progress={row.progress} />}
+      bottomOverlay={
+        <PosterProgressStrip
+          progress={row.progress}
+          color={downloadStatusColor(row.group)}
+        />
+      }
       mediaType={posterEntry?.mediaType}
       fallbackIcon={!posterEntry ? Download : undefined}
       onPress={row.canDrillIn ? () => router.push(`/torrent/${row.hash}`) : undefined}

--- a/components/dashboard/usenet-queue-card.tsx
+++ b/components/dashboard/usenet-queue-card.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/components/ui/icon";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { EmptyState } from "@/components/ui/empty-state";
+import { downloadStatusColor } from "@/lib/download-status";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
@@ -178,7 +179,12 @@ function SlotRow({
           <Text className="text-zinc-200 text-sm" numberOfLines={1}>
             {truncateText(item.name, 40)}
           </Text>
-          <ProgressBar progress={item.progress} showLabel className="mt-1.5" />
+          <ProgressBar
+            progress={item.progress}
+            fillColor={downloadStatusColor(item.status)}
+            showLabel
+            className="mt-1.5"
+          />
           <View className="flex-row gap-3 mt-1">
             <Text className="text-zinc-500 text-xs">{item.sizeLabel}</Text>
             {item.timeleft && item.timeleft !== "0:00:00" && (

--- a/lib/download-status.test.ts
+++ b/lib/download-status.test.ts
@@ -1,0 +1,30 @@
+import { downloadStatusColor } from "@/lib/download-status";
+import { DOWNLOAD_INDICATOR_COLOR } from "@/lib/arr-poster-status";
+
+describe("downloadStatusColor", () => {
+  it("downloading reads the app's purple cue (issue #208)", () => {
+    expect(downloadStatusColor("downloading")).toBe(
+      DOWNLOAD_INDICATOR_COLOR.downloading,
+    );
+  });
+
+  it("seeding / completed → green", () => {
+    expect(downloadStatusColor("seeding")).toBe("#22c55e");
+    expect(downloadStatusColor("completed")).toBe("#22c55e");
+  });
+
+  it("paused → amber", () => {
+    expect(downloadStatusColor("paused")).toBe("#f59e0b");
+  });
+
+  it("errored / failed → red", () => {
+    expect(downloadStatusColor("errored")).toBe("#ef4444");
+    expect(downloadStatusColor("failed")).toBe("#ef4444");
+  });
+
+  it("queued / other / unknown → neutral blue", () => {
+    expect(downloadStatusColor("queued")).toBe("#3b82f6");
+    expect(downloadStatusColor("other")).toBe("#3b82f6");
+    expect(downloadStatusColor("whatever")).toBe("#3b82f6");
+  });
+});

--- a/lib/download-status.ts
+++ b/lib/download-status.ts
@@ -1,0 +1,29 @@
+import { DOWNLOAD_INDICATOR_COLOR } from "@/lib/arr-poster-status";
+
+/**
+ * Download-client item state → progress/indicator color, shared by every
+ * torrent and usenet download surface so they stay in lockstep (issue #208).
+ *
+ * "downloading" reads the app's purple "downloading" cue to match Sonarr/Radarr;
+ * the other states map to their conventional colors so a bar agrees with its
+ * status badge/corner icon. Accepts both the torrent `StateGroup`
+ * ("downloading" | "seeding" | "paused" | "errored" | "other") and the usenet
+ * `UsenetStatus` ("downloading" | "paused" | "queued" | "completed" | "failed"
+ * | "other"); unknown/queued states fall back to neutral blue.
+ */
+export function downloadStatusColor(status: string): string {
+  switch (status) {
+    case "downloading":
+      return DOWNLOAD_INDICATOR_COLOR.downloading; // purple #a855f7
+    case "seeding":
+    case "completed":
+      return "#22c55e"; // green — done (seeding / fully fetched)
+    case "paused":
+      return "#f59e0b"; // amber
+    case "errored":
+    case "failed":
+      return "#ef4444"; // red
+    default: // queued / other
+      return "#3b82f6"; // blue (neutral)
+  }
+}


### PR DESCRIPTION
The dashboard Downloads widget's progress bar was blue. This makes a *downloading* item read **purple** to match Sonarr/Radarr (and the app's downloading cue from #207/#217).

- New shared `lib/download-status.ts` → `downloadStatusColor(status)`: downloading = 🟣 purple, seeding/completed = 🟢 green, paused = 🟠 amber, error/failed = 🔴 red, queued/other = 🔵 blue.
- Applied to both dashboard download widgets so they stay in lockstep: **Downloads** (torrent — `download-card`) and the **Usenet queue** card.

The full Downloads *screen* already shows a colored status Badge per item, so its blue progress fill isn't a status mismatch — left as-is (can extend if you want it purple there too).

Refs #208

## Test plan
- `tsc --noEmit` clean
- `jest` — 671/671 pass (added 5 `downloadStatusColor` cases)
- A downloading torrent/usenet item in the dashboard widget shows a purple bar; seeding=green, paused=amber, errored=red.