### PR TITLE
feat(plex): "Connect with Plex" sign-in

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -93,6 +93,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   plugins: [
     "expo-router",
     "expo-secure-store",
+    "expo-web-browser",
     "./plugins/withAndroidSigning",
     "./plugins/withCleartextTraffic",
     "./plugins/withDevVariant",

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { View, Text, BackHandler, Pressable, Linking, Platform } from "react-native";
 import * as Clipboard from "expo-clipboard";
+import * as WebBrowser from "expo-web-browser";
 import { router, useFocusEffect } from "expo-router";
 import { Image } from "expo-image";
 import { toast, toastError } from "@/components/ui/toast";
@@ -20,6 +21,7 @@ import {
   Bug,
   Heart,
   BookOpen,
+  LogIn,
 } from "lucide-react-native";
 import GithubLogo from "@/assets/services/github.svg";
 import { useUiScale } from "@/hooks/use-ui-scale";
@@ -44,6 +46,14 @@ import { testServiceConnection } from "@/lib/http-client";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import type { HealthStatusKind } from "@/lib/types";
 import { qbClearSession } from "@/services/qbittorrent-api";
+import { getPlexClientId } from "@/lib/plex-client-id";
+import {
+  requestPin,
+  buildAuthUrl,
+  pollPinForToken,
+  discoverServers,
+  type PlexServer,
+} from "@/services/plex-auth";
 import { SERVICE_IDS, SERVICE_DEFAULTS } from "@/lib/constants";
 import type { ServiceId } from "@/lib/constants";
 import {
@@ -972,6 +982,11 @@ function ServiceEditor({
     secrets.customHeaders ?? {},
   );
   const [testing, setTesting] = useState(false);
+  // "Connect with Plex" PIN-OAuth flow (Plex-only). The poll loop is cancelled
+  // on browser-dismiss and on editor unmount via this controller.
+  const [connecting, setConnecting] = useState(false);
+  const plexAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => plexAbortRef.current?.abort(), []);
 
   // Modal sequencing (unsaved sheet → save/discard, HTTP warning → save
   // continuation, delete/close → editor unmount) goes through the flow — see
@@ -983,6 +998,7 @@ function ServiceEditor({
     confirmDelete: void;
     addToDashboards: void;
     httpWarning: { message: string; resolve: (ok: boolean) => void };
+    serverPicker: PlexServer[];
   }>();
 
   const usesBasicAuth =
@@ -1185,6 +1201,100 @@ function ServiceEditor({
     }
   };
 
+  // Fill the in-progress form from a discovered server. The user still reviews
+  // and taps Save (consistent with manual entry), so this never writes directly.
+  const applyServer = (server: PlexServer) => {
+    setApiKey(server.accessToken);
+    setLocalUrl(server.localUrl);
+    setRemoteUrl(server.remoteUrl);
+    // Adopt the server's name only if the user hasn't given it a custom one.
+    setName((prev) =>
+      prev.trim().length === 0 || prev === SERVICE_DEFAULTS_KIND_LABEL[serviceId]
+        ? server.name
+        : prev,
+    );
+    toast(`Connected to ${server.name}`, "success");
+  };
+
+  // Discover servers from the approved token and either auto-fill (0/1 server)
+  // or present the picker (2+).
+  const finishPlexConnect = async (token: string, clientId: string) => {
+    try {
+      const servers = await discoverServers(token, clientId);
+      if (servers.length === 0) {
+        // Token is valid even without a discoverable server (custom proxy,
+        // offline server) — set it so manual URL entry still works.
+        setApiKey(token);
+        toast("Signed in, but no Plex servers found on this account", "error");
+        return;
+      }
+      if (servers.length === 1) {
+        applyServer(servers[0]);
+        return;
+      }
+      // Yield a macrotask so the in-app browser's view controller is fully gone
+      // before the ActionSheet presents (iOS two-VC hang, issue #83). The
+      // discovery network round-trip above usually covers this, but make it
+      // explicit.
+      await new Promise((resolve) => setTimeout(resolve, 16));
+      flow.open("serverPicker", servers);
+    } catch (e) {
+      toastError("Plex sign-in failed", e);
+    }
+  };
+
+  const handleConnectPlex = async () => {
+    if (connecting) return;
+    setConnecting(true);
+    const controller = new AbortController();
+    plexAbortRef.current = controller;
+    try {
+      const clientId = await getPlexClientId();
+      const pin = await requestPin(clientId);
+      const authUrl = buildAuthUrl(pin.code, clientId);
+      // Poll until the PIN is approved. We intentionally do NOT stop polling
+      // when the browser reports closed: expo-web-browser can signal "dismissed"
+      // before the user has finished approving (especially Android), which would
+      // kill the poll right before the token lands. The poll resolves the moment
+      // the approved token appears, or after the timeout.
+      const timeoutMs = pin.expiresIn
+        ? Math.min(pin.expiresIn * 1000, 300000)
+        : 300000;
+
+      // Open the approval page in the system in-app browser (SFSafariViewController
+      // / Chrome Custom Tabs). Unlike an embedded WebView, it shares the device's
+      // browser session, so "Sign in with Google/Apple" uses the account you're
+      // already signed into. This is how plezy and other mobile Plex clients do
+      // it. Fall back to the external browser if no in-app browser is available.
+      void WebBrowser.openBrowserAsync(authUrl).catch(() =>
+        Linking.openURL(authUrl).catch(() => {}),
+      );
+
+      const token = await pollPinForToken(pin.id, clientId, {
+        signal: controller.signal,
+        timeoutMs,
+      });
+
+      // Close the in-app browser if it's still up (token arrived via polling).
+      try {
+        WebBrowser.dismissBrowser();
+      } catch {
+        // no-op: nothing to dismiss
+      }
+
+      if (!token) {
+        toast("Plex sign-in timed out — please try again", "error");
+        return;
+      }
+      await finishPlexConnect(token, clientId);
+    } catch (e) {
+      toastError("Plex sign-in failed", e);
+    } finally {
+      plexAbortRef.current = null;
+      setConnecting(false);
+    }
+  };
+
   const performDelete = () => {
     flow.close();
     // The store write swaps this editor for the "not found" branch and
@@ -1277,6 +1387,20 @@ function ServiceEditor({
         <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
           Authentication
         </Text>
+        {serviceId === "plex" ? (
+          <View className="gap-2">
+            <Button
+              label="Connect with Plex"
+              onPress={() => void handleConnectPlex()}
+              loading={connecting}
+              icon={<Icon icon={LogIn} size={18} color="#fff" />}
+            />
+            <Text className="text-zinc-500 text-xs">
+              Sign in to auto-fill this server&apos;s URLs and token, or enter a
+              token manually below.
+            </Text>
+          </View>
+        ) : null}
         {usesBasicAuth ? (
           <>
             <TextInput
@@ -1403,6 +1527,18 @@ function ServiceEditor({
           flow.close();
           flow.whenClear(() => request?.resolve(false));
         }}
+      />
+
+      <ActionSheet
+        {...flow.bind("serverPicker")}
+        title="Choose your server"
+        subtitle="Pick which Plex server this connects to."
+        actions={(flow.payload("serverPicker") ?? []).map((server) => ({
+          label: server.name,
+          // Apply only once the sheet is fully dismissed — applyServer just sets
+          // form state, but staying consistent with the flow's onClosed rule.
+          onPress: () => flow.whenClear(() => applyServer(server)),
+        }))}
       />
     </ScreenWrapper>
   );

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -528,10 +528,11 @@ export async function testServiceConnection(
     }
     return result;
   } catch (err) {
-    if (
-      (err instanceof DOMException && err.name === "AbortError") ||
-      (err instanceof Error && err.name === "AbortError")
-    ) {
+    // AbortError = our 8s timeout fired. Note: don't reference `DOMException`
+    // here — it isn't a global in React Native's Hermes engine, so
+    // `err instanceof DOMException` throws "Property 'DOMException' doesn't
+    // exist". RN rejects aborted fetches with an Error named "AbortError".
+    if (err instanceof Error && err.name === "AbortError") {
       return { kind: "unreachable", message: "Request timed out" };
     }
     return {

--- a/lib/plex-client-id.ts
+++ b/lib/plex-client-id.ts
@@ -1,0 +1,24 @@
+import { getSecret, setSecret } from "@/store/storage";
+import { generateInstanceId } from "@/lib/uuid";
+
+// Plex ties a PIN → authToken → "Authorized Device" entry to the
+// X-Plex-Client-Identifier sent on every plex.tv call. It MUST be stable across
+// the PIN create, the poll, and the resources lookup (and ideally across app
+// launches, so re-connecting doesn't spawn a new device entry each time). We
+// persist one UUID in SecureStore — mirrors store/backend-store.ts's deviceId.
+const PLEX_CLIENT_ID_KEY = "plex.clientId";
+
+let cached: string | null = null;
+
+export async function getPlexClientId(): Promise<string> {
+  if (cached) return cached;
+  const existing = await getSecret(PLEX_CLIENT_ID_KEY);
+  if (existing && existing.length > 0) {
+    cached = existing;
+    return existing;
+  }
+  const fresh = generateInstanceId();
+  await setSecret(PLEX_CLIENT_ID_KEY, fresh);
+  cached = fresh;
+  return fresh;
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "expo-status-bar": "~3.0.9",
     "expo-system-ui": "^55.0.18",
     "expo-updates": "~29.0.16",
+    "expo-web-browser": "~15.0.11",
     "fast-xml-parser": "^5.8.0",
     "lucide-react-native": "^1.7.0",
     "nativewind": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33)(react-refresh@0.14.2)
       expo:
         specifier: '54'
-        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-application:
         specifier: ~7.0.8
         version: 7.0.8(expo@54.0.33)
@@ -104,6 +104,9 @@ importers:
       expo-updates:
         specifier: ~29.0.16
         version: 29.0.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-web-browser:
+        specifier: ~15.0.11
+        version: 15.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       fast-xml-parser:
         specifier: ^5.8.0
         version: 5.8.0
@@ -2621,6 +2624,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-web-browser@15.0.11:
+    resolution: {integrity: sha512-r2LS4Ro6DgUPZkcaEfgt8mp9eJuoA93x11Jh7S6utFe0FEzvUNn2yFhxg8XVwESaaHGt2k5V8LuK36rsp0BeIw==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo@54.0.33:
     resolution: {integrity: sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==}
     hasBin: true
@@ -4117,6 +4126,12 @@ packages:
   react-native-udp@4.1.7:
     resolution: {integrity: sha512-NUE3zewu61NCdSsLlj+l0ad6qojcVEZPT4hVG/x6DU9U4iCzwtfZSASh9vm7teAcVzLkdD+cO3411LHshAi/wA==}
 
+  react-native-webview@13.15.0:
+    resolution: {integrity: sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-worklets@0.5.1:
     resolution: {integrity: sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==}
     peerDependencies:
@@ -5571,7 +5586,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       env-editor: 0.4.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 1.0.5
       freeport-async: 2.0.0
       getenv: 2.0.0
@@ -5738,7 +5753,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5747,7 +5762,7 @@ snapshots:
   '@expo/metro-runtime@6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       anser: 1.4.10
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       pretty-format: 29.7.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
@@ -5805,7 +5820,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -6958,7 +6973,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -7512,12 +7527,12 @@ snapshots:
 
   expo-application@7.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-asset@12.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.9.3)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
@@ -7527,20 +7542,20 @@ snapshots:
 
   expo-blur@15.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   expo-camera@17.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   expo-clipboard@55.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
@@ -7548,7 +7563,7 @@ snapshots:
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -7556,11 +7571,11 @@ snapshots:
   expo-crypto@15.0.8(expo@54.0.33):
     dependencies:
       base64-js: 1.5.1
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-dev-client@6.0.20(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-dev-launcher: 6.0.20(expo@54.0.33)
       expo-dev-menu: 7.0.18(expo@54.0.33)
       expo-dev-menu-interface: 2.0.0(expo@54.0.33)
@@ -7572,7 +7587,7 @@ snapshots:
   expo-dev-launcher@6.0.20(expo@54.0.33):
     dependencies:
       ajv: 8.18.0
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-dev-menu: 7.0.18(expo@54.0.33)
       expo-manifests: 1.0.10(expo@54.0.33)
     transitivePeerDependencies:
@@ -7580,38 +7595,38 @@ snapshots:
 
   expo-dev-menu-interface@2.0.0(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-dev-menu@7.0.18(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-dev-menu-interface: 2.0.0(expo@54.0.33)
 
   expo-document-picker@14.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-eas-client@1.0.8: {}
 
   expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   expo-haptics@15.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-image@3.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
@@ -7619,12 +7634,12 @@ snapshots:
 
   expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
 
   expo-linear-gradient@15.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
@@ -7640,17 +7655,17 @@ snapshots:
 
   expo-local-authentication@17.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       invariant: 2.2.4
 
   expo-location@19.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-manifests@1.0.10(expo@54.0.33):
     dependencies:
       '@expo/config': 12.0.13
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-json-utils: 0.15.0
     transitivePeerDependencies:
       - supports-color
@@ -7676,7 +7691,7 @@ snapshots:
       abort-controller: 3.0.0
       assert: 2.1.0
       badgin: 1.2.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-application: 7.0.8(expo@54.0.33)
       expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
@@ -7697,7 +7712,7 @@ snapshots:
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
@@ -7729,18 +7744,18 @@ snapshots:
 
   expo-secure-store@15.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-server@1.0.5: {}
 
   expo-sharing@14.0.8(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-splash-screen@31.0.13(expo@54.0.33)(typescript@5.9.3):
     dependencies:
       '@expo/prebuild-config': 54.0.8(expo@54.0.33)(typescript@5.9.3)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7757,14 +7772,14 @@ snapshots:
     dependencies:
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
   expo-updates-interface@2.0.0(expo@54.0.33):
     dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-updates@29.0.16(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -7774,7 +7789,7 @@ snapshots:
       arg: 4.1.0
       chalk: 4.1.2
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-eas-client: 1.0.8
       expo-manifests: 1.0.10(expo@54.0.33)
       expo-structured-headers: 5.0.0
@@ -7788,7 +7803,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  expo-web-browser@15.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  expo@54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
       '@expo/cli': 54.0.23(expo-router@6.0.23)(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(typescript@5.9.3)
@@ -7815,6 +7835,7 @@ snapshots:
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-webview: 13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -8340,7 +8361,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       jest-environment-jsdom: 29.7.0(canvas@3.2.3)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
@@ -9681,6 +9702,14 @@ snapshots:
     dependencies:
       buffer: 5.7.1
       events: 3.3.0
+
+  react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      escape-string-regexp: 4.0.0
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    optional: true
 
   react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/services/plex-auth.test.ts
+++ b/services/plex-auth.test.ts
@@ -1,0 +1,125 @@
+import { buildAuthUrl, discoverServers } from "./plex-auth";
+
+function mockFetchOnce(body: unknown, init?: { ok?: boolean; status?: number }) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+const CLIENT_ID = "client-123";
+const ACCOUNT_TOKEN = "account-tok";
+
+describe("buildAuthUrl", () => {
+  it("encodes params in the URL fragment with the nested context key", () => {
+    const url = buildAuthUrl("pin-code", CLIENT_ID, "dashboarr://plex-auth");
+    expect(url.startsWith("https://app.plex.tv/auth#?")).toBe(true);
+    expect(url).toContain("clientID=client-123");
+    expect(url).toContain("code=pin-code");
+    // context[device][product] must be percent-encoded
+    expect(url).toContain("context%5Bdevice%5D%5Bproduct%5D=Dashboarr");
+    expect(url).toContain(
+      "forwardUrl=" + encodeURIComponent("dashboarr://plex-auth"),
+    );
+  });
+
+  it("omits forwardUrl when no redirect is given (the WebView flow default)", () => {
+    const url = buildAuthUrl("pin-code", CLIENT_ID);
+    expect(url).toContain("clientID=client-123");
+    expect(url).not.toContain("forwardUrl");
+  });
+});
+
+describe("discoverServers", () => {
+  it("keeps only resources that provide a server", async () => {
+    mockFetchOnce([
+      { name: "A player", clientIdentifier: "p1", provides: "player", owned: true, connections: [] },
+      {
+        name: "My PMS",
+        clientIdentifier: "s1",
+        provides: "server,player",
+        owned: true,
+        accessToken: "tok-s1",
+        connections: [],
+      },
+    ]);
+    const servers = await discoverServers(ACCOUNT_TOKEN, CLIENT_ID);
+    expect(servers.map((s) => s.name)).toEqual(["My PMS"]);
+  });
+
+  it("maps local→localUrl, public direct→remoteUrl, preferring https and IPv4", async () => {
+    mockFetchOnce([
+      {
+        name: "Homelab",
+        clientIdentifier: "s1",
+        provides: "server",
+        owned: true,
+        accessToken: "tok-s1",
+        connections: [
+          { protocol: "http", address: "192.168.1.10", port: 32400, uri: "http://192.168.1.10:32400", local: true, relay: false, IPv6: false },
+          { protocol: "https", address: "192.168.1.10", port: 32400, uri: "https://192-168-1-10.abc.plex.direct:32400", local: true, relay: false, IPv6: false },
+          { protocol: "https", address: "fe80::1", port: 32400, uri: "https://[fe80::1]:32400", local: false, relay: false, IPv6: true },
+          { protocol: "https", address: "1.2.3.4", port: 32400, uri: "https://1-2-3-4.abc.plex.direct:32400", local: false, relay: false, IPv6: false },
+          { protocol: "https", address: "relay", port: 443, uri: "https://relay.plex.direct:443", local: false, relay: true, IPv6: false },
+        ],
+      },
+    ]);
+    const [s] = await discoverServers(ACCOUNT_TOKEN, CLIENT_ID);
+    expect(s.localUrl).toBe("https://192-168-1-10.abc.plex.direct:32400"); // https over http
+    expect(s.remoteUrl).toBe("https://1-2-3-4.abc.plex.direct:32400"); // IPv4 over IPv6
+    expect(s.accessToken).toBe("tok-s1"); // per-resource token
+  });
+
+  it("prefers a reachable home-LAN address over a Docker bridge address for local", async () => {
+    mockFetchOnce([
+      {
+        name: "Dockerized",
+        clientIdentifier: "s4",
+        provides: "server",
+        owned: true,
+        accessToken: "tok-s4",
+        connections: [
+          { protocol: "https", address: "172.21.0.1", port: 32400, uri: "https://172-21-0-1.abc.plex.direct:32400", local: true, relay: false, IPv6: false },
+          { protocol: "https", address: "192.168.1.50", port: 32400, uri: "https://192-168-1-50.abc.plex.direct:32400", local: true, relay: false, IPv6: false },
+        ],
+      },
+    ]);
+    const [s] = await discoverServers(ACCOUNT_TOKEN, CLIENT_ID);
+    expect(s.localUrl).toBe("https://192-168-1-50.abc.plex.direct:32400");
+  });
+
+  it("falls back to a relay connection for remoteUrl when no direct public one exists", async () => {
+    mockFetchOnce([
+      {
+        name: "RelayOnly",
+        clientIdentifier: "s2",
+        provides: "server",
+        owned: true,
+        accessToken: "tok-s2",
+        connections: [
+          { protocol: "http", address: "10.0.0.5", port: 32400, uri: "http://10.0.0.5:32400", local: true, relay: false, IPv6: false },
+          { protocol: "https", address: "relay", port: 443, uri: "https://relay.plex.direct:443", local: false, relay: true, IPv6: false },
+        ],
+      },
+    ]);
+    const [s] = await discoverServers(ACCOUNT_TOKEN, CLIENT_ID);
+    expect(s.localUrl).toBe("http://10.0.0.5:32400");
+    expect(s.remoteUrl).toBe("https://relay.plex.direct:443");
+  });
+
+  it("falls back to the account token when a resource omits its accessToken", async () => {
+    mockFetchOnce([
+      { name: "NoTok", clientIdentifier: "s3", provides: "server", owned: true, connections: [] },
+    ]);
+    const [s] = await discoverServers(ACCOUNT_TOKEN, CLIENT_ID);
+    expect(s.accessToken).toBe(ACCOUNT_TOKEN);
+    expect(s.localUrl).toBe("");
+    expect(s.remoteUrl).toBe("");
+  });
+
+  it("throws on a non-OK discovery response", async () => {
+    mockFetchOnce([], { ok: false, status: 401 });
+    await expect(discoverServers(ACCOUNT_TOKEN, CLIENT_ID)).rejects.toThrow(/401/);
+  });
+});

--- a/services/plex-auth.ts
+++ b/services/plex-auth.ts
@@ -1,0 +1,274 @@
+import { Platform } from "react-native";
+import { NATIVE_VERSION } from "@/lib/app-version";
+
+// Client-side Plex PIN OAuth + server discovery. No backend, no app
+// registration with Plex — this is the public flow documented at
+// https://forums.plex.tv/t/authenticating-with-plex/609370. The X-Plex-Product
+// here is just the label shown on the approval screen and in
+// plex.tv → Authorized Devices.
+//
+// Flow: requestPin() → open buildAuthUrl() in a browser → pollPinForToken()
+// until the user approves → discoverServers() to auto-fill the URLs. All calls
+// reuse one stable X-Plex-Client-Identifier (see lib/plex-client-id.ts).
+
+const PLEX_TV = "https://plex.tv/api/v2";
+const PLEX_AUTH_APP = "https://app.plex.tv/auth";
+const PLEX_PRODUCT = "Dashboarr";
+const PLEX_PLATFORM = Platform.OS === "ios" ? "iOS" : "Android";
+
+const REQUEST_TIMEOUT_MS = 15000;
+
+export interface PlexPin {
+  id: number;
+  code: string;
+  /** Seconds until the PIN expires (Plex default ~1800). */
+  expiresIn?: number;
+}
+
+export interface PlexServer {
+  name: string;
+  clientIdentifier: string;
+  owned: boolean;
+  /** Per-server token — the one the PMS accepts, distinct from the account
+   * token for shared/non-owned servers. Stored as the instance's apiKey. */
+  accessToken: string;
+  localUrl: string;
+  remoteUrl: string;
+}
+
+interface PlexPinResponse {
+  id: number;
+  code: string;
+  authToken: string | null;
+  expiresIn?: number;
+}
+
+interface PlexConnection {
+  protocol: string; // "http" | "https"
+  address: string;
+  port: number;
+  uri: string;
+  local: boolean;
+  relay: boolean;
+  IPv6: boolean;
+}
+
+interface PlexResource {
+  name: string;
+  clientIdentifier: string;
+  provides: string; // CSV, e.g. "server" or "server,player"
+  owned: boolean;
+  accessToken?: string;
+  connections?: PlexConnection[];
+}
+
+// The X-Plex-* identity headers Plex reads to attribute the device. Sent as
+// headers (not query) so the product/version never lands in a logged URL.
+function plexHeaders(clientId: string, extra?: Record<string, string>): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "X-Plex-Product": PLEX_PRODUCT,
+    "X-Plex-Version": NATIVE_VERSION,
+    "X-Plex-Client-Identifier": clientId,
+    "X-Plex-Platform": PLEX_PLATFORM,
+    "X-Plex-Device": PLEX_PLATFORM,
+    "X-Plex-Device-Name": PLEX_PRODUCT,
+    ...extra,
+  };
+}
+
+async function plexFetch(
+  url: string,
+  init: RequestInit,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  // Forward an external cancel (browser dismissed) onto our timeout-bound signal.
+  const onAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", onAbort);
+  }
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+    if (signal) signal.removeEventListener("abort", onAbort);
+  }
+}
+
+/** Create a PIN. strong=true returns a long opaque code suited to app flows. */
+export async function requestPin(clientId: string): Promise<PlexPin> {
+  const res = await plexFetch(`${PLEX_TV}/pins?strong=true`, {
+    method: "POST",
+    headers: plexHeaders(clientId),
+  });
+  if (!res.ok) throw new Error(`Plex PIN request failed (HTTP ${res.status})`);
+  const data = (await res.json()) as PlexPinResponse;
+  return { id: data.id, code: data.code, expiresIn: data.expiresIn };
+}
+
+/**
+ * The user-facing approval URL. Params live in the URL fragment and
+ * context[device][product] must be percent-encoded. We render this inside an
+ * in-app WebView (not a redirect-based browser flow), and the token always
+ * comes from polling — so forwardUrl is optional and omitted by default to
+ * avoid the page trying to redirect away once the user approves.
+ */
+export function buildAuthUrl(
+  code: string,
+  clientId: string,
+  redirectUrl?: string,
+): string {
+  const params = [
+    `clientID=${encodeURIComponent(clientId)}`,
+    `code=${encodeURIComponent(code)}`,
+    `context%5Bdevice%5D%5Bproduct%5D=${encodeURIComponent(PLEX_PRODUCT)}`,
+  ];
+  if (redirectUrl) params.push(`forwardUrl=${encodeURIComponent(redirectUrl)}`);
+  return `${PLEX_AUTH_APP}#?${params.join("&")}`;
+}
+
+interface PollOptions {
+  signal: AbortSignal;
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+/**
+ * Poll the PIN until the user approves it. Returns the account authToken, or
+ * null if the caller aborts (browser dismissed) or the foreground timeout
+ * elapses. Throws if the PIN expired/was consumed server-side (404).
+ */
+export async function pollPinForToken(
+  pinId: number,
+  clientId: string,
+  { signal, intervalMs = 2000, timeoutMs = 120000 }: PollOptions,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (!signal.aborted && Date.now() < deadline) {
+    let res: Response;
+    try {
+      res = await plexFetch(
+        `${PLEX_TV}/pins/${pinId}`,
+        { method: "GET", headers: plexHeaders(clientId) },
+        signal,
+      );
+    } catch {
+      // External cancel (browser dismissed) → clean stop. A per-request
+      // timeout / network blip → wait and retry until the deadline.
+      if (signal.aborted) return null;
+      if (await sleepOrAbort(intervalMs, signal)) return null;
+      continue;
+    }
+    if (res.status === 404) throw new Error("Plex PIN expired — please try again");
+    if (res.ok) {
+      const data = (await res.json()) as PlexPinResponse;
+      if (data.authToken) return data.authToken;
+    }
+    // Wait before the next poll, but wake immediately on cancel.
+    if (await sleepOrAbort(intervalMs, signal)) return null;
+  }
+  return null;
+}
+
+/** Discover the account's Plex Media Servers and map each to local/remote URLs. */
+export async function discoverServers(
+  authToken: string,
+  clientId: string,
+): Promise<PlexServer[]> {
+  const res = await plexFetch(`${PLEX_TV}/resources?includeHttps=1&includeRelay=1`, {
+    method: "GET",
+    headers: plexHeaders(clientId, { "X-Plex-Token": authToken }),
+  });
+  if (!res.ok) throw new Error(`Plex server discovery failed (HTTP ${res.status})`);
+  const resources = (await res.json()) as PlexResource[];
+  return resources
+    .filter((r) => providesServer(r.provides))
+    .map((r) => {
+      const { localUrl, remoteUrl } = deriveUrls(r.connections ?? []);
+      return {
+        name: r.name,
+        clientIdentifier: r.clientIdentifier,
+        owned: r.owned,
+        // Per-server accessToken is correct for shared servers; fall back to
+        // the account token for owned servers that omit it.
+        accessToken: r.accessToken ?? authToken,
+        localUrl,
+        remoteUrl,
+      };
+    });
+}
+
+function providesServer(provides: string | undefined): boolean {
+  return (provides ?? "")
+    .split(",")
+    .map((p) => p.trim())
+    .includes("server");
+}
+
+// One localUrl + one remoteUrl per instance (the model holds a single pair, and
+// getActiveUrl switches between them by home/away network state). Prefer https
+// over http and IPv4 over IPv6; use Plex's provided `uri` verbatim so the
+// *.plex.direct wildcard TLS cert stays valid.
+function deriveUrls(connections: PlexConnection[]): {
+  localUrl: string;
+  remoteUrl: string;
+} {
+  const local = connections.filter((c) => c.local && !c.relay);
+  const remote = connections.filter((c) => !c.local && !c.relay);
+  const relay = connections.filter((c) => c.relay);
+
+  // For local, also weigh which address a phone on home Wi-Fi can actually
+  // reach — Plex-in-Docker frequently advertises a 172.16–31.x bridge address.
+  const localPick = pickConnection(local, true);
+  const remotePick = pickConnection(remote) ?? pickConnection(relay);
+  return {
+    localUrl: localPick?.uri ?? "",
+    remoteUrl: remotePick?.uri ?? "",
+  };
+}
+
+// Lower is better. Plex-in-Docker commonly advertises a 172.16–31.x bridge
+// address that's only reachable inside the container host; rank real home-LAN
+// ranges (192.168.x / 10.x) ahead of it so auto-fill prefers a reachable URL
+// when Plex offers more than one local connection.
+function lanReachRank(address: string): number {
+  if (/^(192\.168\.|10\.)/.test(address)) return 0;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(address)) return 2; // Docker-likely
+  return 1;
+}
+
+function connScore(c: PlexConnection, preferLan: boolean): number {
+  return (
+    (preferLan ? lanReachRank(c.address) * 100 : 0) +
+    (c.protocol === "https" ? 0 : 10) + // https (valid plex.direct cert)
+    (c.IPv6 ? 1 : 0) // IPv4 preferred
+  );
+}
+
+function pickConnection(
+  conns: PlexConnection[],
+  preferLan = false,
+): PlexConnection | undefined {
+  if (conns.length === 0) return undefined;
+  return [...conns].sort(
+    (a, b) => connScore(a, preferLan) - connScore(b, preferLan),
+  )[0];
+}
+
+// Resolves true if the wait was cut short by an abort, false if it elapsed.
+function sleepOrAbort(ms: number, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(false);
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    signal.addEventListener("abort", onAbort);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a **Connect with Plex** button: PIN OAuth via the system in-app browser (Google/Apple SSO works), polls plex.tv for the token, then auto-discovers servers and fills the local/remote URLs.
- Local-connection picker prefers reachable home-LAN addresses over Docker bridge IPs.
- Manual API key + URL entry kept as a fallback.
- Fixes a latent crash: `testServiceConnection` referenced `DOMException`, which is not a global in React Native (Hermes).

## Test plan
- `tsc --noEmit` clean; full `jest` suite (695 tests) passes, incl. new `services/plex-auth.test.ts` (8 tests).
- Verified on device: connect -> approve in browser -> token -> server auto-fill -> Test Connection green.