### PR TITLE
fix(releases): persist selected saved *arr filter across searches (Refs #198)

### DIFF
--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -213,19 +213,26 @@ export function ReleasesPicker({
   // Filters persist across searches (#198) so they don't reset every time the
   // picker remounts. Quality persists by NAME (stable cross-search), protocol
   // and the rejected toggle are stable preferences too. The saved *arr filter
-  // (selectedFilterId) stays local — its id is per-instance, so persisting it
-  // could apply the wrong server-side filter across services/instances.
+  // persists as well, but keyed per service+instance (instanceKey below) — its
+  // id is a per-instance auto-increment integer, so a global id could apply the
+  // wrong server-side filter across services/instances.
   const prefHideRejected = useReleaseFilterStore((s) => s.hideRejected);
   const setPrefHideRejected = useReleaseFilterStore((s) => s.setHideRejected);
   const protocolFilter = useReleaseFilterStore((s) => s.protocol);
   const setProtocolFilter = useReleaseFilterStore((s) => s.setProtocol);
   const qualityFilter = useReleaseFilterStore((s) => s.quality);
   const setQualityFilter = useReleaseFilterStore((s) => s.setQuality);
+  const savedFilters = useReleaseFilterStore((s) => s.savedFilters);
+  const setSavedFilter = useReleaseFilterStore((s) => s.setSavedFilter);
   const resetFilters = useReleaseFilterStore((s) => s.reset);
+
+  // Per-instance key for the saved-filter selection. `instanceId` is undefined
+  // for single-instance setups, so fall back to a stable "default" bucket.
+  const instanceKey = `${service}:${instanceId ?? "default"}`;
+  const selectedFilterId = savedFilters[instanceKey] ?? null;
 
   const [autoFlippedRejected, setAutoFlippedRejected] = useState(false);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
-  const [selectedFilterId, setSelectedFilterId] = useState<number | null>(null);
 
   // Effective rejected state: the saved preference, transiently overridden by a
   // one-shot auto-flip when every result was rejected (below). The auto-flip is
@@ -234,8 +241,9 @@ export function ReleasesPicker({
 
   // Saved interactive-search filters configured in the *arr web UI. Only the
   // "releases" section is relevant here; the control is hidden when there are
-  // none. Selection is resolved by id at render so a refetch/deletion in *arr
-  // can't leave a stale pointer to a filter that no longer exists.
+  // none. Selection is resolved by id at render (against the freshly-fetched
+  // list) so a persisted id whose filter was deleted/renamed in *arr just
+  // clears instead of pointing at the wrong one.
   const customFiltersQuery = useArrCustomFilters(service, instanceId);
   const releaseFilters = useMemo(
     () => (customFiltersQuery.data ?? []).filter((f) => f.type === "releases"),
@@ -335,12 +343,13 @@ export function ReleasesPicker({
 
   function handleClearFilters() {
     lightHaptic();
-    // Reset the persisted filters to their defaults (not "show everything"),
-    // so clearing doesn't permanently flip the saved Show pref or leave the
-    // filter pill stuck highlighted. selectedFilterId is local/ephemeral.
+    // Reset the persisted quick filters to their defaults (not "show
+    // everything"), so clearing doesn't permanently flip the saved Show pref or
+    // leave the filter pill stuck highlighted. The saved *arr filter is cleared
+    // for this instance only — other instances keep their selection.
     resetFilters();
     setAutoFlippedRejected(false);
-    setSelectedFilterId(null);
+    setSavedFilter(instanceKey, null);
   }
 
   // Pill summary + highlight. Leads with the saved filter (the headline) when
@@ -371,8 +380,11 @@ export function ReleasesPicker({
         { key: "none", label: "All releases" },
         ...releaseFilters.map((f) => ({ key: String(f.id), label: f.label })),
       ],
-      value: selectedFilterId === null ? "none" : String(selectedFilterId),
-      onChange: (k) => setSelectedFilterId(k === "none" ? null : Number(k)),
+      // Drive the radio off the resolved filter, not the raw persisted id, so a
+      // selection whose filter was deleted in *arr falls back to "All releases".
+      value: selectedFilter ? String(selectedFilter.id) : "none",
+      onChange: (k) =>
+        setSavedFilter(instanceKey, k === "none" ? null : Number(k)),
     });
   }
   if (protocols.size > 1) {

--- a/store/releases-filter-store.test.ts
+++ b/store/releases-filter-store.test.ts
@@ -39,13 +39,16 @@ beforeEach(() => {
 
 describe("useReleaseFilterStore (#198)", () => {
   it("starts at the documented defaults", () => {
-    const { hideRejected, protocol, quality } =
+    const { hideRejected, protocol, quality, savedFilters } =
       useReleaseFilterStore.getState();
-    expect({ hideRejected, protocol, quality }).toEqual(RELEASE_FILTER_DEFAULTS);
+    expect({ hideRejected, protocol, quality, savedFilters }).toEqual(
+      RELEASE_FILTER_DEFAULTS,
+    );
     expect(RELEASE_FILTER_DEFAULTS).toEqual({
       hideRejected: true,
       protocol: "all",
       quality: null,
+      savedFilters: {},
     });
   });
 
@@ -61,47 +64,91 @@ describe("useReleaseFilterStore (#198)", () => {
       protocol: "torrent",
       quality: "WEBDL-1080p",
     });
-    // Only the three persisted fields land in storage — not the methods.
+    // Only the persisted fields land in storage — not the methods.
     expect(getJSON(STORAGE_KEY)).toEqual({
       hideRejected: false,
       protocol: "torrent",
       quality: "WEBDL-1080p",
+      savedFilters: {},
+    });
+  });
+
+  it("setSavedFilter persists a per-instance selection, null clears it", () => {
+    const s = useReleaseFilterStore.getState();
+    s.setSavedFilter("sonarr:default", 3);
+    s.setSavedFilter("radarr:default", 7);
+
+    // Same filter id (3) is a DIFFERENT filter per instance — both kept apart.
+    expect(useReleaseFilterStore.getState().savedFilters).toEqual({
+      "sonarr:default": 3,
+      "radarr:default": 7,
+    });
+    expect(getJSON<typeof RELEASE_FILTER_DEFAULTS>(STORAGE_KEY)?.savedFilters)
+      .toEqual({ "sonarr:default": 3, "radarr:default": 7 });
+
+    s.setSavedFilter("sonarr:default", null);
+    expect(useReleaseFilterStore.getState().savedFilters).toEqual({
+      "radarr:default": 7,
     });
   });
 
   it("hydrate() merges a partial stored blob over defaults", () => {
     // Forward-compat: an older/partial persisted blob (only protocol) must keep
     // the other fields at their current defaults rather than turning them
-    // undefined.
+    // undefined. Pre-savedFilters blobs must still hydrate to an empty map.
     setJSON(STORAGE_KEY, { protocol: "usenet" as ProtocolFilter });
 
     useReleaseFilterStore.getState().hydrate();
 
-    const { hideRejected, protocol, quality } =
+    const { hideRejected, protocol, quality, savedFilters } =
       useReleaseFilterStore.getState();
     expect(protocol).toBe("usenet");
     expect(hideRejected).toBe(RELEASE_FILTER_DEFAULTS.hideRejected);
     expect(quality).toBe(RELEASE_FILTER_DEFAULTS.quality);
+    expect(savedFilters).toEqual({});
+  });
+
+  it("hydrate() restores a persisted saved-filter selection", () => {
+    setJSON(STORAGE_KEY, { savedFilters: { "sonarr:default": 5 } });
+
+    useReleaseFilterStore.getState().hydrate();
+
+    expect(useReleaseFilterStore.getState().savedFilters).toEqual({
+      "sonarr:default": 5,
+    });
   });
 
   it("hydrate() with nothing stored keeps defaults (no throw)", () => {
     expect(() => useReleaseFilterStore.getState().hydrate()).not.toThrow();
-    const { hideRejected, protocol, quality } =
+    const { hideRejected, protocol, quality, savedFilters } =
       useReleaseFilterStore.getState();
-    expect({ hideRejected, protocol, quality }).toEqual(RELEASE_FILTER_DEFAULTS);
+    expect({ hideRejected, protocol, quality, savedFilters }).toEqual(
+      RELEASE_FILTER_DEFAULTS,
+    );
   });
 
-  it("reset() returns state to defaults and persists them", () => {
+  it("reset() resets quick filters to defaults but keeps saved filters", () => {
     const s = useReleaseFilterStore.getState();
     s.setHideRejected(false);
     s.setProtocol("usenet");
     s.setQuality("Bluray-2160p");
+    s.setSavedFilter("sonarr:default", 2);
 
     useReleaseFilterStore.getState().reset();
 
-    const { hideRejected, protocol, quality } =
+    const { hideRejected, protocol, quality, savedFilters } =
       useReleaseFilterStore.getState();
-    expect({ hideRejected, protocol, quality }).toEqual(RELEASE_FILTER_DEFAULTS);
-    expect(getJSON(STORAGE_KEY)).toEqual(RELEASE_FILTER_DEFAULTS);
+    expect({ hideRejected, protocol, quality }).toEqual({
+      hideRejected: RELEASE_FILTER_DEFAULTS.hideRejected,
+      protocol: RELEASE_FILTER_DEFAULTS.protocol,
+      quality: RELEASE_FILTER_DEFAULTS.quality,
+    });
+    // Saved-filter selections survive "Clear filters" — the picker clears only
+    // the current instance's selection on its own.
+    expect(savedFilters).toEqual({ "sonarr:default": 2 });
+    expect(getJSON(STORAGE_KEY)).toEqual({
+      ...RELEASE_FILTER_DEFAULTS,
+      savedFilters: { "sonarr:default": 2 },
+    });
   });
 });

--- a/store/releases-filter-store.ts
+++ b/store/releases-filter-store.ts
@@ -5,13 +5,16 @@ const STORAGE_KEY = "ui.releaseFilters";
 
 // Quick interactive-search release filters. Persisted so they survive the
 // picker remounting on every new search (issue #198) — the sort key already
-// persists via sort-store, which is why sort stuck but these didn't. Shared
-// across Radarr and Sonarr (one global blob), matching how the `releases`
-// sort key is already shared.
+// persists via sort-store, which is why sort stuck but these didn't. The
+// hideRejected/protocol/quality prefs are shared across Radarr and Sonarr (one
+// global blob), matching how the `releases` sort key is already shared.
 //
-// Notably NOT persisted: the saved *arr custom filter selection. Its id is a
-// per-instance auto-increment integer (Radarr #3 ≠ Sonarr #3), so a global id
-// would risk applying the wrong server-side filter; it stays per-search.
+// The saved *arr custom-filter selection is ALSO persisted (#198) — it was the
+// last thing still resetting every search. Its id is a per-instance
+// auto-increment integer (Radarr #3 ≠ Sonarr #3), so it's keyed per
+// `${service}:${instanceId}` rather than stored as one global id; the picker
+// re-resolves the id against the freshly-fetched filter list, so a filter
+// deleted in *arr just clears instead of pointing at the wrong one.
 export type ProtocolFilter = "all" | "torrent" | "usenet";
 
 interface ReleaseFilterPrefs {
@@ -21,12 +24,16 @@ interface ReleaseFilterPrefs {
   /** Quality NAME (e.g. "WEBDL-1080p"), not an id — names are stable across
    *  searches, unlike *arr filter ids. null = all qualities. */
   quality: string | null;
+  /** Selected saved *arr custom-filter id per `${service}:${instanceId}` key.
+   *  A missing key = no saved filter selected for that instance. */
+  savedFilters: Record<string, number>;
 }
 
 export const RELEASE_FILTER_DEFAULTS: ReleaseFilterPrefs = {
   hideRejected: true,
   protocol: "all",
   quality: null,
+  savedFilters: {},
 };
 
 interface ReleaseFilterStore extends ReleaseFilterPrefs {
@@ -34,7 +41,11 @@ interface ReleaseFilterStore extends ReleaseFilterPrefs {
   setHideRejected: (v: boolean) => void;
   setProtocol: (v: ProtocolFilter) => void;
   setQuality: (v: string | null) => void;
-  /** Reset every filter to its default (the "Clear filters" path). */
+  /** Select (or clear, with null) the saved *arr filter for one instance key. */
+  setSavedFilter: (key: string, id: number | null) => void;
+  /** Reset the quick filters to their defaults (the "Clear filters" path).
+   *  Leaves saved-filter selections alone — the picker clears the current
+   *  instance's selection separately, so other instances keep theirs. */
   reset: () => void;
 }
 
@@ -43,6 +54,7 @@ function snapshot(state: ReleaseFilterPrefs): ReleaseFilterPrefs {
     hideRejected: state.hideRejected,
     protocol: state.protocol,
     quality: state.quality,
+    savedFilters: state.savedFilters,
   };
 }
 
@@ -68,8 +80,18 @@ export const useReleaseFilterStore = create<ReleaseFilterStore>((set, get) => ({
     set({ quality });
     setJSON(STORAGE_KEY, snapshot({ ...get(), quality }));
   },
+  setSavedFilter: (key, id) => {
+    const savedFilters = { ...get().savedFilters };
+    if (id === null) delete savedFilters[key];
+    else savedFilters[key] = id;
+    set({ savedFilters });
+    setJSON(STORAGE_KEY, snapshot({ ...get(), savedFilters }));
+  },
   reset: () => {
-    set(RELEASE_FILTER_DEFAULTS);
-    setJSON(STORAGE_KEY, snapshot(RELEASE_FILTER_DEFAULTS));
+    // Preserve saved-filter selections — "Clear filters" only resets the quick
+    // chips; the picker clears the current instance's saved filter on its own.
+    const next = { ...RELEASE_FILTER_DEFAULTS, savedFilters: get().savedFilters };
+    set(next);
+    setJSON(STORAGE_KEY, snapshot(next));
   },
 }));


### PR DESCRIPTION
The quick chips, protocol, quality, and sort already persisted (PR #203). The one control still resetting on every interactive search was the selected saved *arr custom filter, which is what #198 is really about ("remember it as Sonarr does").

It was kept local because filter ids are per-instance. This keys the persisted selection per \`service:instance\` instead, and resolves by id against the freshly-fetched list so a filter deleted/renamed in *arr falls back to "All releases".

Now everything in the filter/sort pill persists across searches and restarts.

## Test plan
- \`jest\`: 697 pass (3 new store cases: per-instance isolation, null-clear, reset preserves saved filters)
- \`tsc --noEmit\`: clean