### PR TITLE
feat(library): add Missing filter to library views

### DIFF
--- a/components/common/monitored-library-grid.tsx
+++ b/components/common/monitored-library-grid.tsx
@@ -32,11 +32,12 @@ export interface PosterStatus {
   progress?: number;
 }
 
-export type MonitorFilter = "monitored" | "unmonitored" | "all";
+export type MonitorFilter = "monitored" | "unmonitored" | "missing" | "all";
 
 export const MONITOR_FILTER_OPTIONS: { value: MonitorFilter; label: string }[] = [
   { value: "monitored", label: "Monitored" },
   { value: "unmonitored", label: "Unmonitored" },
+  { value: "missing", label: "Missing" },
   { value: "all", label: "All" },
 ];
 
@@ -58,6 +59,12 @@ interface MonitoredLibraryGridProps<T extends MonitoredItem, S extends string> {
   isLoading: boolean;
   error: Error | null;
   monitorFilter: MonitorFilter;
+  /**
+   * Predicate for the "Missing" filter — released/aired but not downloaded
+   * (issue #265). Injected per screen since the check reads service-specific
+   * fields the generic item type doesn't know (hasFile / episode counts).
+   */
+  isMissing: (item: T) => boolean;
   sort: S;
   compare: (a: T, b: T, sort: S) => number;
   serviceId: "radarr" | "sonarr" | "lidarr";
@@ -101,6 +108,7 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
   isLoading,
   error,
   monitorFilter,
+  isMissing,
   sort,
   compare,
   serviceId,
@@ -126,10 +134,11 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
     const filtered = data.filter((item) => {
       if (monitorFilter === "monitored") return item.monitored;
       if (monitorFilter === "unmonitored") return !item.monitored;
+      if (monitorFilter === "missing") return isMissing(item);
       return true;
     });
     return [...filtered].sort((a, b) => compare(a, b, sort));
-  }, [data, monitorFilter, sort, compare]);
+  }, [data, monitorFilter, isMissing, sort, compare]);
 
   const emptyState = useMemo(() => {
     if (isLoading) {
@@ -160,7 +169,9 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
         ? `No monitored ${nounPlural}`
         : monitorFilter === "unmonitored"
           ? `No unmonitored ${nounPlural}`
-          : `No ${nounPlural} in library`;
+          : monitorFilter === "missing"
+            ? `No missing ${nounPlural}`
+            : `No ${nounPlural} in library`;
     return (
       <EmptyState
         icon={<Icon icon={placeholderIcon} size={32} color="#71717a" />}

--- a/components/lidarr/music-view.tsx
+++ b/components/lidarr/music-view.tsx
@@ -51,7 +51,9 @@ import {
   cornerColorFor,
   lidarrArtistBarKind,
   lidarrArtistBarProgress,
+  lidarrArtistIsMissing,
   lidarrAlbumBarKind,
+  lidarrAlbumIsMissing,
 } from "@/lib/arr-poster-status";
 import type { LidarrArtist, LidarrAlbum, LidarrQueueItem } from "@/lib/types";
 
@@ -448,6 +450,7 @@ function ArtistLibrary({
       isLoading={isLoading}
       error={error}
       monitorFilter={monitorFilter}
+      isMissing={lidarrArtistIsMissing}
       sort={sort}
       compare={compareArtists}
       serviceId="lidarr"
@@ -557,6 +560,7 @@ function AlbumWanted({
       isLoading={isLoading}
       error={error}
       monitorFilter="all"
+      isMissing={lidarrAlbumIsMissing}
       sort="release-desc"
       compare={compareAlbumsByRelease}
       serviceId="lidarr"

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -50,6 +50,7 @@ import {
   BAR_KIND_COLOR,
   cornerColorFor,
   radarrBarKind,
+  radarrIsMissing,
   DOWNLOAD_INDICATOR_COLOR,
 } from "@/lib/arr-poster-status";
 import { ProgressBar } from "@/components/ui/progress-bar";
@@ -474,6 +475,7 @@ function MovieLibrary({
       isLoading={isLoading}
       error={error}
       monitorFilter={monitorFilter}
+      isMissing={radarrIsMissing}
       sort={sort}
       compare={compareMovies}
       serviceId="radarr"
@@ -586,6 +588,7 @@ function MovieWanted({
       isLoading={isLoading}
       error={error}
       monitorFilter="all"
+      isMissing={radarrIsMissing}
       sort="title-asc"
       compare={compareMovies}
       serviceId="radarr"

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -61,6 +61,7 @@ import {
   cornerColorFor,
   sonarrBarKind,
   sonarrBarProgress,
+  sonarrIsMissing,
   sonarrEpisodeBarKind,
 } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -487,6 +488,7 @@ function SeriesLibrary({
       isLoading={isLoading}
       error={error}
       monitorFilter={monitorFilter}
+      isMissing={sonarrIsMissing}
       sort={sort}
       compare={compareSeries}
       serviceId="sonarr"

--- a/lib/arr-poster-status.test.ts
+++ b/lib/arr-poster-status.test.ts
@@ -1,8 +1,10 @@
 import {
   radarrBarKind,
+  radarrIsMissing,
   sonarrBarKind,
   sonarrEpisodeBarKind,
   sonarrBarProgress,
+  sonarrIsMissing,
   cornerColorFor,
   downloadIndicator,
   DOWNLOAD_INDICATOR_COLOR,
@@ -227,6 +229,75 @@ describe("radarrBarKind", () => {
     expect(
       radarrBarKind(movie({ monitored: true, hasFile: false, isAvailable: false }), false),
     ).toBe("primary");
+  });
+});
+
+describe("radarrIsMissing", () => {
+  it("monitored + available + no file → missing", () => {
+    expect(
+      radarrIsMissing(movie({ monitored: true, isAvailable: true, hasFile: false })),
+    ).toBe(true);
+  });
+
+  it("unreleased (not available) → not missing — the point of #265", () => {
+    expect(
+      radarrIsMissing(movie({ monitored: true, isAvailable: false, hasFile: false })),
+    ).toBe(false);
+  });
+
+  it("downloaded → not missing", () => {
+    expect(
+      radarrIsMissing(movie({ monitored: true, isAvailable: true, hasFile: true })),
+    ).toBe(false);
+  });
+
+  it("unmonitored → not missing", () => {
+    expect(
+      radarrIsMissing(movie({ monitored: false, isAvailable: true, hasFile: false })),
+    ).toBe(false);
+  });
+});
+
+describe("sonarrIsMissing", () => {
+  it("monitored with undownloaded aired episodes → missing", () => {
+    expect(
+      sonarrIsMissing(series({ monitored: true, episodeCount: 10, episodeFileCount: 4 })),
+    ).toBe(true);
+  });
+
+  it("fully downloaded → not missing", () => {
+    expect(
+      sonarrIsMissing(series({ monitored: true, episodeCount: 10, episodeFileCount: 10 })),
+    ).toBe(false);
+  });
+
+  it("zero countable episodes → treated complete, not missing", () => {
+    expect(
+      sonarrIsMissing(series({ monitored: true, episodeCount: 0, episodeFileCount: 0 })),
+    ).toBe(false);
+  });
+
+  it("unmonitored → not missing", () => {
+    expect(
+      sonarrIsMissing(series({ monitored: false, episodeCount: 10, episodeFileCount: 4 })),
+    ).toBe(false);
+  });
+
+  it("prefers statistics over top-level counts", () => {
+    const s = series({
+      monitored: true,
+      episodeCount: 0,
+      episodeFileCount: 0,
+      statistics: {
+        seasonCount: 1,
+        episodeCount: 10,
+        episodeFileCount: 3,
+        totalEpisodeCount: 10,
+        sizeOnDisk: 0,
+        percentOfEpisodes: 30,
+      },
+    });
+    expect(sonarrIsMissing(s)).toBe(true);
   });
 });
 

--- a/lib/arr-poster-status.ts
+++ b/lib/arr-poster-status.ts
@@ -191,6 +191,29 @@ export function lidarrAlbumBarKind(
 }
 
 /**
+ * "Missing" predicates for the library filter (issue #265): released/aired but
+ * not downloaded, monitored only. Each mirrors its service's danger-bar branch
+ * above so the filter and the red poster bar select the same items.
+ */
+export function radarrIsMissing(movie: RadarrMovie): boolean {
+  return movie.monitored && movie.isAvailable && !movie.hasFile;
+}
+
+export function sonarrIsMissing(series: SonarrSeries): boolean {
+  return series.monitored && sonarrBarProgress(series) < 100;
+}
+
+export function lidarrArtistIsMissing(artist: LidarrArtist): boolean {
+  return artist.monitored && lidarrArtistBarProgress(artist) < 100;
+}
+
+export function lidarrAlbumIsMissing(album: LidarrAlbum): boolean {
+  const trackCount = album.statistics?.trackCount ?? 0;
+  const fileCount = album.statistics?.trackFileCount ?? 0;
+  return album.monitored && trackCount > 0 && fileCount < trackCount;
+}
+
+/**
  * Top-right corner triangle color, or null for no triangle.
  * Sonarr: `ended` → red, `deleted` → gray. Radarr movie status is never
  * `ended`, so only `deleted` produces a triangle there.


### PR DESCRIPTION
Adds a "Missing" option to the Filter & sort sheet on the Movies, TV and Music library views: released/aired but not downloaded, monitored only. Pure client-side filter over already-fetched library data; predicates mirror the red danger poster-bar branches in lib/arr-poster-status.ts so the filter and the red bar select the same items. Unlike the Wanted tab, unreleased movies are excluded.

Refs #265

## Test plan
- `pnpm test` (760 passing, incl. new predicate tests in lib/arr-poster-status.test.ts)
- `tsc --noEmit` clean