### PR TITLE
feat(notifications): Apprise delivery sink (Refs #220)

### DIFF
--- a/app/backend.tsx
+++ b/app/backend.tsx
@@ -12,15 +12,18 @@ import { BackendStatusPill } from "@/components/ui/backend-status-pill";
 import { toast, toastError } from "@/components/ui/toast";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useBackendStore } from "@/store/backend-store";
+import { useConfigStore } from "@/store/config-store";
 import {
   getBackendHealth,
   pairClaim,
   pushConfigSnapshot,
+  testApprise,
   testPush,
   unregisterDevice,
 } from "@/services/backend-api";
 import { getExpoPushToken, hasProjectId } from "@/lib/expo-push";
 import { normalizeServiceUrl } from "@/lib/url-validation";
+import { Toggle } from "@/components/ui/toggle";
 
 type Mode = "summary" | "scanning" | "manual";
 
@@ -150,6 +153,60 @@ export default function BackendScreen() {
     }
   }, []);
 
+  // --- Apprise (issue #220) ---
+  // Local-edit the fields and commit the whole object to the store on blur /
+  // toggle, so we don't write AsyncStorage on every keystroke. The store change
+  // auto-syncs to the backend via ConfigSyncBridge (debounced).
+  const storedApprise = useConfigStore((s) => s.notificationSettings.apprise);
+  const setNotificationSetting = useConfigStore((s) => s.setNotificationSetting);
+  const [appriseEnabled, setAppriseEnabled] = useState(storedApprise?.enabled ?? false);
+  const [appriseUrl, setAppriseUrl] = useState(storedApprise?.url ?? "");
+  const [appriseTags, setAppriseTags] = useState(storedApprise?.tags ?? "");
+  const [appriseBusy, setAppriseBusy] = useState(false);
+
+  const commitApprise = useCallback(
+    (next: { enabled: boolean; url: string; tags: string }) => {
+      setNotificationSetting("apprise", next);
+    },
+    [setNotificationSetting],
+  );
+
+  const handleAppriseToggle = useCallback(
+    (value: boolean) => {
+      setAppriseEnabled(value);
+      commitApprise({ enabled: value, url: appriseUrl, tags: appriseTags });
+    },
+    [appriseUrl, appriseTags, commitApprise],
+  );
+
+  const handleAppriseUrlBlur = useCallback(() => {
+    const normalized = normalizeServiceUrl(appriseUrl);
+    setAppriseUrl(normalized);
+    commitApprise({ enabled: appriseEnabled, url: normalized, tags: appriseTags });
+  }, [appriseEnabled, appriseUrl, appriseTags, commitApprise]);
+
+  const handleAppriseTagsBlur = useCallback(() => {
+    commitApprise({ enabled: appriseEnabled, url: appriseUrl, tags: appriseTags });
+  }, [appriseEnabled, appriseUrl, appriseTags, commitApprise]);
+
+  const handleAppriseTest = useCallback(async () => {
+    // Persist + flush immediately so the backend tests against the latest URL,
+    // bypassing the ConfigSyncBridge debounce.
+    const normalized = normalizeServiceUrl(appriseUrl);
+    setAppriseUrl(normalized);
+    commitApprise({ enabled: appriseEnabled, url: normalized, tags: appriseTags });
+    setAppriseBusy(true);
+    try {
+      await pushConfigSnapshot();
+      await testApprise();
+      toast("Apprise test sent", "success");
+    } catch (err) {
+      toastError("Apprise test failed", err);
+    } finally {
+      setAppriseBusy(false);
+    }
+  }, [appriseEnabled, appriseUrl, appriseTags, commitApprise]);
+
   const handleUnpair = useCallback(() => setConfirmUnpair(true), []);
 
   const performUnpair = useCallback(async () => {
@@ -255,6 +312,48 @@ export default function BackendScreen() {
                   className="flex-1"
                 />
               </View>
+
+              <Card className="gap-3 mb-3">
+                <Toggle
+                  label="Apprise notifications"
+                  description="Also send to Discord, Telegram, ntfy, email… via an Apprise server"
+                  value={appriseEnabled}
+                  onValueChange={handleAppriseToggle}
+                />
+                {appriseEnabled ? (
+                  <>
+                    <TextInput
+                      label="Apprise notify URL"
+                      placeholder="http://192.168.1.50:8000/notify/dashboarr"
+                      value={appriseUrl}
+                      onChangeText={setAppriseUrl}
+                      onBlur={handleAppriseUrlBlur}
+                      keyboardType="url"
+                      autoCapitalize="none"
+                    />
+                    <TextInput
+                      label="Tags (optional)"
+                      placeholder="phone,important"
+                      value={appriseTags}
+                      onChangeText={setAppriseTags}
+                      onBlur={handleAppriseTagsBlur}
+                      autoCapitalize="none"
+                    />
+                    <Text className="text-zinc-500 text-xs">
+                      Add your notification services in the Apprise server's own config UI under a
+                      key, then paste its full /notify/&lt;key&gt; URL here. Tags filter which saved
+                      URLs fire (leave blank for all).
+                    </Text>
+                    <Button
+                      label="Send Apprise test"
+                      variant="outline"
+                      onPress={handleAppriseTest}
+                      loading={appriseBusy}
+                      disabled={!appriseUrl.trim()}
+                    />
+                  </>
+                ) : null}
+              </Card>
 
               <Pressable onPress={handleRotate} disabled={busy} className="active:opacity-80 mb-3">
                 <Card className="flex-row items-center justify-center gap-2">

--- a/backend/dashboarr-backend/README.md
+++ b/backend/dashboarr-backend/README.md
@@ -180,8 +180,9 @@ docker run -d --name dashboarr-backend \
 | `POST` | `/pair/claim` | one-time token in body | Exchange token + push token for shared secret |
 | `POST` | `/device/register` | bearer | Refresh push token on reinstall |
 | `POST` | `/device/unregister` | bearer | Remove this device |
-| `PUT`  | `/config` | bearer | Replace config (push-only — no GET by design, avoids exposing API keys), hot-reload pollers. Accepts the multi-instance shape `{ instances: [{ id, kind, … }], notifications }` and the legacy `{ services: [{ id, … }], notifications }` shape for back-compat |
-| `POST` | `/notifications/test` | bearer | Fire a test push to all paired devices |
+| `PUT`  | `/config` | bearer | Replace config (push-only — no GET by design, avoids exposing API keys), hot-reload pollers. Accepts the multi-instance shape `{ instances: [{ id, kind, … }], notifications }` and the legacy `{ services: [{ id, … }], notifications }` shape for back-compat. `notifications` may include an optional `apprise: { enabled, url, tags }` block (see Apprise below) |
+| `POST` | `/notifications/test` | bearer | Fire a test push to all paired devices (also fans out to Apprise when enabled) |
+| `POST` | `/notifications/apprise/test` | bearer | Send a test notification to Apprise only; returns the real success/failure |
 | `POST` | `/webhooks/radarr` | `X-Dashboarr-Secret` header | Radarr "Custom" webhook ingestion (preferred). Optional `?instance=<uuid>` for per-instance attribution |
 | `POST` | `/webhooks/radarr/:secret` | path secret | Same, back-compat for services that can't send custom headers |
 | `POST` | `/webhooks/sonarr` | header | Sonarr "Custom" webhook. Optional `?instance=<uuid>` |
@@ -292,6 +293,35 @@ ones. The instance namespace prevents two enabled instances of the same kind
 from collapsing each other's events when they happen to share an upstream id
 (e.g. two Radarrs both grabbing the same release via the same qBittorrent
 hash).
+
+---
+
+## Apprise delivery (optional second sink)
+
+Every notification can additionally fan out to an [Apprise](https://github.com/caronc/apprise)
+API server (the `caronc/apprise` container), so events reach Discord, Telegram,
+ntfy, email, Matrix, etc. — not just Expo push. It's **additive**: Expo push
+keeps working, and Apprise honors the same global + per-category toggles. It even
+fires when no phone is paired.
+
+We use the **persistent config-key model**: configure your service URLs in the
+Apprise server's own config UI under a key (e.g. `dashboarr`), then point
+Dashboarr at the full notify endpoint. No service secrets are stored in this
+backend's DB — only the notify URL + an optional tag filter, sent in
+`notifications.apprise`:
+
+```jsonc
+"apprise": {
+  "enabled": true,
+  "url": "http://apprise:8000/notify/dashboarr", // full /notify/{KEY} endpoint
+  "tags": ""                                       // optional Apprise tag filter
+}
+```
+
+The backend POSTs `{ title, body, type: "info", format: "text", tag? }` to that
+URL. Apprise returns `200` on success, `204` if no config is saved under the key,
+and `424` if delivery failed or no saved URL matched the tag. Configure it from
+the app (Settings → Backend → Apprise) and use **Send Apprise test** to verify.
 
 ---
 

--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "test": "tsx --test src/types.test.ts src/services/qbittorrent.test.ts",
+    "test": "tsx --test src/types.test.ts src/services/qbittorrent.test.ts src/push/apprise.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/backend/dashboarr-backend/src/db/repos/config.ts
+++ b/backend/dashboarr-backend/src/db/repos/config.ts
@@ -1,5 +1,5 @@
 import { getDb } from "../client.js";
-import type { ServiceId, NotificationSettings, NotifCategory } from "../../types.js";
+import type { ServiceId, NotificationSettings, NotifCategory, AppriseConfig } from "../../types.js";
 import { DEFAULT_NOTIFICATION_SETTINGS } from "../../types.js";
 import type { StoredServiceInstance } from "./service-instance.js";
 
@@ -11,6 +11,7 @@ import type { StoredServiceInstance } from "./service-instance.js";
  */
 
 const PER_INSTANCE_KV_KEY = "notification.perInstance";
+const APPRISE_KV_KEY = "notification.apprise";
 
 export function saveNotificationSettings(settings: NotificationSettings): void {
   const db = getDb();
@@ -19,7 +20,9 @@ export function saveNotificationSettings(settings: NotificationSettings): void {
       "INSERT OR REPLACE INTO notification_settings (key, enabled) VALUES (?, ?)",
     );
     for (const [k, v] of Object.entries(settings)) {
-      if (k === "perInstance") continue; // handled separately below
+      // Non-boolean fields are stored as JSON blobs in `kv` below, not as
+      // key→boolean rows here.
+      if (k === "perInstance" || k === "apprise") continue;
       stmt.run(k, v ? 1 : 0);
     }
 
@@ -30,6 +33,17 @@ export function saveNotificationSettings(settings: NotificationSettings): void {
       );
     } else {
       db.prepare("DELETE FROM kv WHERE key = ?").run(PER_INSTANCE_KV_KEY);
+    }
+
+    // Persist Apprise config whenever a notify URL is present (even if disabled,
+    // so toggling off doesn't drop the URL). Cleared when no URL is set.
+    if (settings.apprise && settings.apprise.url) {
+      db.prepare("INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)").run(
+        APPRISE_KV_KEY,
+        JSON.stringify(settings.apprise),
+      );
+    } else {
+      db.prepare("DELETE FROM kv WHERE key = ?").run(APPRISE_KV_KEY);
     }
   });
   tx();
@@ -61,6 +75,20 @@ export function loadNotificationSettings(): NotificationSettings {
     } catch {
       // Malformed JSON in kv — drop it silently rather than crash the
       // dispatcher. Next saveNotificationSettings call rewrites it.
+    }
+  }
+
+  const appriseRow = getDb()
+    .prepare<[string], { value: string }>("SELECT value FROM kv WHERE key = ?")
+    .get(APPRISE_KV_KEY);
+  if (appriseRow?.value) {
+    try {
+      const parsed = JSON.parse(appriseRow.value);
+      if (parsed && typeof parsed === "object") {
+        result.apprise = parsed as AppriseConfig;
+      }
+    } catch {
+      // Malformed JSON — drop silently, same rationale as perInstance above.
     }
   }
 

--- a/backend/dashboarr-backend/src/push/apprise.test.ts
+++ b/backend/dashboarr-backend/src/push/apprise.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { sendApprise } from "./apprise.js";
+
+const realFetch = globalThis.fetch;
+
+/** Stub globalThis.fetch, capturing the call, and return the given status. */
+function stubFetch(status: number) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      status,
+      text: async () => "",
+    } as Response;
+  }) as typeof fetch;
+  return calls;
+}
+
+test("sendApprise: no-op when url is empty (no fetch)", async () => {
+  let called = false;
+  globalThis.fetch = (async () => {
+    called = true;
+    return { status: 200, text: async () => "" } as Response;
+  }) as typeof fetch;
+  try {
+    await sendApprise({ url: "", tags: "" }, { title: "t", body: "b" });
+    assert.equal(called, false);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("sendApprise: 200 resolves and posts the expected body (no tag when blank)", async () => {
+  const calls = stubFetch(200);
+  try {
+    await sendApprise(
+      { url: "http://host:8000/notify/key", tags: "" },
+      { title: "Done", body: "All set" },
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "http://host:8000/notify/key");
+    assert.equal(calls[0].init.method, "POST");
+    const body = JSON.parse(calls[0].init.body as string);
+    assert.deepEqual(body, {
+      title: "Done",
+      body: "All set",
+      type: "info",
+      format: "text",
+    });
+    assert.equal("tag" in body, false);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("sendApprise: includes trimmed tag when provided", async () => {
+  const calls = stubFetch(200);
+  try {
+    await sendApprise(
+      { url: "http://host:8000/notify/key", tags: "  phone,important  " },
+      { title: "t", body: "b" },
+    );
+    const body = JSON.parse(calls[0].init.body as string);
+    assert.equal(body.tag, "phone,important");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("sendApprise: 204 throws a 'no config under that key' error", async () => {
+  stubFetch(204);
+  try {
+    await assert.rejects(
+      sendApprise({ url: "http://host:8000/notify/key", tags: "" }, { title: "t", body: "b" }),
+      /204/,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("sendApprise: 424 throws a delivery/tag-mismatch error", async () => {
+  stubFetch(424);
+  try {
+    await assert.rejects(
+      sendApprise({ url: "http://host:8000/notify/key", tags: "" }, { title: "t", body: "b" }),
+      /424/,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("sendApprise: other non-200 throws with the raw status", async () => {
+  stubFetch(500);
+  try {
+    await assert.rejects(
+      sendApprise({ url: "http://host:8000/notify/key", tags: "" }, { title: "t", body: "b" }),
+      /HTTP 500/,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});

--- a/backend/dashboarr-backend/src/push/apprise.ts
+++ b/backend/dashboarr-backend/src/push/apprise.ts
@@ -1,0 +1,67 @@
+import type { AppriseConfig } from "../types.js";
+
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Send a notification to a user-run Apprise API server (caronc/apprise), issue
+ * #220. We use the persistent config-key model: `cfg.url` is the full notify
+ * endpoint the user copied from Apprise's own config UI (e.g.
+ * http://host:8000/notify/dashboarr), where their service URLs already live.
+ * We only POST the message + an optional tag filter — no secrets pass through.
+ *
+ * Throws on any non-200 response so the test route can surface the real reason.
+ * The dispatcher calls this WITHOUT awaiting (fire-and-forget, errors swallowed
+ * via .catch) so a flaky Apprise server never blocks push dispatch.
+ */
+export async function sendApprise(
+  cfg: Pick<AppriseConfig, "url" | "tags">,
+  event: { title: string; body: string },
+): Promise<void> {
+  if (!cfg.url) return;
+
+  const tag = cfg.tags?.trim();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetch(cfg.url, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: event.title,
+        body: event.body,
+        type: "info",
+        format: "text",
+        ...(tag ? { tag } : {}),
+      }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    throw new Error(
+      `Apprise request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  // Apprise returns 200 on success. 204 = no config saved under the key in the
+  // URL; 424 = a notification failed or no saved URL matched the tag. Map the
+  // common cases to clear messages; anything else surfaces the raw status.
+  if (res.status === 200) return;
+  if (res.status === 204) {
+    throw new Error(
+      "Apprise returned 204 — no config is saved under that key on the server",
+    );
+  }
+  if (res.status === 424) {
+    throw new Error(
+      "Apprise returned 424 — delivery failed or no saved URLs matched the tag",
+    );
+  }
+  const text = await res.text().catch(() => "");
+  throw new Error(`Apprise HTTP ${res.status}: ${text.slice(0, 200)}`);
+}

--- a/backend/dashboarr-backend/src/push/dispatcher.ts
+++ b/backend/dashboarr-backend/src/push/dispatcher.ts
@@ -2,6 +2,7 @@ import { listActiveDevices } from "../db/repos/devices.js";
 import { loadNotificationSettings } from "../db/repos/config.js";
 import { claimEvent } from "../db/repos/seen-state.js";
 import { sendExpoPush } from "./expo.js";
+import { sendApprise } from "./apprise.js";
 import type { ExpoPushMessage } from "./expo.js";
 import type { PushEvent } from "../types.js";
 
@@ -37,21 +38,36 @@ export async function dispatchPush(event: PushEvent): Promise<void> {
     if (!isFirst) return;
   }
 
+  // Expo push sink — fan out to every paired device, if any. Skipped (but the
+  // Apprise sink below still runs) when no device is paired.
   const devices = listActiveDevices();
-  if (devices.length === 0) return;
+  if (devices.length > 0) {
+    const messages: ExpoPushMessage[] = devices.map((device) => ({
+      to: device.expoPushToken,
+      title: event.title,
+      body: event.body,
+      data: {
+        ...(event.data ?? {}),
+        category: event.category,
+      },
+      sound: "default",
+      channelId: "dashboarr-default",
+      priority: "high",
+    }));
+    await sendExpoPush(messages);
+  }
 
-  const messages: ExpoPushMessage[] = devices.map((device) => ({
-    to: device.expoPushToken,
-    title: event.title,
-    body: event.body,
-    data: {
-      ...(event.data ?? {}),
-      category: event.category,
-    },
-    sound: "default",
-    channelId: "dashboarr-default",
-    priority: "high",
-  }));
-
-  await sendExpoPush(messages);
+  // Apprise sink (issue #220) — independent of Expo. Truly fire-and-forget: we
+  // deliberately do NOT await it, so a flaky/black-holed Apprise server (e.g. a
+  // wrong LAN IP that drops packets, hanging the full 10s timeout) never delays
+  // the dispatcher. That matters because every caller awaits dispatchPush — the
+  // webhook handlers return their HTTP reply after it, and the poller transition
+  // loop awaits it per item — so blocking here would stall those paths. Errors
+  // are swallowed + logged via .catch (never retried; see the dedupe note above).
+  const apprise = settings.apprise;
+  if (apprise?.enabled && apprise.url) {
+    void sendApprise(apprise, { title: event.title, body: event.body }).catch(
+      (err) => console.warn("[apprise] send failed:", err),
+    );
+  }
 }

--- a/backend/dashboarr-backend/src/routes/notifications.ts
+++ b/backend/dashboarr-backend/src/routes/notifications.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from "fastify";
 import { requireBearer } from "../auth/bearer.js";
 import { dispatchPush } from "../push/dispatcher.js";
+import { loadNotificationSettings } from "../db/repos/config.js";
+import { sendApprise } from "../push/apprise.js";
 
 export async function notificationRoutes(app: FastifyInstance): Promise<void> {
   app.post("/notifications/test", { preHandler: requireBearer }, async (request, reply) => {
@@ -21,4 +23,31 @@ export async function notificationRoutes(app: FastifyInstance): Promise<void> {
     });
     return { ok: true };
   });
+
+  // Apprise-only test (issue #220). Sends straight to Apprise (no device needed
+  // — Apprise is device-independent) and surfaces the real result so the app can
+  // tell the user exactly why it failed (unreachable server, unknown key, bad
+  // tag). Independent of the global `notifications.enabled` master flag.
+  app.post(
+    "/notifications/apprise/test",
+    { preHandler: requireBearer },
+    async (_request, reply) => {
+      const apprise = loadNotificationSettings().apprise;
+      if (!apprise?.enabled || !apprise.url) {
+        return reply.code(400).send({ error: "apprise_not_configured" });
+      }
+      try {
+        await sendApprise(apprise, {
+          title: "Dashboarr Apprise test",
+          body: "If you see this, Apprise delivery is working end-to-end.",
+        });
+      } catch (err) {
+        return reply.code(502).send({
+          error: "apprise_failed",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return { ok: true };
+    },
+  );
 }

--- a/backend/dashboarr-backend/src/types.test.ts
+++ b/backend/dashboarr-backend/src/types.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { configPayloadSchema, DEFAULT_NOTIFICATION_SETTINGS } from "./types.js";
+import {
+  configPayloadSchema,
+  notificationSettingsSchema,
+  DEFAULT_NOTIFICATION_SETTINGS,
+} from "./types.js";
 
 /**
  * Regression guard for the bug where the app sends a config entry for a service
@@ -53,4 +57,39 @@ test("a payload with only unknown kinds still parses to an empty instances list"
   assert.equal(result.success, true);
   if (!result.success) return;
   assert.equal(result.data.instances?.length, 0);
+});
+
+// Apprise (issue #220) — the notifications schema gained an optional `apprise`
+// config object. A pre-Apprise client omits it; a newer one sends the full shape.
+
+test("notifications without apprise still parse (back-compat)", () => {
+  const result = notificationSettingsSchema.safeParse(DEFAULT_NOTIFICATION_SETTINGS);
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.equal(result.data.apprise, undefined);
+});
+
+test("notifications with a full apprise config parse", () => {
+  const result = notificationSettingsSchema.safeParse({
+    ...DEFAULT_NOTIFICATION_SETTINGS,
+    apprise: { enabled: true, url: "http://host:8000/notify/dashboarr", tags: "phone" },
+  });
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.deepEqual(result.data.apprise, {
+    enabled: true,
+    url: "http://host:8000/notify/dashboarr",
+    tags: "phone",
+  });
+});
+
+test("apprise sub-fields default when partially provided", () => {
+  const result = notificationSettingsSchema.safeParse({
+    ...DEFAULT_NOTIFICATION_SETTINGS,
+    apprise: { url: "http://host:8000/notify/dashboarr" },
+  });
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.equal(result.data.apprise?.enabled, false);
+  assert.equal(result.data.apprise?.tags, "");
 });

--- a/backend/dashboarr-backend/src/types.ts
+++ b/backend/dashboarr-backend/src/types.ts
@@ -122,6 +122,28 @@ export const perInstanceOverridesSchema = z
   .record(z.string().min(1), z.record(notifCategoryEnum, z.boolean()))
   .optional();
 
+// Apprise (issue #220): a second notification sink alongside Expo push. We use
+// the persistent config-key model — the user saves their service URLs in the
+// caronc/apprise server's own config UI under a key, and stores only the full
+// notify endpoint here (e.g. http://host:8000/notify/dashboarr) plus an optional
+// tag filter. Secrets never touch this DB. Persisted as a JSON blob in `kv`
+// (key "notification.apprise"), like perInstance, since notification_settings is
+// strictly key→boolean.
+export const appriseConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    // Same http(s)-or-empty guard as every service URL (httpUrlOrEmpty above):
+    // this is the one stored URL the backend itself fetch()es, so a compromised
+    // or misconfigured paired device must not be able to point it at another
+    // scheme (SSRF guard). Length-capped like sharedServiceFields against a
+    // multi-MB blob being JSON-stringified into the `kv` table.
+    url: httpUrlOrEmpty.pipe(z.string().max(2048)).default(""),
+    tags: z.string().max(256).default(""),
+  })
+  .optional();
+
+export type AppriseConfig = NonNullable<z.infer<typeof appriseConfigSchema>>;
+
 export const notificationSettingsSchema = z.object({
   enabled: z.boolean().default(true),
   torrentCompleted: z.boolean().default(true),
@@ -140,6 +162,7 @@ export const notificationSettingsSchema = z.object({
   tracearrStreamStarted: z.boolean().default(false),
   tracearrStreamStopped: z.boolean().default(false),
   perInstance: perInstanceOverridesSchema,
+  apprise: appriseConfigSchema,
 });
 
 export type NotificationSettings = z.infer<typeof notificationSettingsSchema>;

--- a/docs/index.html
+++ b/docs/index.html
@@ -226,7 +226,7 @@
       </div>
       <div class="feature-card">
         <h3>Push Notifications</h3>
-        <p>Optional self-hosted backend for real-time notifications when downloads finish or media arrives.</p>
+        <p>Optional self-hosted backend for real-time notifications when downloads finish or media arrives. Fan out to Discord, Telegram, ntfy, email and more via Apprise.</p>
       </div>
       <div class="feature-card">
         <h3>Secure Storage</h3>

--- a/services/backend-api.ts
+++ b/services/backend-api.ts
@@ -167,6 +167,15 @@ export function testPush(): Promise<void> {
 }
 
 /**
+ * Fire an Apprise-only test from the backend. Unlike testPush this hits a
+ * dedicated endpoint that returns the real success/failure, so the caller can
+ * surface why it failed (unreachable server, unknown key, bad tag).
+ */
+export function testApprise(): Promise<void> {
+  return request<void>("/notifications/apprise/test", { method: "POST" });
+}
+
+/**
  * Build a config payload from the app stores and push it to the backend.
  * Called on pairing and debounced after any config/notification change.
  *
@@ -212,6 +221,7 @@ export function pushConfigSnapshot(): Promise<void> {
     serviceOffline,
     overseerrNewRequest,
     perInstance,
+    apprise,
   } = configState.notificationSettings;
 
   return request<void>("/config", {
@@ -230,6 +240,9 @@ export function pushConfigSnapshot(): Promise<void> {
         // v21: per-instance overrides. Sent as `undefined` when no overrides
         // exist so the backend treats it the same as a pre-v21 client.
         perInstance,
+        // v34: Apprise sink config. Sent as `undefined` when unset so older
+        // backends ignore it.
+        apprise,
       },
     }),
   });

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -130,8 +130,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         defaultInstances() iterates SERVICE_IDS and backfills a disabled
  *         transmission instance at import time, so older exports just need the
  *         version field bumped.
+ *   v34 — added optional Apprise notification config (#220). Pure version stamp —
+ *         coerceNotificationSettings treats `apprise` as optional, so older
+ *         exports without it validate and fall back to "unset" at hydrate time.
  */
-export const CURRENT_CONFIG_VERSION = 33;
+export const CURRENT_CONFIG_VERSION = 34;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -623,6 +626,10 @@ const migrations: Record<number, (payload: any) => any> = {
   // v32 → v33: added the transmission service entry. Pure version stamp —
   // defaultInstances() backfills a disabled transmission instance at import.
   32: (payload) => ({ ...payload, version: 33 }),
+  // v33 → v34: added optional Apprise notification config. Pure version stamp —
+  // `apprise` is optional, so older exports without it validate and default to
+  // "unset" at hydrate time.
+  33: (payload) => ({ ...payload, version: 34 }),
 };
 
 /**

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -14,7 +14,7 @@ import type {
   WakeOnLanDevice,
   WidgetSlot,
 } from "@/store/config-store";
-import type { NotificationSettings, NotifCategory } from "@/store/config-store";
+import type { NotificationSettings, NotifCategory, AppriseConfig } from "@/store/config-store";
 import { NOTIF_CATEGORIES } from "@/lib/notification-categories";
 import { MAX_PINNED_TABS } from "@/lib/tab-routes";
 
@@ -305,6 +305,25 @@ function coerceNotificationSettings(v: unknown): NotificationSettings | null {
     }
     if (Object.keys(perInstance).length > 0) {
       out.perInstance = perInstance;
+    }
+  }
+  // v34: optional Apprise sink. Mirror the "drop unknown categories" philosophy
+  // used for perInstance above — a malformed `apprise` is silently dropped rather
+  // than failing the ENTIRE config import (services, secrets, dashboards…) over
+  // one optional field. The live UI stores the URL without scheme validation, so
+  // a legitimate backup can carry a value this importer would otherwise reject;
+  // don't strand the whole restore on it. A missing `apprise` is fine (older
+  // export) and falls back to "unset" at hydrate time.
+  if (isPlainObject(v.apprise)) {
+    const a = v.apprise;
+    if (
+      typeof a.enabled === "boolean" &&
+      isHttpUrlOrEmpty(a.url) &&
+      typeof a.tags === "string" &&
+      a.tags.length <= 256
+    ) {
+      const apprise: AppriseConfig = { enabled: a.enabled, url: a.url, tags: a.tags };
+      out.apprise = apprise;
     }
   }
   return out as NotificationSettings;

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -212,6 +212,16 @@ export type NotifCategory =
   | "tracearrStreamStarted"
   | "tracearrStreamStopped";
 
+// v34 (issue #220): optional Apprise sink. Persistent config-key model — the
+// user configures their service URLs in the Apprise server's own UI under a key
+// and stores only the full notify endpoint (e.g. http://host:8000/notify/
+// dashboarr) plus an optional tag filter here. No service secrets live in the app.
+export interface AppriseConfig {
+  enabled: boolean;
+  url: string;
+  tags: string;
+}
+
 export interface NotificationSettings {
   enabled: boolean;
   torrentCompleted: boolean;
@@ -233,6 +243,8 @@ export interface NotificationSettings {
   // "notify me from the primary Radarr but stay silent from the testing one"
   // without splitting the global toggles per kind.
   perInstance?: Record<string, Partial<Record<NotifCategory, boolean>>>;
+  // v34: Apprise notification sink (additive to Expo push). undefined = unset.
+  apprise?: AppriseConfig;
 }
 
 export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {


### PR DESCRIPTION
Adds an optional Apprise sink so notifications also fan out to Discord, Telegram, ntfy, email, etc. Additive to Expo push and honors the same toggles; works even with no phone paired. Refs #220.

Uses the persistent config-key model — the app stores only the full `/notify/<key>` endpoint + an optional tag filter; no service secrets touch the backend DB. Configure under Settings → Backend → Apprise with a "Send Apprise test" button.

## Test plan
- Backend: `npm test` (13/13 pass, incl. new apprise sender + schema tests)
- App: `tsc --noEmit` clean; 289/289 config schema/migration/store tests pass
- Verified schema guards reject non-http(s) URLs, over-length url/tags; malformed apprise dropped on import without failing the whole restore
