### PR TITLE
feat(arr): grab/download history for a movie or TV episode

### DIFF
--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -11,6 +11,7 @@ import {
   Check,
   ChevronRight,
   FolderTree,
+  History,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { toastError } from "@/components/ui/toast";
@@ -295,6 +296,18 @@ export default function MovieDetailScreen() {
         {...flow.bind("actions")}
         title={movie.title}
         actions={[
+          {
+            label: "History",
+            icon: <Icon icon={History} size={18} color="#a1a1aa" />,
+            onPress: () =>
+              flow.whenClear(() =>
+                router.push(
+                  instanceId
+                    ? `/movie/history/${movie.id}?instanceId=${instanceId}`
+                    : `/movie/history/${movie.id}`,
+                ),
+              ),
+          },
           {
             label: "Delete Movie",
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,

--- a/app/movie/history/[id].tsx
+++ b/app/movie/history/[id].tsx
@@ -1,0 +1,28 @@
+import { View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { BackHeader } from "@/components/common/back-header";
+import { ArrHistoryList } from "@/components/common/arr-history-list";
+import { useRadarrMovie, useRadarrMovieHistory } from "@/hooks/use-radarr";
+import { normalizeRadarrHistory } from "@/lib/arr-history";
+
+export default function MovieHistoryScreen() {
+  const { id, instanceId } = useLocalSearchParams<{
+    id: string;
+    instanceId?: string;
+  }>();
+  const movieId = Number(id);
+  const { data: movie } = useRadarrMovie(movieId, instanceId);
+  const query = useRadarrMovieHistory(movieId, instanceId);
+
+  const title = movie ? `History · ${movie.title}` : "History";
+
+  return (
+    <ScreenWrapper scrollable={false}>
+      <BackHeader title={title} />
+      <View className="flex-1">
+        <ArrHistoryList query={query} normalize={normalizeRadarrHistory} />
+      </View>
+    </ScreenWrapper>
+  );
+}

--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -15,6 +15,7 @@ import {
   Circle,
   FolderTree,
   Pencil,
+  History,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { toastError } from "@/components/ui/toast";
@@ -886,6 +887,18 @@ function EpisodeRow({
             `/series/releases/${seriesId}?episodeId=${episode.id}${
               instanceId ? `&instanceId=${instanceId}` : ""
             }`,
+          ),
+        ),
+    },
+    {
+      label: "History",
+      icon: <Icon icon={History} size={20} color="#a1a1aa" />,
+      onPress: () =>
+        flow.whenClear(() =>
+          router.push(
+            `/series/history/${episode.id}?title=${encodeURIComponent(
+              formatEpisodeCode(episode.seasonNumber, episode.episodeNumber),
+            )}${instanceId ? `&instanceId=${instanceId}` : ""}`,
           ),
         ),
     },

--- a/app/series/history/[id].tsx
+++ b/app/series/history/[id].tsx
@@ -1,0 +1,30 @@
+import { View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { BackHeader } from "@/components/common/back-header";
+import { ArrHistoryList } from "@/components/common/arr-history-list";
+import { useSonarrEpisodeHistory } from "@/hooks/use-sonarr";
+import { normalizeSonarrHistory } from "@/lib/arr-history";
+
+// `id` is the Sonarr episodeId; `title` is a pre-formatted label (e.g. "S02E04")
+// passed by the caller so we don't need to re-fetch the episode for the header.
+export default function EpisodeHistoryScreen() {
+  const { id, instanceId, title } = useLocalSearchParams<{
+    id: string;
+    instanceId?: string;
+    title?: string;
+  }>();
+  const episodeId = Number(id);
+  const query = useSonarrEpisodeHistory(episodeId, instanceId);
+
+  const heading = title ? `History · ${title}` : "History";
+
+  return (
+    <ScreenWrapper scrollable={false}>
+      <BackHeader title={heading} />
+      <View className="flex-1">
+        <ArrHistoryList query={query} normalize={normalizeSonarrHistory} />
+      </View>
+    </ScreenWrapper>
+  );
+}

--- a/components/common/arr-history-list.tsx
+++ b/components/common/arr-history-list.tsx
@@ -1,0 +1,169 @@
+import { useCallback, useMemo } from "react";
+import { View, Text, FlatList, RefreshControl } from "react-native";
+import { AlertTriangle, History } from "lucide-react-native";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { Icon } from "@/components/ui/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getQualityColor } from "@/lib/quality-colors";
+import { getHttpErrorMessage } from "@/lib/http-client";
+import { formatBytes, formatTimeAgo } from "@/lib/utils";
+import { lightHaptic } from "@/lib/haptics";
+import {
+  historyEventMeta,
+  HISTORY_TONE_COLOR,
+  type ArrHistoryEntry,
+} from "@/lib/arr-history";
+
+interface ArrHistoryListProps<T> {
+  query: UseQueryResult<T[], Error>;
+  normalize: (record: T) => ArrHistoryEntry;
+}
+
+function HistoryRow({ entry }: { entry: ArrHistoryEntry }) {
+  const meta = historyEventMeta(entry.eventType);
+  const toneColor = HISTORY_TONE_COLOR[meta.tone];
+  const quality = entry.qualityName ? getQualityColor(entry.qualityName) : null;
+  const timeAgo = formatTimeAgo(entry.date);
+
+  const metaParts: string[] = [];
+  if (entry.indexer) metaParts.push(entry.indexer);
+  if (entry.sizeBytes) metaParts.push(formatBytes(entry.sizeBytes));
+  if (entry.downloadClient) metaParts.push(entry.downloadClient);
+
+  return (
+    <View className="mx-4 mb-2 rounded-2xl bg-surface border border-border overflow-hidden">
+      <View className="flex-row">
+        <View className="w-1" style={{ backgroundColor: toneColor }} />
+        <View className="flex-1 p-3">
+          <View className="flex-row items-center justify-between gap-2 mb-1.5">
+            <View className="flex-row items-center gap-1.5">
+              <Icon icon={meta.icon} size={14} color={toneColor} />
+              <Text
+                className="text-xs font-bold uppercase tracking-wide"
+                style={{ color: toneColor }}
+              >
+                {meta.label}
+              </Text>
+            </View>
+            {timeAgo ? (
+              <Text className="text-zinc-500 text-xs" numberOfLines={1}>
+                {timeAgo}
+              </Text>
+            ) : null}
+          </View>
+
+          <Text
+            className="text-zinc-100 text-sm font-medium leading-5"
+            numberOfLines={2}
+          >
+            {entry.title}
+          </Text>
+
+          {quality || entry.releaseGroup ? (
+            <View className="flex-row items-center flex-wrap gap-1.5 mt-2">
+              {quality ? (
+                <View
+                  className="rounded-md px-1.5 py-0.5"
+                  style={{ backgroundColor: quality.bg }}
+                >
+                  <Text
+                    className="text-xs font-semibold"
+                    style={{ color: quality.text }}
+                  >
+                    {entry.qualityName}
+                  </Text>
+                </View>
+              ) : null}
+              {entry.releaseGroup ? (
+                <Text className="text-xs text-zinc-500" numberOfLines={1}>
+                  {entry.releaseGroup}
+                </Text>
+              ) : null}
+            </View>
+          ) : null}
+
+          {metaParts.length > 0 ? (
+            <Text className="text-zinc-400 text-xs mt-1.5" numberOfLines={1}>
+              {metaParts.join("   ·   ")}
+            </Text>
+          ) : null}
+
+          {entry.reason ? (
+            <Text className="text-red-400 text-xs mt-1.5 leading-4" numberOfLines={2}>
+              {entry.reason}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// Shared history list for both the movie and episode History screens. Radarr
+// and Sonarr records flow through the same `normalize` shape, so this component
+// stays service-agnostic. Records arrive pre-sorted date-descending from the API.
+export function ArrHistoryList<T>({ query, normalize }: ArrHistoryListProps<T>) {
+  const { data, isLoading, isError, error, isFetching, refetch } = query;
+
+  const entries = useMemo(
+    () => (data ?? []).map(normalize),
+    [data, normalize],
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (isFetching) return;
+    lightHaptic();
+    refetch();
+  }, [isFetching, refetch]);
+
+  if (isLoading && !data) {
+    return (
+      <View className="flex-1 gap-2 px-4 pt-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} height={92} borderRadius={16} />
+        ))}
+      </View>
+    );
+  }
+
+  if (isError && !data) {
+    return (
+      <EmptyState
+        icon={<Icon icon={AlertTriangle} size={28} color="#ef4444" />}
+        title="Couldn't load history"
+        message={getHttpErrorMessage(error) ?? error?.message ?? "Unknown error"}
+        action={<Button label="Retry" onPress={handleRefresh} />}
+      />
+    );
+  }
+
+  return (
+    <FlatList
+      data={entries}
+      keyExtractor={(e) => String(e.id)}
+      renderItem={({ item }) => <HistoryRow entry={item} />}
+      contentContainerStyle={{ paddingTop: 8, paddingBottom: 32, flexGrow: 1 }}
+      showsVerticalScrollIndicator={false}
+      refreshControl={
+        <RefreshControl
+          refreshing={isFetching}
+          onRefresh={handleRefresh}
+          tintColor="#3b82f6"
+          colors={["#3b82f6"]}
+          progressBackgroundColor="#18181b"
+        />
+      }
+      ListEmptyComponent={
+        <View className="flex-1 justify-center px-4">
+          <EmptyState
+            icon={<Icon icon={History} size={28} color="#71717a" />}
+            title="No history yet"
+            message="Nothing has been grabbed or imported for this item yet. Pull to refresh."
+          />
+        </View>
+      }
+    />
+  );
+}

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -4,6 +4,7 @@ import {
   getMovie,
   getQueue,
   getHistory,
+  getMovieHistory,
   getAllWantedMissing,
   getCalendar,
   searchMovies,
@@ -67,6 +68,19 @@ export function useRadarrQueue(instanceId?: string) {
     queryFn: () => getQueue(1, 20, true, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
+  });
+}
+
+// Per-movie history for the movie History screen. Scoped cache key so it never
+// collides with the global useRadarrHistory (page-1 activity feed).
+export function useRadarrMovieHistory(movieId: number, instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
+  return useQuery({
+    queryKey: ["radarr", id, "history", "movie", movieId],
+    queryFn: () => getMovieHistory(movieId, id ?? undefined),
+    enabled: enabled && movieId > 0 && !!id,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -8,6 +8,7 @@ import {
   getCalendar,
   getQueue,
   getHistory,
+  getEpisodeHistory,
   searchSeries,
   addSeries,
   deleteSeries,
@@ -92,6 +93,19 @@ export function useSonarrQueue(instanceId?: string) {
     queryFn: () => getQueue(1, 20, true, true, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
+  });
+}
+
+// Per-episode history for the episode History screen. Scoped cache key so it
+// never collides with the global useSonarrHistory (page-1 activity feed).
+export function useSonarrEpisodeHistory(episodeId: number, instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
+  return useQuery({
+    queryKey: ["sonarr", id, "history", "episode", episodeId],
+    queryFn: () => getEpisodeHistory(episodeId, id ?? undefined),
+    enabled: enabled && episodeId > 0 && !!id,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/lib/arr-history.test.ts
+++ b/lib/arr-history.test.ts
@@ -1,0 +1,115 @@
+import {
+  normalizeRadarrHistory,
+  normalizeSonarrHistory,
+  historyEventMeta,
+  HISTORY_TONE_COLOR,
+} from "@/lib/arr-history";
+import type { RadarrHistoryRecord, SonarrHistoryRecord } from "@/lib/types";
+
+describe("normalizeRadarrHistory", () => {
+  it("pulls release, indexer, group, size and client from a grabbed record", () => {
+    const record: RadarrHistoryRecord = {
+      id: 42,
+      eventType: "grabbed",
+      sourceTitle: "Dune.Part.Two.2024.2160p.WEB-DL-GROUP",
+      date: "2024-11-02T20:14:00Z",
+      quality: { quality: { id: 19, name: "WEBDL-2160p" } },
+      data: {
+        indexer: "NZBgeek",
+        releaseGroup: "GROUP",
+        size: "64424509440",
+        downloadClient: "SABnzbd",
+        protocol: "usenet",
+      },
+    };
+    const entry = normalizeRadarrHistory(record);
+    expect(entry).toMatchObject({
+      id: 42,
+      eventType: "grabbed",
+      title: "Dune.Part.Two.2024.2160p.WEB-DL-GROUP",
+      indexer: "NZBgeek",
+      releaseGroup: "GROUP",
+      qualityName: "WEBDL-2160p",
+      sizeBytes: 64424509440,
+      downloadClient: "SABnzbd",
+      protocol: "usenet",
+    });
+  });
+
+  it("falls back to the event label and leaves fields undefined when data is absent", () => {
+    const record: RadarrHistoryRecord = {
+      id: 7,
+      eventType: "movieFileDeleted",
+    };
+    const entry = normalizeRadarrHistory(record);
+    expect(entry.title).toBe("File Deleted");
+    expect(entry.indexer).toBeUndefined();
+    expect(entry.sizeBytes).toBeUndefined();
+    expect(entry.qualityName).toBeUndefined();
+    expect(entry.languages).toEqual([]);
+  });
+
+  it("drops a zero or non-numeric size instead of surfacing 0 bytes", () => {
+    expect(
+      normalizeRadarrHistory({ id: 1, eventType: "grabbed", data: { size: "0" } })
+        .sizeBytes,
+    ).toBeUndefined();
+    expect(
+      normalizeRadarrHistory({ id: 2, eventType: "grabbed", data: { size: "" } })
+        .sizeBytes,
+    ).toBeUndefined();
+  });
+
+  it("prefers downloadClient but falls back to downloadClientName", () => {
+    expect(
+      normalizeRadarrHistory({
+        id: 3,
+        eventType: "grabbed",
+        data: { downloadClientName: "qBittorrent" },
+      }).downloadClient,
+    ).toBe("qBittorrent");
+  });
+});
+
+describe("normalizeSonarrHistory", () => {
+  it("normalizes an import record and its languages", () => {
+    const record: SonarrHistoryRecord = {
+      id: 900,
+      eventType: "downloadFolderImported",
+      sourceTitle: "House.of.the.Dragon.S02E03.1080p-GRP",
+      date: "2024-06-30T12:00:00Z",
+      quality: { quality: { id: 4, name: "WEBDL-1080p" } },
+      languages: [{ id: 1, name: "English" }],
+      data: { indexer: "DrunkenSlug", releaseGroup: "GRP" },
+    };
+    const entry = normalizeSonarrHistory(record);
+    expect(entry.title).toBe("House.of.the.Dragon.S02E03.1080p-GRP");
+    expect(entry.indexer).toBe("DrunkenSlug");
+    expect(entry.qualityName).toBe("WEBDL-1080p");
+    expect(entry.languages).toEqual(["English"]);
+  });
+});
+
+describe("historyEventMeta", () => {
+  it("maps known event types to a label and tone", () => {
+    expect(historyEventMeta("grabbed")).toMatchObject({
+      label: "Grabbed",
+      tone: "grab",
+    });
+    expect(historyEventMeta("downloadFailed").tone).toBe("danger");
+    expect(historyEventMeta("downloadFolderImported").label).toBe("Imported");
+  });
+
+  it("prettifies unknown camelCase event types", () => {
+    expect(historyEventMeta("seriesFolderImported").label).toBe(
+      "Series Folder Imported",
+    );
+    expect(historyEventMeta("").label).toBe("Event");
+  });
+
+  it("exposes a color for every tone it returns", () => {
+    for (const type of ["grabbed", "downloadFailed", "movieFileDeleted", "x"]) {
+      expect(HISTORY_TONE_COLOR[historyEventMeta(type).tone]).toMatch(/^#/);
+    }
+  });
+});

--- a/lib/arr-history.ts
+++ b/lib/arr-history.ts
@@ -1,0 +1,128 @@
+import type { ComponentType } from "react";
+import {
+  Download,
+  CheckCircle2,
+  XCircle,
+  Trash2,
+  Pencil,
+  Ban,
+  History,
+} from "lucide-react-native";
+import type {
+  ArrHistoryData,
+  ArrQualityModel,
+  RadarrHistoryRecord,
+  SonarrHistoryRecord,
+} from "@/lib/types";
+
+// A single grab/import/delete event, normalized so the shared history UI can
+// render Radarr and Sonarr records through one code path. Both services expose
+// the same `data`/`quality`/`languages` shape, so the two normalizers below are
+// thin wrappers around one internal function.
+export interface ArrHistoryEntry {
+  id: number;
+  eventType: string;
+  // The release name (sourceTitle); falls back to the event label when absent.
+  title: string;
+  date?: string;
+  indexer?: string;
+  releaseGroup?: string;
+  qualityName?: string;
+  sizeBytes?: number;
+  downloadClient?: string;
+  protocol?: string;
+  languages: string[];
+  // Populated for failed/ignored events, mirroring a release rejection reason.
+  reason?: string;
+}
+
+export type HistoryTone = "grab" | "success" | "danger" | "muted" | "info";
+
+export interface HistoryEventMeta {
+  label: string;
+  icon: ComponentType<any>;
+  tone: HistoryTone;
+}
+
+// Purple for grabs matches the *arr "grabbing" badge used elsewhere in the app
+// (see lib/arr-poster-status.ts); the rest follow the app's semantic palette.
+export const HISTORY_TONE_COLOR: Record<HistoryTone, string> = {
+  grab: "#a855f7",
+  success: "#22c55e",
+  danger: "#ef4444",
+  muted: "#71717a",
+  info: "#3b82f6",
+};
+
+const EVENT_META: Record<string, HistoryEventMeta> = {
+  grabbed: { label: "Grabbed", icon: Download, tone: "grab" },
+  downloadFolderImported: { label: "Imported", icon: CheckCircle2, tone: "success" },
+  downloadImported: { label: "Imported", icon: CheckCircle2, tone: "success" },
+  movieFolderImported: { label: "Imported", icon: CheckCircle2, tone: "success" },
+  downloadFailed: { label: "Failed", icon: XCircle, tone: "danger" },
+  importFailed: { label: "Import Failed", icon: XCircle, tone: "danger" },
+  downloadIgnored: { label: "Ignored", icon: Ban, tone: "muted" },
+  movieFileDeleted: { label: "File Deleted", icon: Trash2, tone: "muted" },
+  episodeFileDeleted: { label: "File Deleted", icon: Trash2, tone: "muted" },
+  movieFileRenamed: { label: "Renamed", icon: Pencil, tone: "muted" },
+  episodeFileRenamed: { label: "Renamed", icon: Pencil, tone: "muted" },
+};
+
+function prettifyEventType(eventType: string): string {
+  if (!eventType) return "Event";
+  const spaced = eventType.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function historyEventMeta(eventType: string): HistoryEventMeta {
+  return (
+    EVENT_META[eventType] ?? {
+      label: prettifyEventType(eventType),
+      icon: History,
+      tone: "info",
+    }
+  );
+}
+
+interface RawHistoryRecord {
+  id: number;
+  eventType: string;
+  sourceTitle?: string;
+  date?: string;
+  data?: ArrHistoryData;
+  quality?: ArrQualityModel;
+  languages?: { id: number; name: string }[];
+}
+
+function normalize(record: RawHistoryRecord): ArrHistoryEntry {
+  const data = record.data ?? {};
+  const size = data.size ? Number(data.size) : NaN;
+  return {
+    id: record.id,
+    eventType: record.eventType,
+    title: record.sourceTitle || historyEventMeta(record.eventType).label,
+    date: record.date,
+    indexer: data.indexer || undefined,
+    releaseGroup: data.releaseGroup || undefined,
+    qualityName: record.quality?.quality?.name,
+    sizeBytes: Number.isFinite(size) && size > 0 ? size : undefined,
+    downloadClient: data.downloadClient || data.downloadClientName || undefined,
+    protocol: data.protocol || undefined,
+    languages: (record.languages ?? [])
+      .map((l) => l.name)
+      .filter((name): name is string => !!name),
+    reason: data.reason || undefined,
+  };
+}
+
+export function normalizeRadarrHistory(
+  record: RadarrHistoryRecord,
+): ArrHistoryEntry {
+  return normalize(record);
+}
+
+export function normalizeSonarrHistory(
+  record: SonarrHistoryRecord,
+): ArrHistoryEntry {
+  return normalize(record);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -378,6 +378,33 @@ export interface RadarrQueue {
   records: RadarrQueueItem[];
 }
 
+// Quality wrapper shared by releases and history records (the *arr QualityModel).
+export interface ArrQualityModel {
+  quality: { id: number; name: string; source?: string; resolution?: number };
+  revision?: { version?: number; real?: number; isRepack?: boolean };
+}
+
+// The `data` bag on a history record. The *arr API types it as
+// Dictionary<string,string>, so every value is a string (or absent). These are
+// the keys populated for grab/import/failed events; the index signature keeps
+// the type honest for the ones we don't enumerate.
+export interface ArrHistoryData {
+  indexer?: string;
+  releaseGroup?: string;
+  nzbInfoUrl?: string;
+  downloadClient?: string;
+  downloadClientName?: string;
+  size?: string;
+  age?: string;
+  ageHours?: string;
+  publishedDate?: string;
+  protocol?: string;
+  reason?: string;
+  droppedPath?: string;
+  importedPath?: string;
+  [key: string]: string | undefined;
+}
+
 export interface RadarrHistoryRecord {
   id: number;
   eventType: string;
@@ -386,6 +413,9 @@ export interface RadarrHistoryRecord {
   downloadId?: string;
   movieId?: number;
   movie?: RadarrMovie;
+  data?: ArrHistoryData;
+  quality?: ArrQualityModel;
+  languages?: { id: number; name: string }[];
 }
 
 export interface RadarrHistory {
@@ -638,6 +668,9 @@ export interface SonarrHistoryRecord {
   episodeId?: number;
   series?: SonarrSeries;
   episode?: SonarrEpisode;
+  data?: ArrHistoryData;
+  quality?: ArrQualityModel;
+  languages?: { id: number; name: string }[];
 }
 
 export interface SonarrHistory {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -195,6 +195,30 @@ export function formatResolution(resolution: string): string {
  * Compact age label for a release. Prefers ageHours/ageMinutes when fresh so
  * "12m" / "3h" surface instead of "0d" for new uploads.
  */
+/**
+ * Compact "time ago" label for an absolute timestamp, with finer granularity
+ * than relativeDate (which is day-only). Used for history entries ("grabbed 3h
+ * ago"). Falls back to an absolute short date once past a week.
+ */
+export function formatTimeAgo(dateString?: string): string {
+  if (!dateString) return "";
+  const then = new Date(dateString).getTime();
+  if (Number.isNaN(then)) return "";
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 45) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(seconds / 3600);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(seconds / 86400);
+  if (days < 7) return `${days}d ago`;
+  return new Date(then).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 export function formatReleaseAge(
   ageDays: number,
   ageHours?: number,

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -3,6 +3,7 @@ import type {
   RadarrMovie,
   RadarrQueue,
   RadarrHistory,
+  RadarrHistoryRecord,
   RadarrWantedMissing,
   RadarrSearchResult,
   RadarrImage,
@@ -76,6 +77,20 @@ export function getHistory(
       sortDirection: "descending",
       includeMovie: true,
     },
+    instanceId,
+  });
+}
+
+// Per-movie history: grabs, imports, deletions for a single movie. Unlike the
+// global /history above this endpoint returns a plain array (not paged) and is
+// sorted date-descending by the server. includeMovie:false keeps the payload
+// lean since the caller already has the movie.
+export function getMovieHistory(
+  movieId: number,
+  instanceId?: string,
+): Promise<RadarrHistoryRecord[]> {
+  return serviceRequest<RadarrHistoryRecord[]>("radarr", "/history/movie", {
+    params: { movieId, includeMovie: false },
     instanceId,
   });
 }

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -6,6 +6,7 @@ import type {
   SonarrCalendarEntry,
   SonarrQueue,
   SonarrHistory,
+  SonarrHistoryRecord,
   SonarrSearchResult,
   SonarrSeriesType,
   SonarrImage,
@@ -173,6 +174,28 @@ export function getHistory(
     },
     instanceId,
   });
+}
+
+// Per-episode history: grabs, imports, deletions for one episode. Sonarr only
+// exposes episodeId filtering on the paged /history endpoint (the /history/series
+// endpoint filters by season, not episode), so we page one large batch and hand
+// back the records array. Sorted date-descending by the server.
+export function getEpisodeHistory(
+  episodeId: number,
+  instanceId?: string,
+): Promise<SonarrHistoryRecord[]> {
+  return serviceRequest<SonarrHistory>("sonarr", "/history", {
+    params: {
+      episodeId,
+      page: 1,
+      pageSize: 100,
+      sortKey: "date",
+      sortDirection: "descending",
+      includeSeries: false,
+      includeEpisode: false,
+    },
+    instanceId,
+  }).then((res) => res.records);
 }
 
 // --- Search ---


### PR DESCRIPTION
Refs #254

Adds per-item download/grab history for Radarr movies and Sonarr episodes: what release was grabbed, when, and from which indexer.

## What
- **History** entry in the movie `⋯` menu and the episode `⋯` menu, opening a dedicated screen (mirrors the existing `/releases/[id]` pattern).
- Each row shows the event (Grabbed / Imported / Failed / Deleted), release name, quality, indexer, size, download client, and a relative timestamp.
- Radarr and Sonarr records flow through one shared normalizer + list component, so the two integrations stay DRY.

## Notes
- Endpoints verified against Radarr/Sonarr `develop` source: Radarr `GET /history/movie?movieId=`, Sonarr `GET /history?episodeId=`.
- No demo-mode fixtures (global *arr history is already undemoed; Sonarr's demo `/episode` returns `[]`, so the episode screen is unreachable in demo anyway).

## Test plan
- `tsc --noEmit`: clean.
- `jest`: 722 passed (34 suites), including 8 new tests for the history normalizers.
- Not driven on-device against a live *arr instance; data transform + endpoint shape verified.