### PR TITLE
feat(backend): print version in logs + serve from /health (1.2.3)

### DIFF
--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboarr-backend",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/rate-limit": "^10.2.1",

--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Self-hosted companion backend for Dashboarr — polls your *arr stack and sends real Expo push notifications",
   "license": "GPL-3.0",
   "private": true,

--- a/backend/dashboarr-backend/src/index.ts
+++ b/backend/dashboarr-backend/src/index.ts
@@ -10,6 +10,7 @@ import { ensureActiveToken, purgeExpiredTokens } from "./auth/pairing-tokens.js"
 import { getWebhookSecret } from "./db/repos/settings.js";
 import { isEncryptionEnabled } from "./crypto/secrets.js";
 import { SERVICE_IDS } from "./types.js";
+import { VERSION } from "./version.js";
 import { initScheduler, getScheduler } from "./workers/scheduler.js";
 import { healthRoutes } from "./routes/health.js";
 import { pairRoutes } from "./routes/pair.js";
@@ -25,7 +26,7 @@ import { tracearrWebhook } from "./routes/webhooks/tracearr.js";
 
 const BANNER = `
 ===============================================================================
-  Dashboarr Backend — self-hosted companion for the Dashboarr mobile app
+  Dashboarr Backend v${VERSION} — self-hosted companion for the Dashboarr mobile app
 -------------------------------------------------------------------------------
   🚨 OPERATOR WARNING 🚨
   This backend POSTs to https://exp.host/--/api/v2/push/send with NO auth.
@@ -99,6 +100,9 @@ async function printStartupPairing(
 async function main(): Promise<void> {
   const env = getEnv();
   console.log(BANNER);
+  // Explicit, search-friendly line so an operator can confirm the running build
+  // by searching the container log for "version".
+  console.log(`Backend version: ${VERSION}\n`);
 
   if (isEncryptionEnabled()) {
     console.log("🔒 CONFIG_ENCRYPTION_KEY set — service credentials encrypted at rest (AES-256-GCM).\n");

--- a/backend/dashboarr-backend/src/routes/health.ts
+++ b/backend/dashboarr-backend/src/routes/health.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { requireBearer } from "../auth/bearer.js";
 import { getScheduler } from "../workers/scheduler.js";
+import { VERSION } from "../version.js";
 
 /**
  * /health is intentionally behind `requireBearer`. Unauthenticated callers
@@ -15,7 +16,7 @@ export async function healthRoutes(app: FastifyInstance): Promise<void> {
     return {
       ok: true,
       name: "dashboarr-backend",
-      version: "1.2.2",
+      version: VERSION,
       // Reminder surfaced on every health check. Flipping Expo "Enhanced
       // Security for Push Notifications" silently breaks every user-hosted
       // backend — this field is a canary for that misconfiguration.

--- a/backend/dashboarr-backend/src/version.ts
+++ b/backend/dashboarr-backend/src/version.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Single source of truth for the running backend version: read from
+ * package.json at startup so there's nothing to keep in sync by hand. The
+ * Dockerfile copies package.json into the runtime image (/app/package.json)
+ * next to dist/, so `../package.json` resolves both locally
+ * (dist/version.js -> ../package.json) and in the container.
+ *
+ * Surfaced in the startup log banner and the /health response so an operator
+ * can confirm which build is actually running — the `:latest` image tag alone
+ * doesn't tell you that.
+ */
+function readVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+export const VERSION = readVersion();


### PR DESCRIPTION
## Summary
Operators can't easily tell which backend build is running (the `:latest` tag doesn't say). Print the version at startup and serve it from `/health`.

- New `version.ts` reads the version from `package.json` at runtime (single source of truth; the Dockerfile already copies package.json into the image). Removes the hand-maintained hardcoded version in `health.ts`.
- Startup banner shows `Dashboarr Backend vX.Y.Z` and a search-friendly `Backend version: X.Y.Z` line so users can confirm the running build from the container log.
- Bump to 1.2.3.

## Test plan
- `npm run typecheck` / `npm test` (4/4) / `npm run build` all clean.
- Verified `VERSION` resolves to `1.2.3` from built `dist/version.js` (reads package.json at runtime).

Refs #230