### PR TITLE
feat(movies): sort by duration and show it in the library list

### DIFF
--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -50,6 +50,7 @@ import {
   formatBytes,
   formatAudioChannels,
   formatResolution,
+  formatRuntime,
 } from "@/lib/utils";
 import type { RadarrMovie } from "@/lib/types";
 
@@ -458,13 +459,6 @@ function buildMovieStats(movie: RadarrMovie) {
 function capitalize(s: string): string {
   if (!s) return "";
   return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
-function formatRuntime(minutes: number): string {
-  if (minutes < 60) return `${minutes}m`;
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
 function formatReleaseDate(iso?: string): string {

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -79,6 +79,8 @@ const SORT_OPTIONS: { key: MoviesSortKey; label: string }[] = [
   { key: "release-desc", label: "Release Date: Newest First" },
   { key: "release-asc", label: "Release Date: Oldest First" },
   { key: "size-desc", label: "Size: Largest First" },
+  { key: "duration-desc", label: "Duration: Longest First" },
+  { key: "duration-asc", label: "Duration: Shortest First" },
 ];
 
 function nextReleaseTime(m: RadarrMovie): number | null {
@@ -117,6 +119,17 @@ function compareMovies(a: RadarrMovie, b: RadarrMovie, sort: MoviesSortKey): num
     }
     case "size-desc":
       return (b.sizeOnDisk ?? 0) - (a.sizeOnDisk ?? 0);
+    case "duration-desc":
+    case "duration-asc": {
+      // Radarr reports 0 for unknown runtime — sort those last either way.
+      const aR = a.runtime || 0;
+      const bR = b.runtime || 0;
+      if (!aR && !bR)
+        return (a.sortTitle || a.title).localeCompare(b.sortTitle || b.title);
+      if (!aR) return 1;
+      if (!bR) return -1;
+      return sort === "duration-desc" ? bR - aR : aR - bR;
+    }
     case "next-airing-asc": {
       const aT = nextReleaseTime(a);
       const bT = nextReleaseTime(b);

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -31,6 +31,7 @@ import { useSortStore, SORT_DEFAULTS, type MoviesSortKey } from "@/store/sort-st
 
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { ICON } from "@/lib/constants";
+import { formatRuntime } from "@/lib/utils";
 import {
   useRadarrMovies,
   useRadarrQueue,
@@ -93,6 +94,11 @@ function nextReleaseTime(m: RadarrMovie): number | null {
   const future = times.filter((t) => t >= now);
   if (future.length) return Math.min(...future);
   return Math.max(...times);
+}
+
+// Poster footer: year plus duration when Radarr knows the runtime (0 = unknown).
+function movieFooter(m: RadarrMovie): string {
+  return m.runtime ? `${m.year} · ${formatRuntime(m.runtime)}` : String(m.year);
 }
 
 function compareMovies(a: RadarrMovie, b: RadarrMovie, sort: MoviesSortKey): number {
@@ -473,7 +479,7 @@ function MovieLibrary({
       serviceId="radarr"
       placeholderIcon={Film}
       nounPlural="movies"
-      renderFooter={(m) => String(m.year)}
+      renderFooter={movieFooter}
       posterStatus={(m) => ({
         barColor: BAR_KIND_COLOR[radarrBarKind(m, downloading.has(m.id))],
         cornerColor: cornerColorFor(m.status),
@@ -585,7 +591,7 @@ function MovieWanted({
       serviceId="radarr"
       placeholderIcon={Film}
       nounPlural="missing movies"
-      renderFooter={(m) => String(m.year)}
+      renderFooter={movieFooter}
       posterStatus={(m) => ({
         barColor: BAR_KIND_COLOR[radarrBarKind(m, downloading.has(m.id))],
         cornerColor: cornerColorFor(m.status),

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -2,6 +2,7 @@ import {
   formatBytes,
   formatSpeed,
   formatEta,
+  formatRuntime,
   formatProgress,
   truncateText,
   formatEpisodeCode,
@@ -67,6 +68,20 @@ describe("formatEta", () => {
 
   it("formats hours plus minutes", () => {
     expect(formatEta(2 * 3600 + 15 * 60)).toBe("2h 15m");
+  });
+});
+
+describe("formatRuntime", () => {
+  it("formats <60 minutes as 'Nm'", () => {
+    expect(formatRuntime(45)).toBe("45m");
+  });
+
+  it("formats whole hours without a minutes part", () => {
+    expect(formatRuntime(120)).toBe("2h");
+  });
+
+  it("formats hours plus minutes", () => {
+    expect(formatRuntime(138)).toBe("2h 18m");
   });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -53,6 +53,16 @@ export function formatEta(seconds: number): string {
 }
 
 /**
+ * Format a runtime in minutes (e.g., 138 → "2h 18m", 45 → "45m")
+ */
+export function formatRuntime(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+/**
  * Format a percentage (0-1 float to "45.2%")
  */
 export function formatProgress(progress: number): string {

--- a/store/sort-store.ts
+++ b/store/sort-store.ts
@@ -12,9 +12,13 @@ export type MoviesSortKey =
   | "release-desc"
   | "release-asc"
   | "size-desc"
+  | "duration-desc"
+  | "duration-asc"
   | "next-airing-asc";
 
-export type SeriesSortKey = MoviesSortKey;
+// Sonarr's runtime is per-episode, not per-series, so duration isn't a
+// meaningful series sort axis.
+export type SeriesSortKey = Exclude<MoviesSortKey, "duration-desc" | "duration-asc">;
 
 // Lidarr artists have no release year / next-airing axis, so they sort on a
 // narrower set than movies/series.


### PR DESCRIPTION
## What

Adds movie duration to the Movies tab:

- **New sort options** — "Duration: Longest First" / "Duration: Shortest First" in the filter & sort sheet.
- **Duration in the poster footer** — the library and wanted/missing grids now show it next to the year (e.g. `2023 · 2h 18m`), so you no longer need to open a movie's detail just to check its length.

## Implementation notes

- Sorting is client-side like the existing keys: two new `MoviesSortKey` values in `store/sort-store.ts` and the matching cases in `compareMovies`, reading Radarr's `runtime` field (minutes).
- `SeriesSortKey` was an alias of `MoviesSortKey`; it now excludes the duration keys, since Sonarr's `runtime` is per-episode and a series-level duration sort wouldn't be meaningful. The TV view is unchanged.
- Movies with unknown runtime (Radarr reports `0`) sort last in either direction and show only the year — same pattern the comparator already uses for missing release dates.
- `formatRuntime` was promoted from a private helper in the movie detail screen to `lib/utils.ts` and is now shared by both screens (with unit tests).

## Testing

- `npx tsc --noEmit` clean on app code
- Full jest suite passes, including new `formatRuntime` tests

## How to verify

1. Open the **Movies** tab with a Radarr instance connected.
2. Each poster's footer should show the duration next to the year (e.g. `2023 · 2h 18m`).
3. Open **Filter & sort** → pick **Duration: Longest First** — the grid should reorder accordingly; **Duration: Shortest First** reverses it.
4. The movie detail screen should look unchanged (detail screen already showed duration).
5. Optional: change UI scale in settings (1.15 / 1.3) — the footer line scales like the rest of the text.