### PR TITLE
fix(backend): stop unknown service kinds from 400-ing PUT /config (Refs #230)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test
+        run: npm test
+
       - name: Build (tsc)
         run: npm run build
 

--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboarr-backend",
-  "version": "0.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboarr-backend",
-      "version": "0.1.0",
+      "version": "1.2.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/rate-limit": "^10.2.1",

--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboarr-backend",
-  "version": "0.1.0",
+  "version": "1.2.2",
   "description": "Self-hosted companion backend for Dashboarr — polls your *arr stack and sends real Expo push notifications",
   "license": "GPL-3.0",
   "private": true,
@@ -10,6 +10,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
+    "test": "tsx --test src/types.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/backend/dashboarr-backend/src/routes/health.ts
+++ b/backend/dashboarr-backend/src/routes/health.ts
@@ -15,7 +15,7 @@ export async function healthRoutes(app: FastifyInstance): Promise<void> {
     return {
       ok: true,
       name: "dashboarr-backend",
-      version: "0.1.0",
+      version: "1.2.2",
       // Reminder surfaced on every health check. Flipping Expo "Enhanced
       // Security for Push Notifications" silently breaks every user-hosted
       // backend — this field is a canary for that misconfiguration.

--- a/backend/dashboarr-backend/src/types.test.ts
+++ b/backend/dashboarr-backend/src/types.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { configPayloadSchema, DEFAULT_NOTIFICATION_SETTINGS } from "./types.js";
+
+/**
+ * Regression guard for the bug where the app sends a config entry for a service
+ * kind the backend doesn't know yet (it ships a default instance for every kind
+ * in its own list). A strict `kind` enum used to fail the whole `PUT /config`,
+ * which silently disabled ALL push notifications. The schema must now drop the
+ * unknown entry and keep the rest.
+ */
+test("unknown service kind is dropped, not fatal to the whole payload", () => {
+  const result = configPayloadSchema.safeParse({
+    instances: [
+      { id: "a", kind: "sonarr", enabled: true, name: "Sonarr", localUrl: "http://192.168.0.2:8989" },
+      { id: "b", kind: "somefutureservice", enabled: false, name: "Future", localUrl: "" },
+    ],
+    notifications: DEFAULT_NOTIFICATION_SETTINGS,
+  });
+
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.equal(result.data.instances?.length, 1);
+  assert.equal(result.data.instances?.[0]?.kind, "sonarr");
+});
+
+test("rtorrent, lidarr and jellystat are accepted kinds", () => {
+  for (const kind of ["rtorrent", "lidarr", "jellystat"]) {
+    const result = configPayloadSchema.safeParse({
+      instances: [{ id: "x", kind, enabled: false, name: kind, localUrl: "" }],
+      notifications: DEFAULT_NOTIFICATION_SETTINGS,
+    });
+    assert.equal(result.success, true, `${kind} should be accepted`);
+    if (!result.success) continue;
+    assert.equal(result.data.instances?.length, 1);
+  }
+});
+
+test("a known service with a non-http url still fails (no silent acceptance)", () => {
+  const result = configPayloadSchema.safeParse({
+    instances: [{ id: "a", kind: "sonarr", enabled: true, name: "Sonarr", localUrl: "ftp://nope" }],
+    notifications: DEFAULT_NOTIFICATION_SETTINGS,
+  });
+  assert.equal(result.success, false);
+});
+
+test("a payload with only unknown kinds still parses to an empty instances list", () => {
+  const result = configPayloadSchema.safeParse({
+    instances: [{ id: "b", kind: "somefutureservice", enabled: false, name: "Future", localUrl: "" }],
+    notifications: DEFAULT_NOTIFICATION_SETTINGS,
+  });
+
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.equal(result.data.instances?.length, 0);
+});

--- a/backend/dashboarr-backend/src/types.ts
+++ b/backend/dashboarr-backend/src/types.ts
@@ -1,14 +1,23 @@
 import { z } from "zod";
 
+// Keep this list in sync with the app's SERVICE_IDS (lib/constants.ts). The app
+// pushes a config entry for every kind it knows about, so any kind missing here
+// is rejected by `kind`'s enum below — and because one bad entry fails the whole
+// `PUT /config`, that silently disables ALL push notifications, not just the
+// unknown service. `configPayloadSchema` now drops unknown kinds defensively
+// (see dropUnknownKinds), but this list should still mirror the app.
 export const SERVICE_IDS = [
   "qbittorrent",
+  "rtorrent",
   "sabnzbd",
   "nzbget",
   "radarr",
   "sonarr",
+  "lidarr",
   "overseerr",
   "tautulli",
   "tracearr",
+  "jellystat",
   "prowlarr",
   "plex",
   "jellyfin",
@@ -152,15 +161,40 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   tracearrStreamStopped: false,
 };
 
+const KNOWN_SERVICE_IDS = new Set<string>(SERVICE_IDS);
+
+/**
+ * Drop array entries whose service kind this backend doesn't recognize instead
+ * of rejecting the whole config payload. The app sends a default entry for EVERY
+ * kind it knows about (enabled or not), so when a newer app adds a service this
+ * backend version predates, a strict `kind` enum would fail the entire
+ * `PUT /config` and silently disable ALL push notifications — not just the
+ * unknown service. (That is exactly how rtorrent/lidarr/jellystat bricked
+ * notifications before they were added to SERVICE_IDS.) Unknown kinds are
+ * harmless to drop: the scheduler has no poller for them anyway. The kind lives
+ * in `id` for the legacy `services` shape and in `kind` for `instances`.
+ */
+function dropUnknownKinds(keyField: "id" | "kind") {
+  return (value: unknown): unknown => {
+    if (!Array.isArray(value)) return value;
+    return value.filter((entry) => {
+      if (entry === null || typeof entry !== "object") return false;
+      const kind = (entry as Record<string, unknown>)[keyField];
+      return typeof kind === "string" && KNOWN_SERVICE_IDS.has(kind);
+    });
+  };
+}
+
 /**
  * Either shape is accepted: the new app sends `instances`, older builds send
  * `services`. The route handler normalizes both to ServiceInstancePayload[]
- * before persisting (see routes/config.ts).
+ * before persisting (see routes/config.ts). Unknown service kinds are filtered
+ * out first (see dropUnknownKinds) so a newer app never 400s the whole config.
  */
 export const configPayloadSchema = z
   .object({
-    services: z.array(serviceConfigSchema).optional(),
-    instances: z.array(serviceInstanceSchema).optional(),
+    services: z.preprocess(dropUnknownKinds("id"), z.array(serviceConfigSchema).optional()),
+    instances: z.preprocess(dropUnknownKinds("kind"), z.array(serviceInstanceSchema).optional()),
     notifications: notificationSettingsSchema,
   })
   .refine((p) => p.services !== undefined || p.instances !== undefined, {
@@ -186,13 +220,16 @@ export const deviceRegisterSchema = z.object({
 
 export const SERVICE_API_BASE: Record<ServiceId, string> = {
   qbittorrent: "/api/v2",
+  rtorrent: "/RPC2",
   sabnzbd: "/api",
   nzbget: "/jsonrpc",
   radarr: "/api/v3",
   sonarr: "/api/v3",
+  lidarr: "/api/v1",
   overseerr: "/api/v1",
   tautulli: "/api/v2",
   tracearr: "/api/v1/public",
+  jellystat: "",
   prowlarr: "/api/v1",
   plex: "",
   jellyfin: "",
@@ -203,17 +240,25 @@ export const SERVICE_API_BASE: Record<ServiceId, string> = {
 
 export const SERVICE_PING_PATH: Record<ServiceId, string> = {
   qbittorrent: "/app/version",
+  // rTorrent is XML-RPC over the /RPC2 mount; there is no GET ping path (the
+  // app pings it with an XML-RPC POST). No backend poller uses this today.
+  rtorrent: "",
   // SAB has no path-based ping endpoint — pingService synthesises ?mode=version.
   sabnzbd: "",
   // NZBGet uses JSON-RPC POST to /jsonrpc; ping logic POSTs the version method.
   nzbget: "",
   radarr: "/system/status",
   sonarr: "/system/status",
+  // Lidarr is an *arr sibling on the v1 API; same status ping as Radarr/Sonarr.
+  lidarr: "/system/status",
   overseerr: "/status",
   tautulli: "/home",
   // Tracearr's /health is Bearer-authed, so it doubles as a reachability +
   // auth probe (mirrors the app's runConnectionProbe).
   tracearr: "/health",
+  // JellyStat's REST API is root-mounted; a cheap authenticated GET doubles as
+  // the reachability probe (mirrors the app). No backend poller uses this today.
+  jellystat: "/stats/getLibraryOverview",
   prowlarr: "/system/status",
   plex: "/identity",
   jellyfin: "/System/Info/Public",

--- a/backend/dashboarr-backend/tsconfig.json
+++ b/backend/dashboarr-backend/tsconfig.json
@@ -18,5 +18,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
The app pushes a config entry for **every** service kind it knows (it ships a default instance per kind). The backend's strict `kind` enum was missing `rtorrent`, `lidarr`, `jellystat`, so one unknown kind 400'd the **whole** `PUT /config`. The backend then stored no config, spawned no pollers, and **silently disabled all push notifications** (test push still worked since it ignores config). Root cause of #230.

- Add `rtorrent`/`lidarr`/`jellystat` to backend `SERVICE_IDS` (+ their API base / ping paths, mirrored from the app).
- `configPayloadSchema` now **drops unknown kinds** instead of rejecting the payload, so a newer app never bricks notifications again.
- Bump backend to 1.2.2.

## Test plan
- `npm test` (new `src/types.test.ts`, 4 cases) — now also runs in CI.
- `npm run typecheck` clean; `npm run build` clean (test files excluded from `dist`).

Refs #230