### PR TITLE
fix(updates): styled, throttled update prompt instead of native alert on launch

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,12 +21,12 @@ import "@/lib/wifi"; // side-effect: NetInfo.configure({ shouldFetchWiFiSSID: tr
 import "@/lib/expo-image-nativewind"; // side-effect: cssInterop on expo-image's Image
 import { NotificationWatchers } from "@/hooks/use-notification-watchers";
 import { useBackendHealth } from "@/hooks/use-backend-health";
-import { useAppUpdateCheck } from "@/hooks/use-app-update-check";
 import { useNetworkAutoSwitch } from "@/hooks/use-network";
 import { evaluateHomeNetwork } from "@/lib/network";
 import { pushConfigSnapshot } from "@/services/backend-api";
 import { syncInsecureHosts } from "@/lib/insecure-tls";
 import { ErrorBoundary, SilentErrorBoundary } from "@/components/common/error-boundary";
+import { AppUpdateChecker } from "@/components/common/app-update-checker";
 import { ToastContainer } from "@/components/ui/toast";
 import { WorkspaceIntroOverlay } from "@/components/onboarding/workspace-intro-overlay";
 import "../global.css";
@@ -164,11 +164,6 @@ function BackendHealthPoller() {
 
 function NetworkAutoSwitcher() {
   useNetworkAutoSwitch();
-  return null;
-}
-
-function AppUpdateChecker() {
-  useAppUpdateCheck();
   return null;
 }
 

--- a/components/common/app-update-checker.tsx
+++ b/components/common/app-update-checker.tsx
@@ -1,0 +1,46 @@
+import { Sparkles } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { ActionSheet } from "@/components/ui/action-sheet";
+import { ICON } from "@/lib/constants";
+import { NATIVE_VERSION } from "@/lib/app-version";
+import { useAppUpdateCheck } from "@/hooks/use-app-update-check";
+
+/**
+ * Renders the "update available" prompt driven by useAppUpdateCheck. Uses the
+ * styled ActionSheet (not a native Alert) so the launch prompt matches the rest
+ * of the app and respects the no-native-dialog rule. Dismissing the sheet, or
+ * tapping outside it, counts as "Later" and snoozes for a week; "Skip this
+ * version" silences that version for good. Mounted once, at the root layout.
+ */
+export function AppUpdateChecker() {
+  const { pending, openStore, skipVersion, snoozeUpdate } = useAppUpdateCheck();
+
+  return (
+    <ActionSheet
+      visible={pending !== null}
+      // Backdrop tap / swipe-down / cancel all count as "Later".
+      onClose={snoozeUpdate}
+      title="Update available"
+      subtitle={
+        pending
+          ? `Version ${pending.storeVersion} is available. You're on ${NATIVE_VERSION}.`
+          : undefined
+      }
+      actions={
+        pending
+          ? [
+              {
+                label: "Update now",
+                icon: <Icon icon={Sparkles} size={ICON.MD} color="#3b82f6" />,
+                onPress: () => openStore(pending.storeUrl),
+              },
+              {
+                label: "Skip this version",
+                onPress: () => skipVersion(pending.storeVersion),
+              },
+            ]
+          : []
+      }
+    />
+  );
+}

--- a/hooks/use-app-update-check.ts
+++ b/hooks/use-app-update-check.ts
@@ -1,25 +1,50 @@
-import { useEffect, useRef } from "react";
-import { Alert, Linking, Platform } from "react-native";
-import { NATIVE_VERSION, checkStoreVersion } from "@/lib/app-version";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Linking, Platform } from "react-native";
+import { checkStoreVersion } from "@/lib/app-version";
+import {
+  UPDATE_SNOOZE_MS,
+  shouldCheckForUpdate,
+  shouldPromptForUpdate,
+} from "@/lib/app-update-schedule";
 import { getString, setString } from "@/store/storage";
 
 const KEY_LAST_CHECKED = "app-update.last-checked-at";
 const KEY_DISMISSED_VERSION = "app-update.dismissed-version";
-// Throttle the auto-check to once per day so we don't hammer the store on
-// every cold start.
-const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const KEY_SNOOZE_UNTIL = "app-update.snooze-until";
 // Defer the network call so it doesn't compete with the cold-start work that
 // actually matters (rendering, hydration, query refetches).
 const STARTUP_DELAY_MS = 4000;
 
