### PR TITLE
feat(usenet): download speed limit for SABnzbd and NZBGet (Refs #252)

### DIFF
--- a/components/downloads/usenet-downloads-view.tsx
+++ b/components/downloads/usenet-downloads-view.tsx
@@ -101,6 +101,7 @@ export function UsenetDownloadsView({
   const deleteHistorySlot = adapter.useDeleteHistorySlot();
   const pauseAll = adapter.usePauseAll();
   const resumeAll = adapter.useResumeAll();
+  const SpeedLimitsControl = adapter.SpeedLimitsControl;
   const router = useRouter();
 
   const items = useMemo<UnifiedItem[]>(() => {
@@ -278,6 +279,7 @@ export function UsenetDownloadsView({
                 <Icon icon={Pause} size={20} color="#f59e0b" />
               )}
             </Pressable>
+            {SpeedLimitsControl ? <SpeedLimitsControl /> : null}
           </View>
 
           {/* Add NZB by URL */}

--- a/components/nzbget/speed-limits-control.tsx
+++ b/components/nzbget/speed-limits-control.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { Pressable } from "react-native";
+import { Zap } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { useNzbgetStatus, useSetNzbgetRate } from "@/hooks/use-nzbget";
+import { UsenetSpeedLimitsSheet } from "@/components/usenet/speed-limits-sheet";
+
+// Self-contained speed-limits header control for NZBGet: a Zap button that opens
+// the shared usenet speed-limit sheet. Reads the current limit from
+// `status.DownloadLimit` (bytes/s) and sets it via the `rate` method (KB/s).
+// Mirrors the SABnzbd control / the torrent SpeedLimitsControl convention.
+export function NzbgetSpeedLimitsControl() {
+  const [open, setOpen] = useState(false);
+  const { data: status } = useNzbgetStatus();
+  const setRate = useSetNzbgetRate();
+
+  const currentKbps = (status?.DownloadLimit ?? 0) / 1024;
+  const limited = currentKbps > 0;
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        hitSlop={6}
+        accessibilityLabel="Speed limit"
+        className={`w-12 rounded-xl items-center justify-center active:opacity-70 ${
+          limited ? "bg-amber-600/20" : "bg-surface-light"
+        }`}
+      >
+        <Icon
+          icon={Zap}
+          size={20}
+          color={limited ? "#f59e0b" : "#a1a1aa"}
+          fill={limited ? "#f59e0b" : "transparent"}
+        />
+      </Pressable>
+      <UsenetSpeedLimitsSheet
+        visible={open}
+        onClose={() => setOpen(false)}
+        serviceName="NZBGet"
+        currentKbps={currentKbps}
+        saving={setRate.isPending}
+        onSave={(kbps) => setRate.mutateAsync(kbps)}
+      />
+    </>
+  );
+}

--- a/components/sabnzbd/speed-limits-control.tsx
+++ b/components/sabnzbd/speed-limits-control.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { Pressable } from "react-native";
+import { Zap } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { useSabQueue, useSetSabSpeedLimit } from "@/hooks/use-sabnzbd";
+import { UsenetSpeedLimitsSheet } from "@/components/usenet/speed-limits-sheet";
+
+// Self-contained speed-limits header control for SABnzbd: a Zap button that
+// opens the shared usenet speed-limit sheet. The button shows the amber "active"
+// tint whenever a download limit is set. Mirrors the torrent SpeedLimitsControl
+// convention — each client owns its own hooks so the shared view stays generic.
+// Reads the current absolute limit from the queue's `speedlimit_abs` (bytes/s),
+// which shares its cache key with the downloads view's queue poll.
+export function SabnzbdSpeedLimitsControl() {
+  const [open, setOpen] = useState(false);
+  const { data: queue } = useSabQueue();
+  const setLimit = useSetSabSpeedLimit();
+
+  const currentKbps = Number(queue?.speedlimit_abs ?? 0) / 1024;
+  const limited = currentKbps > 0;
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        hitSlop={6}
+        accessibilityLabel="Speed limit"
+        className={`w-12 rounded-xl items-center justify-center active:opacity-70 ${
+          limited ? "bg-amber-600/20" : "bg-surface-light"
+        }`}
+      >
+        <Icon
+          icon={Zap}
+          size={20}
+          color={limited ? "#f59e0b" : "#a1a1aa"}
+          fill={limited ? "#f59e0b" : "transparent"}
+        />
+      </Pressable>
+      <UsenetSpeedLimitsSheet
+        visible={open}
+        onClose={() => setOpen(false)}
+        serviceName="SABnzbd"
+        currentKbps={currentKbps}
+        saving={setLimit.isPending}
+        onSave={(kbps) => setLimit.mutateAsync(kbps)}
+      />
+    </>
+  );
+}

--- a/components/usenet/speed-limits-sheet.tsx
+++ b/components/usenet/speed-limits-sheet.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  ScrollView,
+} from "react-native";
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
+import { cssInterop } from "nativewind";
+import { Zap } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { TextInput } from "@/components/ui/text-input";
+import { Button } from "@/components/ui/button";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { toast, toastError } from "@/components/ui/toast";
+
+cssInterop(KeyboardAwareScrollView, {
+  className: "style",
+  contentContainerClassName: "contentContainerStyle",
+});
+
+interface UsenetSpeedLimitsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  // Client label shown in the sheet copy (e.g. "SABnzbd", "NZBGet").
+  serviceName: string;
+  // Current limit in KB/s (0 = unlimited). Seeds the input on open.
+  currentKbps: number;
+  loading?: boolean;
+  saving?: boolean;
+  onSave: (kbPerSec: number) => Promise<unknown>;
+}
+
+// Both usenet clients expose a single download limit in KB/s (0 = unlimited),
+// so this sheet is client-agnostic: the caller passes the current value and a
+// save handler. One numeric input plus quick presets covering the issue's
+// "quick toggle between unlimited and a configured value" request.
+const PRESETS: { label: string; kbps: number }[] = [
+  { label: "Unlimited", kbps: 0 },
+  { label: "1 MB/s", kbps: 1024 },
+  { label: "5 MB/s", kbps: 5120 },
+  { label: "10 MB/s", kbps: 10240 },
+];
+
+function kbpsToInput(kbps: number): string {
+  return kbps > 0 ? String(Math.round(kbps)) : "";
+}
+
+// "" => 0 (unlimited); reject negatives / non-numbers with null.
+function parseKb(input: string): number | null {
+  const trimmed = input.trim();
+  if (trimmed === "") return 0;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n);
+}
+
+export function UsenetSpeedLimitsSheet({
+  visible,
+  onClose,
+  serviceName,
+  currentKbps,
+  loading = false,
+  saving = false,
+  onSave,
+}: UsenetSpeedLimitsSheetProps) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the input from the current limit each time the sheet opens.
+  useEffect(() => {
+    if (!visible) return;
+    setValue(kbpsToInput(currentKbps));
+    setError(null);
+  }, [visible, currentKbps]);
+
+  const parsed = parseKb(value);
+
+  const handleSave = async () => {
+    if (parsed === null) {
+      setError("Limit must be 0 or a positive number (KB/s)");
+      return;
+    }
+    setError(null);
+    try {
+      await onSave(parsed);
+      toast("Speed limit saved", "success");
+      onClose();
+    } catch (err) {
+      toastError("Failed to save speed limit", err);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Speed Limit" onClose={onClose} />
+
+        <KeyboardAwareScrollView
+          contentContainerClassName="px-4 py-4 pb-8"
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode={Platform.OS === "ios" ? "interactive" : "on-drag"}
+          bottomOffset={20}
+        >
+          {loading ? (
+            <View className="items-center py-10">
+              <ActivityIndicator color="#3b82f6" />
+            </View>
+          ) : (
+            <Card className="gap-3">
+              <View className="flex-row items-center gap-2">
+                <Icon icon={Zap} size={16} color="#f59e0b" />
+                <Text className="text-zinc-300 text-sm font-semibold">
+                  Download limit
+                </Text>
+              </View>
+              <Text className="text-zinc-500 text-xs">
+                Throttle {serviceName} downloads. 0 = unlimited.
+              </Text>
+
+              <TextInput
+                label="Limit (KB/s)"
+                placeholder="0"
+                value={value}
+                onChangeText={setValue}
+                keyboardType="numeric"
+              />
+
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerClassName="gap-2"
+              >
+                {PRESETS.map((preset) => {
+                  const active = parsed === preset.kbps;
+                  return (
+                    <Pressable
+                      key={preset.label}
+                      onPress={() => {
+                        setValue(kbpsToInput(preset.kbps));
+                        setError(null);
+                      }}
+                      className={`px-4 py-2 rounded-full border active:opacity-70 ${
+                        active
+                          ? "bg-amber-600/20 border-amber-500"
+                          : "bg-surface-light border-border"
+                      }`}
+                    >
+                      <Text
+                        className={`text-sm font-medium ${
+                          active ? "text-amber-400" : "text-zinc-300"
+                        }`}
+                      >
+                        {preset.label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </ScrollView>
+
+              {error && <Text className="text-danger text-sm">{error}</Text>}
+
+              <Button label="Save Limit" onPress={handleSave} loading={saving} />
+            </Card>
+          )}
+        </KeyboardAwareScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/hooks/use-nzbget.ts
+++ b/hooks/use-nzbget.ts
@@ -9,6 +9,7 @@ import {
   pauseNzbgetGroup,
   resumeNzbgetAll,
   resumeNzbgetGroup,
+  setNzbgetRate,
 } from "@/services/nzbget-api";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { useServiceQuery, useServiceMutation } from "@/hooks/use-service-query";
@@ -103,6 +104,16 @@ export function useAddNzbgetUrl(instanceId?: string) {
     "nzbget",
     ({ url, category }: { url: string; category?: string }, id) =>
       addNzbgetUrl(url, category, id),
+    instanceId,
+  );
+}
+
+// Set the download speed limit in KB/s (0 = unlimited). Invalidates the
+// ["nzbget", id] slice so `status.DownloadLimit` (and the control tint) refresh.
+export function useSetNzbgetRate(instanceId?: string) {
+  return useServiceMutation(
+    "nzbget",
+    (kbPerSec: number, id) => setNzbgetRate(kbPerSec, id),
     instanceId,
   );
 }

--- a/hooks/use-sabnzbd.ts
+++ b/hooks/use-sabnzbd.ts
@@ -8,6 +8,7 @@ import {
   deleteSabSlot,
   deleteSabHistorySlot,
   addSabUrl,
+  setSabSpeedLimit,
 } from "@/services/sabnzbd-api";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { useServiceQuery, useServiceMutation } from "@/hooks/use-service-query";
@@ -93,6 +94,17 @@ export function useAddSabUrl(instanceId?: string) {
     "sabnzbd",
     ({ url, category }: { url: string; category?: string }, id) =>
       addSabUrl(url, category, id),
+    instanceId,
+  );
+}
+
+// Set the download speed limit in KB/s (0 = unlimited). useServiceMutation
+// invalidates the whole ["sabnzbd", id] slice on success, so the queue's
+// `speedlimit_abs` (and the control's amber tint) refresh right after saving.
+export function useSetSabSpeedLimit(instanceId?: string) {
+  return useServiceMutation(
+    "sabnzbd",
+    (kbPerSec: number, id) => setSabSpeedLimit(kbPerSec, id),
     instanceId,
   );
 }

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -158,6 +158,7 @@ const DEMO_SAB_QUEUE = {
     paused: false,
     speed: "4.2 M",
     speedlimit: "0",
+    speedlimit_abs: "0",
     size: "8.4 GB",
     sizeleft: "5.1 GB",
     noofslots: 3,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -148,6 +148,9 @@ export interface SabQueue {
   paused: boolean;
   speed: string;
   speedlimit: string;
+  // Absolute speed limit in bytes/s ("0" = unlimited). `speedlimit` above is a
+  // percentage of the configured line speed; this is the value we surface.
+  speedlimit_abs: string;
   size: string;
   sizeleft: string;
   noofslots: number;

--- a/lib/usenet-adapter.ts
+++ b/lib/usenet-adapter.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import type {
   UseMutationResult,
   UseQueryOptions,
@@ -101,6 +102,12 @@ export interface UsenetAdapter {
   >;
   usePauseAll: (instanceId?: string) => UseMutationResult<unknown, Error, void>;
   useResumeAll: (instanceId?: string) => UseMutationResult<unknown, Error, void>;
+
+  // Optional self-contained speed-limits header control (a button + sheet that
+  // owns its own client-specific hooks). Rendered in the speed row of the shared
+  // downloads view when present. Keeping the client-specific speed-limit hooks
+  // inside the control keeps the shared view free of any optional-hook hazard.
+  SpeedLimitsControl?: ComponentType;
 }
 
 export function usenetBadgeVariant(

--- a/lib/usenet-adapters/nzbget.ts
+++ b/lib/usenet-adapters/nzbget.ts
@@ -15,6 +15,7 @@ import {
 } from "@/services/nzbget-api";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { NzbgetSpeedLimitsControl } from "@/components/nzbget/speed-limits-control";
 import { combineHiLo, formatBytes, formatEta, formatSpeed } from "@/lib/utils";
 import type {
   UnifiedItem,
@@ -266,6 +267,8 @@ export const nzbgetAdapter: UsenetAdapter = {
       onSuccess: () => queryClient.invalidateQueries({ queryKey: ["nzbget", id] }),
     });
   },
+
+  SpeedLimitsControl: NzbgetSpeedLimitsControl,
 };
 
 // Suppress unused-export warning for NzbgetStatus — kept reachable for

--- a/lib/usenet-adapters/sabnzbd.ts
+++ b/lib/usenet-adapters/sabnzbd.ts
@@ -14,6 +14,7 @@ import {
 } from "@/services/sabnzbd-api";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { SabnzbdSpeedLimitsControl } from "@/components/sabnzbd/speed-limits-control";
 import type {
   UnifiedItem,
   UsenetAdapter,
@@ -230,4 +231,6 @@ export const sabnzbdAdapter: UsenetAdapter = {
         queryClient.invalidateQueries({ queryKey: ["sabnzbd", id] }),
     });
   },
+
+  SpeedLimitsControl: SabnzbdSpeedLimitsControl,
 };

--- a/services/nzbget-api.ts
+++ b/services/nzbget-api.ts
@@ -65,6 +65,18 @@ export async function resumeNzbgetAll(instanceId?: string): Promise<void> {
   await nzbgetRpc<boolean>("resumedownload", [], instanceId);
 }
 
+// --- Speed limit ---
+
+// `rate` sets the download speed limit in KB/s; `0` disables throttling. Note
+// the scale mismatch NZBGet documents: `rate` takes KB/s, while the current
+// limit reported on `status.DownloadLimit` is in bytes/s.
+export async function setNzbgetRate(
+  kbPerSec: number,
+  instanceId?: string,
+): Promise<void> {
+  await nzbgetRpc<boolean>("rate", [Math.max(0, Math.round(kbPerSec))], instanceId);
+}
+
 // --- Per-group actions ---
 // editqueue takes [Command, Param, IDs[]]. For Group* commands the Param is
 // an empty string and IDs is the list of NZBIDs to act on.

--- a/services/sabnzbd-api.ts
+++ b/services/sabnzbd-api.ts
@@ -59,6 +59,24 @@ export async function resumeSabAll(instanceId?: string): Promise<void> {
   });
 }
 
+// --- Speed limit ---
+
+// SAB's `config&name=speedlimit&value=X` treats a bare number as a *percentage*
+// of the user's configured max line speed. Appending `K` makes it an absolute
+// KB/s limit, which is what we expose (works even when no line speed is set and
+// matches how qBittorrent's limit reads). `value=0` clears the limit. The
+// current absolute limit comes back on the queue as `speedlimit_abs` (bytes/s).
+export async function setSabSpeedLimit(
+  kbPerSec: number,
+  instanceId?: string,
+): Promise<void> {
+  const value = kbPerSec > 0 ? `${Math.round(kbPerSec)}K` : "0";
+  await serviceRequest<SabStatusEnvelope>("sabnzbd", "", {
+    params: { mode: "config", name: "speedlimit", value },
+    instanceId,
+  });
+}
+
 // --- Per-slot actions ---
 
 export async function pauseSabSlot(

--- a/services/usenet-speed-limit.test.ts
+++ b/services/usenet-speed-limit.test.ts
@@ -1,0 +1,88 @@
+// Locks down the request shapes for the usenet download speed-limit setters.
+// The correctness-critical bit is SAB's unit convention: a bare `value` is a
+// PERCENTAGE of the configured line speed, so an absolute KB/s limit MUST carry
+// a `K` suffix. NZBGet's `rate` takes KB/s directly (0 = unlimited). We mock the
+// transport (serviceRequest) to capture the exact params/body each builds.
+
+jest.mock("@/lib/http-client", () => ({
+  serviceRequest: jest.fn(),
+}));
+
+import { serviceRequest } from "@/lib/http-client";
+import { setSabSpeedLimit } from "@/services/sabnzbd-api";
+import { setNzbgetRate } from "@/services/nzbget-api";
+
+const mockServiceRequest = serviceRequest as jest.MockedFunction<
+  typeof serviceRequest
+>;
+
+function lastCall() {
+  const calls = mockServiceRequest.mock.calls;
+  return calls[calls.length - 1]!;
+}
+
+beforeEach(() => {
+  mockServiceRequest.mockReset();
+  mockServiceRequest.mockResolvedValue({ status: true } as never);
+});
+
+describe("setSabSpeedLimit", () => {
+  it("sends an absolute KB/s value with the load-bearing K suffix", async () => {
+    await setSabSpeedLimit(5120);
+    const [service, path, opts] = lastCall();
+    expect(service).toBe("sabnzbd");
+    expect(path).toBe("");
+    expect((opts as { params: Record<string, unknown> }).params).toEqual({
+      mode: "config",
+      name: "speedlimit",
+      // "5120K" — NOT "5120", which SAB would read as 5120%.
+      value: "5120K",
+    });
+  });
+
+  it("sends '0' (no suffix) for unlimited", async () => {
+    await setSabSpeedLimit(0);
+    const opts = lastCall()[2] as { params: Record<string, unknown> };
+    expect(opts.params.value).toBe("0");
+  });
+
+  it("rounds fractional KB/s before appending K", async () => {
+    await setSabSpeedLimit(1536.7);
+    const opts = lastCall()[2] as { params: Record<string, unknown> };
+    expect(opts.params.value).toBe("1537K");
+  });
+
+  it("passes the instanceId through", async () => {
+    await setSabSpeedLimit(1024, "sab-2");
+    const opts = lastCall()[2] as { instanceId?: string };
+    expect(opts.instanceId).toBe("sab-2");
+  });
+});
+
+describe("setNzbgetRate", () => {
+  function bodyOf(call: unknown[]): { method: string; params: unknown[] } {
+    return JSON.parse((call[2] as { body: string }).body);
+  }
+
+  it("calls the rate method with the KB/s value as a positional param", async () => {
+    await setNzbgetRate(5120);
+    const [service, , opts] = lastCall();
+    expect(service).toBe("nzbget");
+    const body = bodyOf(lastCall());
+    expect(body.method).toBe("rate");
+    expect(body.params).toEqual([5120]);
+    expect((opts as { instanceId?: string }).instanceId).toBeUndefined();
+  });
+
+  it("sends 0 for unlimited and clamps negatives to 0", async () => {
+    await setNzbgetRate(0);
+    expect(bodyOf(lastCall()).params).toEqual([0]);
+    await setNzbgetRate(-50);
+    expect(bodyOf(lastCall()).params).toEqual([0]);
+  });
+
+  it("rounds fractional KB/s", async () => {
+    await setNzbgetRate(2048.4);
+    expect(bodyOf(lastCall()).params).toEqual([2048]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a download speed-limit control to the SABnzbd and NZBGet downloads views, mirroring the qBittorrent speed-limit pattern (Refs #252).

- A `Zap` button in the speed row (amber when a limit is set) opens a shared sheet: a KB/s input (0 = unlimited) plus quick presets (Unlimited / 1 / 5 / 10 MB/s).
- SAB: `config/speedlimit` with a `K` suffix so the value is absolute KB/s (a bare number is a percentage). NZBGet: `rate` (KB/s). Both `0` = unlimited; current limit read from `speedlimit_abs` / `status.DownloadLimit` (bytes/s).
- Wired via an optional `SpeedLimitsControl` on the usenet adapter, matching the torrent adapter convention.

## Test plan
- `tsc --noEmit`: clean.
- New `services/usenet-speed-limit.test.ts` (7 tests) covers the K-suffix/absolute vs percentage, unlimited=0, rounding, instanceId passthrough. Full suite: 741 pass.
- Device: set e.g. 5 MB/s on SABnzbd, confirm the web UI shows an absolute ~5120 KB/s limit (not 5120%) and downloads throttle; button turns amber; Unlimited clears it. Same flow on NZBGet.