### PR TITLE
feat(usenet): upload .nzb files to SABnzbd and NZBGet (Refs #267)

### DIFF
--- a/components/downloads/usenet-downloads-view.tsx
+++ b/components/downloads/usenet-downloads-view.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import { View, Text, Pressable, BackHandler } from "react-native";
+import * as DocumentPicker from "expo-document-picker";
 import { toastError } from "@/components/ui/toast";
 import { useRouter, useFocusEffect } from "expo-router";
 import {
@@ -9,6 +10,7 @@ import {
   Plus,
   CheckCircle2,
   Circle,
+  FileUp,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ServiceHeader } from "@/components/common/service-header";
@@ -92,6 +94,7 @@ export function UsenetDownloadsView({
   const { data: healthData } = useServiceHealth();
 
   const addUrl = adapter.useAddUrl();
+  const addFile = adapter.useAddFile();
   const pauseSlot = adapter.usePauseSlot();
   const resumeSlot = adapter.useResumeSlot();
   const deleteSlot = adapter.useDeleteSlot();
@@ -144,6 +147,29 @@ export function UsenetDownloadsView({
           setShowAddModal(false);
         },
         onError: (err) => toastError("Failed to add NZB", err),
+      },
+    );
+  };
+
+  const handlePickFile = async () => {
+    // iOS maps the `type` filter via UTType(mimeType:), which returns nil for
+    // niche types like application/x-nzb and leaves the picker unusable — use
+    // the wildcard (same workaround as config import) and let the server
+    // reject non-nzb files.
+    const result = await DocumentPicker.getDocumentAsync({
+      type: "*/*",
+      copyToCacheDirectory: true,
+    });
+    if (result.canceled || !result.assets?.[0]) return;
+    const asset = result.assets[0];
+    addFile.mutate(
+      { fileUri: asset.uri, fileName: asset.name },
+      {
+        onSuccess: () => {
+          setNzbUrl("");
+          setShowAddModal(false);
+        },
+        onError: (err) => toastError("Failed to upload NZB", err),
       },
     );
   };
@@ -283,6 +309,14 @@ export function UsenetDownloadsView({
                   className="flex-1"
                 />
               </View>
+              <Button
+                label="Upload .nzb File"
+                variant="outline"
+                size="sm"
+                onPress={handlePickFile}
+                loading={addFile.isPending}
+                icon={<Icon icon={FileUp} size={16} color="#a1a1aa" />}
+              />
             </Card>
           ) : (
             <Button

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -292,7 +292,14 @@ export async function serviceRequest<T>(
     }
   }
 
-  if (!headers.has("Content-Type") && fetchOptions.body) {
+  // FormData bodies (SAB addfile upload) must keep fetch's own multipart
+  // Content-Type — the boundary parameter is generated per-request and a
+  // manual header would omit it, breaking the upload.
+  if (
+    !headers.has("Content-Type") &&
+    fetchOptions.body &&
+    !(fetchOptions.body instanceof FormData)
+  ) {
     headers.set("Content-Type", "application/json");
   }
 

--- a/lib/usenet-adapter.ts
+++ b/lib/usenet-adapter.ts
@@ -88,6 +88,17 @@ export interface UsenetAdapter {
   useAddUrl: (
     instanceId?: string,
   ) => UseMutationResult<unknown, Error, { url: string; category?: string }>;
+  // Upload a local .nzb picked with the document picker. `fileUri` is the
+  // picker's cache-copy URI; `fileName` is the original filename (services
+  // need it — SAB names the multipart file part, NZBGet can't derive a name
+  // from base64 content).
+  useAddFile: (
+    instanceId?: string,
+  ) => UseMutationResult<
+    unknown,
+    Error,
+    { fileUri: string; fileName: string; category?: string }
+  >;
   usePauseAll: (instanceId?: string) => UseMutationResult<unknown, Error, void>;
   useResumeAll: (instanceId?: string) => UseMutationResult<unknown, Error, void>;
 }

--- a/lib/usenet-adapters/nzbget.ts
+++ b/lib/usenet-adapters/nzbget.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { File } from "expo-file-system";
 import {
+  addNzbgetFile,
   addNzbgetUrl,
   deleteNzbgetGroup,
   deleteNzbgetHistorySlot,
@@ -222,6 +224,27 @@ export const nzbgetAdapter: UsenetAdapter = {
     return useMutation({
       mutationFn: ({ url, category }: { url: string; category?: string }) =>
         addNzbgetUrl(url, category, id ?? undefined),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
+    });
+  },
+
+  useAddFile: (instanceId) => {
+    const queryClient = useQueryClient();
+    const { instanceId: id } = useInstanceTarget("nzbget", instanceId);
+    return useMutation({
+      mutationFn: async ({
+        fileUri,
+        fileName,
+        category,
+      }: {
+        fileUri: string;
+        fileName: string;
+        category?: string;
+      }) => {
+        // NZBGet's append RPC takes the nzb as base64 text, not multipart.
+        const content = await new File(fileUri).base64();
+        return addNzbgetFile(fileName, content, category, id ?? undefined);
+      },
       onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
     });
   },

--- a/lib/usenet-adapters/sabnzbd.ts
+++ b/lib/usenet-adapters/sabnzbd.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SabQueue } from "@/lib/types";
 import {
+  addSabFile,
   addSabUrl,
   deleteSabHistorySlot,
   deleteSabSlot,
@@ -187,6 +188,24 @@ export const sabnzbdAdapter: UsenetAdapter = {
     return useMutation({
       mutationFn: ({ url, category }: { url: string; category?: string }) =>
         addSabUrl(url, category, id ?? undefined),
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] }),
+    });
+  },
+
+  useAddFile: (instanceId) => {
+    const queryClient = useQueryClient();
+    const { instanceId: id } = useInstanceTarget("sabnzbd", instanceId);
+    return useMutation({
+      mutationFn: ({
+        fileUri,
+        fileName,
+        category,
+      }: {
+        fileUri: string;
+        fileName: string;
+        category?: string;
+      }) => addSabFile(fileUri, fileName, category, id ?? undefined),
       onSuccess: () =>
         queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] }),
     });

