### PR TITLE
fix(http): surface auth-proxy login pages instead of crashing

### DIFF
--- a/components/common/monitored-library-grid.tsx
+++ b/components/common/monitored-library-grid.tsx
@@ -118,7 +118,11 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
   const { width: cellWidth, columns, gap } = usePosterCellLayout();
 
   const sorted = useMemo(() => {
-    if (!data) return [];
+    // Guard against a non-array slipping through (e.g. an auth-proxy HTML page
+    // returned in place of JSON): a truthy string would reach .filter and crash
+    // with "undefined is not a function". serviceRequest now throws on that, but
+    // keep the call site itself safe against any non-array data.
+    if (!Array.isArray(data)) return [];
     const filtered = data.filter((item) => {
       if (monitorFilter === "monitored") return item.monitored;
       if (monitorFilter === "unmonitored") return !item.monitored;

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -276,17 +276,18 @@ export function ReleasesPicker({
 
   const protocols = useMemo(() => {
     const set = new Set<string>();
-    data?.forEach((r) => set.add(r.protocol));
+    if (Array.isArray(data)) data.forEach((r) => set.add(r.protocol));
     return set;
   }, [data]);
 
   const qualityNames = useMemo(() => {
     const map = new Map<string, number>();
-    data?.forEach((r) => {
-      const name = r.quality?.quality?.name;
-      if (!name) return;
-      map.set(name, (map.get(name) ?? 0) + 1);
-    });
+    if (Array.isArray(data))
+      data.forEach((r) => {
+        const name = r.quality?.quality?.name;
+        if (!name) return;
+        map.set(name, (map.get(name) ?? 0) + 1);
+      });
     // Show only names with at least one entry; sort by count desc.
     return Array.from(map.entries())
       .sort((a, b) => b[1] - a[1])
@@ -294,7 +295,7 @@ export function ReleasesPicker({
   }, [data]);
 
   const filtered = useMemo(() => {
-    if (!data) return [];
+    if (!Array.isArray(data)) return [];
     let out = data;
     if (hideRejected) out = out.filter((r) => !r.rejected);
     if (protocolFilter !== "all")
@@ -315,7 +316,7 @@ export function ReleasesPicker({
     if (
       !flippedOnceRef.current &&
       prefHideRejected &&
-      data &&
+      Array.isArray(data) &&
       data.length > 0 &&
       data.every((r) => r.rejected)
     ) {

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -1,4 +1,9 @@
-import { serviceRequest, pingService } from "./http-client";
+import {
+  serviceRequest,
+  pingService,
+  testServiceConnection,
+  AuthProxyResponseError,
+} from "./http-client";
 
 // jest.mock factories run before module-scope code; the only refs allowed
 // inside are auto-imports + names prefixed with `mock`.
@@ -59,6 +64,7 @@ const FIXTURE_KINDS = [
   { id: "jellyfin", url: "http://jelly.local:8096", secrets: { apiKey: "jelly-token" } },
   { id: "emby", url: "http://emby.local:8096", secrets: { apiKey: "emby-token" } },
   { id: "glances", url: "http://glances.local:61208", secrets: { username: "u", password: "p" } },
+  { id: "rtorrent", url: "http://seedbox.local/RPC2", secrets: { username: "u", password: "p" } },
 ];
 
 function makeState(overrides: Partial<FakeState> = {}): FakeState {
@@ -332,5 +338,159 @@ describe("off-WiFi LAN guard — VPN awareness (#185)", () => {
     mockStateRef.current.isVpnActive = false;
     await serviceRequest("radarr", "/system/status");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// An auth proxy (Authentik/Authelia/…) in front of a service answers the app's
+// API-key-only requests with its own HTML login page. serviceRequest must throw
+// an actionable error instead of returning the HTML string, which would crash
+// downstream array methods with "undefined is not a function" (#239).
+describe("serviceRequest — auth-proxy HTML detection (#239)", () => {
+  let originalFetch: typeof global.fetch;
+  let fetchSpy: jest.Mock;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchSpy = fetchMock();
+    global.fetch = fetchSpy as any;
+    mockStateRef.current = makeState();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // A mock Response with sensible defaults; pass overrides per test.
+  function respond(over: Record<string, any>) {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      json: async () => ({}),
+      text: async () => "",
+      clone() {
+        return this;
+      },
+      ...over,
+    };
+  }
+
+  it("throws AuthProxyResponseError on a 2xx text/html login page", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        headers: new Headers({ "content-type": "text/html" }),
+        text: async () => "<!DOCTYPE html><html><body>Sign in</body></html>",
+      }),
+    );
+    await expect(serviceRequest("radarr", "/movie")).rejects.toBeInstanceOf(
+      AuthProxyResponseError,
+    );
+  });
+
+  it("sniffs the body when the content-type is missing or wrong", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        headers: new Headers(),
+        text: async () =>
+          '  <html lang="en"><head><title>authentik</title></head></html>',
+      }),
+    );
+    await expect(serviceRequest("radarr", "/movie")).rejects.toThrow(
+      /authentication proxy/i,
+    );
+  });
+
+  it("treats an HTML body on a 401 as an auth proxy too", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers({ "content-type": "text/html" }),
+        json: async () => {
+          throw new Error("not json");
+        },
+        text: async () => "<html>login</html>",
+      }),
+    );
+    await expect(serviceRequest("sonarr", "/series")).rejects.toBeInstanceOf(
+      AuthProxyResponseError,
+    );
+  });
+
+  it("still returns rtorrent's XML-RPC string (not mistaken for HTML)", async () => {
+    const xml =
+      '<?xml version="1.0"?><methodResponse><params><param><value><array><data></data></array></value></param></params></methodResponse>';
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        headers: new Headers({ "content-type": "text/xml" }),
+        text: async () => xml,
+      }),
+    );
+    await expect(
+      serviceRequest<string>("rtorrent", "", {
+        method: "POST",
+        headers: { "Content-Type": "text/xml" },
+        body: '<?xml version="1.0"?><methodCall></methodCall>',
+      }),
+    ).resolves.toBe(xml);
+  });
+
+  it("still parses a normal JSON response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ version: "5.0" }),
+      }),
+    );
+    await expect(serviceRequest("radarr", "/system/status")).resolves.toEqual({
+      version: "5.0",
+    });
+  });
+});
+
+// The connection test / health dots must not show green for a proxied service:
+// a 2xx that isn't JSON means we reached the proxy's login page, not the API.
+describe("testServiceConnection — auth-proxy detection (#239)", () => {
+  let originalFetch: typeof global.fetch;
+  let fetchSpy: jest.Mock;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchSpy = fetchMock();
+    global.fetch = fetchSpy as any;
+    mockStateRef.current = makeState();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("reports unreachable when the *arr probe gets HTML instead of JSON", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "content-type": "text/html" }),
+      json: async () => ({}),
+      text: async () => "<html></html>",
+      clone() {
+        return this;
+      },
+    });
+    const result = await testServiceConnection("radarr", {
+      url: "http://radarr.local:7878",
+      apiKey: "k",
+    });
+    expect(result.kind).toBe("unreachable");
+  });
+
+  it("reports ok when the *arr probe gets JSON (the default mock)", async () => {
+    const result = await testServiceConnection("radarr", {
+      url: "http://radarr.local:7878",
+      apiKey: "k",
+    });
+    expect(result.kind).toBe("ok");
   });
 });

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -87,6 +87,44 @@ export class HttpError extends Error {
   }
 }
 
