### PR TITLE
feat(widget): Android home-screen calendar widget (Refs #224)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -118,5 +118,31 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         cameraPermission: "Allow Dashboarr to scan your backend pairing QR code.",
       },
     ],
+    // Android home-screen "Releasing Soon" calendar widget (issue #224). The
+    // widget UI + data live in widgets/*; this plugin injects the AppWidget
+    // <receiver> + provider metadata into the manifest. `name` MUST match
+    // WIDGET_NAME in widgets/widget-config.ts. updatePeriodMillis is Android's
+    // 30-min floor (smaller is clamped); the reliable refresh is the in-app
+    // foreground push (hooks/use-widget-refresh). The dev variant's ".dev"
+    // applicationIdSuffix doesn't rename the manifest namespace, so prod and dev
+    // install as two distinct providers with no plugin change.
+    [
+      "react-native-android-widget",
+      {
+        widgets: [
+          {
+            name: "Calendar",
+            label: "Releasing Soon",
+            description: "Upcoming TV episodes and movie releases",
+            minWidth: "250dp",
+            minHeight: "110dp",
+            targetCellWidth: 4,
+            targetCellHeight: 2,
+            updatePeriodMillis: 1800000,
+            resizeMode: "horizontal|vertical",
+          },
+        ],
+      },
+    ],
   ],
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -23,6 +23,7 @@ import "@/lib/expo-image-nativewind"; // side-effect: cssInterop on expo-image's
 import { NotificationWatchers } from "@/hooks/use-notification-watchers";
 import { useBackendHealth } from "@/hooks/use-backend-health";
 import { useNetworkAutoSwitch } from "@/hooks/use-network";
+import { useWidgetRefresh } from "@/hooks/use-widget-refresh";
 import { evaluateHomeNetwork } from "@/lib/network";
 import { pushConfigSnapshot } from "@/services/backend-api";
 import { syncInsecureHosts } from "@/lib/insecure-tls";
