### PR TITLE
feat(services): native "Checking…" indicator + gray re-check dots (Refs #196)

### DIFF
--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -8,7 +8,7 @@ import Sortable, {
 import { useRouter } from "expo-router";
 import { Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
-import { Spinner } from "@/components/ui/spinner";
+import { CheckingIndicator } from "@/components/ui/checking-indicator";
 import { StatusDot } from "@/components/ui/status-dot";
 import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -120,7 +120,10 @@ export default function ServicesScreen() {
   const renderTile = ({ item: id }: SortableGridRenderItemInfo<ServiceId>) => {
     const service = services[id];
     const status = health?.find((h) => h.id === id);
-    const checking = determining && !status;
+    // Pulse gray whenever a probe is in flight (cold start, or a network/dashboard
+    // re-key), matching the dashboard Services widget, not only when there's no
+    // prior status yet. (#196)
+    const checking = determining;
     const healthStatus: HealthStatusKind = status?.status ?? "offline";
     const online = healthStatus !== "offline";
     // Surface WHY a tile isn't green (timeout, wrong key, off-WiFi LAN, …) so a
@@ -140,7 +143,10 @@ export default function ServicesScreen() {
       >
         <View className="relative">
           <View className="bg-surface-light rounded-xl p-3">
-            <ServiceLogo id={id} size={28} online={online} />
+            {/* Keep the logo lit while the probe is still in flight (checking)
+                so it doesn't flash the dimmed offline look before the verdict
+                lands. The pulsing "checking" dot signals the in-progress state (#196). */}
+            <ServiceLogo id={id} size={28} online={checking || online} />
           </View>
           <StatusDot state={checking ? "checking" : healthStatus} overlay />
         </View>
@@ -163,7 +169,7 @@ export default function ServicesScreen() {
         <View className="flex-1 pr-3">
           <View className="flex-row items-center gap-2">
             <Text className="text-zinc-100 text-2xl font-bold">Services</Text>
-            {determining ? <Spinner size={18} color="#71717a" /> : null}
+            {determining ? <CheckingIndicator /> : null}
           </View>
           {canReorder && (
             <Text className="text-zinc-500 text-xs mt-0.5">

--- a/components/dashboard/arr-health-card.tsx
+++ b/components/dashboard/arr-health-card.tsx
@@ -6,11 +6,13 @@ import { ServiceLogo } from "@/components/ui/service-logo";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
+import { CheckingIndicator } from "@/components/ui/checking-indicator";
 import { HealthIssuesSheet } from "@/components/services/health-issues-sheet";
 import {
   useArrHealthSections,
   type ArrInstanceHealth,
 } from "@/hooks/use-arr-health";
+import { useManualRefresh } from "@/store/manual-refresh-store";
 import { SERVICE_DEFAULTS } from "@/lib/constants";
 import { lightHaptic } from "@/lib/haptics";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
@@ -20,7 +22,12 @@ import type { WidgetComponentProps } from "@/components/dashboard/widget-registr
 // (grouped by instance when a kind has more than one). Shows a clean "all
 // healthy" state otherwise so the widget is reassuring, not just an alarm.
 export function ArrHealthCard({ slotId }: WidgetComponentProps) {
-  const { sections, isLoading } = useArrHealthSections();
+  const { sections, isLoading, isFetching } = useArrHealthSections();
+  // Mirror the Services widget: show the "Checking…" indicator on the first
+  // load and during a user pull-to-refresh, but stay silent on the routine 30s
+  // background poll (which also flips isFetching) so the header doesn't blink (#196).
+  const manualRefreshing = useManualRefresh((s) => s.count > 0);
+  const determining = isLoading || (manualRefreshing && isFetching);
   const [sheet, setSheet] = useState<{
     serviceName: string;
     instances: ArrInstanceHealth[];
@@ -32,7 +39,10 @@ export function ArrHealthCard({ slotId }: WidgetComponentProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Health Alerts</CardTitle>
+        <View className="flex-row items-center gap-2">
+          <CardTitle>Health Alerts</CardTitle>
+          {determining ? <CheckingIndicator /> : null}
+        </View>
         {totalIssues > 0 ? (
           <Badge
             label={`${totalIssues}`}

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "expo-router";
 import { WifiOff } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ServiceLogo, hasServiceLogo } from "@/components/ui/service-logo";
-import { Spinner } from "@/components/ui/spinner";
+import { CheckingIndicator } from "@/components/ui/checking-indicator";
 import { StatusDot } from "@/components/ui/status-dot";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -49,8 +49,11 @@ interface RenderEntry {
   // (away from home / workspace pinned remote) but has no remote URL set — the
   // #168 case. Drives the away badge, which takes the L/R badge's corner.
   awayBlocked: boolean;
-  // True while the health batch is still settling and we have no verdict yet
-  // for this instance — render the dot as "checking" instead of red (#196).
+  // True while a probe is in flight for this instance and we want to surface it
+  // as activity: a cold start (no verdict yet) or an explicit re-check (pull to
+  // refresh, or a network/dashboard change). Renders the dot as a gray "checking"
+  // pulse over the lit logo. The silent 30s background poll is excluded so the
+  // dots don't flicker every interval (#196).
   checking: boolean;
 }
 
@@ -172,8 +175,10 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
         awayBlocked,
         // Away-blocked instances are deterministically offline-by-config (no
         // remote URL while remote-only), so they keep their red dot + away
-        // badge rather than a misleading "checking" pulse.
-        checking: determining && !health && !awayBlocked,
+        // badge rather than a misleading "checking" pulse. Otherwise mirror the
+        // title spinner: pulse gray whenever a probe is in flight (incl. pulling
+        // to refresh over a known verdict), not only when no verdict exists yet.
+        checking: determining && !awayBlocked,
       });
     }
   }
@@ -185,7 +190,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
       <CardHeader>
         <View className="flex-row items-center gap-2">
           <CardTitle>Services</CardTitle>
-          {determining ? <Spinner size={14} color="#71717a" /> : null}
+          {determining ? <CheckingIndicator /> : null}
         </View>
       </CardHeader>
       <View className="flex-row flex-wrap gap-4">
@@ -222,7 +227,12 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
                   <ServiceLogo
                     id={entry.kindId}
                     size={ICON.LG}
-                    online={entry.status !== "offline"}
+                    // While the probe batch is still settling we don't yet know
+                    // this instance's verdict, so keep the logo lit (the pulsing
+                    // "checking" dot carries the in-progress signal) instead of
+                    // dimming it to the offline look, so the grid doesn't read
+                    // as "everything offline" for ~15s on cold start (#196).
+                    online={entry.checking || entry.status !== "offline"}
                   />
                 </View>
                 {settings.showAwayBadge && entry.awayBlocked ? (

--- a/components/ui/checking-indicator.tsx
+++ b/components/ui/checking-indicator.tsx
@@ -1,0 +1,37 @@
+import { View, Text, ActivityIndicator, Platform } from "react-native";
+import { useUiScale } from "@/hooks/use-ui-scale";
+
+interface CheckingIndicatorProps {
+  label?: string;
+  color?: string;
+}
+
+// Inline "determining status" indicator: a spinner + a short label, shown in a
+// card/title header while a connectivity or health probe is in flight (#196).
+//
+// Deliberately uses React Native's NATIVE ActivityIndicator, NOT the reanimated
+// `Spinner`. The whole point of this issue is that the reanimated loader sat
+// FROZEN on a real iPhone (the original "spinner don't spin" report) and never
+// reliably animated even after the ReduceMotion.Never patch: a multi-second
+// pull-to-refresh window showed no visible motion. ActivityIndicator is drawn
+// and animated by the OS, so it always spins on iOS regardless of Reduce Motion,
+// Low Power Mode, or the New Architecture. The "Checking…" text is the belt to
+// that suspenders: even in a worst case the state is still legible.
+export function CheckingIndicator({
+  label = "Checking…",
+  color = "#a1a1aa",
+}: CheckingIndicatorProps) {
+  const scale = useUiScale();
+  return (
+    <View className="flex-row items-center gap-1.5">
+      <ActivityIndicator
+        // iOS clamps numeric sizes to small/large, so use "small" there; on
+        // Android pass a scaled pixel size so the glyph tracks the UI-scale
+        // setting like the rem-based "Checking…" text beside it.
+        size={Platform.OS === "android" ? Math.round(16 * scale) : "small"}
+        color={color}
+      />
+      <Text className="text-zinc-400 text-xs">{label}</Text>
+    </View>
+  );
+}

--- a/hooks/use-arr-health.ts
+++ b/hooks/use-arr-health.ts
@@ -50,6 +50,7 @@ interface ArrHealthTarget {
 export function useArrHealthSections(): {
   sections: ArrHealthSection[];
   isLoading: boolean;
+  isFetching: boolean;
 } {
   // Scope to the active dashboard, like every other fan-out widget. No
   // per-widget instance binding (yet), so the "all attached" default is used.
@@ -74,6 +75,11 @@ export function useArrHealthSections(): {
   });
 
   const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  // True whenever any instance's /health request is in flight (initial load,
+  // re-key, manual pull, or background poll). The widget gates its "Checking…"
+  // indicator on this together with the manual-refresh flag, so a routine poll
+  // stays silent while a pull-to-refresh reads clearly (#196).
+  const isFetching = queries.some((q) => q.isFetching);
 
   // Group instances-with-issues under their kind.
   const byKind = new Map<ArrHealthServiceId, ArrInstanceHealth[]>();
@@ -104,7 +110,7 @@ export function useArrHealthSections(): {
     ];
   });
 
-  return { sections, isLoading: isInitialLoading };
+  return { sections, isLoading: isInitialLoading, isFetching };
 }
 
 // Single-instance variant for a service screen's health banner: follows the


### PR DESCRIPTION
Makes the service-status "Checking…" indicator actually visible on iOS and extends it to the Health Alerts widget. The prior reanimated spinner sat frozen on a real iPhone, so it read as "no spinner" on app open and pull-to-refresh.

- Native ActivityIndicator + "Checking…" label (shared `CheckingIndicator`); the OS animates it, so it can't freeze under Reduce Motion, Low Power Mode, or the New Architecture.
- Service logos stay lit and dots pulse gray during any in-flight probe (cold start, pull-to-refresh, VPN/dashboard re-key). The silent 30s background poll keeps dots green, so no flicker between refreshes.
- Health Alerts widget gets the same indicator (`isFetching` surfaced from `useArrHealthSections`).

Test plan:
- Dev build on a physical iPhone: pull-to-refresh on Home shows "Checking…" + gray pulsing dots settling to green; force-quit + reopen shows the same on cold start; 30s poll stays green.
- `npx tsc --noEmit` clean.

Refs #196
