### PR TITLE
feat(seerr): delete request and remove media

### DIFF
--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -11,8 +11,14 @@ import {
   Compass,
   ListFilter,
   SlidersHorizontal,
+  MoreHorizontal,
+  Trash2,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
+import { ConfirmModal } from "@/components/common/confirm-modal";
+import { toast, toastError } from "@/components/ui/toast";
+import { useModalFlow } from "@/hooks/use-modal-flow";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
 import { Card } from "@/components/ui/card";
@@ -30,7 +36,7 @@ import {
   type RequestsSortKey,
 } from "@/store/sort-store";
 import { ICON } from "@/lib/constants";
-import { successHaptic, errorHaptic } from "@/lib/haptics";
+import { successHaptic, errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { MediaRow } from "@/components/overseerr/media-row";
 import { PosterCard } from "@/components/overseerr/poster-card";
 import {
@@ -55,6 +61,8 @@ import {
   useOverseerrCustomSlider,
   useApproveRequest,
   useDeclineRequest,
+  useDeleteRequest,
+  useDeleteMedia,
 } from "@/hooks/use-overseerr";
 import { getPosterUrl, getBackdropUrl } from "@/services/overseerr-api";
 import {
@@ -71,6 +79,7 @@ import {
   type OverseerrRequest,
   type OverseerrMediaResult,
   type OverseerrMediaType,
+  type OverseerrMediaStatus,
   type DiscoverSlider,
 } from "@/lib/types";
 
@@ -686,6 +695,17 @@ function PosterGridItem({
 
 // ─── Requests Tab ──────────────────────────────────────────────
 
+// Identity of the row whose ActionSheet / confirm is open. Carries both ids the
+// two actions need (requestId for delete-request, mediaId for remove-media)
+// plus the media status used to decide whether "Remove media" is offered.
+type RowTarget = {
+  requestId: number;
+  mediaId: number;
+  mediaStatus: OverseerrMediaStatus;
+  title: string;
+};
+type ConfirmIntent = RowTarget & { mode: "deleteRequest" | "removeMedia" };
+
 function RequestsList() {
   const [filter, setFilter] = useState<RequestFilter>("all");
   const sort = useSortStore((s) => s.requests);
@@ -696,8 +716,71 @@ function RequestsList() {
   const { data: counts } = useOverseerrRequestCount();
   const approve = useApproveRequest();
   const decline = useDeclineRequest();
+  const del = useDeleteRequest();
+  const removeMedia = useDeleteMedia();
+
+  // The tapped row drives the ActionSheet contents; the confirm step + mutation
+  // read their target from the flow payload (sticky through the dismiss
+  // animation), so the chain survives the iOS modal teardown (issue #83).
+  const [sheetTarget, setSheetTarget] = useState<RowTarget | null>(null);
+  const flow = useModalFlow<{ actions: void; confirm: ConfirmIntent }>();
 
   const requests = data?.results ?? [];
+
+  const busy =
+    approve.isPending ||
+    decline.isPending ||
+    del.isPending ||
+    removeMedia.isPending;
+
+  const openRowSheet = (target: RowTarget) => {
+    mediumHaptic();
+    setSheetTarget(target);
+    flow.open("actions");
+  };
+
+  const actions: ActionSheetAction[] = useMemo(() => {
+    if (!sheetTarget) return [];
+    const t = sheetTarget;
+    const list: ActionSheetAction[] = [
+      {
+        label: "Delete request",
+        icon: <Icon icon={Trash2} size={ICON.MD} color="#ef4444" />,
+        variant: "danger",
+        onPress: () => flow.open("confirm", { ...t, mode: "deleteRequest" }),
+      },
+    ];
+    // "Remove media" only applies once media exists (processing / partial /
+    // available); pending or declined requests have nothing to untrack.
+    if (t.mediaStatus >= 3) {
+      list.push({
+        label: "Remove media",
+        icon: <Icon icon={Film} size={ICON.MD} color="#ef4444" />,
+        variant: "danger",
+        onPress: () => flow.open("confirm", { ...t, mode: "removeMedia" }),
+      });
+    }
+    return list;
+  }, [sheetTarget, flow]);
+
+  const pending = flow.payload("confirm");
+  const onConfirm = () => {
+    // Guard against a double-tap firing a second DELETE during the confirm's
+    // fade-out (the payload stays sticky and the button isn't disabled mid-press).
+    if (!pending || del.isPending || removeMedia.isPending) return;
+    flow.close();
+    if (pending.mode === "deleteRequest") {
+      del.mutate(pending.requestId, {
+        onSuccess: () => toast("Request deleted"),
+        onError: (err) => toastError("Failed to delete request", err),
+      });
+    } else {
+      removeMedia.mutate(pending.mediaId, {
+        onSuccess: () => toast("Media removed"),
+        onError: (err) => toastError("Failed to remove media", err),
+      });
+    }
+  };
 
   const filterOptions: { key: RequestFilter; label: string }[] = (
     ["all", "pending", "approved", "processing"] as RequestFilter[]
@@ -733,7 +816,15 @@ function RequestsList() {
               request={req}
               onApprove={() => approve.mutate(req.id)}
               onDecline={() => decline.mutate(req.id)}
-              busy={approve.isPending || decline.isPending}
+              onMore={(title) =>
+                openRowSheet({
+                  requestId: req.id,
+                  mediaId: req.media.id,
+                  mediaStatus: req.media.status,
+                  title,
+                })
+              }
+              busy={busy}
             />
           ))}
         </View>
@@ -750,6 +841,28 @@ function RequestsList() {
         sortValue={sort}
         onSortChange={setSort}
       />
+
+      <ActionSheet
+        {...flow.bind("actions")}
+        title={sheetTarget?.title}
+        actions={actions}
+      />
+
+      <ConfirmModal
+        {...flow.bind("confirm")}
+        title={pending?.mode === "removeMedia" ? "Remove media?" : "Delete request?"}
+        message={
+          pending
+            ? pending.mode === "removeMedia"
+              ? `Remove "${pending.title}" from Seerr? It can be requested again afterwards. This does not delete files from your server.`
+              : `Delete the request for "${pending.title}"? This removes it from your Seerr requests.`
+            : ""
+        }
+        icon={Trash2}
+        tone="danger"
+        confirmLabel={pending?.mode === "removeMedia" ? "Remove" : "Delete"}
+        onConfirm={onConfirm}
+      />
     </View>
   );
 }
@@ -758,11 +871,13 @@ function RequestCard({
   request,
   onApprove,
   onDecline,
+  onMore,
   busy,
 }: {
   request: OverseerrRequest;
   onApprove: () => void;
   onDecline: () => void;
+  onMore: (title: string) => void;
   busy?: boolean;
 }) {
   const isPending = request.status === 1;
@@ -821,7 +936,18 @@ function RequestCard({
             >
               {title}
             </Text>
-            <Badge label={statusLabel} variant={statusVariant} />
+            <View className="flex-row items-center gap-1">
+              <Badge label={statusLabel} variant={statusVariant} />
+              <Pressable
+                onPress={() => onMore(title)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Request actions"
+                className="p-0.5 active:opacity-70"
+              >
+                <Icon icon={MoreHorizontal} size={ICON.MD} color="#a1a1aa" />
+              </Pressable>
+            </View>
           </View>
 
           <Text className="text-zinc-500 text-xs">

--- a/components/overseerr/media-detail-modal.tsx
+++ b/components/overseerr/media-detail-modal.tsx
@@ -22,8 +22,10 @@ import {
   Play,
   SlidersHorizontal,
   ExternalLink,
+  Trash2,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { ConfirmModal } from "@/components/common/confirm-modal";
 import { BlurView } from "expo-blur";
 import Animated, {
   useSharedValue,
@@ -31,7 +33,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { Button } from "@/components/ui/button";
-import { toast } from "@/components/ui/toast";
+import { toast, toastError } from "@/components/ui/toast";
 import { getHttpErrorMessage, formatErrorForCopy } from "@/lib/http-client";
 import {
   getPosterUrl,
@@ -49,6 +51,7 @@ import {
   useOverseerrSonarrServers,
   useRequestMovie,
   useRequestTV,
+  useDeleteMedia,
 } from "@/hooks/use-overseerr";
 import type {
   OverseerrMediaResult,
@@ -108,6 +111,7 @@ export function MediaDetailModal({
   const [optionsIs4k, setOptionsIs4k] = useState(false);
   const [quickKind, setQuickKind] = useState<null | "hd" | "4k">(null);
   const [quickError, setQuickError] = useState<RequestError | null>(null);
+  const [removeConfirmVisible, setRemoveConfirmVisible] = useState(false);
   // Set when a request succeeded in the options sheet: this modal dismisses
   // itself only once the sheet reports fully gone (its onClosed) — dismissing
   // both stacked pageSheets in the same tick races the child's teardown on
@@ -143,6 +147,7 @@ export function MediaDetailModal({
 
   const requestMovie = useRequestMovie();
   const requestTV = useRequestTV();
+  const removeMedia = useDeleteMedia();
 
   useEffect(() => {
     if (visible) {
@@ -152,7 +157,10 @@ export function MediaDetailModal({
   }, [visible, item?.id]);
 
   useEffect(() => {
-    if (!visible) setOptionsVisible(false);
+    if (!visible) {
+      setOptionsVisible(false);
+      setRemoveConfirmVisible(false);
+    }
   }, [visible]);
 
   if (!item) return null;
@@ -167,6 +175,11 @@ export function MediaDetailModal({
   const mediaInfo = detailsData?.mediaInfo ?? item.mediaInfo;
   const statusHd = mediaInfo?.status;
   const status4k = mediaInfo?.status4k;
+
+  // Internal Seerr media id — only present once full details load and the title
+  // is actually tracked. Required by deleteMedia (the list item's mediaInfo
+  // carries status but no id).
+  const mediaDbId = detailsData?.mediaInfo?.id;
 
   const isAvailableHd = statusHd === 5;
   const isPendingHd = statusHd === 2 || statusHd === 3;
@@ -215,6 +228,28 @@ export function MediaDetailModal({
     // Default the advanced sheet to the tier the user can actually request.
     setOptionsIs4k(!canRequestHd && canRequest4k);
     setOptionsVisible(true);
+  };
+
+  // Untrack the media in Seerr (resets status so it can be re-requested; does
+  // not delete files). Keep this modal open afterwards — closing it in the same
+  // tick as the confirm's dismiss would race the iOS pageSheet teardown (issue
+  // #83). The status re-renders to "Request" once the cache invalidates.
+  //
+  // Tracked = Seerr holds a media record for either tier in any requested state:
+  // pending (2) / processing (3) / partial (4) / available (5). status 1
+  // (unknown) is excluded. Checked directly off the status because the
+  // isPending*/isAvailable* flags above skip PARTIAL (4).
+  const isTracked =
+    mediaDbId !== undefined &&
+    [statusHd, status4k].some((s) => s !== undefined && s >= 2);
+
+  const handleRemoveMedia = () => {
+    if (mediaDbId === undefined || removeMedia.isPending) return;
+    setRemoveConfirmVisible(false);
+    removeMedia.mutate(mediaDbId, {
+      onSuccess: () => toast(`${title} removed from Seerr`),
+      onError: (err) => toastError("Failed to remove media", err),
+    });
   };
 
   return (
@@ -414,6 +449,29 @@ export function MediaDetailModal({
               ) : null}
 
               <RequestErrorBanner error={quickError} />
+
+              {/* Remove from Seerr — untracks the media so it can be requested
+                  again. Only shown once the title is tracked. */}
+              {isTracked ? (
+                <Pressable
+                  onPress={() => setRemoveConfirmVisible(true)}
+                  disabled={submitting || removeMedia.isPending}
+                  accessibilityRole="button"
+                  accessibilityLabel="Remove from Seerr"
+                  className={`flex-row items-center justify-center gap-2 py-3 rounded-xl border border-danger/30 bg-danger/10 ${submitting || removeMedia.isPending ? "opacity-50" : "active:opacity-70"}`}
+                >
+                  {removeMedia.isPending ? (
+                    <ActivityIndicator size="small" color="#ef4444" />
+                  ) : (
+                    <>
+                      <Icon icon={Trash2} size={16} color="#ef4444" />
+                      <Text className="text-danger font-medium text-sm">
+                        Remove from Seerr
+                      </Text>
+                    </>
+                  )}
+                </Pressable>
+              ) : null}
             </View>
 
             {/* Overview */}
@@ -447,6 +505,17 @@ export function MediaDetailModal({
               onClose();
             }
           }}
+        />
+
+        <ConfirmModal
+          visible={removeConfirmVisible}
+          title="Remove media?"
+          message={`Remove "${title}" from Seerr? It can be requested again afterwards. This does not delete files from your server.`}
+          icon={Trash2}
+          tone="danger"
+          confirmLabel="Remove"
+          onConfirm={handleRemoveMedia}
+          onCancel={() => setRemoveConfirmVisible(false)}
         />
       </View>
     </Modal>

--- a/hooks/use-overseerr.ts
+++ b/hooks/use-overseerr.ts
@@ -29,6 +29,8 @@ import {
   requestTV,
   approveRequest,
   declineRequest,
+  deleteRequest,
+  deleteMedia,
   getMovieDetails,
   getTVDetails,
   getOverseerrRadarrServers,
@@ -290,6 +292,34 @@ export function useDeclineRequest(instanceId?: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["overseerr", id, "requests"] });
       queryClient.invalidateQueries({ queryKey: ["overseerr", id, "requestCount"] });
+    },
+  });
+}
+
+// Deletes the request record only. Mirrors approve/decline invalidation since
+// the underlying media availability is unaffected.
+export function useDeleteRequest(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("overseerr", instanceId);
+  return useMutation({
+    mutationFn: (requestId: number) => deleteRequest(requestId, id ?? undefined),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["overseerr", id, "requests"] });
+      queryClient.invalidateQueries({ queryKey: ["overseerr", id, "requestCount"] });
+    },
+  });
+}
+
+// Untracks the media in Seerr (resets status so it can be re-requested; does not
+// touch files). Invalidates the whole "overseerr" subtree because this also
+// changes media-detail availability, not just the requests list.
+export function useDeleteMedia(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("overseerr", instanceId);
+  return useMutation({
+    mutationFn: (mediaId: number) => deleteMedia(mediaId, id ?? undefined),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["overseerr"] });
     },
   });
 }

--- a/services/overseerr-api.ts
+++ b/services/overseerr-api.ts
@@ -344,6 +344,19 @@ export function declineRequest(
   });
 }
 
+// Removes just the request record. With MANAGE_REQUESTS any request can be
+// deleted; otherwise only pending ones. Leaves the underlying media untouched —
+// use deleteMedia() to untrack the media itself.
+export function deleteRequest(
+  requestId: number,
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("overseerr", `/request/${requestId}`, {
+    method: "DELETE",
+    instanceId,
+  });
+}
+
 // --- Media Details ---
 
 export function getMovieDetails(


### PR DESCRIPTION
Adds two destructive Seerr actions:

- **Requests tab**: per-row action sheet to **Delete request** or **Remove media** (untrack). Sheet/confirm chained via useModalFlow (issue #83 safe).
- **Media detail**: **Remove from Seerr** action with confirm, shown once tracked.

`removeMedia` untracks the media (re-requestable) and does not delete files (`DELETE /media/{id}`). New `deleteRequest` service + `useDeleteRequest`/`useDeleteMedia` hooks with proper cache invalidation.

## Test plan
- Requests tab: delete a request; remove media on a processing/available item; verify list refreshes.
- Media detail: remove a tracked title; status reverts to Request.
- iOS: confirm no frozen-modal hang on sheet -> confirm.