### PR TITLE
fix(qbittorrent): support newer WebUI authentication

### DIFF
--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "test": "tsx --test src/types.test.ts",
+    "test": "tsx --test src/types.test.ts src/services/qbittorrent.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/backend/dashboarr-backend/src/services/http.ts
+++ b/backend/dashboarr-backend/src/services/http.ts
@@ -38,7 +38,7 @@ export function activeBaseUrl(config: StoredServiceConfig): string {
 // `new URL("/api/v3", base)` discards base.pathname per spec, which breaks
 // reverse-proxy bases like http://host/radarr. Concatenate explicitly so the
 // proxy prefix survives, then parse to attach searchParams.
-function buildUrl(
+export function buildUrl(
   baseUrl: string,
   apiBase: string,
   path: string,

--- a/backend/dashboarr-backend/src/services/qbittorrent.test.ts
+++ b/backend/dashboarr-backend/src/services/qbittorrent.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractSessionCookie, interpretLoginResponse } from "./qbittorrent.js";
+
+// The real Set-Cookie a qBittorrent 5.2.x instance returned (issue #246).
+const QBT_5_2 =
+  "QBT_SID_8080=fDLLe+7+1AxYgftpduTLJIgE51T4ioYW; HttpOnly; SameSite=Lax; expires=Fri, 26-Jun-2026 19:46:32 GMT; path=/";
+const QBT_5_2_PAIR = "QBT_SID_8080=fDLLe+7+1AxYgftpduTLJIgE51T4ioYW";
+const AUTH_BYPASS_SENTINEL = "__qbt_no_cookie__";
+
+test("extractSessionCookie: 5.2.0+ QBT_SID_<port> returns the full name=value", () => {
+  assert.equal(extractSessionCookie([QBT_5_2]), QBT_5_2_PAIR);
+});
+
+test("extractSessionCookie: legacy SID cookie", () => {
+  assert.equal(extractSessionCookie(["SID=abc123; HttpOnly; path=/"]), "SID=abc123");
+});
+
+test("extractSessionCookie: preserves +, / and = padding in the value", () => {
+  assert.equal(extractSessionCookie(["QBT_SID_9090=aB+c/d=; path=/"]), "QBT_SID_9090=aB+c/d=");
+});
+
+test("extractSessionCookie: ignores non-session cookies (no JSESSIONID false positive)", () => {
+  assert.equal(extractSessionCookie(["JSESSIONID=xyz; path=/"]), null);
+  assert.equal(extractSessionCookie(["XSRF-TOKEN=abc"]), null);
+});
+
+test("extractSessionCookie: order-independent when a proxy cookie comes first", () => {
+  assert.equal(extractSessionCookie(["XSRF-TOKEN=proxy; path=/", QBT_5_2]), QBT_5_2_PAIR);
+});
+
+test("extractSessionCookie: empty list -> null", () => {
+  assert.equal(extractSessionCookie([]), null);
+});
+
+test("interpretLoginResponse: 204 + cookie -> ok(pair)", () => {
+  assert.deepEqual(interpretLoginResponse(204, "", [QBT_5_2]), {
+    kind: "ok",
+    cookie: QBT_5_2_PAIR,
+  });
+});
+
+test("interpretLoginResponse: 204 + no cookie -> ok(bypass sentinel)", () => {
+  assert.deepEqual(interpretLoginResponse(204, "", []), {
+    kind: "ok",
+    cookie: AUTH_BYPASS_SENTINEL,
+  });
+});
+
+test("interpretLoginResponse: 200 'Ok.' + cookie -> ok(pair) (legacy)", () => {
+  assert.deepEqual(interpretLoginResponse(200, "Ok.", ["SID=abc; path=/"]), {
+    kind: "ok",
+    cookie: "SID=abc",
+  });
+});
+
+test("interpretLoginResponse: 200 'Ok.' + no cookie -> ok(bypass sentinel)", () => {
+  assert.deepEqual(interpretLoginResponse(200, "Ok.", []), {
+    kind: "ok",
+    cookie: AUTH_BYPASS_SENTINEL,
+  });
+});
+
+test("interpretLoginResponse: 200 'Fails.' -> rejected", () => {
+  assert.deepEqual(interpretLoginResponse(200, "Fails.", []), { kind: "rejected" });
+});
+
+test("interpretLoginResponse: auth-proxy HTML login page (no cookie) -> rejected", () => {
+  assert.deepEqual(interpretLoginResponse(200, "<html>login</html>", []), { kind: "rejected" });
+});
+
+test("interpretLoginResponse: unexpected body but valid cookie -> ok (cookie authoritative)", () => {
+  assert.deepEqual(interpretLoginResponse(200, "weird", [QBT_5_2]), {
+    kind: "ok",
+    cookie: QBT_5_2_PAIR,
+  });
+});

--- a/backend/dashboarr-backend/src/services/qbittorrent.ts
+++ b/backend/dashboarr-backend/src/services/qbittorrent.ts
@@ -53,12 +53,19 @@ async function login(config: StoredServiceConfig): Promise<string> {
   });
 
   if (!res.ok) throw new Error(`qBittorrent login HTTP ${res.status}`);
-  const text = await res.text();
-  if (text !== "Ok.") throw new Error("qBittorrent login rejected");
+  const text = (await res.text()).trim();
+  // Older qBittorrent versions return HTTP 200 with "Ok."
+  // Newer versions may return HTTP 204 No Content.
+  if (res.status !== 204 && text !== "" && text !== "Ok.") {
+    throw new Error(`qBittorrent login rejected: ${text || "<empty response>"}`);
+  }
 
   const setCookie = res.headers.get("set-cookie") ?? "";
-  const match = setCookie.match(/SID=([^;]+)/);
-  if (!match || !match[1]) throw new Error("qBittorrent login missing SID cookie");
+  // Accept any session cookie name (SID, QBT_SID, QBT_SID_8080, ...)
+  const match = setCookie.match(/^([^=]+=[^;]+)/);
+  if (!match) {
+    throw new Error("qBittorrent login missing session cookie");
+  }
   return match[1];
 }
 