+export interface PendingUpdate {
+  storeVersion: string;
+  storeUrl: string;
+}
+
+export interface AppUpdateState {
+  /** Non-null while the styled prompt should be shown. */
+  pending: PendingUpdate | null;
+  /** "Update now" — open the store / release page. */
+  openStore: (url: string) => void;
+  /** "Skip this version" — never prompt for this version again. */
+  skipVersion: (version: string) => void;
+  /** "Later" / dismiss — silence the prompt for a week. */
+  snoozeUpdate: () => void;
+}
+
 /**
  * Once per day, on cold start, asks the relevant store (App Store on iOS,
- * Play Store on Android) what version is published, and prompts the user
- * if a newer version exists. Skipped in development. Users can dismiss a
- * specific version with "Skip this version" so we don't nag on every check.
+ * Play Store / GitHub on Android) what version is published and, if a newer
+ * one exists, surfaces a prompt. The actual UI is a styled ActionSheet (see
+ * components/common/app-update-checker.tsx) — never a native Alert — so it
+ * matches the rest of the app and obeys the no-native-dialog rule.
+ *
+ * Anti-spam: "Later" (or dismissing the sheet) snoozes the prompt for a week,
+ * and "Skip this version" silences that version for good. Skipped in
+ * development. The manual "Check for updates" button in settings is unaffected.
  */
