### PR TITLE
fix(build): make google-services.json optional for dev builds, mandatory for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ pnpm start
 
 Scan the QR code with [Expo Go](https://expo.dev/go) on your device, or press `a` for Android emulator / `i` for iOS simulator.
 
+For a native development build, run `pnpm android` / `pnpm ios` (or `pnpm android:dev` / `pnpm ios:dev` for the side-by-side dev variant). `google-services.json` (Firebase Cloud Messaging credentials) is not included in the repo — native builds work without it, but push notifications will be unavailable. Release builds fail without it by design.
+
 ### Building for Production
 
 ```bash

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,4 +1,6 @@
 import { ExpoConfig, ConfigContext } from "expo/config";
+import fs from "fs";
+import path from "path";
 import pkg from "./package.json";
 
 // Derives a monotonic integer from semver so `pnpm bump:*` propagates to the
@@ -14,6 +16,37 @@ const IS_DEV = process.env.APP_VARIANT === "development";
 const APP_NAME = IS_DEV ? "Dashboarr Dev" : "Dashboarr";
 const BUNDLE_ID = IS_DEV ? "com.dashboarr.app.dev" : "com.dashboarr.app";
 const APP_SCHEME = IS_DEV ? "dashboarr-dev" : "dashboarr";
+
+// google-services.json holds real FCM credentials, so it's gitignored and a
+// fresh clone won't have it. Local dev builds must still work: when the file
+// is missing we omit android.googleServicesFile entirely, prebuild skips the
+// Google Services gradle plugin, and push tokens are simply unavailable at
+// runtime. Without this, a missing file aborts prebuild partway and leaves a
+// broken half-generated android/ folder.
+// Builds that ship must instead fail loudly — silently dropping FCM would
+// break push for every user. That means any EAS Android build (the file
+// arrives there via the GOOGLE_SERVICES_JSON file secret) and local release
+// builds (scripts/build-android-prod.js sets DASHBOARR_RELEASE=1). iOS never
+// uses this file — push goes through APNs.
+const GOOGLE_SERVICES_FILE = process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json";
+const HAS_GOOGLE_SERVICES = fs.existsSync(
+  path.isAbsolute(GOOGLE_SERVICES_FILE) ? GOOGLE_SERVICES_FILE : path.join(__dirname, GOOGLE_SERVICES_FILE)
+);
+const IS_ANDROID_RELEASE =
+  process.env.DASHBOARR_RELEASE === "1" || process.env.EAS_BUILD_PLATFORM === "android";
+if (!HAS_GOOGLE_SERVICES) {
+  if (IS_ANDROID_RELEASE) {
+    throw new Error(
+      `google-services.json not found (looked for ${GOOGLE_SERVICES_FILE}). ` +
+        "Release builds require real FCM credentials: place google-services.json at the " +
+        "project root, or point GOOGLE_SERVICES_JSON at it (EAS file secret on cloud builds)."
+    );
+  }
+  console.warn(
+    "[app.config] google-services.json not found — building without FCM. " +
+      "Push notifications will be unavailable in this build."
+  );
+}
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
@@ -77,7 +110,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // when invoking gradlew, without a second prebuild.
     package: "com.dashboarr.app",
     versionCode: nativeBuildNumber,
-    googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
+    ...(HAS_GOOGLE_SERVICES ? { googleServicesFile: GOOGLE_SERVICES_FILE } : {}),
   },
   scheme: APP_SCHEME,
   // Shared EAS project used by every install. Required for real push tokens —

--- a/scripts/build-android-prod.js
+++ b/scripts/build-android-prod.js
@@ -4,6 +4,10 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
+// Release builds must not silently ship without FCM credentials — this makes
+// app.config.ts fail hard if google-services.json is missing (see there).
+process.env.DASHBOARR_RELEASE = '1';
+
 const ROOT = path.join(__dirname, '..');
 const ANDROID_DIR = path.join(ROOT, 'android');
 const IS_WINDOWS = process.platform === 'win32';


### PR DESCRIPTION
## Problem
On a fresh clone, `google-services.json` doesn't exist (gitignored FCM credentials), and `expo prebuild` crashes partway on the missing file. This leaves a half-generated `android/` folder (still on the template's sanitized package name, missing `color/iconBackground`), and every later `pnpm android` skips prebuild and fails in Gradle with a confusing AAPT "resource color/iconBackground not found" error.

## Change
- `app.config.ts` only sets `android.googleServicesFile` when the file actually exists. When missing, dev/debug builds print a warning and build cleanly without FCM (push unavailable).
- Builds that ship still fail loudly if credentials are missing: any EAS Android build (via `EAS_BUILD_PLATFORM`) and local releases (`scripts/build-android-prod.js` now sets `DASHBOARR_RELEASE=1`). Note this means EAS Android builds on *all* profiles now require the `GOOGLE_SERVICES_JSON` file secret — intentional, so a deleted secret can't silently ship a build with broken push.
- README: short note in Getting Started about native builds without the file.
- iOS is unaffected (APNs, no Firebase).

## Verified
- File present: resolved config is byte-identical to before (same `googleServicesFile`, fingerprint unchanged); full `assembleDebug` passes.
- File missing (dev): config resolves, key omitted, warning printed, exit 0.
- File missing + `DASHBOARR_RELEASE=1` or `EAS_BUILD_PLATFORM=android`: config evaluation fails with a clear error.