### PR TITLE
fix(seerr): show partial availability in green and refresh status faster

### DIFF
--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -156,7 +156,7 @@ const MEDIA_STATUS_VARIANT_OVERRIDE: Record<
   "info" | "success" | "warning" | undefined
 > = {
   3: "info",
-  4: "warning",
+  4: "success",
   5: "success",
 };
 

--- a/components/overseerr/media-detail-modal.tsx
+++ b/components/overseerr/media-detail-modal.tsx
@@ -181,13 +181,19 @@ export function MediaDetailModal({
   // carries status but no id).
   const mediaDbId = detailsData?.mediaInfo?.id;
 
+  // Partial (4) only occurs for TV upstream; a partially available show can
+  // still request its remaining seasons (Seerr's "Request More").
   const isAvailableHd = statusHd === 5;
+  const isPartialHd = statusHd === 4;
   const isPendingHd = statusHd === 2 || statusHd === 3;
-  const canRequestHd = !isAvailableHd && !isPendingHd;
+  const canRequestHd =
+    !isAvailableHd && !isPendingHd && (!isPartialHd || isTv);
 
   const isAvailable4k = status4k === 5;
+  const isPartial4k = status4k === 4;
   const isPending4k = status4k === 2 || status4k === 3;
-  const canRequest4k = has4kServer && !isAvailable4k && !isPending4k;
+  const canRequest4k =
+    has4kServer && !isAvailable4k && !isPending4k && (!isPartial4k || isTv);
 
   const trailer = pickTrailer(detailsData?.relatedVideos);
   const submitting = quickKind !== null;
@@ -237,8 +243,8 @@ export function MediaDetailModal({
   //
   // Tracked = Seerr holds a media record for either tier in any requested state:
   // pending (2) / processing (3) / partial (4) / available (5). status 1
-  // (unknown) is excluded. Checked directly off the status because the
-  // isPending*/isAvailable* flags above skip PARTIAL (4).
+  // (unknown) is excluded. Checked directly off the status rather than
+  // combining the per-tier flags above.
   const isTracked =
     mediaDbId !== undefined &&
     [statusHd, status4k].some((s) => s !== undefined && s >= 2);
@@ -380,9 +386,20 @@ export function MediaDetailModal({
             {/* Request actions */}
             <View className="mt-3 gap-2.5">
               {/* HD / regular */}
+              {isAvailableHd ? (
+                <StatusPill tone="success" icon={Check} label="Available" />
+              ) : isPartialHd ? (
+                <StatusPill
+                  tone="success"
+                  icon={Check}
+                  label="Partially Available"
+                />
+              ) : !canRequestHd ? (
+                <StatusPill tone="warning" icon={Clock} label="Requested" />
+              ) : null}
               {canRequestHd ? (
                 <Button
-                  label="Request"
+                  label={isPartialHd ? "Request More" : "Request"}
                   onPress={() => handleQuickRequest("hd")}
                   loading={quickKind === "hd"}
                   disabled={submitting}
@@ -390,46 +407,53 @@ export function MediaDetailModal({
                   size="lg"
                   className="w-full"
                 />
-              ) : isAvailableHd ? (
-                <StatusPill tone="success" icon={Check} label="Available" />
-              ) : (
-                <StatusPill tone="warning" icon={Clock} label="Requested" />
-              )}
+              ) : null}
 
               {/* 4K — only when Seerr has a 4K-capable server for this type */}
               {has4kServer ? (
-                canRequest4k ? (
-                  <Pressable
-                    onPress={() => handleQuickRequest("4k")}
-                    disabled={submitting}
-                    accessibilityRole="button"
-                    accessibilityLabel="Request in 4K"
-                    className={`flex-row items-center justify-center gap-2 px-6 py-3.5 rounded-xl bg-violet-600 ${submitting ? "opacity-50" : "active:opacity-80"}`}
-                  >
-                    {quickKind === "4k" ? (
-                      <ActivityIndicator size="small" color="#fff" />
-                    ) : (
-                      <>
-                        <Icon icon={Plus} size={16} color="#fff" />
-                        <Text className="text-white font-semibold text-base">
-                          Request 4K
-                        </Text>
-                      </>
-                    )}
-                  </Pressable>
-                ) : isAvailable4k ? (
-                  <StatusPill
-                    tone="success"
-                    icon={Check}
-                    label="Available in 4K"
-                  />
-                ) : (
-                  <StatusPill
-                    tone="warning"
-                    icon={Clock}
-                    label="Requested in 4K"
-                  />
-                )
+                <>
+                  {isAvailable4k ? (
+                    <StatusPill
+                      tone="success"
+                      icon={Check}
+                      label="Available in 4K"
+                    />
+                  ) : isPartial4k ? (
+                    <StatusPill
+                      tone="success"
+                      icon={Check}
+                      label="Partially Available in 4K"
+                    />
+                  ) : !canRequest4k ? (
+                    <StatusPill
+                      tone="warning"
+                      icon={Clock}
+                      label="Requested in 4K"
+                    />
+                  ) : null}
+                  {canRequest4k ? (
+                    <Pressable
+                      onPress={() => handleQuickRequest("4k")}
+                      disabled={submitting}
+                      accessibilityRole="button"
+                      accessibilityLabel={
+                        isPartial4k ? "Request more in 4K" : "Request in 4K"
+                      }
+                      className={`flex-row items-center justify-center gap-2 px-6 py-3.5 rounded-xl bg-violet-600 ${submitting ? "opacity-50" : "active:opacity-80"}`}
+                    >
+                      {quickKind === "4k" ? (
+                        <ActivityIndicator size="small" color="#fff" />
+                      ) : (
+                        <>
+                          <Icon icon={Plus} size={16} color="#fff" />
+                          <Text className="text-white font-semibold text-base">
+                            {isPartial4k ? "Request More 4K" : "Request 4K"}
+                          </Text>
+                        </>
+                      )}
+                    </Pressable>
+                  ) : null}
+                </>
               ) : null}
 
               {/* Advanced options */}

--- a/components/overseerr/poster-card.tsx
+++ b/components/overseerr/poster-card.tsx
@@ -33,6 +33,9 @@ export function PosterCard({ item, onPress, size = "sm", widthOverride }: Poster
     item.releaseDate?.slice(0, 4) || item.firstAirDate?.slice(0, 4);
   const posterUrl = getPosterUrl(item.posterPath, poster);
   const isAvailable = item.mediaInfo?.status === 5;
+  // Partially available (TV with some seasons present) — green like Seerr,
+  // but with a clock glyph to distinguish it from fully available.
+  const isPartial = item.mediaInfo?.status === 4;
   const isPending =
     item.mediaInfo?.status === 2 || item.mediaInfo?.status === 3;
 
@@ -67,6 +70,11 @@ export function PosterCard({ item, onPress, size = "sm", widthOverride }: Poster
         {isAvailable && (
           <View className="absolute top-1.5 right-1.5 bg-green-600 rounded-full p-1">
             <Icon icon={Check} size={10} color="#fff" />
+          </View>
+        )}
+        {isPartial && (
+          <View className="absolute top-1.5 right-1.5 bg-green-600 rounded-full p-1">
+            <Icon icon={Clock} size={10} color="#fff" />
           </View>
         )}
         {isPending && (

--- a/hooks/use-overseerr.ts
+++ b/hooks/use-overseerr.ts
@@ -101,7 +101,10 @@ export function useOverseerrMediaDetails(
       mediaType === "movie"
         ? getMovieDetails(tmdbId, id ?? undefined)
         : getTVDetails(tmdbId, id ?? undefined),
-    staleTime: 600000, // 10 min — titles don't change
+    // Short: the payload carries live mediaInfo.status, which flips when a
+    // Seerr availability scan runs — a long staleTime kept showing
+    // "Requested" for titles already available (#266).
+    staleTime: 30000,
     enabled: enabled && !!id && tmdbId > 0 && active,
   });
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -890,7 +890,9 @@ export type OverseerrMediaStatus =
   | 2 // PENDING
   | 3 // PROCESSING
   | 4 // PARTIALLY_AVAILABLE
-  | 5; // AVAILABLE
+  | 5 // AVAILABLE
+  | 6 // BLOCKLISTED (Jellyseerr)
+  | 7; // DELETED (Jellyseerr)
 
 export const OVERSEERR_STATUS_LABELS: Record<number, string> = {
   1: "Unknown",
@@ -898,6 +900,8 @@ export const OVERSEERR_STATUS_LABELS: Record<number, string> = {
   3: "Processing",
   4: "Partial",
   5: "Available",
+  6: "Blocklisted",
+  7: "Deleted",
 };
 
 export interface OverseerrRequest {


### PR DESCRIPTION
Refs #266

- Detail modal: status 4 (partially available, TV) now shows a green "Partially Available" pill plus a "Request More" button for remaining seasons, matching Seerr's UI (same for the 4K tier).
- Poster cards: green clock badge for partial titles; requests tab "Partial" badge switched from yellow to green.
- Media details staleTime lowered from 10 min to 30 s so a fresh Seerr availability scan is reflected on reopen.
- Types: added Jellyseerr statuses 6 (Blocklisted) and 7 (Deleted).

Test plan: tsc --noEmit clean, 760 jest tests pass; on device, a partially available show reads green in modal/grid/requests tab and a newly available title flips to Available on reopen.