-export function useAppUpdateCheck() {
+export function useAppUpdateCheck(): AppUpdateState {
   const ranRef = useRef(false);
+  const [pending, setPending] = useState<PendingUpdate | null>(null);
 
   useEffect(() => {
     if (ranRef.current) return;
@@ -28,50 +53,61 @@ export function useAppUpdateCheck() {
     if (__DEV__) return;
     if (Platform.OS !== "ios" && Platform.OS !== "android") return;
 
-    const lastCheckedRaw = getString(KEY_LAST_CHECKED);
-    const lastChecked = lastCheckedRaw ? Number(lastCheckedRaw) || 0 : 0;
     const now = Date.now();
-    if (now - lastChecked < CHECK_INTERVAL_MS) return;
+    const lastChecked = Number(getString(KEY_LAST_CHECKED)) || 0;
+    const snoozeUntil = Number(getString(KEY_SNOOZE_UNTIL)) || 0;
+    if (!shouldCheckForUpdate({ now, lastChecked, snoozeUntil })) return;
 
     const timer = setTimeout(() => {
-      void runUpdateCheck();
+      void runUpdateCheck(setPending);
     }, STARTUP_DELAY_MS);
     return () => clearTimeout(timer);
   }, []);
+
+  // The action's data (url / version) is captured by the caller at render time,
+  // so these handlers don't read `pending` — which the sheet's onClose has
+  // already cleared by the time an action fires.
+  const openStore = useCallback((url: string) => {
+    if (url) void Linking.openURL(url);
+    setPending(null);
+  }, []);
+
+  const skipVersion = useCallback((version: string) => {
+    if (version) setString(KEY_DISMISSED_VERSION, version);
+    setPending(null);
+  }, []);
+
+  const snoozeUpdate = useCallback(() => {
+    setString(KEY_SNOOZE_UNTIL, String(Date.now() + UPDATE_SNOOZE_MS));
+    setPending(null);
+  }, []);
+
+  return { pending, openStore, skipVersion, snoozeUpdate };
 }
 
-async function runUpdateCheck(): Promise<void> {
+async function runUpdateCheck(
+  setPending: (p: PendingUpdate | null) => void,
+): Promise<void> {
   try {
     const result = await checkStoreVersion();
     // Stamp the check time even on "unknown" so a transient store fetch
     // failure doesn't make us retry on every launch.
     setString(KEY_LAST_CHECKED, String(Date.now()));
 
-    if (!result.hasUpdate || !result.storeVersion) return;
+    const dismissedVersion = getString(KEY_DISMISSED_VERSION);
+    const { storeVersion, storeUrl } = result;
+    if (
+      !storeVersion ||
+      !shouldPromptForUpdate({
+        hasUpdate: result.hasUpdate,
+        storeVersion,
+        dismissedVersion,
+      })
+    ) {
+      return;
+    }
 
-    const dismissed = getString(KEY_DISMISSED_VERSION);
-    if (dismissed === result.storeVersion) return;
-
-    const storeVersion = result.storeVersion;
-    const storeUrl = result.storeUrl;
-
-    Alert.alert(
-      "Update available",
-      `A newer version (${storeVersion}) is available. You're on ${NATIVE_VERSION}.`,
-      [
-        {
-          text: "Skip this version",
-          onPress: () => setString(KEY_DISMISSED_VERSION, storeVersion),
-        },
-        { text: "Later", style: "cancel" },
-        {
-          text: "Update",
-          onPress: () => {
-            if (storeUrl) void Linking.openURL(storeUrl);
-          },
-        },
-      ],
-    );
+    setPending({ storeVersion, storeUrl });
   } catch {
     // Auto-check failures are silent — the manual button on the settings
     // screen surfaces errors when the user explicitly asks.

--- a/lib/app-update-schedule.test.ts
+++ b/lib/app-update-schedule.test.ts
@@ -1,0 +1,107 @@
+import {
+  UPDATE_CHECK_INTERVAL_MS,
+  UPDATE_SNOOZE_MS,
+  shouldCheckForUpdate,
+  shouldPromptForUpdate,
+} from "@/lib/app-update-schedule";
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("shouldCheckForUpdate", () => {
+  it("checks on a fresh install (no prior check, no snooze)", () => {
+    expect(
+      shouldCheckForUpdate({ now: NOW, lastChecked: 0, snoozeUntil: 0 }),
+    ).toBe(true);
+  });
+
+  it("throttles to once per day", () => {
+    expect(
+      shouldCheckForUpdate({
+        now: NOW,
+        lastChecked: NOW - (UPDATE_CHECK_INTERVAL_MS - 1),
+        snoozeUntil: 0,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCheckForUpdate({
+        now: NOW,
+        lastChecked: NOW - UPDATE_CHECK_INTERVAL_MS,
+        snoozeUntil: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays silent for the whole snooze window even after the daily throttle lapses", () => {
+    // Checked 2 days ago (throttle elapsed) but snoozed for another 5 days.
+    expect(
+      shouldCheckForUpdate({
+        now: NOW,
+        lastChecked: NOW - 2 * DAY,
+        snoozeUntil: NOW + 5 * DAY,
+      }),
+    ).toBe(false);
+  });
+
+  it("resumes once the snooze window has passed", () => {
+    expect(
+      shouldCheckForUpdate({
+        now: NOW,
+        lastChecked: NOW - UPDATE_SNOOZE_MS,
+        snoozeUntil: NOW - 1,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldPromptForUpdate", () => {
+  it("prompts when a newer version exists and nothing was skipped", () => {
+    expect(
+      shouldPromptForUpdate({
+        hasUpdate: true,
+        storeVersion: "1.4.0",
+        dismissedVersion: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not prompt when already up to date", () => {
+    expect(
+      shouldPromptForUpdate({
+        hasUpdate: false,
+        storeVersion: "1.3.0",
+        dismissedVersion: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not prompt when the store version is unknown", () => {
+    expect(
+      shouldPromptForUpdate({
+        hasUpdate: true,
+        storeVersion: null,
+        dismissedVersion: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("never prompts again for a version the user skipped", () => {
+    expect(
+      shouldPromptForUpdate({
+        hasUpdate: true,
+        storeVersion: "1.4.0",
+        dismissedVersion: "1.4.0",
+      }),
+    ).toBe(false);
+  });
+
+  it("prompts again once a newer version than the skipped one ships", () => {
+    expect(
+      shouldPromptForUpdate({
+        hasUpdate: true,
+        storeVersion: "1.5.0",
+        dismissedVersion: "1.4.0",
+      }),
+    ).toBe(true);
+  });
+});

--- a/lib/app-update-schedule.ts
+++ b/lib/app-update-schedule.ts
@@ -1,0 +1,41 @@
+// Pure scheduling logic for the app-update auto-check. Kept free of native
+// imports so it stays trivially testable (see app-update-schedule.test.ts) and
+// is the single source of truth for "should we check / should we nag".
+
+/** Minimum time between background store checks, so we don't hit the store on
+ *  every cold start. */
+export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** How long tapping "Later" (or dismissing the prompt) silences the launch
+ *  prompt before we surface it again. */
+export const UPDATE_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Whether the background check should hit the store now. Stays quiet while
+ * snoozed ("Later" was tapped) and while inside the once-per-day throttle
+ * window, so an open app never re-checks (or re-prompts) on every launch.
+ */
+export function shouldCheckForUpdate(opts: {
+  now: number;
+  lastChecked: number;
+  snoozeUntil: number;
+}): boolean {
+  const { now, lastChecked, snoozeUntil } = opts;
+  if (now < snoozeUntil) return false;
+  return now - lastChecked >= UPDATE_CHECK_INTERVAL_MS;
+}
+
+/**
+ * Whether a fetched store result should surface the launch prompt. A version
+ * the user tapped "Skip this version" on never prompts again, even after the
+ * snooze window lapses.
+ */
+export function shouldPromptForUpdate(opts: {
+  hasUpdate: boolean;
+  storeVersion: string | null;
+  dismissedVersion: string | null | undefined;
+}): boolean {
+  const { hasUpdate, storeVersion, dismissedVersion } = opts;
+  if (!hasUpdate || !storeVersion) return false;
+  return dismissedVersion !== storeVersion;
+}


### PR DESCRIPTION
The on-launch update check used a native `Alert.alert`, which looks out of place and re-prompted daily until the user updated. (The manual Settings check already used the styled modal — only the launch path was native.)

## Changes
- Replace the launch native alert with the styled `ActionSheet`
- "Later" / dismiss snoozes the prompt for 7 days (was effectively daily)
- "Skip this version" stays a permanent per-version silence
- Extract pure check/snooze scheduling to `lib/app-update-schedule.ts`

## Test plan
- `tsc --noEmit` clean; full jest suite passes (680, incl. 9 new schedule tests)
- Note: users only get the styled prompt after installing a build with this change