### PR TITLE
fix(backend): patch fast-uri CVEs and strip npm/yarn from runtime image

### DIFF
--- a/backend/dashboarr-backend/Dockerfile
+++ b/backend/dashboarr-backend/Dockerfile
@@ -13,7 +13,12 @@ RUN npm run build && npm prune --omit=dev
 # ---------- runtime ----------
 FROM node:22-alpine
 # tini is PID 1; su-exec drops privileges from the entrypoint.
-RUN apk upgrade --no-cache && apk add --no-cache tini su-exec
+# npm/yarn/corepack are build-time tools the runtime never invokes (the
+# entrypoint execs plain `node`); removing them keeps their bundled deps
+# out of CVE scans and off the attack surface.
+RUN apk upgrade --no-cache && apk add --no-cache tini su-exec \
+    && rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx \
+       /opt/yarn* /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/corepack
 WORKDIR /app
 
 COPY --from=build /app/node_modules ./node_modules

--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Bump fast-uri 3.1.0 -> 3.1.3 in the backend package-lock.json (clears code scanning alerts #39/#40, CVE-2026-6321/6322)
- Remove npm, npx, yarn and corepack from the runtime image stage; the container only runs `node dist/index.js`, so the npm CLI's bundled deps (sigstore, tar, picomatch, ip-address, brace-expansion) no longer appear in Trivy scans (alerts #21, #35, #36, #38, #41, #42, #43)

## Test plan
- Built the image locally: npm/yarn gone from the final image, fast-uri 3.1.3 in /app/node_modules
- Smoke-tested container startup (tini -> entrypoint -> su-exec node) - boots normally
- CI Trivy scan on this PR should come back clean