+// An authentication proxy (Authentik, Authelia, Cloudflare Access, …) placed in
+// front of a service answers unauthenticated requests with its own HTML login
+// page instead of proxying through to the API. The app sends the service's API
+// key but holds no proxy session, so it receives that login page — often with a
+// 200, sometimes a 302/401/403. We detect it and throw this so the UI shows an
+// actionable message instead of crashing when downstream code runs array methods
+// on what it assumed was JSON (issue #239).
+export const AUTH_PROXY_MESSAGE =
+  "This service is behind an authentication proxy. The server returned an HTML " +
+  "login page instead of data, which usually means a reverse proxy like Authentik " +
+  "or Authelia is intercepting the request. Add an exception for this app's API " +
+  "path in your proxy, or send the proxy's auth headers under Custom Headers in " +
+  "the service settings.";
+
+export class AuthProxyResponseError extends HttpError {
+  constructor(status: number, statusText: string, url: string, body?: unknown) {
+    super(status, statusText, url, body);
+    this.name = "AuthProxyResponseError";
+    // Override the bare "HTTP 200 …" message HttpError builds with an actionable
+    // one. ErrorBanner/ErrorBoundary fall back to error.message (an HTML body is
+    // too long for getHttpErrorMessage to extract), so this is what users see;
+    // formatErrorForCopy still reports status + redacted URL + body for debugging.
+    this.message = AUTH_PROXY_MESSAGE;
+  }
+}
+
+// True when a response body is (or looks like) an HTML document rather than the
+// expected JSON/XML payload. Checks the content-type first, then cheaply sniffs
+// the body head so a proxy that mislabels or omits the content-type is still
+// caught. rtorrent's XML-RPC responses start with "<?xml" and never match here,
+// so the one legitimate non-JSON caller is unaffected.
+function looksLikeHtml(contentType: string | null, body: unknown): boolean {
+  if (contentType && contentType.toLowerCase().includes("text/html")) return true;
+  if (typeof body !== "string") return false;
+  const head = body.slice(0, 256).trimStart().toLowerCase();
+  return head.startsWith("<!doctype html") || head.startsWith("<html");
+}
+
 // *arr 4xx responses look like `{ message, description }` — surface that
 // message to the user when present, falling back to a string body, then to
 // the HTTP status line.
