### PR TITLE
feat(downloads): register app as magnet link handler

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -112,7 +112,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     versionCode: nativeBuildNumber,
     ...(HAS_GOOGLE_SERVICES ? { googleServicesFile: GOOGLE_SERVICES_FILE } : {}),
   },
-  scheme: APP_SCHEME,
+  // APP_SCHEME must stay first — expo-linking's createURL uses the first entry.
+  // "magnet" registers the app as a magnet-link handler (Android intent filter
+  // + iOS CFBundleURLSchemes); incoming URLs are rewritten by app/+native-intent.ts.
+  scheme: [APP_SCHEME, "magnet"],
   // Shared EAS project used by every install. Required for real push tokens —
   // Notifications.getExpoPushTokenAsync({ projectId }) reads from extra.eas.projectId.
   // Keep this stable across releases; replace with the real EAS project UUID

--- a/app/(tabs)/downloads.tsx
+++ b/app/(tabs)/downloads.tsx
@@ -11,7 +11,12 @@ import { qbittorrentTorrentAdapter } from "@/lib/torrent-adapters/qbittorrent";
 import { rtorrentTorrentAdapter } from "@/lib/torrent-adapters/rtorrent";
 import { transmissionTorrentAdapter } from "@/lib/torrent-adapters/transmission";
 import { EmptyState } from "@/components/ui/empty-state";
-import { useLocalSearchParams } from "expo-router";
+import { ActionSheet } from "@/components/ui/action-sheet";
+import { toastError } from "@/components/ui/toast";
+import { useActiveInstance } from "@/hooks/use-active-instance";
+import { magnetDisplayName } from "@/lib/utils";
+import type { ServiceInstance } from "@/store/config-store";
+import { useLocalSearchParams, useRouter } from "expo-router";
 
 type DownloadClient =
   | "qbittorrent"
@@ -19,6 +24,14 @@ type DownloadClient =
   | "transmission"
   | "sabnzbd"
   | "nzbget";
+
+// One candidate destination for an incoming magnet link: a torrent client
+// kind + a specific configured instance of it.
+interface MagnetTarget {
+  client: DownloadClient;
+  instanceId: string;
+  label: string;
+}
 
 // Top-level switcher for the Downloads tab. When more than one download client
 // is enabled the user picks via a segmented control; otherwise the available