@@ -165,6 +166,11 @@ function NotificationRouter() {
 
 function BackendHealthPoller() {
   useBackendHealth();
+  return null;
+}
+
+function WidgetRefreshBridge() {
+  useWidgetRefresh();
   return null;
 }
 
@@ -327,6 +333,9 @@ export default function RootLayout() {
               </SilentErrorBoundary>
               <SilentErrorBoundary label="insecure-tls">
                 <InsecureTlsBridge />
+              </SilentErrorBoundary>
+              <SilentErrorBoundary label="widget-refresh">
+                <WidgetRefreshBridge />
               </SilentErrorBoundary>
               <SilentErrorBoundary label="ui-scale">
                 <UiScaleBridge />

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/services/radarr-api";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
+import { pickRadarrDate } from "@/lib/calendar-agenda";
 import {
   radarrBarKind,
   sonarrEpisodeBarKind,
@@ -49,30 +50,6 @@ type CalendarItem =
       instanceId: string;
     }
   | { kind: "movie"; date: string; movie: RadarrMovie; instanceId: string };
-
-function pickRadarrDate(
-  movie: RadarrMovie,
-  type: CalendarSettingsValue["radarrReleaseType"],
-): string | null {
-  const cinemas = movie.inCinemas;
-  const digital = movie.digitalRelease;
-  const physical = movie.physicalRelease;
-  switch (type) {
-    case "cinemas":
-      return cinemas ?? null;
-    case "digital":
-      return digital ?? null;
-    case "physical":
-      return physical ?? null;
-    case "any":
-    default:
-      // Match the Calendar tab's waterfall (digital → physical → cinemas)
-      // so the same movie lands on the same day in both views. Picking the
-      // earliest candidate diverged from the calendar and caused movies to
-      // appear under different dates across the two surfaces.
-      return digital ?? physical ?? cinemas ?? null;
-  }
-}
 
 function isToday(dateString: string): boolean {
   return dateString === localDateKey();

--- a/hooks/use-widget-refresh.tsx
+++ b/hooks/use-widget-refresh.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import { AppState, Platform } from "react-native";
+import { requestWidgetUpdate } from "react-native-android-widget";
+import { useConfigStore } from "@/store/config-store";
+import { queryClient } from "@/lib/query-client";
+import { fetchAgenda } from "@/widgets/fetch-agenda";
+import { CalendarWidget } from "@/widgets/calendar-widget";
+import { resolveScheme } from "@/widgets/widget-task-handler";
+import { WIDGET_NAME } from "@/widgets/widget-config";
+
+// Keeps any placed Android widget fresh while the app is used: pushes an update
+// on foreground and shortly after the in-app calendar queries settle. This is
+// the *reliable* refresh path (the OS 30-min updatePeriodMillis is best-effort
+// and OEM battery savers suppress it). requestWidgetUpdate only invokes
+// renderWidget when a widget is actually on the home screen, so fetchAgenda
+// doesn't run otherwise.
+
+const DEBOUNCE_MS = 2000;
+
+function isCalendarQueryKey(key: readonly unknown[]): boolean {
+  return (
+    (key[0] === "sonarr" || key[0] === "radarr") && key.includes("calendar")
+  );
+}
+
+export function useWidgetRefresh() {
+  const hydrated = useConfigStore((s) => s.hydrated);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (Platform.OS !== "android" || !hydrated) return;
+
+    const pushUpdate = () => {
+      void requestWidgetUpdate({
+        widgetName: WIDGET_NAME,
+        renderWidget: async () => {
+          const vm = await fetchAgenda();
+          return <CalendarWidget {...vm} scheme={resolveScheme()} />;
+        },
+        widgetNotFound: () => {},
+      }).catch(() => {});
+    };
+
+    const schedule = () => {
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(pushUpdate, DEBOUNCE_MS);
+    };
+
+    // Initial push so opening the app refreshes any placed widget.
+    schedule();
+
+    const unsub = queryClient.getQueryCache().subscribe((event) => {
+      const key = event?.query?.queryKey;
+      if (Array.isArray(key) && isCalendarQueryKey(key)) schedule();
+    });
+
+    const appStateSub = AppState.addEventListener("change", (status) => {
+      // Debounce covers the concurrent evaluateHomeNetwork() on resume, so the
+      // pushed data reflects the correct home/away URL posture.
+      if (status === "active") schedule();
+    });
+
+    return () => {
+      unsub();
+      appStateSub.remove();
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [hydrated]);
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+// Custom entry point. Registers the app root (expo-router) AND the Android
+// widget headless task, so a cold-started headless process (app killed, OS
+// updating the widget) has the task handler before Android dispatches to it.
+import "expo-router/entry";
+import { registerWidgetTaskHandler } from "react-native-android-widget";
+import { widgetTaskHandler } from "./widgets/widget-task-handler";
+
+registerWidgetTaskHandler(widgetTaskHandler);

--- a/lib/calendar-agenda.test.ts
+++ b/lib/calendar-agenda.test.ts
@@ -1,0 +1,168 @@
+import { buildAgenda, pickRadarrDate } from "@/lib/calendar-agenda";
+import { getDateOffset } from "@/lib/utils";
+import type { RadarrMovie, SonarrCalendarEntry } from "@/lib/types";
+
+// Episodes key off `airDate` verbatim when `airDateUtc` is absent (see
+// airDateKey), so we drive the day-window with getDateOffset — deterministic
+// regardless of the machine's real date.
+function episode(over: Partial<SonarrCalendarEntry>): SonarrCalendarEntry {
+  return {
+    id: 1,
+    seriesId: 10,
+    episodeNumber: 2,
+    seasonNumber: 1,
+    title: "Pilot",
+    airDate: getDateOffset(1),
+    hasFile: false,
+    monitored: true,
+    series: { title: "Show", images: [] },
+    ...over,
+  } as SonarrCalendarEntry;
+}
+
+function movie(over: Partial<RadarrMovie>): RadarrMovie {
+  return {
+    id: 5,
+    title: "Film",
+    year: 2024,
+    hasFile: false,
+    monitored: true,
+    status: "released",
+    isAvailable: true,
+    images: [],
+    digitalRelease: getDateOffset(1),
+    ...over,
+  } as RadarrMovie;
+}
+
+const BASE = {
+  daysAhead: 7,
+  radarrReleaseType: "any" as const,
+  maxItems: 8,
+};
+
+describe("pickRadarrDate", () => {
+  it("'any' waterfalls digital → physical → cinemas", () => {
+    expect(
+      pickRadarrDate(
+        movie({ digitalRelease: "2024-01-03", physicalRelease: "2024-02-01", inCinemas: "2023-12-01" }),
+        "any",
+      ),
+    ).toBe("2024-01-03");
+    expect(
+      pickRadarrDate(
+        movie({ digitalRelease: undefined, physicalRelease: "2024-02-01", inCinemas: "2023-12-01" }),
+        "any",
+      ),
+    ).toBe("2024-02-01");
+    expect(
+      pickRadarrDate(
+        movie({ digitalRelease: undefined, physicalRelease: undefined, inCinemas: "2023-12-01" }),
+        "any",
+      ),
+    ).toBe("2023-12-01");
+  });
+
+  it("honors an explicit release type", () => {
+    const m = movie({ digitalRelease: "2024-01-03", inCinemas: "2023-12-01" });
+    expect(pickRadarrDate(m, "cinemas")).toBe("2023-12-01");
+    expect(pickRadarrDate(m, "physical")).toBeNull();
+  });
+});
+
+describe("buildAgenda", () => {
+  it("keeps only items within [today, today + daysAhead]", () => {
+    const sonarr = [
+      {
+        instanceId: "s1",
+        entries: [
+          episode({ id: 1, airDate: getDateOffset(0), series: { title: "Today", images: [] } as any }),
+          episode({ id: 2, airDate: getDateOffset(-2), series: { title: "Past", images: [] } as any }),
+          episode({ id: 3, airDate: getDateOffset(9), series: { title: "TooFar", images: [] } as any }),
+        ],
+      },
+    ];
+    const items = buildAgenda({ ...BASE, sonarr, radarr: [] });
+    expect(items.map((i) => i.title)).toEqual(["Today"]);
+  });
+
+  it("merges Sonarr + Radarr, sorted by date then title", () => {
+    const sonarr = [
+      {
+        instanceId: "s1",
+        entries: [
+          episode({ id: 1, airDate: getDateOffset(2), series: { title: "Bravo", images: [] } as any }),
+        ],
+      },
+    ];
+    const radarr = [
+      {
+        instanceId: "r1",
+        entries: [
+          movie({ id: 9, title: "Alpha", digitalRelease: getDateOffset(2) }),
+          movie({ id: 8, title: "Zeta", digitalRelease: getDateOffset(1) }),
+        ],
+      },
+    ];
+    const items = buildAgenda({ ...BASE, sonarr, radarr });
+    // Day 1 (Zeta), then day 2 sorted by title (Alpha, Bravo).
+    expect(items.map((i) => i.title)).toEqual(["Zeta", "Alpha", "Bravo"]);
+    expect(items[0].kind).toBe("movie");
+  });
+
+  it("caps to maxItems", () => {
+    const entries = Array.from({ length: 12 }, (_, n) =>
+      episode({ id: n, airDate: getDateOffset(1), series: { title: `S${n}`, images: [] } as any }),
+    );
+    const items = buildAgenda({ ...BASE, maxItems: 5, sonarr: [{ instanceId: "s1", entries }], radarr: [] });
+    expect(items).toHaveLength(5);
+  });
+
+  it("maps subtitle, route, id, and prefers the public remoteUrl poster only", () => {
+    const sonarr = [
+      {
+        instanceId: "s1",
+        entries: [
+          episode({
+            id: 7,
+            seriesId: 42,
+            seasonNumber: 3,
+            episodeNumber: 4,
+            title: "Finale",
+            airDate: getDateOffset(1),
+            series: {
+              title: "Show",
+              images: [
+                { coverType: "poster", url: "/local/proxy.jpg", remoteUrl: "https://image.tmdb.org/t/p/original/x.jpg" },
+              ],
+            } as any,
+          }),
+        ],
+      },
+    ];
+    const [item] = buildAgenda({ ...BASE, sonarr, radarr: [] });
+    expect(item.subtitle).toBe("S03E04 — Finale");
+    expect(item.route).toBe("/series/42?instanceId=s1");
+    expect(item.id).toBe("ep-s1-7");
+    // remoteUrl downscaled to w500, never the local proxy url.
+    expect(item.posterUrl).toBe("https://image.tmdb.org/t/p/w500/x.jpg");
+  });
+
+  it("returns null poster when only a local proxy url is present", () => {
+    const radarr = [
+      {
+        instanceId: "r1",
+        entries: [
+          movie({
+            id: 3,
+            title: "NoRemote",
+            digitalRelease: getDateOffset(1),
+            images: [{ coverType: "poster", url: "/local/only.jpg", remoteUrl: "" } as any],
+          }),
+        ],
+      },
+    ];
+    const [item] = buildAgenda({ ...BASE, sonarr: [], radarr });
+    expect(item.posterUrl).toBeNull();
+  });
+});

--- a/lib/calendar-agenda.ts
+++ b/lib/calendar-agenda.ts
@@ -1,0 +1,160 @@
+import {
+  airDateKey,
+  formatEpisodeCode,
+  getDateOffset,
+  localDateKey,
+  relativeDate,
+  releaseDateKey,
+} from "@/lib/utils";
+import {
+  BAR_KIND_COLOR,
+  radarrBarKind,
+  sonarrEpisodeBarKind,
+} from "@/lib/arr-poster-status";
+import type {
+  RadarrImage,
+  RadarrMovie,
+  SonarrCalendarEntry,
+  SonarrImage,
+} from "@/lib/types";
+
+// Shared "Releasing Soon" calendar logic used by the dashboard card
+// (components/dashboard/calendar-card.tsx), the Calendar tab, AND the Android
+// home-screen widget (widgets/*). Keeping the fragile bits — the Radarr
+// release-date waterfall and the day-window filter — in one pure module is what
+// keeps a movie landing on the SAME day across all three surfaces (past
+// divergence: a movie showing under different dates in the card vs the tab).
+//
+// This module must stay pure (no React, no react-query, no native imports) so
+// the widget's headless task can import it cheaply.
+
+export type RadarrReleaseType = "cinemas" | "digital" | "physical" | "any";
+
+/**
+ * Which Radarr release date a movie lands on, honoring the user's preference.
+ * "any" mirrors the Calendar tab's waterfall (digital → physical → cinemas) so
+ * the same movie buckets onto the same day in every surface.
+ */
+export function pickRadarrDate(
+  movie: RadarrMovie,
+  type: RadarrReleaseType,
+): string | null {
+  const cinemas = movie.inCinemas;
+  const digital = movie.digitalRelease;
+  const physical = movie.physicalRelease;
+  switch (type) {
+    case "cinemas":
+      return cinemas ?? null;
+    case "digital":
+      return digital ?? null;
+    case "physical":
+      return physical ?? null;
+    case "any":
+    default:
+      return digital ?? physical ?? cinemas ?? null;
+  }
+}
+
+/**
+ * Poster URL for the widget: the PUBLIC TMDB `remoteUrl` only (never the local
+ * `/MediaCover` proxy `url`). The widget's native ImageWidget fetches with no
+ * API key and no LAN reachability, so a proxy URL would both fail off-Wi-Fi and
+ * risk leaking the host/key — return null (widget shows a placeholder) instead.
+ * TMDB originals are ~6MB; downscale to w500 like hooks/use-service-image.ts.
+ */
+function widgetPosterUrl(
+  images: (SonarrImage | RadarrImage)[] | undefined | null,
+): string | null {
+  const remote = images?.find((i) => i.coverType === "poster")?.remoteUrl;
+  if (!remote) return null;
+  return remote.replace("/t/p/original/", "/t/p/w500/");
+}
+
+// One calendar source: the entries returned for a single Sonarr/Radarr instance.
+export interface InstanceCalendar<T> {
+  instanceId: string;
+  entries: T[];
+}
+
+export interface BuildAgendaOptions {
+  sonarr: InstanceCalendar<SonarrCalendarEntry>[];
+  radarr: InstanceCalendar<RadarrMovie>[];
+  daysAhead: number;
+  radarrReleaseType: RadarrReleaseType;
+  maxItems: number;
+}
+
+// A single serializable widget row. Plain JSON only — this crosses into the
+// RemoteViews render and (optionally) a persisted last-known cache.
+export interface AgendaItem {
+  id: string;
+  kind: "episode" | "movie";
+  title: string;
+  subtitle: string;
+  dateKey: string; // local YYYY-MM-DD, for grouping/day-headers
+  dateLabel: string; // relativeDate(dateKey): "Today" / "Tomorrow" / "Mon Jul 7"
+  posterUrl: string | null; // public TMDB w500, or null
+  barColor: string; // hex status spine color (BAR_KIND_COLOR)
+  hasFile: boolean;
+  route: string; // in-app route for the deep link, e.g. "/movie/45?instanceId=abc"
+}
+
+/**
+ * Merge Sonarr episodes + Radarr movies into a flat, day-sorted, capped agenda
+ * for the widget. Mirrors calendar-card.tsx's window filter (today → today +
+ * daysAhead, inclusive) and title sort; the "downloading" purple state is
+ * intentionally omitted here (the widget skips the queue fetch), so bar colors
+ * are computed with isDownloading=false — hasFile still distinguishes
+ * downloaded (green) from pending.
+ */
+export function buildAgenda(opts: BuildAgendaOptions): AgendaItem[] {
+  const { sonarr, radarr, daysAhead, radarrReleaseType, maxItems } = opts;
+  const todayIso = localDateKey();
+  const horizonIso = getDateOffset(daysAhead);
+
+  const items: AgendaItem[] = [];
+
+  for (const { instanceId, entries } of sonarr) {
+    for (const ep of entries) {
+      const date = airDateKey(ep);
+      if (!date || date < todayIso || date > horizonIso) continue;
+      items.push({
+        id: `ep-${instanceId}-${ep.id}`,
+        kind: "episode",
+        title: ep.series.title,
+        subtitle: `${formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} — ${ep.title}`,
+        dateKey: date,
+        dateLabel: relativeDate(date),
+        posterUrl: widgetPosterUrl(ep.series.images),
+        barColor: BAR_KIND_COLOR[sonarrEpisodeBarKind(ep, false)],
+        hasFile: ep.hasFile,
+        route: `/series/${ep.seriesId}?instanceId=${instanceId}`,
+      });
+    }
+  }
+
+  for (const { instanceId, entries } of radarr) {
+    for (const movie of entries) {
+      const date = releaseDateKey(pickRadarrDate(movie, radarrReleaseType));
+      if (!date || date < todayIso || date > horizonIso) continue;
+      items.push({
+        id: `mv-${instanceId}-${movie.id}`,
+        kind: "movie",
+        title: movie.title,
+        subtitle: movie.year ? `${movie.year} • Movie` : "Movie",
+        dateKey: date,
+        dateLabel: relativeDate(date),
+        posterUrl: widgetPosterUrl(movie.images),
+        barColor: BAR_KIND_COLOR[radarrBarKind(movie, false)],
+        hasFile: movie.hasFile,
+        route: `/movie/${movie.id}?instanceId=${instanceId}`,
+      });
+    }
+  }
+
+  items.sort(
+    (a, b) =>
+      a.dateKey.localeCompare(b.dateKey) || a.title.localeCompare(b.title),
+  );
+  return items.slice(0, maxItems);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboarr",
   "version": "1.11.0",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "packageManager": "pnpm@9.15.4",
   "scripts": {
     "start": "expo start",
@@ -66,6 +66,7 @@
     "nativewind": "^4.1.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-android-widget": "^0.20.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.21.7",
     "react-native-reanimated": "~4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      react-native-android-widget:
+        specifier: ^0.20.3
+        version: 0.20.3(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4039,6 +4042,16 @@ packages:
 
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
+
+  react-native-android-widget@0.20.3:
+    resolution: {integrity: sha512-/HZpZda3h4xACK5anrdSuPsL3shqMZ/m5wxL/sk+DTjEI24Yj5/kROUJAQ0uwG4evjPoaLi4x++fuLC9a7qYnw==}
+    peerDependencies:
+      expo: '>=54.0.0'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
 
   react-native-css-interop@0.2.3:
     resolution: {integrity: sha512-wc+JI7iUfdFBqnE18HhMTtD0q9vkhuMczToA87UdHGWwMyxdT5sCcNy+i4KInPCE855IY0Ic8kLQqecAIBWz7w==}
@@ -9602,6 +9615,13 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.5: {}
+
+  react-native-android-widget@0.20.3(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   react-native-css-interop@0.2.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.3)):
     dependencies:

--- a/widgets/calendar-widget.tsx
+++ b/widgets/calendar-widget.tsx
@@ -1,0 +1,181 @@
+import { FlexWidget, ImageWidget, TextWidget } from "react-native-android-widget";
+import type { AgendaItem } from "@/lib/calendar-agenda";
+import type { WidgetState } from "@/widgets/fetch-agenda";
+import { DAYS_AHEAD } from "@/widgets/widget-config";
+
+// The Android home-screen ("Releasing Soon") widget, rendered to RemoteViews via
+// react-native-android-widget. Uses only the library's primitives — NativeWind,
+// lucide, and expo-image do NOT apply to RemoteViews. Colors are inline hex from
+// the app palette (matches components/common/calendar-event-row.tsx).
+
+const COLORS = {
+  surface: "#09090b" as const,
+  title: "#fafafa" as const,
+  muted: "#a1a1aa" as const,
+  faint: "#71717a" as const,
+  placeholder: "#27272a" as const,
+};
+
+type HexColor = `#${string}`;
+
+// expo-router parses the empty-host form (scheme:///path). `route` already
+// starts with "/", so `${scheme}://${route}` yields the triple-slash form.
+function deepLink(scheme: string, route: string): string {
+  return `${scheme}://${route}`;
+}
+
+function Row({ item, scheme }: { item: AgendaItem; scheme: string }) {
+  return (
+    <FlexWidget
+      clickAction="OPEN_URI"
+      clickActionData={{ uri: deepLink(scheme, item.route) }}
+      style={{
+        width: "match_parent",
+        flexDirection: "row",
+        alignItems: "center",
+        paddingVertical: 5,
+      }}
+    >
+      <FlexWidget
+        style={{
+          width: 3,
+          height: 42,
+          borderRadius: 2,
+          backgroundColor: item.barColor as HexColor,
+        }}
+      />
+      {item.posterUrl ? (
+        <ImageWidget
+          image={item.posterUrl as `https:${string}`}
+          imageWidth={30}
+          imageHeight={42}
+          radius={4}
+          style={{ marginLeft: 8 }}
+        />
+      ) : (
+        <FlexWidget
+          style={{
+            width: 30,
+            height: 42,
+            borderRadius: 4,
+            marginLeft: 8,
+            backgroundColor: COLORS.placeholder,
+          }}
+        />
+      )}
+      <FlexWidget
+        style={{
+          flex: 1,
+          flexDirection: "column",
+          marginLeft: 8,
+        }}
+      >
+        <TextWidget
+          text={item.title}
+          maxLines={1}
+          truncate="END"
+          style={{ color: COLORS.title, fontSize: 13, fontWeight: "500" }}
+        />
+        <TextWidget
+          text={item.subtitle}
+          maxLines={1}
+          truncate="END"
+          style={{ color: COLORS.muted, fontSize: 11, marginTop: 1 }}
+        />
+      </FlexWidget>
+      <TextWidget
+        text={item.dateLabel}
+        maxLines={1}
+        style={{ color: COLORS.muted, fontSize: 11, marginLeft: 6 }}
+      />
+    </FlexWidget>
+  );
+}
+
+function Message({ text }: { text: string }) {
+  return (
+    <FlexWidget
+      style={{
+        width: "match_parent",
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        paddingVertical: 12,
+      }}
+    >
+      <TextWidget
+        text={text}
+        style={{ color: COLORS.faint, fontSize: 12, textAlign: "center" }}
+      />
+    </FlexWidget>
+  );
+}
+
+const MESSAGES: Record<Exclude<WidgetState, "ok">, string> = {
+  empty: `Nothing releasing in the next ${DAYS_AHEAD} days`,
+  not_configured: "Add Sonarr or Radarr in Dashboarr to see releases",
+  unavailable: "Releases unavailable. Add a Remote URL in Dashboarr",
+  error: "Couldn't refresh. Tap to open Dashboarr",
+};
+
+export function CalendarWidget({
+  state,
+  items,
+  scheme,
+}: {
+  state: WidgetState;
+  items: AgendaItem[];
+  scheme: string;
+}) {
+  // "error" still renders the last-known agenda when we have one (stale but
+  // useful); it only falls back to the message when there's nothing cached.
+  const showRows = (state === "ok" || state === "error") && items.length > 0;
+
+  return (
+    <FlexWidget
+      clickAction="OPEN_URI"
+      clickActionData={{ uri: deepLink(scheme, "/calendar") }}
+      style={{
+        height: "match_parent",
+        width: "match_parent",
+        flexDirection: "column",
+        backgroundColor: COLORS.surface,
+        borderRadius: 16,
+        padding: 12,
+      }}
+    >
+      <FlexWidget
+        style={{
+          width: "match_parent",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 6,
+        }}
+      >
+        <TextWidget
+          text="Releasing Soon"
+          style={{ color: COLORS.title, fontSize: 15, fontWeight: "bold" }}
+        />
+        {showRows ? (
+          <TextWidget
+            text={`${items.length} ${items.length === 1 ? "release" : "releases"}`}
+            style={{ color: COLORS.faint, fontSize: 12 }}
+          />
+        ) : (
+          <FlexWidget style={{ width: 0, height: 0 }} />
+        )}
+      </FlexWidget>
+
+      {showRows ? (
+        <FlexWidget style={{ width: "match_parent", flexDirection: "column" }}>
+          {items.map((item) => (
+            <Row key={item.id} item={item} scheme={scheme} />
+          ))}
+        </FlexWidget>
+      ) : (
+        <Message text={MESSAGES[state === "ok" ? "empty" : state]} />
+      )}
+    </FlexWidget>
+  );
+}

--- a/widgets/fetch-agenda.ts
+++ b/widgets/fetch-agenda.ts
@@ -1,0 +1,142 @@
+import { useConfigStore } from "@/store/config-store";
+import { detectVpnActive } from "@/lib/vpn";
+import { getJSON, setJSON } from "@/store/storage";
+import { getDateOffset } from "@/lib/utils";
+import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
+import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
+import {
+  buildAgenda,
+  type AgendaItem,
+  type InstanceCalendar,
+} from "@/lib/calendar-agenda";
+import type { RadarrMovie, SonarrCalendarEntry } from "@/lib/types";
+import {
+  DAYS_AHEAD,
+  INCLUDE_RADARR,
+  INCLUDE_SONARR,
+  INCLUDE_UNMONITORED,
+  LAST_AGENDA_KEY,
+  MAX_ITEMS,
+  RADARR_RELEASE_TYPE,
+} from "@/widgets/widget-config";
+
+export type WidgetState =
+  | "ok"
+  | "empty"
+  | "not_configured"
+  | "unavailable"
+  | "error";
+
+export interface WidgetViewModel {
+  state: WidgetState;
+  items: AgendaItem[];
+}
+
+function readLastAgenda(): AgendaItem[] {
+  return getJSON<AgendaItem[]>(LAST_AGENDA_KEY) ?? [];
+}
+
+/**
+ * Build the widget's view-model. Runs in BOTH the headless widget task (app
+ * killed → fresh JS context) and the in-app foreground refresh, so it must
+ * bootstrap the store itself and never throw.
+ *
+ * Security invariant: it reuses the exact same service layer + getActiveUrl the
+ * app uses, so the local-only-when-home / remote-otherwise / never-leak-the-key
+ * rules hold for free. In a fresh headless context `networkAwayFromHome`
+ * defaults to `true` (safe → remote-only); the only way it serves a local URL
+ * headless is the user's explicit VPN-as-home opt-in (below) or an auto-switch
+ * that's turned off (in which case getActiveUrl returns local by the user's own
+ * choice, exactly as the app does). We deliberately do NOT run background SSID
+ * detection — Android restricts it and it would weaken the guard.
+ */
+export async function fetchAgenda(): Promise<WidgetViewModel> {
+  try {
+    if (!useConfigStore.getState().hydrated) {
+      await useConfigStore.getState().hydrate();
+    }
+
+    const store = useConfigStore.getState();
+
+    // VPN-as-home: the only safe way to permit a local URL headless. The tunnel
+    // routes the private range to the user's own LAN, so there's no foreign-LAN
+    // exposure — but only when they opted in and a tunnel is actually up.
+    const vpn = detectVpnActive();
+    store.setIsVpnActive(vpn);
+    if (store.autoSwitchNetwork && store.treatVpnAsHome && vpn) {
+      store.setNetworkAwayFromHome(false);
+    }
+
+    const sonarrInsts = INCLUDE_SONARR
+      ? store.getEnabledInstances("sonarr")
+      : [];
+    const radarrInsts = INCLUDE_RADARR
+      ? store.getEnabledInstances("radarr")
+      : [];
+
+    if (sonarrInsts.length === 0 && radarrInsts.length === 0) {
+      return { state: "not_configured", items: [] };
+    }
+
+    // Only query instances that resolve to a non-empty URL in the current
+    // network posture. When every instance resolves to "" (e.g. a LAN-only
+    // setup while away, with no remote URL) the honest result is "unavailable"
+    // — not an error and not a leak.
+    const reachableSonarr = sonarrInsts.filter((i) =>
+      store.getActiveUrl("sonarr", i.id),
+    );
+    const reachableRadarr = radarrInsts.filter((i) =>
+      store.getActiveUrl("radarr", i.id),
+    );
+    if (reachableSonarr.length === 0 && reachableRadarr.length === 0) {
+      return { state: "unavailable", items: [] };
+    }
+
+    const start = getDateOffset(-1);
+    const end = getDateOffset(DAYS_AHEAD + 1);
+    const opts = { unmonitored: INCLUDE_UNMONITORED };
+
+    const [sonarrSettled, radarrSettled] = await Promise.all([
+      Promise.allSettled(
+        reachableSonarr.map((i) => getSonarrCalendar(start, end, opts, i.id)),
+      ),
+      Promise.allSettled(
+        reachableRadarr.map((i) => getRadarrCalendar(start, end, opts, i.id)),
+      ),
+    ]);
+
+    const sonarr: InstanceCalendar<SonarrCalendarEntry>[] = [];
+    reachableSonarr.forEach((inst, idx) => {
+      const r = sonarrSettled[idx];
+      if (r.status === "fulfilled") {
+        sonarr.push({ instanceId: inst.id, entries: r.value });
+      }
+    });
+    const radarr: InstanceCalendar<RadarrMovie>[] = [];
+    reachableRadarr.forEach((inst, idx) => {
+      const r = radarrSettled[idx];
+      if (r.status === "fulfilled") {
+        radarr.push({ instanceId: inst.id, entries: r.value });
+      }
+    });
+
+    // Every reachable instance failed → keep the last-known agenda rather than
+    // blanking the widget on a transient blip.
+    if (sonarr.length === 0 && radarr.length === 0) {
+      return { state: "error", items: readLastAgenda() };
+    }
+
+    const items = buildAgenda({
+      sonarr,
+      radarr,
+      daysAhead: DAYS_AHEAD,
+      radarrReleaseType: RADARR_RELEASE_TYPE,
+      maxItems: MAX_ITEMS,
+    });
+
+    setJSON(LAST_AGENDA_KEY, items);
+    return { state: items.length ? "ok" : "empty", items };
+  } catch {
+    return { state: "error", items: readLastAgenda() };
+  }
+}

--- a/widgets/widget-config.ts
+++ b/widgets/widget-config.ts
@@ -1,0 +1,27 @@
+import type { RadarrReleaseType } from "@/lib/calendar-agenda";
+
+// Fixed global config for the Android home-screen widget.
+//
+// Unlike the dashboard CalendarCard (per-slot, per-workspace settings resolved
+// through React hooks), the OS widget is a single global surface with no React
+// context, so it ships with sensible defaults mirroring CALENDAR_DEFAULT_SETTINGS
+// (components/dashboard/widget-settings/calendar-settings.tsx). A user-facing
+// widget config screen is a possible follow-up.
+
+// Widget name — MUST match the `name` in the app.config.ts plugin block and the
+// widgetName passed to requestWidgetUpdate.
+export const WIDGET_NAME = "Calendar";
+
+export const DAYS_AHEAD = 7;
+export const RADARR_RELEASE_TYPE: RadarrReleaseType = "any";
+export const INCLUDE_UNMONITORED = false;
+export const INCLUDE_SONARR = true;
+export const INCLUDE_RADARR = true;
+
+// RemoteViews has a hard limit on view count / nesting depth, and every rendered
+// bitmap counts against the ~1MB binder payload — keep the agenda compact.
+export const MAX_ITEMS = 8;
+
+// Last successfully-built agenda, rendered on a transient fetch failure so a
+// network blip doesn't blank the widget.
+export const LAST_AGENDA_KEY = "widget.calendar.lastAgenda";

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -1,0 +1,33 @@
+import Constants from "expo-constants";
+import type { WidgetTaskHandlerProps } from "react-native-android-widget";
+import { CalendarWidget } from "@/widgets/calendar-widget";
+import { fetchAgenda } from "@/widgets/fetch-agenda";
+
+// The app URL scheme differs per variant (dashboarr / dashboarr-dev). Read it at
+// runtime so deep links resolve into the right install; never hardcode.
+export function resolveScheme(): string {
+  const s = Constants.expoConfig?.scheme;
+  return (Array.isArray(s) ? s[0] : s) ?? "dashboarr";
+}
+
+// Headless task invoked by the OS on widget add / periodic update / resize, and
+// on tap. Registered at app entry (index.js) so a cold-started process has it
+// before Android dispatches. Rendering data-driven actions re-fetches; clicks
+// are handled natively by the library via clickAction="OPEN_URI".
+export async function widgetTaskHandler(
+  props: WidgetTaskHandlerProps,
+): Promise<void> {
+  const { widgetAction, renderWidget } = props;
+  switch (widgetAction) {
+    case "WIDGET_ADDED":
+    case "WIDGET_UPDATE":
+    case "WIDGET_RESIZED": {
+      const vm = await fetchAgenda();
+      renderWidget(<CalendarWidget {...vm} scheme={resolveScheme()} />);
+      break;
+    }
+    case "WIDGET_CLICK":
+    case "WIDGET_DELETED":
+      break;
+  }
+}


### PR DESCRIPTION
## Summary
Android launcher widget showing the "Releasing Soon" calendar (Sonarr episodes + Radarr movies), via `react-native-android-widget`. The widget UI is JSX and a headless task reuses the existing service layer, so calendar logic stays single-source and the home/away key-leak invariant holds for free (`getActiveUrl` reused; remote-only when away).

- Shared `lib/calendar-agenda.ts` (extracted `pickRadarrDate`) keeps the dashboard card, Calendar tab, and widget in lockstep.
- Refreshes on app foreground and when calendar queries settle; periodic OS update at the 30-min floor.
- Tap opens the Calendar tab; rows deep-link to the movie/series detail (native OPEN_URI).
- Android-only; iOS no-ops behind a `Platform.OS` gate. Ships in a new native build (fingerprint runtimeVersion bump).

## Test plan
- `tsc --noEmit` clean; full jest suite green (729 tests, incl. 7 new for `buildAgenda`).
- `expo config --type introspect` confirms the AppWidget `<receiver>`, provider metadata, `RNWidgetCollectionService`, and the `dashboarr` deep-link scheme.
- On device (needs prebuild + install): place the widget, verify render/refresh/deep-links, and the security check (LAN-only + away shows "unavailable", no `X-Api-Key` to any LAN address).