@@ -266,6 +304,8 @@ export async function serviceRequest<T>(
       signal: controller.signal,
     });
 
+    const contentType = response.headers.get("content-type");
+
     if (!response.ok) {
       // The body stream can only be read once — clone before trying JSON so
       // we can fall back to text() if the response isn't JSON.
@@ -273,15 +313,39 @@ export async function serviceRequest<T>(
       const errorBody = await response
         .json()
         .catch(() => clone.text().catch(() => undefined));
+      // A failing status whose body is an HTML login page is an auth proxy in
+      // front of the service, not the service itself — surface that.
+      if (looksLikeHtml(contentType, errorBody)) {
+        throw new AuthProxyResponseError(
+          response.status,
+          response.statusText,
+          url,
+          errorBody,
+        );
+      }
       throw new HttpError(response.status, response.statusText, url, errorBody);
     }
 
-    const contentType = response.headers.get("content-type");
     if (contentType?.includes("application/json")) {
       return (await response.json()) as T;
     }
 
-    return (await response.text()) as unknown as T;
+    // Not JSON. A 2xx HTML body is almost always an auth-proxy login page
+    // returned in place of the API response (issue #239): the request carried
+    // the service API key but no proxy session, so the proxy answered with its
+    // login page and a 200. Returning that string lets callers run array methods
+    // on it and crash with "undefined is not a function"; throw instead. Genuine
+    // non-JSON payloads (rtorrent's XML-RPC, which starts with <?xml) pass through.
+    const body = await response.text();
+    if (looksLikeHtml(contentType, body)) {
+      throw new AuthProxyResponseError(
+        response.status,
+        response.statusText,
+        url,
+        body,
+      );
+    }
+    return body as unknown as T;
   } finally {
     clearTimeout(timeoutId);
   }
@@ -820,7 +884,19 @@ async function runConnectionProbe(
         return { kind: "auth_failed", message: "Invalid API key" };
       if (res.status >= 500)
         return { kind: "unreachable", message: `Server error ${res.status}` };
-      if (res.ok) return { kind: "ok" };
+      if (res.ok) {
+        // A 200 that isn't JSON is almost always an auth-proxy login page
+        // standing in for the API (issue #239). Reporting "ok" here would light
+        // the health dot green and pass Test Connection, then crash the data
+        // screen — so flag the proxy instead.
+        const ct = res.headers.get("content-type");
+        if (ct?.toLowerCase().includes("application/json")) return { kind: "ok" };
+        return {
+          kind: "unreachable",
+          message:
+            "Got an HTML page instead of the API. The service may be behind an auth proxy (Authentik/Authelia) — exclude its API path from the proxy.",
+        };
+      }
       return { kind: "unreachable", message: `Unexpected status ${res.status}` };
     }
 


### PR DESCRIPTION
Refs #239

A service behind an auth proxy (Authentik/Authelia) returns its HTML login page with a 200 because the app sends only the API key, not a proxy session. `serviceRequest` returned that HTML as a string and the data grid then ran `.filter()` on it, crashing with "undefined is not a function".

## Changes
- `serviceRequest` throws `AuthProxyResponseError` on an HTML login page (2xx and 302/401/403), surfaced via the styled `ErrorBanner` with an actionable message. rtorrent XML-RPC is unaffected.
- *arr Test Connection / health probe now requires a JSON content-type, so a proxied service reports the proxy instead of showing false green.
- `Array.isArray` guards in `monitored-library-grid` and `releases-picker` as defense in depth.

## Test plan
- `npx jest lib/http-client.test.ts` (21 passed, 7 new)
- `npx tsc --noEmit` clean (excluding backend)