--- a/services/nzbget-api.ts
+++ b/services/nzbget-api.ts
@@ -132,3 +132,22 @@ export async function addNzbgetUrl(
     instanceId,
   );
 }
+
+// --- Add NZB by file upload ---
+
+export async function addNzbgetFile(
+  fileName: string,
+  base64Content: string,
+  category?: string,
+  instanceId?: string,
+): Promise<number> {
+  // Same `append` method as URL adds. NZBGet decides by inspecting Content:
+  // a URL is fetched, anything else is treated as base64-encoded .nzb data —
+  // so the file body goes in Content and NZBFilename supplies the name it
+  // can't derive.
+  return nzbgetRpc<number>(
+    "append",
+    [fileName, base64Content, category ?? "", 0, false, false, "", 0, "SCORE"],
+    instanceId,
+  );
+}

--- a/services/sabnzbd-api.ts
+++ b/services/sabnzbd-api.ts
@@ -132,3 +132,33 @@ export async function addSabUrl(
   if (category) params.cat = category;
   await serviceRequest<SabStatusEnvelope>("sabnzbd", "", { params, instanceId });
 }
+
+// --- Add NZB by file upload ---
+
+export async function addSabFile(
+  fileUri: string,
+  fileName: string,
+  category?: string,
+  instanceId?: string,
+): Promise<void> {
+  // mode=addfile takes the .nzb as a multipart/form-data part named "name".
+  // React Native's fetch uploads a { uri, name, type } descriptor as a file
+  // part and sets the multipart Content-Type (with boundary) itself —
+  // serviceRequest skips its JSON default for FormData bodies.
+  const form = new FormData();
+  form.append("name", {
+    uri: fileUri,
+    name: fileName,
+    type: "application/x-nzb",
+  } as unknown as Blob);
+  const params: Record<string, string | number | boolean> = {
+    mode: "addfile",
+  };
+  if (category) params.cat = category;
+  await serviceRequest<SabStatusEnvelope>("sabnzbd", "", {
+    method: "POST",
+    body: form,
+    params,
+    instanceId,
+  });
+}


### PR DESCRIPTION
## Summary
Adds NZB file upload alongside the existing add-by-URL, since private trackers don't allow pasting links (Refs #267). The Add NZB card in the shared usenet downloads view gets an "Upload .nzb File" button that opens the document picker.

- SABnzbd: `mode=addfile` multipart POST (file part named `name` per the SAB API docs); http-client no longer forces JSON Content-Type on FormData bodies so fetch sets the multipart boundary
- NZBGet: same `append` JSON-RPC call as URL adds, with the picked file read as base64 and the original filename passed so NZBGet detects the type by extension
- Wildcard picker type on iOS (same UTType(mimeType:) nil workaround as config import)

## Test plan
- `tsc --noEmit` passes
- Verify on device: pick a .nzb from Files on both SABnzbd and NZBGet instances, job appears in queue; queue refreshes after upload; error toast on invalid file