### PR TITLE
feat: *arr System Health alerts widget + service banners (Refs #210)

### DIFF
--- a/app/(tabs)/indexers.tsx
+++ b/app/(tabs)/indexers.tsx
@@ -14,6 +14,7 @@ import { TextInput } from "@/components/ui/text-input";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
+import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import {
   useProwlarrIndexers,
@@ -48,6 +49,8 @@ function IndexersScreenInner() {
   return (
     <ScreenWrapper refreshing={refreshing} onRefresh={onRefresh}>
       <ServiceHeader name="Indexers" online={prowlarrHealth?.online} serviceId="prowlarr" />
+
+      <HealthIssuesBanner serviceId="prowlarr" className="mb-4" />
 
       <ScrollView
         horizontal

--- a/components/dashboard/arr-health-card.tsx
+++ b/components/dashboard/arr-health-card.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { ChevronRight, ShieldCheck } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { ServiceLogo } from "@/components/ui/service-logo";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SkeletonCardContent } from "@/components/ui/skeleton";
+import { HealthIssuesSheet } from "@/components/services/health-issues-sheet";
+import {
+  useArrHealthSections,
+  type ArrInstanceHealth,
+} from "@/hooks/use-arr-health";
+import { SERVICE_DEFAULTS } from "@/lib/constants";
+import { lightHaptic } from "@/lib/haptics";
+import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
+
+// Consolidated System > Health view for the *arr stack (issue #210). One row per
+// service kind that has warnings/errors; tapping a row opens the full issue list
+// (grouped by instance when a kind has more than one). Shows a clean "all
+// healthy" state otherwise so the widget is reassuring, not just an alarm.
+export function ArrHealthCard({ slotId }: WidgetComponentProps) {
+  const { sections, isLoading } = useArrHealthSections();
+  const [sheet, setSheet] = useState<{
+    serviceName: string;
+    instances: ArrInstanceHealth[];
+  } | null>(null);
+
+  const totalIssues = sections.reduce((acc, s) => acc + s.count, 0);
+  const anyError = sections.some((s) => s.severity === "error");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Health Alerts</CardTitle>
+        {totalIssues > 0 ? (
+          <Badge
+            label={`${totalIssues}`}
+            variant={anyError ? "error" : "warning"}
+          />
+        ) : null}
+      </CardHeader>
+
+      {isLoading ? (
+        <SkeletonCardContent rows={2} />
+      ) : sections.length === 0 ? (
+        <View className="flex-row items-center gap-2 py-1">
+          <Icon icon={ShieldCheck} size={18} color="#22c55e" />
+          <Text className="text-zinc-400 text-sm">All services healthy</Text>
+        </View>
+      ) : (
+        <View className="gap-2">
+          {sections.map((section) => {
+            const serviceName = SERVICE_DEFAULTS[section.serviceId].name;
+            const preview = section.previewMessage;
+            const accent = section.severity === "error" ? "#ef4444" : "#f59e0b";
+            // When a kind has issues on more than one instance, hint at the
+            // spread; the sheet breaks it down per instance on tap.
+            const instanceHint =
+              section.instances.length > 1
+                ? ` · ${section.instances.length} instances`
+                : "";
+            return (
+              <Pressable
+                key={section.serviceId}
+                onPress={() => {
+                  lightHaptic();
+                  setSheet({ serviceName, instances: section.instances });
+                }}
+                className="flex-row items-center gap-3 rounded-xl bg-surface-light px-3 py-2.5 active:opacity-70"
+              >
+                <ServiceLogo id={section.serviceId} size={22} />
+                <View className="flex-1">
+                  <View className="flex-row items-center gap-2">
+                    <Text className="text-zinc-100 text-sm font-semibold">
+                      {serviceName}
+                    </Text>
+                    <View
+                      className="rounded-full px-1.5 py-0.5"
+                      style={{ backgroundColor: accent }}
+                    >
+                      <Text className="text-white text-[0.65rem] font-bold leading-none">
+                        {section.count}
+                      </Text>
+                    </View>
+                  </View>
+                  <Text className="text-zinc-500 text-xs" numberOfLines={1}>
+                    {preview}
+                    {instanceHint ? (
+                      <Text className="text-zinc-600">{instanceHint}</Text>
+                    ) : null}
+                  </Text>
+                </View>
+                <Icon icon={ChevronRight} size={16} color="#71717a" />
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+
+      <HealthIssuesSheet
+        visible={!!sheet}
+        serviceName={sheet?.serviceName ?? ""}
+        instances={sheet?.instances ?? null}
+        onClose={() => setSheet(null)}
+      />
+    </Card>
+  );
+}

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -19,6 +19,7 @@ import {
   PlayCircle,
   Power,
   Radar,
+  ShieldAlert,
   Tv,
   type LucideIcon,
 } from "lucide-react-native";
@@ -44,6 +45,7 @@ import { JellyfinNowPlayingCard } from "@/components/dashboard/jellyfin-now-play
 import { EmbyNowPlayingCard } from "@/components/dashboard/emby-now-playing-card";
 import { CombinedNowPlayingCard } from "@/components/dashboard/combined-now-playing-card";
 import { ProwlarrStatsCard } from "@/components/dashboard/prowlarr-stats-card";
+import { ArrHealthCard } from "@/components/dashboard/arr-health-card";
 import { BazarrWantedCard } from "@/components/dashboard/bazarr-wanted-card";
 import { WolDevicesCard } from "@/components/dashboard/wol-devices-card";
 import { DiskSpaceCard } from "@/components/dashboard/disk-space-card";
@@ -460,6 +462,14 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     component: DiskSpaceCard,
     settingsComponent: DiskSpaceSettings,
     defaultSettings: DISK_SPACE_DEFAULT_SETTINGS,
+  },
+  "arr-health": {
+    id: "arr-health",
+    label: "Health Alerts",
+    description: "System Health warnings and errors from Sonarr, Radarr, Prowlarr and Lidarr",
+    icon: ShieldAlert,
+    service: ["radarr", "sonarr", "prowlarr", "lidarr"],
+    component: ArrHealthCard,
   },
 };
 

--- a/components/lidarr/music-view.tsx
+++ b/components/lidarr/music-view.tsx
@@ -12,6 +12,7 @@ import { Search, Disc3, Mic2, Eye, EyeOff, Trash2, Info, ScanSearch } from "luci
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -271,6 +272,8 @@ export const MusicView = memo(function MusicView({
           </Pressable>
         </View>
       </View>
+
+      <HealthIssuesBanner serviceId="lidarr" className="mb-4" />
 
       <ScrollView
         horizontal

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -12,6 +12,7 @@ import { Search, Film, Eye, EyeOff, Trash2, Info, ScanSearch } from "lucide-reac
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -300,6 +301,8 @@ export const MoviesView = memo(function MoviesView({
           </Pressable>
         </View>
       </View>
+
+      <HealthIssuesBanner serviceId="radarr" className="mb-4" />
 
       <ScrollView
         horizontal

--- a/components/services/health-issues-banner.tsx
+++ b/components/services/health-issues-banner.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { AlertTriangle, ChevronRight } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { HealthIssuesSheet } from "@/components/services/health-issues-sheet";
+import { useArrInstanceHealth } from "@/hooks/use-arr-health";
+import { worstSeverity, type ArrHealthServiceId } from "@/services/arr-health";
+import { SERVICE_DEFAULTS } from "@/lib/constants";
+import { lightHaptic } from "@/lib/haptics";
+
+interface HealthIssuesBannerProps {
+  serviceId: ArrHealthServiceId;
+  // Follows the screen's active instance when omitted.
+  instanceId?: string;
+  className?: string;
+}
+
+// Top-of-screen banner for an *arr service view: when the active instance's
+// System > Health has warnings/errors, it shows a tappable summary that opens
+// the full issue list (#210). Renders null when there's nothing wrong, so it
+// takes no space on a healthy instance.
+export function HealthIssuesBanner({
+  serviceId,
+  instanceId,
+  className = "",
+}: HealthIssuesBannerProps) {
+  const { data } = useArrInstanceHealth(serviceId, instanceId);
+  const [open, setOpen] = useState(false);
+
+  const issues = (data ?? []).filter((i) => i.type !== "ok");
+  const severity = worstSeverity(issues);
+  if (!severity) return null;
+
+  const isError = severity === "error";
+  const serviceName = SERVICE_DEFAULTS[serviceId].name;
+  const label =
+    issues.length === 1 ? "1 health issue" : `${issues.length} health issues`;
+
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          lightHaptic();
+          setOpen(true);
+        }}
+        className={`flex-row items-center gap-2.5 rounded-xl border px-3 py-2.5 active:opacity-70 ${
+          isError
+            ? "border-red-600/40 bg-red-600/10"
+            : "border-amber-500/40 bg-amber-500/10"
+        } ${className}`}
+      >
+        <Icon
+          icon={AlertTriangle}
+          size={16}
+          color={isError ? "#f87171" : "#fbbf24"}
+        />
+        <View className="flex-1">
+          <Text
+            className={`text-sm font-semibold ${
+              isError ? "text-red-300" : "text-amber-200"
+            }`}
+          >
+            {label}
+          </Text>
+          <Text
+            className={`text-xs ${
+              isError ? "text-red-200/80" : "text-amber-100/80"
+            }`}
+          >
+            {`Tap to view ${serviceName} System Health`}
+          </Text>
+        </View>
+        <Icon
+          icon={ChevronRight}
+          size={16}
+          color={isError ? "#fca5a5" : "#fcd34d"}
+        />
+      </Pressable>
+
+      <HealthIssuesSheet
+        visible={open}
+        serviceName={serviceName}
+        instances={[{ instanceId: serviceId, instanceName: serviceName, issues }]}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}

--- a/components/services/health-issues-sheet.tsx
+++ b/components/services/health-issues-sheet.tsx
@@ -1,0 +1,101 @@
+import { Modal, View, Text, Pressable, ScrollView, Linking } from "react-native";
+import { AlertTriangle, Info, ExternalLink } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { lightHaptic } from "@/lib/haptics";
+import { HEALTH_TYPE_COLOR, type ArrHealthType } from "@/services/arr-health";
+import type { ArrInstanceHealth } from "@/hooks/use-arr-health";
+
+interface HealthIssuesSheetProps {
+  visible: boolean;
+  // Display name of the tapped service kind (e.g. "Sonarr").
+  serviceName: string;
+  // Instances that currently have actionable health issues. null when closed.
+  instances: ArrInstanceHealth[] | null;
+  onClose: () => void;
+}
+
+// Read-only, non-chaining info sheet → plain props/useState (no useModalFlow),
+// per the modal-sequencing rules in CLAUDE.md. Mirrors the pageSheet pattern in
+// components/qbittorrent/category-sheet.tsx.
+export function HealthIssuesSheet({
+  visible,
+  serviceName,
+  instances,
+  onClose,
+}: HealthIssuesSheetProps) {
+  // Only label each section by instance when there's more than one to
+  // disambiguate; a single-instance setup needs no header noise.
+  const showInstanceNames = (instances?.length ?? 0) > 1;
+
+  const openWiki = (url?: string) => {
+    if (!url) return;
+    lightHaptic();
+    Linking.openURL(url).catch(() => {});
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title={`${serviceName} Health`} onClose={onClose} />
+
+        <ScrollView
+          contentContainerClassName="px-4 py-4 gap-4"
+          showsVerticalScrollIndicator={false}
+        >
+          {instances?.map((inst) => (
+            <View key={inst.instanceId} className="gap-2">
+              {showInstanceNames ? (
+                <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wide">
+                  {inst.instanceName}
+                </Text>
+              ) : null}
+
+              {inst.issues.map((issue, idx) => (
+                <View
+                  key={`${issue.source}:${idx}`}
+                  className="flex-row gap-3 bg-surface border border-border rounded-2xl p-3"
+                >
+                  <View className="pt-0.5">
+                    <Icon
+                      icon={issueIcon(issue.type)}
+                      size={18}
+                      color={HEALTH_TYPE_COLOR[issue.type]}
+                    />
+                  </View>
+                  <View className="flex-1 gap-1">
+                    <Text className="text-zinc-200 text-sm font-semibold">
+                      {issue.source}
+                    </Text>
+                    <Text className="text-zinc-400 text-sm">{issue.message}</Text>
+                    {issue.wikiUrl ? (
+                      <Pressable
+                        onPress={() => openWiki(issue.wikiUrl)}
+                        hitSlop={6}
+                        className="flex-row items-center gap-1.5 mt-1 active:opacity-70"
+                      >
+                        <Icon icon={ExternalLink} size={13} color="#3b82f6" />
+                        <Text className="text-primary text-sm font-medium">
+                          Open wiki
+                        </Text>
+                      </Pressable>
+                    ) : null}
+                  </View>
+                </View>
+              ))}
+            </View>
+          ))}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+function issueIcon(type: ArrHealthType) {
+  return type === "notice" ? Info : AlertTriangle;
+}

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -23,6 +23,7 @@ import {
   useScreenBottomPadding,
 } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
+import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterChip } from "@/components/ui/filter-chip";
@@ -331,6 +332,8 @@ export const TvView = memo(function TvView({
           </Pressable>
         </View>
       </View>
+
+      <HealthIssuesBanner serviceId="sonarr" className="mb-4" />
 
       <ScrollView
         horizontal

--- a/hooks/use-arr-health.ts
+++ b/hooks/use-arr-health.ts
@@ -1,0 +1,125 @@
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
+import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import { POLLING_INTERVALS } from "@/lib/constants";
+import {
+  getArrHealth,
+  worstSeverity,
+  ARR_HEALTH_SERVICE_IDS,
+  type ArrHealthIssue,
+  type ArrHealthServiceId,
+  type ArrHealthSeverity,
+} from "@/services/arr-health";
+
+export interface ArrInstanceHealth {
+  instanceId: string;
+  instanceName: string;
+  issues: ArrHealthIssue[];
+}
+
+// One service kind's aggregated health, ready for the Health Alerts widget: the
+// instances that currently have issues, the total count, and the worst severity
+// across them.
+export interface ArrHealthSection {
+  serviceId: ArrHealthServiceId;
+  instances: ArrInstanceHealth[];
+  count: number;
+  severity: ArrHealthSeverity;
+  // A representative message for the collapsed row — the first issue matching
+  // the worst severity, so the row's preview text agrees with its colour even
+  // when issues span multiple instances.
+  previewMessage: string;
+}
+
+interface ArrHealthTarget {
+  kind: ArrHealthServiceId;
+  instanceId: string;
+  instanceName: string;
+}
+
+// Polls System > Health across the active workspace's Sonarr/Radarr/Prowlarr/
+// Lidarr instances and groups the actionable issues into per-kind sections for
+// the Health Alerts widget (issue #210). This is application-level health,
+// distinct from the connectivity probe in useServiceHealth (which drives the
+// status dot): an offline/errored instance yields no data here, so it
+// contributes no section — only its red connectivity dot shows elsewhere.
+//
+// `useWorkspaceScopedInstances` returns stable (memoized) arrays, which keeps
+// the `useQueries` query list from rebuilding on every unrelated store change.
+export function useArrHealthSections(): {
+  sections: ArrHealthSection[];
+  isLoading: boolean;
+} {
+  // Scope to the active dashboard, like every other fan-out widget. No
+  // per-widget instance binding (yet), so the "all attached" default is used.
+  const radarr = useWorkspaceScopedInstances("radarr", undefined);
+  const sonarr = useWorkspaceScopedInstances("sonarr", undefined);
+  const prowlarr = useWorkspaceScopedInstances("prowlarr", undefined);
+  const lidarr = useWorkspaceScopedInstances("lidarr", undefined);
+
+  const targets: ArrHealthTarget[] = [
+    ...radarr.map((i) => ({ kind: "radarr" as const, instanceId: i.id, instanceName: i.name })),
+    ...sonarr.map((i) => ({ kind: "sonarr" as const, instanceId: i.id, instanceName: i.name })),
+    ...prowlarr.map((i) => ({ kind: "prowlarr" as const, instanceId: i.id, instanceName: i.name })),
+    ...lidarr.map((i) => ({ kind: "lidarr" as const, instanceId: i.id, instanceName: i.name })),
+  ];
+
+  const queries = useQueries({
+    queries: targets.map((t) => ({
+      queryKey: [t.kind, t.instanceId, "health"],
+      queryFn: () => getArrHealth(t.kind, t.instanceId),
+      refetchInterval: POLLING_INTERVALS.serviceHealth,
+    })),
+  });
+
+  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+
+  // Group instances-with-issues under their kind.
+  const byKind = new Map<ArrHealthServiceId, ArrInstanceHealth[]>();
+  queries.forEach((q, idx) => {
+    // Drop "ok" entries — only notice/warning/error are actionable alerts.
+    const issues = q.data?.filter((i) => i.type !== "ok") ?? [];
+    if (issues.length === 0) return;
+    const t = targets[idx];
+    const list = byKind.get(t.kind) ?? [];
+    list.push({ instanceId: t.instanceId, instanceName: t.instanceName, issues });
+    byKind.set(t.kind, list);
+  });
+
+  // Emit sections in canonical *arr order so the widget list is stable.
+  const sections: ArrHealthSection[] = ARR_HEALTH_SERVICE_IDS.flatMap((kind) => {
+    const instances = byKind.get(kind);
+    if (!instances?.length) return [];
+    const allIssues = instances.flatMap((i) => i.issues);
+    const severity = worstSeverity(allIssues);
+    if (!severity) return [];
+    const previewMessage = (
+      allIssues.find((i) =>
+        severity === "error" ? i.type === "error" : i.type !== "error",
+      ) ?? allIssues[0]
+    ).message;
+    return [
+      { serviceId: kind, instances, count: allIssues.length, severity, previewMessage },
+    ];
+  });
+
+  return { sections, isLoading: isInitialLoading };
+}
+
+// Single-instance variant for a service screen's health banner: follows the
+// screen's active instance (like the other per-service hooks) and shares its
+// query key with useArrHealthSections, so the widget and banner reuse one cached
+// /health request per instance rather than each fetching their own.
+export function useArrInstanceHealth(
+  serviceId: ArrHealthServiceId,
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled } = useInstanceTarget(serviceId, instanceId);
+  return useQuery({
+    queryKey: [serviceId, id, "health"],
+    queryFn: () => getArrHealth(serviceId, id ?? undefined),
+    refetchInterval: POLLING_INTERVALS.serviceHealth,
+    enabled: enabled && !!id,
+  });
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -120,6 +120,7 @@ export const DASHBOARD_WIDGET_IDS = [
   "bazarr-wanted",
   "wol-devices",
   "disk-space",
+  "arr-health",
 ] as const;
 
 export type WidgetId = (typeof DASHBOARD_WIDGET_IDS)[number];

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1357,6 +1357,41 @@ const DEMO_ARR_DISKSPACE = [
   { path: "/data", label: "/data", freeSpace: 2_400_000_000_000, totalSpace: 16_000_000_000_000 }, // ~85% used → red
 ];
 
+// System > Health issues for the *arr alert badge (#210). Sonarr shows the
+// issue from the feature request (a long-down indexer) plus an update notice;
+// Radarr/Prowlarr a warning each; Lidarr is healthy (empty) to show the
+// no-badge case.
+const DEMO_SONARR_HEALTH = [
+  {
+    source: "IndexerStatusCheck",
+    type: "error",
+    message: "Indexers unavailable due to failures for more than 6 hours: NZBgeek",
+    wikiUrl: "https://wiki.servarr.com/sonarr/system#indexers-are-unavailable-due-to-failures",
+  },
+  {
+    source: "UpdateCheck",
+    type: "warning",
+    message: "New update is available",
+    wikiUrl: "https://wiki.servarr.com/sonarr/system#updates",
+  },
+];
+const DEMO_RADARR_HEALTH = [
+  {
+    source: "ImportListStatusCheck",
+    type: "warning",
+    message: "Lists unavailable due to failures: Trakt Watchlist",
+    wikiUrl: "https://wiki.servarr.com/radarr/system#lists-are-unavailable-due-to-failures",
+  },
+];
+const DEMO_PROWLARR_HEALTH = [
+  {
+    source: "IndexerStatusCheck",
+    type: "warning",
+    message: "Indexers unavailable due to failures for more than 6 hours: 1337x",
+    wikiUrl: "https://wiki.servarr.com/prowlarr/system#indexers-are-unavailable-due-to-failures",
+  },
+];
+
 export function getDemoResponse(
   serviceId: ServiceId,
   path: string,
@@ -1379,6 +1414,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/tag")) return [];
       if (normalized.startsWith("/customfilter")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
+      if (normalized.startsWith("/health")) return DEMO_RADARR_HEALTH;
       if (normalized.startsWith("/movie/lookup")) return [];
       return undefined;
     }
@@ -1393,6 +1429,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/tag")) return [];
       if (normalized.startsWith("/customfilter")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
+      if (normalized.startsWith("/health")) return DEMO_SONARR_HEALTH;
       if (normalized.startsWith("/series/lookup")) return [];
       if (normalized.startsWith("/episode")) return [];
       return undefined;
@@ -1428,6 +1465,8 @@ export function getDemoResponse(
       if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;
       if (normalized.startsWith("/tag")) return [];
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
+      // Lidarr intentionally healthy — exercises the no-badge path.
+      if (normalized.startsWith("/health")) return [];
       return undefined;
     }
     case "overseerr": {
@@ -1446,6 +1485,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/indexerstats")) return DEMO_PROWLARR_STATS;
       if (normalized.startsWith("/search")) return DEMO_PROWLARR_SEARCH_RESULTS;
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
+      if (normalized.startsWith("/health")) return DEMO_PROWLARR_HEALTH;
       return undefined;
     }
     case "bazarr": {

--- a/services/arr-health.ts
+++ b/services/arr-health.ts
@@ -1,0 +1,57 @@
+import { serviceRequest } from "@/lib/http-client";
+
+// Sonarr/Radarr/Prowlarr/Lidarr all expose `GET <apiBasePath>/health`, the
+// array of issues surfaced on each app's System > Health page (down indexers,
+// pending updates, failed lists, …). The relative path is identical across the
+// four — it resolves under each service's apiBasePath — so one shared fetch
+// covers all of them rather than four copies (issue #210).
+
+export type ArrHealthType = "ok" | "notice" | "warning" | "error";
+
+export interface ArrHealthIssue {
+  source: string;
+  type: ArrHealthType;
+  message: string;
+  wikiUrl?: string;
+}
+
+// The *arr kinds that expose a /health endpoint.
+export type ArrHealthServiceId = "radarr" | "sonarr" | "prowlarr" | "lidarr";
+
+export const ARR_HEALTH_SERVICE_IDS: readonly ArrHealthServiceId[] = [
+  "radarr",
+  "sonarr",
+  "prowlarr",
+  "lidarr",
+] as const;
+
+export function getArrHealth(
+  serviceId: ArrHealthServiceId,
+  instanceId?: string,
+): Promise<ArrHealthIssue[]> {
+  return serviceRequest<ArrHealthIssue[]>(serviceId, "/health", { instanceId });
+}
+
+// Worst severity across a set of issues, used to colour the alert badge.
+// "notice" is folded into "warning" (amber); only "error" escalates to red.
+// Returns null when there's nothing to flag.
+export type ArrHealthSeverity = "warning" | "error";
+
+export function worstSeverity(
+  issues: ArrHealthIssue[],
+): ArrHealthSeverity | null {
+  let severity: ArrHealthSeverity | null = null;
+  for (const issue of issues) {
+    if (issue.type === "error") return "error";
+    if (issue.type === "warning" || issue.type === "notice") severity = "warning";
+  }
+  return severity;
+}
+
+// Per-issue accent colour in the details sheet (notice shares warning's amber).
+export const HEALTH_TYPE_COLOR: Record<ArrHealthType, string> = {
+  ok: "#22c55e",
+  notice: "#f59e0b",
+  warning: "#f59e0b",
+  error: "#ef4444",
+};


### PR DESCRIPTION
## Summary
Surfaces each *arr app's **System > Health** issues (down indexers, pending updates, etc.) so problems get noticed without opening the web UI (Refs #210).

- Shared `/health` fetch + hooks for Sonarr/Radarr/Prowlarr/Lidarr (one cached request per instance).
- New **opt-in "Health Alerts" dashboard widget**: one row per service kind with issues (count + worst-severity color), tap opens a details sheet grouped by instance. Workspace-scoped; shows "all healthy" when clean.
- **Health banner** on each *arr service screen (Movies/TV/Music/Indexers) for the active instance, opening the same list.
- The Services tab and Services Health widget are left unchanged (no icon clutter).

## Test plan
- Enable demo mode → add the "Health Alerts" widget: Sonarr (2, red), Radarr (1, amber), Prowlarr (1, amber), Lidarr healthy.
- Open Movies/TV/Music/Indexers → banner shows for instances with issues; tap → details sheet with "Open wiki" links.
- Healthy/offline instances show no alert; multi-instance kinds aggregate in the widget and split per instance in the sheet.
- `tsc --noEmit` passes.