### PR TITLE
fix(home-network): retry SSID read so iOS stops sticking "away" on home WiFi

### DIFF
--- a/lib/network.test.ts
+++ b/lib/network.test.ts
@@ -16,8 +16,9 @@ jest.mock("@react-native-community/netinfo", () => ({
 // expo-location — mock it so the import is native-free and the permission
 // prompt is controllable.
 const mockReqPerm = jest.fn();
+const mockGetPerm = jest.fn();
 jest.mock("expo-location", () => ({
-  getForegroundPermissionsAsync: jest.fn(),
+  getForegroundPermissionsAsync: (...a: any[]) => mockGetPerm(...a),
   requestForegroundPermissionsAsync: (...a: any[]) => mockReqPerm(...a),
 }));
 
@@ -48,6 +49,9 @@ const cellular = () => ({ type: "cellular", isConnected: true, details: {} }) as
 beforeEach(() => {
   jest.clearAllMocks();
   mockDetectVpnActive.mockReturnValue(false);
+  // Default: Location granted, so the #234 null-SSID refresh fallback is
+  // allowed to run. The denied-path test overrides this.
+  mockGetPerm.mockResolvedValue({ status: "granted", canAskAgain: false });
 });
 
 describe("isHomeNetwork", () => {
@@ -118,6 +122,80 @@ describe("evaluateHomeNetwork", () => {
 
     await evaluateHomeNetwork();
 
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+  });
+
+  // --- iOS null-SSID transient after cold start / resume (#234) ---
+  //
+  // NetInfo.fetch() can briefly report type "wifi" with a null SSID on iOS
+  // before the OS surfaces it. Without a refresh+retry the evaluator would
+  // conclude "away" and, since no NetInfo change event follows on an already-
+  // connected device, stay stuck there until a restart. The steady-state path
+  // now falls back to refreshWifiIdentity() (NetInfo.refresh) in that case.
+
+  it("refreshes and clears away when the SSID surfaces after a null-SSID fetch", async () => {
+    (Platform as any).OS = "ios";
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    // First fetch: on WiFi but SSID not surfaced yet (the transient).
+    mockFetch.mockResolvedValueOnce(wifi(null));
+    // refresh() surfaces it; the post-refresh re-fetch reads it.
+    mockRefresh.mockResolvedValue(wifi("Home"));
+    mockFetch.mockResolvedValueOnce(wifi("Home"));
+
+    await evaluateHomeNetwork();
+
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("refreshes on the null-SSID transient but stays away when the surfaced SSID isn't home", async () => {
+    (Platform as any).OS = "ios";
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValueOnce(wifi(null));
+    mockRefresh.mockResolvedValue(wifi("Cafe"));
+    mockFetch.mockResolvedValueOnce(wifi("Cafe"));
+
+    await evaluateHomeNetwork();
+
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+  });
+
+  it("does NOT refresh when the first fetch already has the SSID (fast path, no wasted work)", async () => {
+    (Platform as any).OS = "ios";
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(wifi("Home"));
+
+    await evaluateHomeNetwork();
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(false);
+  });
+
+  it("does NOT refresh on a genuinely-away network (cellular resolves on the first fetch)", async () => {
+    (Platform as any).OS = "ios";
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(cellular());
+
+    await evaluateHomeNetwork();
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
+  });
+
+  it("falls back to away (never throws) when the refresh path errors", async () => {
+    (Platform as any).OS = "ios";
+    const store = fakeStore();
+    mockGetState.mockReturnValue(store);
+    mockFetch.mockResolvedValue(wifi(null)); // stuck on the null-SSID transient
+    mockRefresh.mockRejectedValue(new Error("native refresh blew up"));
+
+    // Must resolve (not reject) and conclude away — the pre-retry behavior.
+    await expect(evaluateHomeNetwork()).resolves.toBeUndefined();
     expect(store.setNetworkAwayFromHome).toHaveBeenCalledWith(true);
   });
 
@@ -370,6 +448,9 @@ describe("reevaluateHomeNetworkAfterImport", () => {
     const store = fakeStore();
     mockGetState.mockReturnValue(store);
     mockReqPerm.mockResolvedValue({ status: "denied" });
+    // Non-prompting status read (used by the #234 refresh guard) also denied,
+    // so the null-SSID fetch below must NOT trigger a pointless refresh loop.
+    mockGetPerm.mockResolvedValue({ status: "denied", canAskAgain: true });
     mockFetch.mockResolvedValue(wifi(null));
 
     await reevaluateHomeNetworkAfterImport();

--- a/lib/network.ts
+++ b/lib/network.ts
@@ -1,7 +1,11 @@
 import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
 import { useConfigStore } from "@/store/config-store";
 import type { Dashboard, HomeNetwork } from "@/store/config-store";
-import { detectWifiWithRefresh } from "@/lib/wifi";
+import {
+  detectWifiWithRefresh,
+  getWifiPermissionStatus,
+  refreshWifiIdentity,
+} from "@/lib/wifi";
 import { detectVpnActive } from "@/lib/vpn";
 
 /**
@@ -136,7 +140,40 @@ async function evaluateHomeNetworkOnce(): Promise<void> {
     if (store.treatVpnAsHome) store.setNetworkAwayFromHome(true);
     return;
   }
-  const state = await NetInfo.fetch();
+  let state = await NetInfo.fetch();
+  // iOS transient (#234): NetInfo.fetch() can report type "wifi" with a null
+  // SSID for a brief window after cold start or app resume, before the OS
+  // surfaces it. A bare fetch would conclude "away" here — and because we're
+  // already connected to home WiFi, no NetInfo change event follows, so the
+  // flag stays stuck at away (remote-only, the orange "away" indicator) until
+  // the next resume or a full app restart. That is the "says I'm not on my
+  // WiFi when I am / restart fixes it" report. Force a NetInfo.refresh()+retry
+  // (the same #168 machinery) to surface the SSID before deciding. This only
+  // runs in the failure case (on WiFi but no SSID yet); genuinely-away states
+  // (cellular / VPN-masked / non-matching SSID) resolve on the first fetch
+  // with no extra work, and once the SSID surfaces subsequent evaluations skip
+  // the refresh entirely.
+  if (state.type === "wifi" && !state.details?.ssid) {
+    try {
+      // Only worth retrying if we can actually read the SSID: without Location
+      // permission NetInfo returns a null SSID no matter how many times we
+      // refresh, so a denied device would spin the retry loop on every
+      // evaluation for nothing. Read the status WITHOUT prompting (the steady
+      // state never prompts) — denied simply stays "away", the honest result.
+      const { granted } = await getWifiPermissionStatus();
+      if (granted) {
+        // Warms NetInfo's singleton via refresh()+retry, so the re-fetch below
+        // reads the now-surfaced SSID.
+        await refreshWifiIdentity();
+        state = await NetInfo.fetch();
+      }
+    } catch {
+      // A refresh/permission hiccup must never throw out of the evaluator: fall
+      // back to the original null-SSID state, which concludes "away" exactly as
+      // it did before this retry existed. Worst case = the old behavior, never
+      // worse.
+    }
+  }
   store.setNetworkAwayFromHome(!isHomeNetwork(state, effective));
 }
 


### PR DESCRIPTION
## Summary
On iOS, `NetInfo.fetch()` transiently reports wifi with a null SSID right after cold start or app resume. The steady-state home-network check concluded "away" from that and, since the device is already on home WiFi (no NetInfo change event follows), stayed stuck there until an app restart. That is the orange "away" indicator on your own WiFi, and matches both reporters (Refs #234).

Fix: on a wifi-but-null-SSID read, fall back to `NetInfo.refresh()`+retry (the existing #168 machinery) before deciding, guarded on Location permission actually being granted (read without prompting, so no steady-state prompt). Any error in that path degrades to the prior "away" result.

Only the wifi+null-SSID branch changes; every other path is byte-identical, and away=false still requires a confirmed SSID match, so the local-URL-off-home security invariant is intact.

## Test plan
- Added network tests: SSID surfaces on refresh, surfaced-but-not-home, fast path (no refresh), cellular (no refresh), refresh-throws-still-away
- Full related suite green (132 tests across network/wifi/config-store/http-client), `tsc --noEmit` clean
- iOS-only timing transient, not reproducible in CI; still needs on-device confirmation across cold starts/resumes on home WiFi
