### PR TITLE
feat(movies): Radarr collections on movie detail and add flow

### DIFF
--- a/app/movie/[id].tsx
+++ b/app/movie/[id].tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { View, Text, ScrollView, Linking, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
@@ -14,6 +14,7 @@ import {
   FolderTree,
   History,
   Pencil,
+  Plus,
 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { toastError } from "@/components/ui/toast";
@@ -33,6 +34,8 @@ import { ActionSheet } from "@/components/ui/action-sheet";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import {
   useRadarrMovie,
+  useRadarrMovies,
+  useRadarrCollection,
   useRadarrQueue,
   useDeleteMovie,
   useToggleMovieMonitored,
@@ -43,7 +46,15 @@ import {
   useRadarrTags,
 } from "@/hooks/use-radarr";
 import { MovieOptionsSheet } from "@/components/radarr/movie-options-sheet";
-import { MIN_AVAILABILITY_OPTIONS } from "@/components/radarr/add-movie-sheet";
+import {
+  AddMovieSheet,
+  MIN_AVAILABILITY_OPTIONS,
+} from "@/components/radarr/add-movie-sheet";
+import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
+import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
+import { PosterProgressStrip } from "@/components/dashboard/poster-progress-strip";
+import { BAR_KIND_COLOR, radarrBarKind } from "@/lib/arr-poster-status";
+import { getRadarrPoster } from "@/services/radarr-api";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import {
@@ -52,7 +63,12 @@ import {
   formatResolution,
   formatRuntime,
 } from "@/lib/utils";
-import type { RadarrMovie } from "@/lib/types";
+import type {
+  RadarrMovie,
+  RadarrCollection,
+  RadarrCollectionMovie,
+  RadarrSearchResult,
+} from "@/lib/types";
 
 type DeleteMode = "keep" | "withFiles";
 
@@ -72,6 +88,11 @@ export default function MovieDetailScreen() {
   const updateRootFolder = useUpdateMovieRootFolder(instanceId);
   const { data: tags } = useRadarrTags(instanceId);
   const [optionsVisible, setOptionsVisible] = useState(false);
+  // Missing collection member being added. Plain useState, not a flow step:
+  // AddMediaSheet is a pageSheet Modal without onClosed plumbing, and nothing
+  // else is open when a poster tile is tapped (mirrors app/movie/search.tsx).
+  const [collectionAddTarget, setCollectionAddTarget] =
+    useState<RadarrSearchResult | null>(null);
 
   // All modal sequencing (sheet → confirm, sheet → sheet, confirm → pop) goes
   // through the flow — see hooks/use-modal-flow.ts.
@@ -296,6 +317,12 @@ export default function MovieDetailScreen() {
             </View>
           ) : null}
 
+          <CollectionBlock
+            movie={movie}
+            instanceId={instanceId}
+            onAddMissing={setCollectionAddTarget}
+          />
+
           <ReleaseDatesBlock movie={movie} />
         </View>
       </ScreenWrapper>
@@ -359,6 +386,13 @@ export default function MovieDetailScreen() {
         visible={optionsVisible}
         onClose={() => setOptionsVisible(false)}
         movie={movie}
+        instanceId={instanceId}
+      />
+
+      <AddMovieSheet
+        result={collectionAddTarget}
+        visible={collectionAddTarget !== null}
+        onClose={() => setCollectionAddTarget(null)}
         instanceId={instanceId}
       />
 
@@ -643,6 +677,137 @@ function ReleaseDatesBlock({ movie }: { movie: RadarrMovie }) {
       </View>
     </View>
   );
+}
+
+// Horizontal poster row of the movie's TMDB collection (issue #244). Owned
+// members show the standard status strip and navigate to their detail screen;
+// missing members show a Plus badge and open the AddMovieSheet.
+function CollectionBlock({
+  movie,
+  instanceId,
+  onAddMissing,
+}: {
+  movie: RadarrMovie;
+  instanceId?: string;
+  onAddMissing: (result: RadarrSearchResult) => void;
+}) {
+  const router = useRouter();
+  const collectionTmdbId = movie.collection?.tmdbId;
+  const { data: collection, isLoading, error } = useRadarrCollection(
+    collectionTmdbId,
+    instanceId,
+  );
+  // Ownership + status color come from the live library, not the collection's
+  // cached isExisting flags. The queue query shares the parent's cache entry.
+  const { data: library } = useRadarrMovies(instanceId);
+  const { data: queue } = useRadarrQueue(instanceId);
+
+  const libraryByTmdbId = useMemo(
+    () => new Map((library ?? []).map((m) => [m.tmdbId, m])),
+    [library],
+  );
+  const downloadingIds = useMemo(
+    () => new Set((queue?.records ?? []).map((r) => r.movieId)),
+    [queue],
+  );
+
+  if (!collectionTmdbId) return null;
+  // Supplementary content — hide quietly on error instead of a banner.
+  if (error) return null;
+  if (isLoading) {
+    return (
+      <View className="mb-5">
+        <SectionLabel>{movie.collection?.title || "Collection"}</SectionLabel>
+        <PosterSkeletonRow count={3} showSubtitle />
+      </View>
+    );
+  }
+  if (!collection || collection.movies.length < 2) return null;
+
+  const members = [...collection.movies].sort(
+    (a, b) => (a.year || 9999) - (b.year || 9999),
+  );
+
+  return (
+    <View className="mb-5">
+      <SectionLabel>{collection.title || "Collection"}</SectionLabel>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 12 }}
+      >
+        {members.map((cm) => {
+          const owned = libraryByTmdbId.get(cm.tmdbId);
+          const isCurrent = cm.tmdbId === movie.tmdbId;
+          // isExisting is the fallback while the library query is loading, so
+          // an owned movie never shows an Add affordance that would 400.
+          const isOwned = !!owned || cm.isExisting;
+          return (
+            <MediaPosterTile
+              key={cm.tmdbId}
+              posterUrl={getRadarrPoster(cm.images)}
+              title={cm.title}
+              subtitle={cm.year ? String(cm.year) : undefined}
+              fallbackIcon={Film}
+              mediaType="movie"
+              cornerBadge={
+                isOwned
+                  ? undefined
+                  : { icon: Plus, color: BAR_KIND_COLOR.primary }
+              }
+              bottomOverlay={
+                isOwned ? (
+                  <PosterProgressStrip
+                    progress={1}
+                    color={
+                      owned
+                        ? BAR_KIND_COLOR[
+                            radarrBarKind(owned, downloadingIds.has(owned.id))
+                          ]
+                        : BAR_KIND_COLOR.default
+                    }
+                  />
+                ) : undefined
+              }
+              onPress={
+                isCurrent
+                  ? undefined
+                  : owned
+                    ? () =>
+                        router.push(
+                          instanceId
+                            ? `/movie/${owned.id}?instanceId=${instanceId}`
+                            : `/movie/${owned.id}`,
+                        )
+                    : isOwned
+                      ? undefined
+                      : () => onAddMissing(toSearchResult(cm, collection))
+              }
+            />
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+// AddMovieSheet only reads tmdbId/title/year/overview/images; ratings and
+// runtime just satisfy the RadarrSearchResult shape. Filling `collection`
+// makes the sheet's "Part of …" meta line show here too.
+function toSearchResult(
+  cm: RadarrCollectionMovie,
+  collection: RadarrCollection,
+): RadarrSearchResult {
+  return {
+    tmdbId: cm.tmdbId,
+    title: cm.title,
+    year: cm.year,
+    overview: cm.overview ?? "",
+    images: cm.images,
+    ratings: { votes: 0, value: 0 },
+    runtime: cm.runtime ?? 0,
+    collection: { title: collection.title, tmdbId: collection.tmdbId },
+  };
 }
 
 function AboutRow({

--- a/components/radarr/add-movie-sheet.tsx
+++ b/components/radarr/add-movie-sheet.tsx
@@ -19,6 +19,9 @@ interface AddMovieSheetProps {
   result: RadarrSearchResult | null;
   visible: boolean;
   onClose: () => void;
+  // Scopes profiles/folders/tags and the add itself to a specific Radarr
+  // instance; undefined keeps the active-instance behavior.
+  instanceId?: string;
 }
 
 // Shared with the movie-edit sheet (components/radarr/movie-options-sheet.tsx),
@@ -43,11 +46,16 @@ const MONITOR_OPTIONS: {
   { value: "none", label: "None", description: "Don't monitor" },
 ];
 
-export function AddMovieSheet({ result, visible, onClose }: AddMovieSheetProps) {
-  const { data: profiles } = useRadarrQualityProfiles();
-  const { data: folders } = useRadarrRootFolders();
-  const { data: tags } = useRadarrTags();
-  const addMovie = useAddMovie();
+export function AddMovieSheet({
+  result,
+  visible,
+  onClose,
+  instanceId,
+}: AddMovieSheetProps) {
+  const { data: profiles } = useRadarrQualityProfiles(instanceId);
+  const { data: folders } = useRadarrRootFolders(instanceId);
+  const { data: tags } = useRadarrTags(instanceId);
+  const addMovie = useAddMovie(instanceId);
 
   const [minimumAvailability, setMinimumAvailability] =
     useState<RadarrMinimumAvailability>("released");
@@ -62,6 +70,16 @@ export function AddMovieSheet({ result, visible, onClose }: AddMovieSheetProps) 
       sheetTitle="Add Movie"
       submitLabel="Add Movie"
       placeholderIcon={Film}
+      metaLine={
+        result?.collection?.title
+          ? [
+              result.year ? String(result.year) : undefined,
+              `Part of ${result.collection.title}`,
+            ]
+              .filter(Boolean)
+              .join(" · ")
+          : undefined
+      }
       profiles={profiles}
       folders={folders}
       tags={tags}

--- a/components/search/radarr-search-row.tsx
+++ b/components/search/radarr-search-row.tsx
@@ -55,7 +55,16 @@ export function RadarrSearchRow({
       poster={result.images.find((i) => i.coverType === "poster")}
       fallbackIcon={Film}
       title={result.title}
-      metaLine={result.year ? String(result.year) : undefined}
+      metaLine={
+        [
+          result.year ? String(result.year) : undefined,
+          result.collection?.title
+            ? `Part of ${result.collection.title}`
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join(" · ") || undefined
+      }
       overview={result.overview}
       alreadyAdded={existingMovieId !== undefined}
       addPending={addMovie.isPending}

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getMovies,
   getMovie,
+  getCollectionByTmdbId,
   getQueue,
   getHistory,
   getMovieHistory,
@@ -58,6 +59,23 @@ export function useRadarrMovie(movieId: number, instanceId?: string) {
     queryKey: ["radarr", id, "movie", movieId],
     queryFn: () => getMovie(movieId, id ?? undefined),
     enabled: movieId > 0 && !!id,
+  });
+}
+
+// Collection membership is static TMDB metadata, so it caches like the other
+// static lookups (profiles/rootFolders/tags). Ownership of each member is
+// derived client-side from the live ["radarr", id, "movies"] cache, not from
+// the cached `isExisting` flags.
+export function useRadarrCollection(
+  collectionTmdbId: number | undefined,
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
+  return useQuery({
+    queryKey: ["radarr", id, "collection", collectionTmdbId],
+    queryFn: () => getCollectionByTmdbId(collectionTmdbId!, id ?? undefined),
+    enabled: enabled && !!id && !!collectionTmdbId,
+    staleTime: Infinity,
   });
 }
 
@@ -129,6 +147,8 @@ export function useAddMovie(instanceId?: string) {
       addMovie(movie, id ?? undefined),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["radarr", id, "movies"] });
+      // Refresh cached collections so their `isExisting` flags don't go stale.
+      queryClient.invalidateQueries({ queryKey: ["radarr", id, "collection"] });
     },
   });
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -333,6 +333,9 @@ export interface RadarrMovie {
   tags?: number[];
   certification?: string;
   studio?: string;
+  // Lightweight collection ref on MovieResource; null/absent when the movie
+  // isn't part of a TMDB collection.
+  collection?: { title: string; tmdbId: number } | null;
 }
 
 export interface RatingChild {
@@ -446,6 +449,44 @@ export interface RadarrSearchResult {
   images: RadarrImage[];
   ratings: { votes: number; value: number };
   runtime: number;
+  collection?: { title: string; tmdbId: number } | null;
+}
+
+// --- Collections ---
+
+// Member of a Radarr /collection response: every TMDB movie in the collection,
+// whether or not it's in the library. `isExisting` marks members already added.
+export interface RadarrCollectionMovie {
+  tmdbId: number;
+  imdbId?: string;
+  title: string;
+  sortTitle?: string;
+  status: string;
+  overview?: string;
+  runtime: number;
+  images: RadarrImage[];
+  year: number;
+  genres?: string[];
+  folder?: string;
+  isExisting: boolean;
+  isExcluded: boolean;
+}
+
+export interface RadarrCollection {
+  id: number;
+  title: string;
+  sortTitle?: string;
+  tmdbId: number;
+  images: RadarrImage[];
+  overview?: string;
+  monitored: boolean;
+  rootFolderPath?: string;
+  qualityProfileId?: number;
+  searchOnAdd?: boolean;
+  minimumAvailability?: string;
+  movies: RadarrCollectionMovie[];
+  missingMovies?: number;
+  tags?: number[];
 }
 
 // --- Interactive search (releases) ---

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -8,6 +8,7 @@ import type {
   RadarrSearchResult,
   RadarrImage,
   RadarrRelease,
+  RadarrCollection,
 } from "@/lib/types";
 
 // Interactive search hits indexers live and frequently exceeds the 15s
@@ -46,6 +47,25 @@ export function getMovies(instanceId?: string): Promise<RadarrMovie[]> {
 
 export function getMovie(id: number, instanceId?: string): Promise<RadarrMovie> {
   return serviceRequest<RadarrMovie>("radarr", `/movie/${id}`, { instanceId });
+}
+
+// --- Collections ---
+
+// Radarr filters /collection by the COLLECTION's TMDB id (the `collection`
+// field on a movie resource). The endpoint always returns an array; match on
+// tmdbId defensively and fall back to the first element. Returns null (not
+// undefined — TanStack Query rejects undefined) when Radarr knows nothing
+// about the collection.
+export function getCollectionByTmdbId(
+  collectionTmdbId: number,
+  instanceId?: string,
+): Promise<RadarrCollection | null> {
+  return serviceRequest<RadarrCollection[]>("radarr", "/collection", {
+    params: { tmdbId: collectionTmdbId },
+    instanceId,
+  }).then(
+    (list) => list.find((c) => c.tmdbId === collectionTmdbId) ?? list[0] ?? null,
+  );
 }
 
 // --- Queue ---


### PR DESCRIPTION
Refs #244

## Summary
- Collection poster row on the movie detail screen: owned entries use the standard status colors and open their detail screen; missing entries show a Plus badge and open the AddMovieSheet prefilled
- "Part of <collection>" hint in movie search results and in the AddMovieSheet meta line
- New GET /api/v3/collection integration (getCollectionByTmdbId + useRadarrCollection); collection typed on RadarrMovie/RadarrSearchResult
- AddMovieSheet now accepts instanceId for multi-instance correctness

## Test plan
- tsc --noEmit clean, all 760 tests pass
- Manual: open a library movie in a collection (row, colors, add-from-row), a movie without one (no section, no request), search a franchise film (hint in row + sheet)