@@ -77,8 +84,8 @@ async function qbFetch<T>(config: StoredServiceConfig, path: string): Promise<T>
   const url = `${base}${apiBase}${path}`;
   let cookie = await ensureCookie(config);
 
-  const doFetch = (c: string) =>
-    fetch(url, { headers: { Cookie: `SID=${c}` } });
+const doFetch = (cookie: string) =>
+    fetch(url, {headers: { Cookie: cookie,},});
 
   let res = await doFetch(cookie);
   if (res.status === 403) {

--- a/backend/dashboarr-backend/src/services/qbittorrent.ts
+++ b/backend/dashboarr-backend/src/services/qbittorrent.ts
@@ -1,6 +1,6 @@
 import type { StoredServiceConfig } from "../db/repos/config.js";
 import { SERVICE_API_BASE } from "../types.js";
-import { activeBaseUrl } from "./http.js";
+import { activeBaseUrl, buildUrl } from "./http.js";
 
 // qBittorrent 5.0 renamed `pausedUP`/`pausedDL` to `stoppedUP`/`stoppedDL`.
 export type TorrentState =
@@ -33,12 +33,59 @@ export interface QBTorrent {
   category: string;
 }
 
-// Simple in-process session cookie cache keyed by `<baseUrl>`.
+// Simple in-process session cookie cache keyed by `<baseUrl>|<username>`. The
+// cached value is the verbatim `name=value` cookie to resend, or the sentinel
+// below when the server authenticates this client without a cookie.
 const sessionCookies = new Map<string, { cookie: string; expiresAt: number }>();
 const COOKIE_TTL_MS = 30 * 60 * 1000;
 
+// Login succeeded but qBittorrent issued no session cookie. This happens when
+// the server bypasses auth for the client ("Bypass authentication for clients
+// on localhost / in whitelisted subnets"); qbFetch then sends no Cookie header.
+const AUTH_BYPASS_SENTINEL = "__qbt_no_cookie__";
+
 function cookieKey(config: StoredServiceConfig): string {
   return `${activeBaseUrl(config)}|${config.username ?? ""}`;
+}
+
+/**
+ * Pick qBittorrent's session cookie out of a Set-Cookie list and return the
+ * verbatim `name=value` token (everything up to the first `;`) so it can be
+ * resent unchanged. qBittorrent 5.2.0+ names the cookie `QBT_SID_<webui_port>`
+ * (e.g. `QBT_SID_8080`); older builds used `SID`. Matching by those names
+ * ignores any cookies a reverse proxy may have injected (JSESSIONID, XSRF-TOKEN,
+ * ...) and is independent of header order. Returns null when none is present.
+ */
+export function extractSessionCookie(setCookieList: string[]): string | null {
+  for (const raw of setCookieList) {
+    const pair = (raw.split(";", 1)[0] ?? "").trim();
+    const name = (pair.split("=", 1)[0] ?? "").trim();
+    if (name === "SID" || name.startsWith("QBT_SID_")) return pair;
+  }
+  return null;
+}
+
+/**
+ * Decide, from a 2xx `/auth/login` response, whether we're authenticated and
+ * what to cache: the `name=value` cookie to resend, or AUTH_BYPASS_SENTINEL when
+ * login succeeded without a cookie. `body` is "" for a 204 (No Content).
+ */
+export function interpretLoginResponse(
+  status: number,
+  body: string,
+  setCookieList: string[],
+): { kind: "ok"; cookie: string } | { kind: "rejected" } {
+  // A rejected login replies 200 "Fails.".
+  if (body.trim() === "Fails.") return { kind: "rejected" };
+
+  const cookie = extractSessionCookie(setCookieList);
+  // Success signals: 204 No Content (5.2.0+), 200 "Ok." (older builds), or a
+  // session cookie regardless of body (the cookie is authoritative). Anything
+  // else (e.g. an auth-proxy HTML login page) is treated as a rejection.
+  const success = status === 204 || body.trim() === "Ok." || cookie !== null;
+  if (!success) return { kind: "rejected" };
+
+  return { kind: "ok", cookie: cookie ?? AUTH_BYPASS_SENTINEL };
 }
 
 async function login(config: StoredServiceConfig): Promise<string> {
@@ -46,27 +93,20 @@ async function login(config: StoredServiceConfig): Promise<string> {
   if (!base) throw new Error("qBittorrent URL not configured");
   const apiBase = SERVICE_API_BASE.qbittorrent;
 
-  const res = await fetch(`${base}${apiBase}/auth/login`, {
+  const res = await fetch(buildUrl(base, apiBase, "/auth/login"), {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: `username=${encodeURIComponent(config.username ?? "")}&password=${encodeURIComponent(config.password ?? "")}`,
   });
 
+  // A 403 here is qBittorrent's brute-force ban ("Your IP is banned..."); let it
+  // surface as an HTTP error rather than a generic "rejected".
   if (!res.ok) throw new Error(`qBittorrent login HTTP ${res.status}`);
-  const text = (await res.text()).trim();
-  // Older qBittorrent versions return HTTP 200 with "Ok."
-  // Newer versions may return HTTP 204 No Content.
-  if (res.status !== 204 && text !== "" && text !== "Ok.") {
-    throw new Error(`qBittorrent login rejected: ${text || "<empty response>"}`);
-  }
 
-  const setCookie = res.headers.get("set-cookie") ?? "";
-  // Accept any session cookie name (SID, QBT_SID, QBT_SID_8080, ...)
-  const match = setCookie.match(/^([^=]+=[^;]+)/);
-  if (!match) {
-    throw new Error("qBittorrent login missing session cookie");
-  }
-  return match[1];
+  const body = res.status === 204 ? "" : await res.text();
+  const result = interpretLoginResponse(res.status, body, res.headers.getSetCookie());
+  if (result.kind === "rejected") throw new Error("qBittorrent login rejected");
+  return result.cookie;
 }
 
 async function ensureCookie(config: StoredServiceConfig): Promise<string> {
@@ -81,11 +121,13 @@ async function ensureCookie(config: StoredServiceConfig): Promise<string> {
 async function qbFetch<T>(config: StoredServiceConfig, path: string): Promise<T> {
   const base = activeBaseUrl(config);
   const apiBase = SERVICE_API_BASE.qbittorrent;
-  const url = `${base}${apiBase}${path}`;
+  const url = buildUrl(base, apiBase, path);
   let cookie = await ensureCookie(config);
 
-const doFetch = (cookie: string) =>
-    fetch(url, {headers: { Cookie: cookie,},});
+  // Resend whatever name=value cookie qBittorrent issued (SID, or QBT_SID_<port>
+  // on 5.2.0+). The sentinel means the server authenticates by IP — send none.
+  const doFetch = (c: string) =>
+    fetch(url, c === AUTH_BYPASS_SENTINEL ? {} : { headers: { Cookie: c } });
 
   let res = await doFetch(cookie);
   if (res.status === 403) {


### PR DESCRIPTION
This Pull request is related with the issue #246 I opened.

Summary

Fix compatibility with newer qBittorrent WebUI versions.

Recent qBittorrent releases may return HTTP 204 No Content after a successful login instead of HTTP 200 with the body "Ok.".

Additionally, the session cookie is no longer guaranteed to be named SID; newer versions may use names such as QBT_SID or QBT_SID_8080.

Changes
Accept both legacy (200 + "Ok.") and newer (204 No Content) login responses.
Accept any session cookie name instead of assuming SID.
Send the session cookie exactly as returned by the server.
Compatibility

This change is backwards compatible with older qBittorrent releases while adding support for newer versions.

Testing

Tested against a recent qBittorrent installation returning:

HTTP 204 No Content
Set-Cookie: QBT_SID_8080=...

After this change, authentication succeeds and subsequent requests to /api/v2/torrents/info return HTTP 200 successfully.

I tested downloading a movie out of Radarr (via .torrent file directly on qBittorrent) and, after the download completed, I received a push notification correctly from qBittorrent.