### PR TITLE
Global search across services (Refs #223)

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -8,6 +8,7 @@ import {
   Copy,
   Pencil,
   Check,
+  Search,
   Settings,
   SlidersHorizontal,
   Sparkles,
@@ -32,6 +33,7 @@ import { AddWidgetSheet } from "@/components/dashboard/add-widget-sheet";
 import { WidgetSettingsSheet } from "@/components/dashboard/widget-settings-sheet";
 import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sheet";
 import { useAttachedKinds } from "@/hooks/use-active-dashboard";
+import { hasSearchableKind } from "@/lib/global-search";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 import { resolveDashboardIcon } from "@/lib/dashboard-icons";
 import { ActionSheet } from "@/components/ui/action-sheet";
@@ -201,6 +203,19 @@ export default function DashboardScreen() {
           <Icon icon={ChevronsUpDown} size={ICON.SM} color="#71717a" />
         </TouchableOpacity>
         <View className="flex-row items-center">
+          {hasSearchableKind(attachedKinds) && (
+            <TouchableOpacity
+              onPress={() => {
+                Haptics.selectionAsync();
+                router.push("/search");
+              }}
+              className="p-2"
+              hitSlop={8}
+              accessibilityLabel="Global search"
+            >
+              <Icon icon={Search} size={ICON.MD} color="#71717a" />
+            </TouchableOpacity>
+          )}
           {activeDashboard && (
             <TouchableOpacity
               onPress={() => {

--- a/app/artist/search.tsx
+++ b/app/artist/search.tsx
@@ -1,30 +1,19 @@
 import { useMemo, useState } from "react";
-import { View, Text, Pressable } from "react-native";
-import { Image } from "expo-image";
-import { useRouter } from "expo-router";
-import { toast, toastError } from "@/components/ui/toast";
-import { Mic2, Plus, Check, SlidersHorizontal } from "lucide-react-native";
-import { Icon } from "@/components/ui/icon";
-import { useServiceImage } from "@/hooks/use-service-image";
+import { View, Text } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { TextInput } from "@/components/ui/text-input";
-import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AddArtistSheet } from "@/components/lidarr/add-artist-sheet";
-import {
-  useLidarrSearch,
-  useAddArtist,
-  useLidarrArtists,
-  useLidarrQualityProfiles,
-  useLidarrMetadataProfiles,
-  useLidarrRootFolders,
-} from "@/hooks/use-lidarr";
+import { LidarrSearchRow } from "@/components/search/lidarr-search-row";
+import { useLidarrSearch, useLidarrArtists } from "@/hooks/use-lidarr";
 import type { LidarrArtistSearchResult } from "@/lib/types";
 
 export default function ArtistSearchScreen() {
   const router = useRouter();
-  const [query, setQuery] = useState("");
+  const { q } = useLocalSearchParams<{ q?: string }>();
+  const [query, setQuery] = useState(q ?? "");
   const { data: results, isLoading } = useLidarrSearch(query);
   const { data: existing } = useLidarrArtists();
   const [advancedTarget, setAdvancedTarget] = useState<LidarrArtistSearchResult | null>(
@@ -62,7 +51,7 @@ export default function ArtistSearchScreen() {
           {results.map((result) => {
             const existingId = existingByForeignId.get(result.foreignArtistId);
             return (
-              <SearchResultCard
+              <LidarrSearchRow
                 key={result.foreignArtistId}
                 result={result}
                 existingArtistId={existingId}
@@ -82,106 +71,5 @@ export default function ArtistSearchScreen() {
         onClose={() => setAdvancedTarget(null)}
       />
     </ScreenWrapper>
-  );
-}
-
-function SearchResultCard({
-  result,
-  existingArtistId,
-  onAdvanced,
-  onOpenExisting,
-}: {
-  result: LidarrArtistSearchResult;
-  existingArtistId: number | undefined;
-  onAdvanced: () => void;
-  onOpenExisting: () => void;
-}) {
-  const alreadyAdded = existingArtistId !== undefined;
-  const addArtist = useAddArtist();
-  const { data: profiles } = useLidarrQualityProfiles();
-  const { data: metadataProfiles } = useLidarrMetadataProfiles();
-  const { data: folders } = useLidarrRootFolders();
-
-  const poster = result.images.find((i) => i.coverType === "poster");
-  const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, "lidarr");
-
-  const handleQuickAdd = () => {
-    if (!profiles?.length || !metadataProfiles?.length || !folders?.length) {
-      toast("Could not load profiles or root folders", "error");
-      return;
-    }
-
-    addArtist.mutate(
-      {
-        foreignArtistId: result.foreignArtistId,
-        artistName: result.artistName,
-        qualityProfileId: profiles[0].id,
-        metadataProfileId: metadataProfiles[0].id,
-        rootFolderPath: folders[0].path,
-      },
-      {
-        onSuccess: () => toast(`${result.artistName} added to Lidarr`),
-        onError: (err) => toastError("Failed to add artist", err),
-      },
-    );
-  };
-
-  const subtitle = [result.artistType, result.disambiguation]
-    .filter(Boolean)
-    .join(" · ");
-
-  return (
-    <Card
-      className="flex-row gap-3"
-      onPress={alreadyAdded ? onOpenExisting : undefined}
-    >
-      {posterUrl ? (
-        <Image
-          source={{ uri: posterUrl }}
-          className="w-16 h-24 rounded-lg bg-surface-light"
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
-          recyclingKey={posterUrl}
-          onError={onPosterError}
-        />
-      ) : (
-        <View className="w-16 h-24 rounded-lg bg-surface-light items-center justify-center">
-          <Icon icon={Mic2} size={20} color="#71717a" />
-        </View>
-      )}
-      <View className="flex-1 justify-center">
-        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
-          {result.artistName}
-        </Text>
-        {subtitle ? (
-          <Text className="text-zinc-500 text-xs">{subtitle}</Text>
-        ) : null}
-        {result.overview && (
-          <Text className="text-zinc-500 text-xs mt-1" numberOfLines={2}>
-            {result.overview}
-          </Text>
-        )}
-      </View>
-      {alreadyAdded ? (
-        <View className="self-center p-2">
-          <Icon icon={Check} size={20} color="#22c55e" />
-        </View>
-      ) : (
-        <View className="flex-row items-center self-center">
-          <Pressable onPress={onAdvanced} className="p-2 active:opacity-70" hitSlop={4}>
-            <Icon icon={SlidersHorizontal} size={18} color="#a1a1aa" />
-          </Pressable>
-          <Pressable
-            onPress={handleQuickAdd}
-            className="p-2 active:opacity-70"
-            disabled={addArtist.isPending}
-            hitSlop={4}
-          >
-            <Icon icon={Plus} size={20} color="#3b82f6" />
-          </Pressable>
-        </View>
-      )}
-    </Card>
   );
 }

--- a/app/movie/search.tsx
+++ b/app/movie/search.tsx
@@ -1,29 +1,19 @@
 import { useMemo, useState } from "react";
-import { View, Text, Pressable } from "react-native";
-import { Image } from "expo-image";
-import { useRouter } from "expo-router";
-import { toast, toastError } from "@/components/ui/toast";
-import { Film, Plus, Check, SlidersHorizontal } from "lucide-react-native";
-import { Icon } from "@/components/ui/icon";
-import { useServiceImage } from "@/hooks/use-service-image";
+import { View, Text } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { TextInput } from "@/components/ui/text-input";
-import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AddMovieSheet } from "@/components/radarr/add-movie-sheet";
-import {
-  useRadarrSearch,
-  useAddMovie,
-  useRadarrMovies,
-  useRadarrQualityProfiles,
-  useRadarrRootFolders,
-} from "@/hooks/use-radarr";
+import { RadarrSearchRow } from "@/components/search/radarr-search-row";
+import { useRadarrSearch, useRadarrMovies } from "@/hooks/use-radarr";
 import type { RadarrSearchResult } from "@/lib/types";
 
 export default function MovieSearchScreen() {
   const router = useRouter();
-  const [query, setQuery] = useState("");
+  const { q } = useLocalSearchParams<{ q?: string }>();
+  const [query, setQuery] = useState(q ?? "");
   const { data: results, isLoading } = useRadarrSearch(query);
   const { data: existing } = useRadarrMovies();
   const [advancedTarget, setAdvancedTarget] = useState<RadarrSearchResult | null>(null);
@@ -59,14 +49,13 @@ export default function MovieSearchScreen() {
           {results.map((result) => {
             const existingId = existingByTmdbId.get(result.tmdbId);
             return (
-              <SearchResultCard
+              <RadarrSearchRow
                 key={result.tmdbId}
                 result={result}
                 existingMovieId={existingId}
                 onAdvanced={() => setAdvancedTarget(result)}
                 onOpenExisting={() =>
-                  existingId !== undefined &&
-                  router.push(`/movie/${existingId}`)
+                  existingId !== undefined && router.push(`/movie/${existingId}`)
                 }
               />
             );
@@ -80,102 +69,5 @@ export default function MovieSearchScreen() {
         onClose={() => setAdvancedTarget(null)}
       />
     </ScreenWrapper>
-  );
-}
-
-function SearchResultCard({
-  result,
-  existingMovieId,
-  onAdvanced,
-  onOpenExisting,
-}: {
-  result: RadarrSearchResult;
-  existingMovieId: number | undefined;
-  onAdvanced: () => void;
-  onOpenExisting: () => void;
-}) {
-  const alreadyAdded = existingMovieId !== undefined;
-  const addMovie = useAddMovie();
-  const { data: profiles } = useRadarrQualityProfiles();
-  const { data: folders } = useRadarrRootFolders();
-
-  const poster = result.images.find((i) => i.coverType === "poster");
-  const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, "radarr");
-
-  const handleQuickAdd = () => {
-    if (!profiles?.length || !folders?.length) {
-      toast("Could not load quality profiles or root folders", "error");
-      return;
-    }
-
-    addMovie.mutate(
-      {
-        tmdbId: result.tmdbId,
-        title: result.title,
-        qualityProfileId: profiles[0].id,
-        rootFolderPath: folders[0].path,
-      },
-      {
-        onSuccess: () => toast(`${result.title} added to Radarr`),
-        onError: (err) => toastError("Failed to add movie", err),
-      },
-    );
-  };
-
-  return (
-    <Card
-      className="flex-row gap-3"
-      onPress={alreadyAdded ? onOpenExisting : undefined}
-    >
-      {posterUrl ? (
-        <Image
-          source={{ uri: posterUrl }}
-          className="w-16 h-24 rounded-lg bg-surface-light"
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
-          recyclingKey={posterUrl}
-          onError={onPosterError}
-        />
-      ) : (
-        <View className="w-16 h-24 rounded-lg bg-surface-light items-center justify-center">
-          <Icon icon={Film} size={20} color="#71717a" />
-        </View>
-      )}
-      <View className="flex-1 justify-center">
-        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
-          {result.title}
-        </Text>
-        <Text className="text-zinc-500 text-xs">{result.year}</Text>
-        {result.overview && (
-          <Text className="text-zinc-500 text-xs mt-1" numberOfLines={2}>
-            {result.overview}
-          </Text>
-        )}
-      </View>
-      {alreadyAdded ? (
-        <View className="self-center p-2">
-          <Icon icon={Check} size={20} color="#22c55e" />
-        </View>
-      ) : (
-        <View className="flex-row items-center self-center">
-          <Pressable
-            onPress={onAdvanced}
-            className="p-2 active:opacity-70"
-            hitSlop={4}
-          >
-            <Icon icon={SlidersHorizontal} size={18} color="#a1a1aa" />
-          </Pressable>
-          <Pressable
-            onPress={handleQuickAdd}
-            className="p-2 active:opacity-70"
-            disabled={addMovie.isPending}
-            hitSlop={4}
-          >
-            <Icon icon={Plus} size={20} color="#3b82f6" />
-          </Pressable>
-        </View>
-      )}
-    </Card>
   );
 }

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { Search } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { BackHeader } from "@/components/common/back-header";
+import { TextInput } from "@/components/ui/text-input";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useAttachedKinds } from "@/hooks/use-active-dashboard";
+import { hasSearchableKind } from "@/lib/global-search";
+import { RadarrSearchSection } from "@/components/search/radarr-search-section";
+import { SonarrSearchSection } from "@/components/search/sonarr-search-section";
+import { LidarrSearchSection } from "@/components/search/lidarr-search-section";
+import { OverseerrSearchSection } from "@/components/search/overseerr-search-section";
+import { ProwlarrSearchSection } from "@/components/search/prowlarr-search-section";
+
+const MIN_QUERY = 2;
+
+/**
+ * Global search (#223): one input that fans out across the services attached to
+ * the active dashboard, grouped into per-category collapsible sections. Reuses
+ * the existing per-service search hooks/components unchanged; sections render
+ * independently so a slow indexer search never blocks the fast lookups.
+ */
+export default function GlobalSearchScreen() {
+  const [query, setQuery] = useState("");
+  const debounced = useDebouncedValue(query.trim(), 300);
+  const attachedKinds = useAttachedKinds();
+
+  const hasRadarr = attachedKinds.has("radarr");
+  const hasSonarr = attachedKinds.has("sonarr");
+  const hasLidarr = attachedKinds.has("lidarr");
+  const hasOverseerr = attachedKinds.has("overseerr");
+  const hasProwlarr = attachedKinds.has("prowlarr");
+  const anySearchable = hasSearchableKind(attachedKinds);
+
+  const active = debounced.length >= MIN_QUERY;
+
+  return (
+    <ScreenWrapper>
+      <BackHeader title="Search" />
+
+      <TextInput
+        placeholder="Search across your services..."
+        value={query}
+        onChangeText={setQuery}
+        autoFocus
+        containerClassName="mb-4"
+      />
+
+      {!anySearchable ? (
+        <EmptyState
+          icon={<Icon icon={Search} size={32} color="#71717a" />}
+          title="No searchable services"
+          message="Attach Radarr, Sonarr, Lidarr, Seerr, or Prowlarr to this dashboard to search them here."
+        />
+      ) : !active ? (
+        <EmptyState
+          icon={<Icon icon={Search} size={32} color="#71717a" />}
+          title="Search across your services"
+          message="Type at least 2 characters to search Movies, TV, Music, Requests, and Releases."
+        />
+      ) : (
+        <>
+          {hasRadarr && <RadarrSearchSection query={debounced} />}
+          {hasSonarr && <SonarrSearchSection query={debounced} />}
+          {hasLidarr && <LidarrSearchSection query={debounced} />}
+          {hasOverseerr && <OverseerrSearchSection query={debounced} />}
+          {hasProwlarr && <ProwlarrSearchSection query={debounced} />}
+        </>
+      )}
+    </ScreenWrapper>
+  );
+}

--- a/app/series/search.tsx
+++ b/app/series/search.tsx
@@ -1,29 +1,19 @@
 import { useMemo, useState } from "react";
-import { View, Text, Pressable } from "react-native";
-import { Image } from "expo-image";
-import { useRouter } from "expo-router";
-import { toast, toastError } from "@/components/ui/toast";
-import { Tv, Plus, Check, SlidersHorizontal } from "lucide-react-native";
-import { Icon } from "@/components/ui/icon";
-import { useServiceImage } from "@/hooks/use-service-image";
+import { View, Text } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { TextInput } from "@/components/ui/text-input";
-import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AddSeriesSheet } from "@/components/sonarr/add-series-sheet";
-import {
-  useSonarrSearch,
-  useAddSeries,
-  useSonarrSeries,
-  useSonarrQualityProfiles,
-  useSonarrRootFolders,
-} from "@/hooks/use-sonarr";
+import { SonarrSearchRow } from "@/components/search/sonarr-search-row";
+import { useSonarrSearch, useSonarrSeries } from "@/hooks/use-sonarr";
 import type { SonarrSearchResult } from "@/lib/types";
 
 export default function SeriesSearchScreen() {
   const router = useRouter();
-  const [query, setQuery] = useState("");
+  const { q } = useLocalSearchParams<{ q?: string }>();
+  const [query, setQuery] = useState(q ?? "");
   const { data: results, isLoading } = useSonarrSearch(query);
   const { data: existing } = useSonarrSeries();
   const [advancedTarget, setAdvancedTarget] = useState<SonarrSearchResult | null>(null);
@@ -59,14 +49,13 @@ export default function SeriesSearchScreen() {
           {results.map((result) => {
             const existingId = existingByTvdbId.get(result.tvdbId);
             return (
-              <SearchResultCard
+              <SonarrSearchRow
                 key={result.tvdbId}
                 result={result}
                 existingSeriesId={existingId}
                 onAdvanced={() => setAdvancedTarget(result)}
                 onOpenExisting={() =>
-                  existingId !== undefined &&
-                  router.push(`/series/${existingId}`)
+                  existingId !== undefined && router.push(`/series/${existingId}`)
                 }
               />
             );
@@ -80,110 +69,5 @@ export default function SeriesSearchScreen() {
         onClose={() => setAdvancedTarget(null)}
       />
     </ScreenWrapper>
-  );
-}
-
-function SearchResultCard({
-  result,
-  existingSeriesId,
-  onAdvanced,
-  onOpenExisting,
-}: {
-  result: SonarrSearchResult;
-  existingSeriesId: number | undefined;
-  onAdvanced: () => void;
-  onOpenExisting: () => void;
-}) {
-  const alreadyAdded = existingSeriesId !== undefined;
-  const addSeries = useAddSeries();
-  const { data: profiles } = useSonarrQualityProfiles();
-  const { data: folders } = useSonarrRootFolders();
-
-  const poster = result.images.find((i) => i.coverType === "poster");
-  const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, "sonarr");
-
-  const handleQuickAdd = () => {
-    if (!profiles?.length || !folders?.length) {
-      toast("Could not load quality profiles or root folders", "error");
-      return;
-    }
-
-    addSeries.mutate(
-      {
-        tvdbId: result.tvdbId,
-        title: result.title,
-        qualityProfileId: profiles[0].id,
-        rootFolderPath: folders[0].path,
-      },
-      {
-        onSuccess: () => toast(`${result.title} added to Sonarr`),
-        onError: (err) => toastError("Failed to add series", err),
-      },
-    );
-  };
-
-  return (
-    <Card
-      className="flex-row gap-3"
-      onPress={alreadyAdded ? onOpenExisting : undefined}
-    >
-      {posterUrl ? (
-        <Image
-          source={{ uri: posterUrl }}
-          className="w-16 h-24 rounded-lg bg-surface-light"
-          contentFit="cover"
-          cachePolicy="memory-disk"
-          transition={200}
-          recyclingKey={posterUrl}
-          onError={onPosterError}
-        />
-      ) : (
-        <View className="w-16 h-24 rounded-lg bg-surface-light items-center justify-center">
-          <Icon icon={Tv} size={20} color="#71717a" />
-        </View>
-      )}
-      <View className="flex-1 justify-center">
-        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
-          {result.title}
-        </Text>
-        <Text className="text-zinc-500 text-xs">
-          {[
-            result.year,
-            result.network,
-            `${result.seasonCount} season${result.seasonCount !== 1 ? "s" : ""}`,
-          ]
-            .filter(Boolean)
-            .join(" · ")}
-        </Text>
-        {result.overview && (
-          <Text className="text-zinc-500 text-xs mt-1" numberOfLines={2}>
-            {result.overview}
-          </Text>
-        )}
-      </View>
-      {alreadyAdded ? (
-        <View className="self-center p-2">
-          <Icon icon={Check} size={20} color="#22c55e" />
-        </View>
-      ) : (
-        <View className="flex-row items-center self-center">
-          <Pressable
-            onPress={onAdvanced}
-            className="p-2 active:opacity-70"
-            hitSlop={4}
-          >
-            <Icon icon={SlidersHorizontal} size={18} color="#a1a1aa" />
-          </Pressable>
-          <Pressable
-            onPress={handleQuickAdd}
-            className="p-2 active:opacity-70"
-            disabled={addSeries.isPending}
-            hitSlop={4}
-          >
-            <Icon icon={Plus} size={20} color="#3b82f6" />
-          </Pressable>
-        </View>
-      )}
-    </Card>
   );
 }

--- a/components/search/lidarr-search-row.tsx
+++ b/components/search/lidarr-search-row.tsx
@@ -1,0 +1,73 @@
+import { Mic2 } from "lucide-react-native";
+import { toast, toastError } from "@/components/ui/toast";
+import { MediaSearchResultCard } from "@/components/search/media-search-result-card";
+import {
+  useAddArtist,
+  useLidarrQualityProfiles,
+  useLidarrMetadataProfiles,
+  useLidarrRootFolders,
+} from "@/hooks/use-lidarr";
+import type { LidarrArtistSearchResult } from "@/lib/types";
+
+/**
+ * One Lidarr artist lookup result row: owns the quick-add mutation and renders
+ * the shared MediaSearchResultCard. Reused by the dedicated /artist/search
+ * screen and the global-search Music section.
+ */
+export function LidarrSearchRow({
+  result,
+  existingArtistId,
+  onAdvanced,
+  onOpenExisting,
+}: {
+  result: LidarrArtistSearchResult;
+  existingArtistId: number | undefined;
+  onAdvanced: () => void;
+  onOpenExisting: () => void;
+}) {
+  const addArtist = useAddArtist();
+  const { data: profiles } = useLidarrQualityProfiles();
+  const { data: metadataProfiles } = useLidarrMetadataProfiles();
+  const { data: folders } = useLidarrRootFolders();
+
+  const handleQuickAdd = () => {
+    if (!profiles?.length || !metadataProfiles?.length || !folders?.length) {
+      toast("Could not load profiles or root folders", "error");
+      return;
+    }
+
+    addArtist.mutate(
+      {
+        foreignArtistId: result.foreignArtistId,
+        artistName: result.artistName,
+        qualityProfileId: profiles[0].id,
+        metadataProfileId: metadataProfiles[0].id,
+        rootFolderPath: folders[0].path,
+      },
+      {
+        onSuccess: () => toast(`${result.artistName} added to Lidarr`),
+        onError: (err) => toastError("Failed to add artist", err),
+      },
+    );
+  };
+
+  const metaLine = [result.artistType, result.disambiguation]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <MediaSearchResultCard
+      serviceId="lidarr"
+      poster={result.images.find((i) => i.coverType === "poster")}
+      fallbackIcon={Mic2}
+      title={result.artistName}
+      metaLine={metaLine || undefined}
+      overview={result.overview}
+      alreadyAdded={existingArtistId !== undefined}
+      addPending={addArtist.isPending}
+      onQuickAdd={handleQuickAdd}
+      onAdvanced={onAdvanced}
+      onOpenExisting={onOpenExisting}
+    />
+  );
+}

--- a/components/search/lidarr-search-section.tsx
+++ b/components/search/lidarr-search-section.tsx
@@ -1,0 +1,67 @@
+import { useMemo, useState } from "react";
+import { useRouter } from "expo-router";
+import { Music } from "lucide-react-native";
+import { SearchSection } from "@/components/search/search-section";
+import { LidarrSearchRow } from "@/components/search/lidarr-search-row";
+import { AddArtistSheet } from "@/components/lidarr/add-artist-sheet";
+import { useLidarrSearch, useLidarrArtists } from "@/hooks/use-lidarr";
+import type { LidarrArtistSearchResult } from "@/lib/types";
+
+const PREVIEW_LIMIT = 5;
+
+/** Music section of global search — Lidarr artist lookup, dedup by foreignArtistId. */
+export function LidarrSearchSection({ query }: { query: string }) {
+  const router = useRouter();
+  const { data: results, isLoading, isError, error } = useLidarrSearch(query);
+  const { data: existing } = useLidarrArtists();
+  const [advancedTarget, setAdvancedTarget] =
+    useState<LidarrArtistSearchResult | null>(null);
+
+  const existingByForeignId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const a of existing ?? []) {
+      map.set(a.foreignArtistId, a.id);
+    }
+    return map;
+  }, [existing]);
+
+  const all = results ?? [];
+  const preview = all.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <>
+      <SearchSection
+        title="Music"
+        icon={Music}
+        serviceLabel="Lidarr"
+        total={all.length}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        hasMore={all.length > preview.length}
+        onShowAll={() => router.push({ pathname: "/artist/search", params: { q: query } })}
+      >
+        {preview.map((result) => {
+          const existingId = existingByForeignId.get(result.foreignArtistId);
+          return (
+            <LidarrSearchRow
+              key={result.foreignArtistId}
+              result={result}
+              existingArtistId={existingId}
+              onAdvanced={() => setAdvancedTarget(result)}
+              onOpenExisting={() =>
+                existingId !== undefined && router.push(`/artist/${existingId}`)
+              }
+            />
+          );
+        })}
+      </SearchSection>
+
+      <AddArtistSheet
+        result={advancedTarget}
+        visible={advancedTarget !== null}
+        onClose={() => setAdvancedTarget(null)}
+      />
+    </>
+  );
+}

--- a/components/search/media-search-result-card.tsx
+++ b/components/search/media-search-result-card.tsx
@@ -1,0 +1,116 @@
+import type { ComponentType } from "react";
+import { View, Text, Pressable } from "react-native";
+import { Image } from "expo-image";
+import { Plus, Check, SlidersHorizontal } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { useServiceImage } from "@/hooks/use-service-image";
+import type { ServiceId } from "@/lib/constants";
+
+// The shape useServiceImage needs from a result image. The *arr result image
+// types (RadarrImage/SonarrImage/LidarrImage) all satisfy this structurally.
+interface PosterImage {
+  url: string;
+  remoteUrl: string;
+}
+
+interface MediaSearchResultCardProps {
+  /** Used to resolve the poster against the right service URL + api key. */
+  serviceId: ServiceId;
+  /** The `coverType === "poster"` entry from the result, if any. */
+  poster?: PosterImage;
+  /** Lucide icon shown when no poster resolves (Film / Tv / Mic2). */
+  fallbackIcon: ComponentType<{ size?: number; color?: string }>;
+  title: string;
+  /** Single metadata line (year, or year · network · seasons, or type · disambiguation). */
+  metaLine?: string;
+  overview?: string;
+  /** When true, shows the green Check + makes the card tap-to-open-existing. */
+  alreadyAdded: boolean;
+  /** Disables the quick-add button while the add mutation is in flight. */
+  addPending?: boolean;
+  onQuickAdd: () => void;
+  onAdvanced: () => void;
+  onOpenExisting: () => void;
+}
+
+/**
+ * Shared result row for the Radarr / Sonarr / Lidarr add-search flows. Extracted
+ * verbatim from the three near-identical per-service search screens so the
+ * dedicated screens and the global-search sections render the exact same card.
+ * Purely presentational: the caller owns the search hook, the library-dedup
+ * lookup, and the quick-add/advanced mutations.
+ */
+export function MediaSearchResultCard({
+  serviceId,
+  poster,
+  fallbackIcon,
+  title,
+  metaLine,
+  overview,
+  alreadyAdded,
+  addPending = false,
+  onQuickAdd,
+  onAdvanced,
+  onOpenExisting,
+}: MediaSearchResultCardProps) {
+  const { src: posterUrl, onError: onPosterError } = useServiceImage(
+    poster,
+    serviceId,
+  );
+
+  return (
+    <Card
+      className="flex-row gap-3"
+      onPress={alreadyAdded ? onOpenExisting : undefined}
+    >
+      {posterUrl ? (
+        <Image
+          source={{ uri: posterUrl }}
+          className="w-16 h-24 rounded-lg bg-surface-light"
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          transition={200}
+          recyclingKey={posterUrl}
+          onError={onPosterError}
+        />
+      ) : (
+        <View className="w-16 h-24 rounded-lg bg-surface-light items-center justify-center">
+          <Icon icon={fallbackIcon} size={20} color="#71717a" />
+        </View>
+      )}
+      <View className="flex-1 justify-center">
+        <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
+          {title}
+        </Text>
+        {metaLine ? (
+          <Text className="text-zinc-500 text-xs">{metaLine}</Text>
+        ) : null}
+        {overview ? (
+          <Text className="text-zinc-500 text-xs mt-1" numberOfLines={2}>
+            {overview}
+          </Text>
+        ) : null}
+      </View>
+      {alreadyAdded ? (
+        <View className="self-center p-2">
+          <Icon icon={Check} size={20} color="#22c55e" />
+        </View>
+      ) : (
+        <View className="flex-row items-center self-center">
+          <Pressable onPress={onAdvanced} className="p-2 active:opacity-70" hitSlop={4}>
+            <Icon icon={SlidersHorizontal} size={18} color="#a1a1aa" />
+          </Pressable>
+          <Pressable
+            onPress={onQuickAdd}
+            className="p-2 active:opacity-70"
+            disabled={addPending}
+            hitSlop={4}
+          >
+            <Icon icon={Plus} size={20} color="#3b82f6" />
+          </Pressable>
+        </View>
+      )}
+    </Card>
+  );
+}

--- a/components/search/overseerr-search-section.tsx
+++ b/components/search/overseerr-search-section.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { View } from "react-native";
+import { useRouter } from "expo-router";
+import { Inbox } from "lucide-react-native";
+import { SearchSection } from "@/components/search/search-section";
+import { PosterCard } from "@/components/overseerr/poster-card";
+import { MediaDetailModal } from "@/components/overseerr/media-detail-modal";
+import { usePosterCellWidth } from "@/hooks/use-poster-cell";
+import { useOverseerrSearch } from "@/hooks/use-overseerr";
+import type { OverseerrMediaResult } from "@/lib/types";
+
+// One full grid row at default scale (3 columns) and three rows at Large+ (2
+// columns) — a tidy preview either way.
+const PREVIEW_LIMIT = 6;
+
+/**
+ * Requests section of global search — Seerr media lookup. Reuses the poster grid
+ * + MediaDetailModal from the Requests tab; PosterCard already surfaces the
+ * available / pending availability indicator, so users see what they own.
+ */
+export function OverseerrSearchSection({ query }: { query: string }) {
+  const router = useRouter();
+  const cellWidth = usePosterCellWidth();
+  const { data, isLoading, isError, error } = useOverseerrSearch(query);
+  const [selected, setSelected] = useState<OverseerrMediaResult | null>(null);
+
+  const all = data?.results ?? [];
+  const preview = all.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <>
+      <SearchSection
+        title="Requests"
+        icon={Inbox}
+        serviceLabel="Seerr"
+        total={all.length}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        hasMore={all.length > preview.length}
+        onShowAll={() => router.push({ pathname: "/requests", params: { tab: "search" } })}
+      >
+        <View className="flex-row flex-wrap gap-3">
+          {preview.map((item) => (
+            <PosterCard
+              key={`${item.mediaType}-${item.id}`}
+              item={item}
+              onPress={setSelected}
+              widthOverride={cellWidth}
+            />
+          ))}
+        </View>
+      </SearchSection>
+
+      <MediaDetailModal
+        item={selected}
+        visible={selected !== null}
+        onClose={() => setSelected(null)}
+      />
+    </>
+  );
+}

--- a/components/search/prowlarr-search-section.tsx
+++ b/components/search/prowlarr-search-section.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { useRouter } from "expo-router";
+import { Radar } from "lucide-react-native";
+import { SearchSection } from "@/components/search/search-section";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ConfirmModal } from "@/components/common/confirm-modal";
+import { toast, toastError } from "@/components/ui/toast";
+import { useProwlarrSearch, useGrabRelease } from "@/hooks/use-prowlarr";
+import { formatBytes } from "@/lib/utils";
+import type { ProwlarrSearchResult } from "@/lib/types";
+
+const PREVIEW_LIMIT = 5;
+
+/**
+ * Releases section of global search — Prowlarr indexer search. Reuses the dense
+ * release card + ConfirmModal grab flow from the Indexers tab. Collapsed by
+ * default since interactive indexer searches are the slowest and the noisiest.
+ */
+export function ProwlarrSearchSection({ query }: { query: string }) {
+  const router = useRouter();
+  const { data: results, isLoading, isError, error } = useProwlarrSearch(query);
+  const grabRelease = useGrabRelease();
+  const [pendingGrab, setPendingGrab] = useState<ProwlarrSearchResult | null>(null);
+
+  const all = results ?? [];
+  const preview = all.slice(0, PREVIEW_LIMIT);
+
+  const confirmGrab = () => {
+    if (!pendingGrab) return;
+    grabRelease.mutate(
+      { guid: pendingGrab.guid, indexerId: pendingGrab.indexerId },
+      {
+        onSuccess: () => toast("Sent to download client"),
+        onError: (err) => toastError("Failed to grab release", err),
+      },
+    );
+    setPendingGrab(null);
+  };
+
+  return (
+    <>
+      <SearchSection
+        title="Releases"
+        icon={Radar}
+        serviceLabel="Prowlarr"
+        total={all.length}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        hasMore={all.length > preview.length}
+        onShowAll={() => router.push("/indexers")}
+        defaultExpanded={false}
+      >
+        {preview.map((result) => (
+          <Card key={result.guid}>
+            <Pressable
+              onPress={() => setPendingGrab(result)}
+              className="active:opacity-80"
+            >
+              <Text className="text-zinc-200 text-sm" numberOfLines={2}>
+                {result.title}
+              </Text>
+              <View className="flex-row items-center gap-3 mt-1.5">
+                <Text className="text-zinc-500 text-xs">
+                  {formatBytes(result.size)}
+                </Text>
+                <Text className="text-zinc-500 text-xs">{result.indexer}</Text>
+                {result.seeders !== undefined && (
+                  <Text className="text-success text-xs">S:{result.seeders}</Text>
+                )}
+                {result.leechers !== undefined && (
+                  <Text className="text-danger text-xs">L:{result.leechers}</Text>
+                )}
+                <Badge
+                  label={result.protocol}
+                  variant={result.protocol === "torrent" ? "downloading" : "default"}
+                />
+              </View>
+            </Pressable>
+          </Card>
+        ))}
+      </SearchSection>
+
+      <ConfirmModal
+        visible={pendingGrab !== null}
+        title="Grab Release"
+        message={
+          pendingGrab ? `Send "${pendingGrab.title}" to download client?` : ""
+        }
+        confirmLabel="Grab"
+        onConfirm={confirmGrab}
+        onCancel={() => setPendingGrab(null)}
+      />
+    </>
+  );
+}

--- a/components/search/radarr-search-row.tsx
+++ b/components/search/radarr-search-row.tsx
@@ -1,0 +1,67 @@
+import { Film } from "lucide-react-native";
+import { toast, toastError } from "@/components/ui/toast";
+import { MediaSearchResultCard } from "@/components/search/media-search-result-card";
+import {
+  useAddMovie,
+  useRadarrQualityProfiles,
+  useRadarrRootFolders,
+} from "@/hooks/use-radarr";
+import type { RadarrSearchResult } from "@/lib/types";
+
+/**
+ * One Radarr lookup result row: owns the quick-add mutation (first quality
+ * profile + first root folder) and renders the shared MediaSearchResultCard.
+ * Reused by both the dedicated /movie/search screen and the global-search
+ * Movies section, so the two stay in lockstep.
+ */
+export function RadarrSearchRow({
+  result,
+  existingMovieId,
+  onAdvanced,
+  onOpenExisting,
+}: {
+  result: RadarrSearchResult;
+  existingMovieId: number | undefined;
+  onAdvanced: () => void;
+  onOpenExisting: () => void;
+}) {
+  const addMovie = useAddMovie();
+  const { data: profiles } = useRadarrQualityProfiles();
+  const { data: folders } = useRadarrRootFolders();
+
+  const handleQuickAdd = () => {
+    if (!profiles?.length || !folders?.length) {
+      toast("Could not load quality profiles or root folders", "error");
+      return;
+    }
+
+    addMovie.mutate(
+      {
+        tmdbId: result.tmdbId,
+        title: result.title,
+        qualityProfileId: profiles[0].id,
+        rootFolderPath: folders[0].path,
+      },
+      {
+        onSuccess: () => toast(`${result.title} added to Radarr`),
+        onError: (err) => toastError("Failed to add movie", err),
+      },
+    );
+  };
+
+  return (
+    <MediaSearchResultCard
+      serviceId="radarr"
+      poster={result.images.find((i) => i.coverType === "poster")}
+      fallbackIcon={Film}
+      title={result.title}
+      metaLine={result.year ? String(result.year) : undefined}
+      overview={result.overview}
+      alreadyAdded={existingMovieId !== undefined}
+      addPending={addMovie.isPending}
+      onQuickAdd={handleQuickAdd}
+      onAdvanced={onAdvanced}
+      onOpenExisting={onOpenExisting}
+    />
+  );
+}

--- a/components/search/radarr-search-section.tsx
+++ b/components/search/radarr-search-section.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useState } from "react";
+import { useRouter } from "expo-router";
+import { Film } from "lucide-react-native";
+import { SearchSection } from "@/components/search/search-section";
+import { RadarrSearchRow } from "@/components/search/radarr-search-row";
+import { AddMovieSheet } from "@/components/radarr/add-movie-sheet";
+import { useRadarrSearch, useRadarrMovies } from "@/hooks/use-radarr";
+import type { RadarrSearchResult } from "@/lib/types";
+
+const PREVIEW_LIMIT = 5;
+
+/** Movies section of global search — Radarr lookup, library dedup by tmdbId. */
+export function RadarrSearchSection({ query }: { query: string }) {
+  const router = useRouter();
+  const { data: results, isLoading, isError, error } = useRadarrSearch(query);
+  const { data: existing } = useRadarrMovies();
+  const [advancedTarget, setAdvancedTarget] = useState<RadarrSearchResult | null>(null);
+
+  const existingByTmdbId = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const m of existing ?? []) {
+      map.set(m.tmdbId, m.id);
+    }
+    return map;
+  }, [existing]);
+
+  const all = results ?? [];
+  const preview = all.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <>
+      <SearchSection
+        title="Movies"
+        icon={Film}
+        serviceLabel="Radarr"
+        total={all.length}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        hasMore={all.length > preview.length}
+        onShowAll={() => router.push({ pathname: "/movie/search", params: { q: query } })}
+      >
+        {preview.map((result) => {
+          const existingId = existingByTmdbId.get(result.tmdbId);
+          return (
+            <RadarrSearchRow
+              key={result.tmdbId}
+              result={result}
+              existingMovieId={existingId}
+              onAdvanced={() => setAdvancedTarget(result)}
+              onOpenExisting={() =>
+                existingId !== undefined && router.push(`/movie/${existingId}`)
+              }
+            />
+          );
+        })}
+      </SearchSection>
+
+      <AddMovieSheet
+        result={advancedTarget}
+        visible={advancedTarget !== null}
+        onClose={() => setAdvancedTarget(null)}
+      />
+    </>
+  );
+}

--- a/components/search/search-section.tsx
+++ b/components/search/search-section.tsx
@@ -1,0 +1,91 @@
+import { useState, type ComponentType, type ReactNode } from "react";
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
+import { ChevronDown, ChevronRight } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { ErrorBanner } from "@/components/common/error-banner";
+import { ICON } from "@/lib/constants";
+
+interface SearchSectionProps {
+  /** Category label, e.g. "Movies". */
+  title: string;
+  /** Lucide icon for the category. */
+  icon: ComponentType<{ size?: number; color?: string }>;
+  /** Right-aligned source label, e.g. "Radarr". */
+  serviceLabel: string;
+  /** Total number of matches (drives the count + the "Show all" affordance). */
+  total: number;
+  isLoading: boolean;
+  isError: boolean;
+  error?: unknown;
+  /** True when there are more matches than the preview renders. */
+  hasMore?: boolean;
+  /** Deep-link into the dedicated per-service search screen. */
+  onShowAll?: () => void;
+  defaultExpanded?: boolean;
+  /** The (preview-capped) result rows. */
+  children?: ReactNode;
+}
+
+/**
+ * Collapsible category section shared by every global-search section. Renders
+ * its own header (chevron + icon + label + count + inline spinner + source
+ * label), an inline ErrorBanner on failure, a compact "No matches" line once it
+ * settles empty (so the user can see every service was searched), and a
+ * "Show all (N)" deep-link when there are more matches than the preview.
+ */
+export function SearchSection({
+  title,
+  icon,
+  serviceLabel,
+  total,
+  isLoading,
+  isError,
+  error,
+  hasMore = false,
+  onShowAll,
+  defaultExpanded = true,
+  children,
+}: SearchSectionProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const settledEmpty = !isLoading && !isError && total === 0;
+
+  return (
+    <View className="mb-5">
+      <Pressable
+        onPress={() => setExpanded((e) => !e)}
+        className="flex-row items-center gap-2 mb-2 active:opacity-70"
+        hitSlop={6}
+      >
+        <Icon icon={expanded ? ChevronDown : ChevronRight} size={ICON.SM} color="#71717a" />
+        <Icon icon={icon} size={ICON.SM} color="#a1a1aa" />
+        <Text className="text-zinc-200 text-sm font-semibold">{title}</Text>
+        {total > 0 && <Text className="text-zinc-500 text-xs">({total})</Text>}
+        {isLoading && (
+          <View className="ml-1">
+            <ActivityIndicator size="small" color="#71717a" />
+          </View>
+        )}
+        <View className="flex-1" />
+        <Text className="text-zinc-600 text-xs">{serviceLabel}</Text>
+      </Pressable>
+
+      {expanded &&
+        (isError ? (
+          <ErrorBanner error={error} title={`Couldn't search ${serviceLabel}`} />
+        ) : settledEmpty ? (
+          <Text className="text-zinc-600 text-xs px-1 pb-1">No matches</Text>
+        ) : (
+          <View className="gap-2">
+            {children}
+            {hasMore && onShowAll && (
+              <Pressable onPress={onShowAll} className="py-1.5 active:opacity-70" hitSlop={4}>
+                <Text className="text-primary text-sm font-medium">
+                  Show all {total} →
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        ))}
+    </View>
+  );
+}

--- a/components/search/sonarr-search-row.tsx
+++ b/components/search/sonarr-search-row.tsx
@@ -1,0 +1,74 @@
+import { Tv } from "lucide-react-native";
+import { toast, toastError } from "@/components/ui/toast";
+import { MediaSearchResultCard } from "@/components/search/media-search-result-card";
+import {
+  useAddSeries,
+  useSonarrQualityProfiles,
+  useSonarrRootFolders,
+} from "@/hooks/use-sonarr";
+import type { SonarrSearchResult } from "@/lib/types";
+
+/**
+ * One Sonarr lookup result row: owns the quick-add mutation and renders the
+ * shared MediaSearchResultCard. Reused by the dedicated /series/search screen
+ * and the global-search TV section.
+ */
+export function SonarrSearchRow({
+  result,
+  existingSeriesId,
+  onAdvanced,
+  onOpenExisting,
+}: {
+  result: SonarrSearchResult;
+  existingSeriesId: number | undefined;
+  onAdvanced: () => void;
+  onOpenExisting: () => void;
+}) {
+  const addSeries = useAddSeries();
+  const { data: profiles } = useSonarrQualityProfiles();
+  const { data: folders } = useSonarrRootFolders();
+
+  const handleQuickAdd = () => {
+    if (!profiles?.length || !folders?.length) {
+      toast("Could not load quality profiles or root folders", "error");
+      return;
+    }
+
+    addSeries.mutate(
+      {
+        tvdbId: result.tvdbId,
+        title: result.title,
+        qualityProfileId: profiles[0].id,
+        rootFolderPath: folders[0].path,
+      },
+      {
+        onSuccess: () => toast(`${result.title} added to Sonarr`),
+        onError: (err) => toastError("Failed to add series", err),
+      },
+    );
+  };
+
+  const metaLine = [
+    result.year,
+    result.network,
+    `${result.seasonCount} season${result.seasonCount !== 1 ? "s" : ""}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <MediaSearchResultCard
+      serviceId="sonarr"
+      poster={result.images.find((i) => i.coverType === "poster")}
+      fallbackIcon={Tv}
+      title={result.title}
+      metaLine={metaLine}
+      overview={result.overview}
+      alreadyAdded={existingSeriesId !== undefined}
+      addPending={addSeries.isPending}
+      onQuickAdd={handleQuickAdd}
+      onAdvanced={onAdvanced}
+      onOpenExisting={onOpenExisting}
+    />
+  );
+}

--- a/components/search/sonarr-search-section.tsx
+++ b/components/search/sonarr-search-section.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useState } from "react";
+import { useRouter } from "expo-router";
+import { Tv } from "lucide-react-native";
+import { SearchSection } from "@/components/search/search-section";
+import { SonarrSearchRow } from "@/components/search/sonarr-search-row";
+import { AddSeriesSheet } from "@/components/sonarr/add-series-sheet";
+import { useSonarrSearch, useSonarrSeries } from "@/hooks/use-sonarr";
+import type { SonarrSearchResult } from "@/lib/types";
+
+const PREVIEW_LIMIT = 5;
+
+/** TV section of global search — Sonarr lookup, library dedup by tvdbId. */
+export function SonarrSearchSection({ query }: { query: string }) {
+  const router = useRouter();
+  const { data: results, isLoading, isError, error } = useSonarrSearch(query);
+  const { data: existing } = useSonarrSeries();
+  const [advancedTarget, setAdvancedTarget] = useState<SonarrSearchResult | null>(null);
+
+  const existingByTvdbId = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const s of existing ?? []) {
+      map.set(s.tvdbId, s.id);
+    }
+    return map;
+  }, [existing]);
+
+  const all = results ?? [];
+  const preview = all.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <>
+      <SearchSection
+        title="TV Shows"
+        icon={Tv}
+        serviceLabel="Sonarr"
+        total={all.length}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        hasMore={all.length > preview.length}
+        onShowAll={() => router.push({ pathname: "/series/search", params: { q: query } })}
+      >
+        {preview.map((result) => {
+          const existingId = existingByTvdbId.get(result.tvdbId);
+          return (
+            <SonarrSearchRow
+              key={result.tvdbId}
+              result={result}
+              existingSeriesId={existingId}
+              onAdvanced={() => setAdvancedTarget(result)}
+              onOpenExisting={() =>
+                existingId !== undefined && router.push(`/series/${existingId}`)
+              }
+            />
+          );
+        })}
+      </SearchSection>
+
+      <AddSeriesSheet
+        result={advancedTarget}
+        visible={advancedTarget !== null}
+        onClose={() => setAdvancedTarget(null)}
+      />
+    </>
+  );
+}

--- a/hooks/use-debounced-value.ts
+++ b/hooks/use-debounced-value.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a copy of `value` that only updates after it has stayed unchanged for
+ * `delayMs`. Used by global search so typing updates the input immediately but
+ * the query that fans out to up to five services trails the keystrokes, instead
+ * of firing a network search per character across self-hosted boxes.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/hooks/use-lidarr.ts
+++ b/hooks/use-lidarr.ts
@@ -101,11 +101,11 @@ export function useLidarrWantedMissing(instanceId?: string) {
 }
 
 export function useLidarrSearch(term: string, instanceId?: string) {
-  const { instanceId: id } = useInstanceTarget("lidarr", instanceId);
+  const { instanceId: id, enabled } = useInstanceTarget("lidarr", instanceId);
   return useQuery({
     queryKey: ["lidarr", id, "search", term],
     queryFn: () => searchArtists(term, id ?? undefined),
-    enabled: term.length >= 2 && !!id,
+    enabled: enabled && term.length >= 2 && !!id,
   });
 }
 

--- a/hooks/use-overseerr.ts
+++ b/hooks/use-overseerr.ts
@@ -78,11 +78,11 @@ export function useOverseerrRequestCount(instanceId?: string) {
 }
 
 export function useOverseerrSearch(query: string, instanceId?: string) {
-  const { instanceId: id } = useInstanceTarget("overseerr", instanceId);
+  const { instanceId: id, enabled } = useInstanceTarget("overseerr", instanceId);
   return useQuery({
     queryKey: ["overseerr", id, "search", query],
     queryFn: () => searchMedia(query, 1, id ?? undefined),
-    enabled: query.length >= 2 && !!id,
+    enabled: enabled && query.length >= 2 && !!id,
   });
 }
 

--- a/hooks/use-prowlarr.ts
+++ b/hooks/use-prowlarr.ts
@@ -45,11 +45,11 @@ export function useProwlarrSearch(
   indexerIds?: number[],
   instanceId?: string,
 ) {
-  const { instanceId: id } = useInstanceTarget("prowlarr", instanceId);
+  const { instanceId: id, enabled } = useInstanceTarget("prowlarr", instanceId);
   return useQuery({
     queryKey: ["prowlarr", id, "search", query, indexerIds],
     queryFn: () => searchAll(query, indexerIds, undefined, id ?? undefined),
-    enabled: query.length >= 2 && !!id,
+    enabled: enabled && query.length >= 2 && !!id,
   });
 }
 

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -99,11 +99,11 @@ export function useWantedMissing(instanceId?: string) {
 }
 
 export function useRadarrSearch(term: string, instanceId?: string) {
-  const { instanceId: id } = useInstanceTarget("radarr", instanceId);
+  const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
     queryKey: ["radarr", id, "search", term],
     queryFn: () => searchMovies(term, id ?? undefined),
-    enabled: term.length >= 2 && !!id,
+    enabled: enabled && term.length >= 2 && !!id,
   });
 }
 

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -106,11 +106,11 @@ export function useSonarrHistory(instanceId?: string, active = true) {
 }
 
 export function useSonarrSearch(term: string, instanceId?: string) {
-  const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
+  const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "search", term],
     queryFn: () => searchSeries(term, id ?? undefined),
-    enabled: term.length >= 2 && !!id,
+    enabled: enabled && term.length >= 2 && !!id,
   });
 }
 

--- a/lib/global-search.ts
+++ b/lib/global-search.ts
@@ -1,0 +1,20 @@
+import type { ServiceId } from "@/lib/constants";
+
+/**
+ * Service kinds that participate in global search (#223). v1 is the set of
+ * kinds that already expose a text-query search function (Radarr/Sonarr/Lidarr
+ * lookup, Seerr media search, Prowlarr indexer search). Plex/Jellyfin/Emby
+ * library search is a planned follow-up — add their ids here when it lands.
+ */
+export const GLOBAL_SEARCH_KINDS = [
+  "radarr",
+  "sonarr",
+  "lidarr",
+  "overseerr",
+  "prowlarr",
+] as const satisfies readonly ServiceId[];
+
+/** True when at least one searchable kind is attached to the active workspace. */
+export function hasSearchableKind(attached: ReadonlySet<ServiceId>): boolean {
+  return GLOBAL_SEARCH_KINDS.some((k) => attached.has(k));
+}


### PR DESCRIPTION
## Summary
nzb360-style global search: a Search icon in the dashboard header opens a new `/search` route that queries all attached services at once, grouped into collapsible per-category sections — Movies (Radarr), TV (Sonarr), Music (Lidarr), Requests (Seerr), Releases (Prowlarr). Debounced input, sections render independently, "Show all" deep-links into each service's full search.

Pure aggregation over the existing search hooks (no new HTTP). The three near-identical *arr search cards are extracted into one shared card + per-service rows, reused by both the dedicated search screens and the new sections.

v1 covers the 5 services that already have text search; Plex/Jellyfin/Emby library search is a planned follow-up.

## Test plan
- `tsc --noEmit` passes (0 errors excl. backend)
- Dedicated `/movie`,`/series`,`/artist` search screens unchanged in behavior (quick-add, advanced sheet, in-library check)
- `/search`: only attached-kind sections appear; each loads independently; "Show all" lands in the right screen pre-seeded
- Requests open the detail modal; Releases grab via confirm