@@ -49,8 +62,12 @@ export default function DownloadsScreen() {
 
   // `?client=...` lets the Services tab (and dashboard Status widget) deep-link
   // straight to the matching segment instead of always landing on whichever
-  // client was opened first.
-  const { client: clientParam } = useLocalSearchParams<{ client?: string }>();
+  // client was opened first. `?magnet=...` arrives from the OS magnet-link
+  // handler (see app/+native-intent.ts) and prefills the add card.
+  const { client: clientParam, magnet: magnetParam } = useLocalSearchParams<{
+    client?: string;
+    magnet?: string;
+  }>();
   const paramClient =
     clientParam === "qbittorrent" ||
     clientParam === "rtorrent" ||
@@ -74,6 +91,85 @@ export default function DownloadsScreen() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [paramClient]);
+
+  // Incoming magnet link. Stash it in state (not the route) so the prefill
+  // survives segment switches — TorrentDownloadsView remounts per client — and
+  // clear the param immediately so tab revisits don't re-trigger the add card.
+  //
+  // Candidate destinations are every enabled+attached instance of every
+  // enabled torrent client. One candidate → open the add card directly;
+  // several → an ActionSheet picks the client + instance first.
+  const router = useRouter();
+  const [pendingMagnet, setPendingMagnet] = useState<string>();
+  // Magnet waiting on the destination ActionSheet (only set with 2+ targets).
+  const [magnetPick, setMagnetPick] = useState<string>();
+  const qbInstances = useActiveInstance("qbittorrent").instances;
+  const rtInstances = useActiveInstance("rtorrent").instances;
+  const trInstances = useActiveInstance("transmission").instances;
+  const setActiveInstance = useConfigStore((s) => s.setActiveInstance);
+
+  const torrentInstances: [DownloadClient, ServiceInstance[]][] = [
+    ["qbittorrent", qbInstances],
+    ["rtorrent", rtInstances],
+    ["transmission", trInstances],
+  ];
+  const magnetTargets: MagnetTarget[] = torrentInstances.flatMap(
+    ([kind, instances]) =>
+      enabledClients.includes(kind)
+        ? instances.map((i) => ({
+            client: kind,
+            instanceId: i.id,
+            // Only disambiguate with the instance name when the kind has
+            // several instances — "qBittorrent · Seedbox" vs just "qBittorrent".
+            label:
+              instances.length > 1
+                ? `${SEGMENT_LABELS[kind]} · ${i.name || i.id}`
+                : SEGMENT_LABELS[kind],
+          }))
+        : [],
+  );
+
+  const applyMagnetTarget = (target: MagnetTarget, magnet: string) => {
+    setClient(target.client);
+    // Switch the tab to the picked instance so the torrent list and add card
+    // show the actual destination (useAddTorrent follows the active instance).
+    setActiveInstance(target.client, target.instanceId);
+    setPendingMagnet(magnet);
+  };
+
+  useEffect(() => {
+    if (!magnetParam) return;
+    router.setParams({ magnet: undefined });
+    if (magnetTargets.length === 0) {
+      toastError("No torrent client enabled");
+      return;
+    }
+    if (magnetTargets.length === 1) {
+      applyMagnetTarget(magnetTargets[0], magnetParam);
+    } else {
+      setMagnetPick(magnetParam);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [magnetParam]);
+
+  // Destination picker for incoming magnets. Action presses only set inline
+  // state (no second modal, no navigation), so this doesn't need useModalFlow.
+  const magnetSheet = (
+    <ActionSheet
+      visible={magnetPick !== undefined}
+      onClose={() => setMagnetPick(undefined)}
+      title="Add Torrent To"
+      subtitle={
+        magnetPick ? magnetDisplayName(magnetPick) ?? undefined : undefined
+      }
+      actions={magnetTargets.map((t) => ({
+        label: t.label,
+        onPress: () => {
+          if (magnetPick) applyMagnetTarget(t, magnetPick);
+        },
+      }))}
+    />
+  );
 
   if (enabledClients.length === 0) {
     return (
@@ -109,6 +205,7 @@ export default function DownloadsScreen() {
           showHeader={!showSegmented}
           segmentedControl={segmentedControl}
         />
+        {magnetSheet}
       </ScreenWrapper>
     );
   }
@@ -121,6 +218,7 @@ export default function DownloadsScreen() {
           showHeader={!showSegmented}
           segmentedControl={segmentedControl}
         />
+        {magnetSheet}
       </ScreenWrapper>
     );
   }
@@ -136,11 +234,16 @@ export default function DownloadsScreen() {
         ? transmissionTorrentAdapter
         : qbittorrentTorrentAdapter;
   return (
-    <TorrentDownloadsView
-      key={activeClient}
-      adapter={torrentAdapter}
-      segmentedControl={segmentedControl}
-    />
+    <>
+      <TorrentDownloadsView
+        key={activeClient}
+        adapter={torrentAdapter}
+        segmentedControl={segmentedControl}
+        incomingMagnet={pendingMagnet}
+        onMagnetConsumed={() => setPendingMagnet(undefined)}
+      />
+      {magnetSheet}
+    </>
   );
 }
 

--- a/app/+native-intent.ts
+++ b/app/+native-intent.ts
@@ -1,0 +1,15 @@
+// Rewrites OS-delivered URLs before expo-router routes them. Magnet links
+// (registered via the "magnet" entry in app.config.ts `scheme`) are not valid
+// routes, so they're redirected to the Downloads tab which prefills the add
+// card from the `magnet` param.
+export function redirectSystemPath({ path }: { path: string; initial: boolean }) {
+  try {
+    if (path.startsWith("magnet:")) {
+      return `/downloads?magnet=${encodeURIComponent(path)}`;
+    }
+    return path;
+  } catch {
+    // expo-router requirement: never throw here — fall back to the home route.
+    return "/";
+  }
+}

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -48,7 +48,13 @@ import {
 } from "@/store/sort-store";
 import { useMultiSelect } from "@/hooks/use-multi-select";
 import { useServiceHealth } from "@/hooks/use-service-health";
-import { formatSpeed, formatEta, formatBytes, truncateText } from "@/lib/utils";
+import {
+  formatSpeed,
+  formatEta,
+  formatBytes,
+  truncateText,
+  magnetDisplayName,
+} from "@/lib/utils";
 import {
   torrentBadgeVariant,
   type TorrentAdapter,
@@ -85,6 +91,11 @@ interface ViewProps {
   adapter: TorrentAdapter;
   showHeader?: boolean;
   segmentedControl?: React.ReactNode;
+  // Magnet URI from the OS-level magnet: handler (app/+native-intent.ts →
+  // downloads.tsx). Prefills and opens the add card; the parent clears it via
+  // onMagnetConsumed once the torrent is added or the card is dismissed.
+  incomingMagnet?: string;
+  onMagnetConsumed?: () => void;
 }
 
 // Shared downloads view for every torrent client. Driven entirely by the
@@ -95,6 +106,8 @@ export function TorrentDownloadsView({
   adapter,
   showHeader = true,
   segmentedControl,
+  incomingMagnet,
+  onMagnetConsumed,
 }: ViewProps) {
   const [filter, setFilter] = useState<TorrentFilterType>("all");
   const [category, setCategory] = useState<string>(ALL_CATEGORIES);
@@ -105,6 +118,14 @@ export function TorrentDownloadsView({
   const [categoryBulkOpen, setCategoryBulkOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
+
+  // Runs on mount too (segment switches remount this view per client), so a
+  // pending magnet re-prefills whichever client the user lands on.
+  useEffect(() => {
+    if (!incomingMagnet) return;
+    setMagnetUri(incomingMagnet);
+    setShowAddModal(true);
+  }, [incomingMagnet]);
 
   // "all" sentinel → omit the param entirely (qBittorrent reads no param as
   // "all categories"); "" stays "" so it maps to uncategorized.
@@ -184,6 +205,10 @@ export function TorrentDownloadsView({
     }, [multiSelect.isActive, multiSelect.clear]),
   );
 
+  // Torrent name from the magnet's `dn` param, shown above the input so the
+  // user sees what they're adding (covers pasted and incoming magnets alike).
+  const magnetName = magnetDisplayName(magnetUri.trim());
+
   const handleAdd = () => {
     if (!magnetUri.trim()) return;
     addTorrent.mutate(
@@ -192,6 +217,8 @@ export function TorrentDownloadsView({
         onSuccess: () => {
           setMagnetUri("");
           setShowAddModal(false);
+          onMagnetConsumed?.();
+          toast("Torrent added");
         },
         onError: (err) => toastError("Failed to add torrent", err),
       },
@@ -342,11 +369,18 @@ export function TorrentDownloadsView({
       {/* Add Torrent */}
       {showAddModal ? (
         <Card className="mb-4 gap-3">
+          {magnetName ? (
+            <Text className="text-zinc-100 text-sm font-semibold" numberOfLines={2}>
+              {magnetName}
+            </Text>
+          ) : null}
           <TextInput
             placeholder="Paste magnet link..."
             value={magnetUri}
             onChangeText={setMagnetUri}
-            autoFocus
+            // Incoming magnets arrive prefilled — popping the keyboard would
+            // just cover the Add button.
+            autoFocus={!incomingMagnet}
           />
           <View className="flex-row gap-2">
             <Button
@@ -356,6 +390,7 @@ export function TorrentDownloadsView({
               onPress={() => {
                 setShowAddModal(false);
                 setMagnetUri("");
+                onMagnetConsumed?.();
               }}
               className="flex-1"
             />

--- a/docs/index.html
+++ b/docs/index.html
@@ -240,6 +240,10 @@
         <h3>Multiple Instances</h3>
         <p>Configure two qBittorrents, split 4K and 1080p Radarrs, or any combination — switch in-tab and aggregate on the dashboard.</p>
       </div>
+      <div class="feature-card">
+        <h3>Magnet Link Handler</h3>
+        <p>Tap a magnet link anywhere and send it straight to qBittorrent, rTorrent, or Transmission.</p>
+      </div>
     </div>
   </section>
 

--- a/lib/native-intent.test.ts
+++ b/lib/native-intent.test.ts
@@ -1,0 +1,26 @@
+// Tests live here rather than next to app/+native-intent.ts — files inside
+// app/ are treated as expo-router routes.
+import { redirectSystemPath } from "../app/+native-intent";
+
+describe("redirectSystemPath", () => {
+  it("rewrites magnet URIs to the downloads route with the URI encoded", () => {
+    const magnet = "magnet:?xt=urn:btih:abc123&dn=Some+Name&tr=udp://tracker";
+    expect(redirectSystemPath({ path: magnet, initial: true })).toBe(
+      `/downloads?magnet=${encodeURIComponent(magnet)}`,
+    );
+  });
+
+  it("round-trips the magnet URI through URL decoding intact", () => {
+    const magnet = "magnet:?xt=urn:btih:abc123&dn=Some%20Name&tr=udp://tracker";
+    const result = redirectSystemPath({ path: magnet, initial: false });
+    const param = new URLSearchParams(result.split("?")[1]).get("magnet");
+    expect(param).toBe(magnet);
+  });
+
+  it("passes non-magnet paths through unchanged", () => {
+    expect(redirectSystemPath({ path: "/settings", initial: false })).toBe("/settings");
+    expect(
+      redirectSystemPath({ path: "dashboarr://downloads?client=rtorrent", initial: true }),
+    ).toBe("dashboarr://downloads?client=rtorrent");
+  });
+});

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatRuntime,
   formatProgress,
   truncateText,
+  magnetDisplayName,
   formatEpisodeCode,
   relativeDate,
   formatAudioChannels,
@@ -106,6 +107,27 @@ describe("truncateText", () => {
 
   it("ellipsizes when too long", () => {
     expect(truncateText("hello world", 5)).toBe("hell…");
+  });
+});
+
+describe("magnetDisplayName", () => {
+  it("extracts a percent-encoded dn param", () => {
+    expect(
+      magnetDisplayName("magnet:?xt=urn:btih:abc123&dn=Some%20Torrent%20Name&tr=udp"),
+    ).toBe("Some Torrent Name");
+  });
+
+  it("decodes + as space", () => {
+    expect(magnetDisplayName("magnet:?xt=urn:btih:abc&dn=Some+Name")).toBe("Some Name");
+  });
+
+  it("returns null when dn is absent", () => {
+    expect(magnetDisplayName("magnet:?xt=urn:btih:abc123")).toBeNull();
+  });
+
+  it("returns null for non-magnet text and malformed encodings", () => {
+    expect(magnetDisplayName("hello world")).toBeNull();
+    expect(magnetDisplayName("magnet:?xt=urn:btih:abc&dn=%E0%A4%A")).toBeNull();
   });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -78,6 +78,20 @@ export function truncateText(text: string, maxLength: number): string {
 }
 
 /**
+ * Display name (`dn` param) from a magnet URI, or null when absent/malformed.
+ */
+export function magnetDisplayName(uri: string): string | null {
+  const match = uri.match(/[?&]dn=([^&]+)/);
+  if (!match) return null;
+  try {
+    const name = decodeURIComponent(match[1].replace(/\+/g, " ")).trim();
+    return name || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Format season/episode as S01E05
  */
 export function formatEpisodeCode(season: number, episode: number): string {


### PR DESCRIPTION
## Summary
- Registers the magnet: scheme on Android (intent filter) and iOS (CFBundleURLSchemes) via the app config scheme array
- New app/+native-intent.ts rewrites incoming magnet URLs to the Downloads tab
- Add card opens prefilled with the magnet and shows the torrent name (dn param)
- With multiple clients or instances, a styled ActionSheet picks the destination and pins that instance before the add card opens

## Test plan
- tsc --noEmit clean, 751 jest tests pass (new tests for magnetDisplayName and redirectSystemPath)
- Verified prebuild output: AndroidManifest gets the magnet data element, Info.plist gets the magnet URL scheme
- On-device: needs a new dev build; adb shell am start -a android.intent.action.VIEW -d "magnet:?xt=urn:btih:abc" or xcrun simctl openurl booted