### PR TITLE
feat(radarr): edit minimum availability and movie path

### DIFF
--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { View, Text, ScrollView, Linking, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
@@ -12,6 +13,7 @@ import {
   ChevronRight,
   FolderTree,
   History,
+  Pencil,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { toastError } from "@/components/ui/toast";
@@ -35,11 +37,13 @@ import {
   useDeleteMovie,
   useToggleMovieMonitored,
   useRadarrQualityProfiles,
-  useUpdateMovieQualityProfile,
+  useUpdateMovieFields,
   useRadarrRootFolders,
   useUpdateMovieRootFolder,
   useRadarrTags,
 } from "@/hooks/use-radarr";
+import { MovieOptionsSheet } from "@/components/radarr/movie-options-sheet";
+import { MIN_AVAILABILITY_OPTIONS } from "@/components/radarr/add-movie-sheet";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import {
@@ -62,10 +66,11 @@ export default function MovieDetailScreen() {
   const deleteMutation = useDeleteMovie(instanceId);
   const toggleMonitored = useToggleMovieMonitored(instanceId);
   const { data: qualityProfiles } = useRadarrQualityProfiles(instanceId);
-  const updateProfile = useUpdateMovieQualityProfile(instanceId);
+  const updateFields = useUpdateMovieFields(instanceId);
   const { data: rootFolders } = useRadarrRootFolders(instanceId);
   const updateRootFolder = useUpdateMovieRootFolder(instanceId);
   const { data: tags } = useRadarrTags(instanceId);
+  const [optionsVisible, setOptionsVisible] = useState(false);
 
   // All modal sequencing (sheet → confirm, sheet → sheet, confirm → pop) goes
   // through the flow — see hooks/use-modal-flow.ts.
@@ -165,7 +170,7 @@ export default function MovieDetailScreen() {
       key: "quality",
       icon: Award,
       label: qualityProfileName ?? "Quality",
-      loading: updateProfile.isPending,
+      loading: updateFields.isPending,
       onPress: () => flow.open("quality"),
       disabled: !qualityProfiles || qualityProfiles.length === 0,
     },
@@ -250,6 +255,8 @@ export default function MovieDetailScreen() {
                 : undefined
             }
           />
+
+          <OptionsBlock movie={movie} onPress={() => setOptionsVisible(true)} />
 
           {movie.overview ? (
             <View className="mb-5">
@@ -338,12 +345,20 @@ export default function MovieDetailScreen() {
           ),
           onPress: () => {
             if (p.id === movie.qualityProfileId) return;
-            updateProfile.mutate({
+            updateFields.mutate({
               movieId: movie.id,
-              qualityProfileId: p.id,
+              fields: { qualityProfileId: p.id },
+              errorLabel: "Failed to update quality profile",
             });
           },
         }))}
+      />
+
+      <MovieOptionsSheet
+        visible={optionsVisible}
+        onClose={() => setOptionsVisible(false)}
+        movie={movie}
+        instanceId={instanceId}
       />
 
       <ActionSheet
@@ -543,6 +558,58 @@ function MovieFileBlock({
           <AboutRow label="Added" value={formatReleaseDate(movie.added)} />
         </View>
       </View>
+    </View>
+  );
+}
+
+// Editable Radarr movie options (issue #216): minimum availability + path. The
+// whole card is one tap target and opens the MovieOptionsSheet editor — mirrors
+// Sonarr's OptionsBlock.
+function OptionsBlock({
+  movie,
+  onPress,
+}: {
+  movie: RadarrMovie;
+  onPress: () => void;
+}) {
+  const availabilityLabel =
+    MIN_AVAILABILITY_OPTIONS.find((o) => o.value === movie.minimumAvailability)
+      ?.label ??
+    (movie.minimumAvailability ? capitalize(movie.minimumAvailability) : "—");
+  return (
+    <View className="mb-5">
+      <SectionLabel>Options</SectionLabel>
+      <Pressable
+        onPress={onPress}
+        className="rounded-2xl bg-surface border border-border p-4 flex-row items-center active:opacity-70"
+        accessibilityRole="button"
+        accessibilityLabel="Edit movie options"
+      >
+        <View className="flex-1 gap-2.5">
+          <OptionRow label="Availability" value={availabilityLabel} />
+          {movie.path ? <OptionRow label="Path" value={movie.path} /> : null}
+        </View>
+        <View className="ml-3 w-9 h-9 rounded-full bg-surface-light items-center justify-center">
+          <Icon icon={Pencil} size={16} color="#a1a1aa" />
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+function OptionRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-row items-center">
+      <Text className="text-zinc-500 text-[0.65rem] uppercase font-semibold tracking-wider w-20">
+        {label}
+      </Text>
+      <Text
+        className="text-zinc-300 text-xs flex-1 ml-2"
+        numberOfLines={1}
+        ellipsizeMode="middle"
+      >
+        {value}
+      </Text>
     </View>
   );
 }

--- a/components/radarr/add-movie-sheet.tsx
+++ b/components/radarr/add-movie-sheet.tsx
@@ -21,7 +21,9 @@ interface AddMovieSheetProps {
   onClose: () => void;
 }
 
-const MIN_AVAILABILITY_OPTIONS: {
+// Shared with the movie-edit sheet (components/radarr/movie-options-sheet.tsx),
+// mirroring how Sonarr shares SERIES_TYPE_OPTIONS between add + edit sheets.
+export const MIN_AVAILABILITY_OPTIONS: {
   value: RadarrMinimumAvailability;
   label: string;
   description: string;

--- a/components/radarr/movie-options-sheet.tsx
+++ b/components/radarr/movie-options-sheet.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import { Modal, Platform, Text, View } from "react-native";
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
+import { cssInterop } from "nativewind";
+import { Select } from "@/components/ui/select";
+import { TextInput } from "@/components/ui/text-input";
+import { Toggle } from "@/components/ui/toggle";
+import { Button } from "@/components/ui/button";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { MIN_AVAILABILITY_OPTIONS } from "@/components/radarr/add-movie-sheet";
+import { useUpdateMovieFields } from "@/hooks/use-radarr";
+import type { RadarrMinimumAvailability } from "@/services/radarr-api";
+import type { RadarrMovie } from "@/lib/types";
+
+// The sheet holds a TextInput, so it uses the pageSheet keyboard pattern
+// (KeyboardAwareScrollView) — see CLAUDE.md and components/qbittorrent/speed-limits-sheet.tsx.
+cssInterop(KeyboardAwareScrollView, {
+  className: "style",
+  contentContainerClassName: "contentContainerStyle",
+});
+
+interface MovieOptionsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  movie: RadarrMovie;
+  instanceId?: string;
+}
+
+const DEFAULT_MIN_AVAILABILITY: RadarrMinimumAvailability = "released";
+
+// Editable Radarr movie options to match Radarr's Edit dialog (issue #216):
+// minimum availability + the movie's full folder path. A dedicated pageSheet
+// with full-size controls; Save sends all changed fields in a single PUT. The
+// "Move files on disk" toggle is the explicit, defaulted-off opt-in for the
+// destructive move — a separate confirm modal is intentionally avoided because
+// this plain pageSheet Modal must never chain into another modal on iOS
+// (CLAUDE.md modal-sequencing rules / #83 frozen-app hang).
+export function MovieOptionsSheet({
+  visible,
+  onClose,
+  movie,
+  instanceId,
+}: MovieOptionsSheetProps) {
+  const updateFields = useUpdateMovieFields(instanceId);
+
+  const [minimumAvailability, setMinimumAvailability] =
+    useState<RadarrMinimumAvailability>(
+      (movie.minimumAvailability as RadarrMinimumAvailability) ??
+        DEFAULT_MIN_AVAILABILITY,
+    );
+  const [path, setPath] = useState(movie.path ?? "");
+  const [moveFiles, setMoveFiles] = useState(false);
+
+  // Re-seed from the server values whenever the sheet opens.
+  useEffect(() => {
+    if (!visible) return;
+    setMinimumAvailability(
+      (movie.minimumAvailability as RadarrMinimumAvailability) ??
+        DEFAULT_MIN_AVAILABILITY,
+    );
+    setPath(movie.path ?? "");
+    setMoveFiles(false);
+  }, [visible, movie]);
+
+  const trimmedPath = path.trim();
+  const pathChanged = movie.path != null && trimmedPath !== movie.path;
+
+  const fields: Partial<RadarrMovie> = {};
+  if (minimumAvailability !== movie.minimumAvailability) {
+    fields.minimumAvailability = minimumAvailability;
+  }
+  if (pathChanged && trimmedPath.length > 0) {
+    fields.path = trimmedPath;
+  }
+  const dirty = Object.keys(fields).length > 0;
+
+  const handleSave = () => {
+    if (!dirty) return;
+    // Optimistic update keeps the Options card in sync immediately; on error the
+    // hook rolls the caches back and shows a toast.
+    updateFields.mutate({
+      movieId: movie.id,
+      fields,
+      moveFiles: fields.path != null && moveFiles,
+      errorLabel: "Failed to update movie options",
+    });
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Movie Options" onClose={onClose} />
+
+        <KeyboardAwareScrollView
+          className="flex-1"
+          contentContainerClassName="px-4 py-4 pb-8"
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode={Platform.OS === "ios" ? "interactive" : "on-drag"}
+          bottomOffset={20}
+        >
+          <Select
+            label="Minimum Availability"
+            value={minimumAvailability}
+            options={MIN_AVAILABILITY_OPTIONS}
+            onChange={setMinimumAvailability}
+            containerClassName="mb-4"
+          />
+
+          {movie.path != null ? (
+            <>
+              <TextInput
+                label="Path"
+                value={path}
+                onChangeText={setPath}
+                placeholder="/movies/Movie Title (Year)"
+                autoCapitalize="none"
+                autoCorrect={false}
+                containerClassName="mb-2"
+              />
+
+              {pathChanged ? (
+                <Toggle
+                  label="Move files on disk"
+                  description="Move the existing files to the new folder. Leave off to only update the path in Radarr."
+                  value={moveFiles}
+                  onValueChange={setMoveFiles}
+                />
+              ) : null}
+
+              {pathChanged && !moveFiles ? (
+                <Text className="text-yellow-500 text-xs mt-1">
+                  Files on disk will stay in place; only the path recorded in
+                  Radarr changes.
+                </Text>
+              ) : null}
+            </>
+          ) : null}
+
+          <Button
+            label="Save"
+            onPress={handleSave}
+            disabled={!dirty}
+            className="mt-6"
+          />
+        </KeyboardAwareScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -241,16 +241,25 @@ export function useToggleMovieMonitored(instanceId?: string) {
   });
 }
 
-export function useUpdateMovieQualityProfile(instanceId?: string) {
+// Generic movie field update (quality profile, minimum availability, path, …):
+// forwards the cached movie with `fields` overridden via full PUT and mirrors
+// the change optimistically into both caches. Mirrors Sonarr's
+// useUpdateSeriesFields. Pass moveFiles when changing `path` so Radarr moves the
+// files on disk to the new folder. Root-folder switches must NOT use this — they
+// go through useUpdateMovieRootFolder / the /movie/editor endpoint (issue #83).
+export function useUpdateMovieFields(instanceId?: string) {
   const queryClient = useQueryClient();
   const { instanceId: id } = useInstanceTarget("radarr", instanceId);
   return useMutation({
     mutationFn: ({
       movieId,
-      qualityProfileId,
+      fields,
+      moveFiles,
     }: {
       movieId: number;
-      qualityProfileId: number;
+      fields: Partial<RadarrMovie>;
+      errorLabel?: string;
+      moveFiles?: boolean;
     }) => {
       const cached = queryClient.getQueryData<RadarrMovie>([
         "radarr",
@@ -259,12 +268,11 @@ export function useUpdateMovieQualityProfile(instanceId?: string) {
         movieId,
       ]);
       if (!cached) throw new Error("Movie not loaded");
-      return updateMovie(
-        { ...cached, qualityProfileId },
-        id ?? undefined,
-      );
+      return updateMovie({ ...cached, ...fields }, id ?? undefined, {
+        moveFiles,
+      });
     },
-    onMutate: async ({ movieId, qualityProfileId }) => {
+    onMutate: async ({ movieId, fields }) => {
       await queryClient.cancelQueries({ queryKey: ["radarr", id, "movie", movieId] });
       await queryClient.cancelQueries({ queryKey: ["radarr", id, "movies"] });
 
@@ -283,21 +291,19 @@ export function useUpdateMovieQualityProfile(instanceId?: string) {
       if (prevDetail) {
         queryClient.setQueryData<RadarrMovie>(
           ["radarr", id, "movie", movieId],
-          { ...prevDetail, qualityProfileId },
+          { ...prevDetail, ...fields },
         );
       }
       if (prevList) {
         queryClient.setQueryData<RadarrMovie[]>(
           ["radarr", id, "movies"],
-          prevList.map((m) =>
-            m.id === movieId ? { ...m, qualityProfileId } : m,
-          ),
+          prevList.map((m) => (m.id === movieId ? { ...m, ...fields } : m)),
         );
       }
 
       return { prevDetail, prevList };
     },
-    onError: (err, { movieId }, context) => {
+    onError: (err, { movieId, errorLabel }, context) => {
       if (context?.prevDetail) {
         queryClient.setQueryData(
           ["radarr", id, "movie", movieId],
@@ -307,7 +313,7 @@ export function useUpdateMovieQualityProfile(instanceId?: string) {
       if (context?.prevList) {
         queryClient.setQueryData(["radarr", id, "movies"], context.prevList);
       }
-      toastError("Failed to update quality profile", err);
+      toastError(errorLabel ?? "Failed to update movie", err);
     },
     onSettled: (_data, _err, { movieId }) => {
       queryClient.invalidateQueries({ queryKey: ["radarr", id, "movie", movieId] });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -322,6 +322,9 @@ export interface RadarrMovie {
   runtime: number;
   qualityProfileId: number;
   rootFolderPath: string;
+  // Full movie folder path (e.g. "/movies/Inception (2010)"). Editable in
+  // Radarr's Edit dialog; a real runtime field on the GET response.
+  path?: string;
   movieFile?: RadarrMovieFile;
   genres?: string[];
   tags?: number[];


### PR DESCRIPTION
Refs #216

Adds Radarr Edit-dialog parity to the movie detail screen: an Options card (pencil) that opens an edit sheet for Minimum Availability and the movie Path. Mirrors Sonarr's SeriesOptionsSheet. Path changes have an explicit "Move files on disk" toggle (defaulted off) as the destructive-move opt-in; no chained confirm modal, per the iOS modal-sequencing rules. Movie field updates are generalized into useUpdateMovieFields (quality profile now routes through it). The existing root-folder picker and #83 editor flow are untouched.

## Test plan
- tsc --noEmit passes
- Change Minimum Availability, Save, reopen: persists (and reflected in Radarr web UI)
- Edit Path with move off: Radarr path updates, files stay in place
- Edit Path with move on: PUT /movie/{id}?moveFiles=true moves files and persists on next GET (no revert)
- Invalid path surfaces a toast and rolls back the optimistic cache update