### PR TITLE
feat(arr): user-defined default profiles and root folder for add flows

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -79,6 +79,7 @@ import { ActionSheet } from "@/components/ui/action-sheet";
 import { SettingsGroup } from "@/components/settings/settings-group";
 import { SettingsRow } from "@/components/settings/settings-row";
 import { SettingsToggleRow } from "@/components/settings/settings-toggle-row";
+import { ArrDefaultsCard } from "@/components/settings/arr-defaults-card";
 import { AddToDashboardsSheet } from "@/components/dashboard/add-to-dashboards-sheet";
 import {
   forgetRememberedPassphrase,
@@ -1464,6 +1465,8 @@ function ServiceEditor({
           helperText="Sent on every request to this instance. Combined with the global headers (Settings → Custom Headers). The service's own auth (API Key, Plex Token, etc.) always wins on collision."
         />
       </Card>
+
+      <ArrDefaultsCard serviceId={serviceId} instanceId={instanceId} />
 
       <InstanceNotificationsCard serviceId={serviceId} instanceId={instanceId} />
 

--- a/components/common/add-media-sheet.tsx
+++ b/components/common/add-media-sheet.tsx
@@ -9,6 +9,7 @@ import { Toggle } from "@/components/ui/toggle";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { SheetHeader } from "@/components/ui/sheet-header";
 import { useServiceImage } from "@/hooks/use-service-image";
+import { useTargetInstance } from "@/hooks/use-instance-target";
 import { formatBytes } from "@/lib/utils";
 
 export interface AddMediaSheetCommonState {
@@ -49,6 +50,9 @@ interface AddMediaSheetProps {
     images: MediaImage[];
   } | null;
   serviceId: "radarr" | "sonarr" | "lidarr";
+  /** Scopes which instance's stored defaults preselect the Quality Profile and
+   *  Root Folder. Omit to follow the active instance for `serviceId`. */
+  instanceId?: string;
   sheetTitle: string;
   submitLabel: string;
   metaLine?: string;
@@ -69,6 +73,7 @@ export function AddMediaSheet({
   onClose,
   result,
   serviceId,
+  instanceId,
   sheetTitle,
   submitLabel,
   metaLine,
@@ -86,8 +91,24 @@ export function AddMediaSheet({
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [searchOnAdd, setSearchOnAdd] = useState(true);
 
-  const effectiveQualityProfileId = qualityProfileId ?? profiles?.[0]?.id;
-  const effectiveRootFolderPath = rootFolderPath ?? folders?.[0]?.path;
+  // User-configured defaults for this instance (Settings → Add Defaults), with
+  // first-in-list as the fallback when unset or when the stored value no longer
+  // exists on the server (profile/folder deleted upstream). An in-sheet pick
+  // (qualityProfileId / rootFolderPath state) always wins over the default.
+  const inst = useTargetInstance(serviceId, instanceId);
+  const storedProfileId = inst?.defaultQualityProfileId;
+  const defaultProfileId =
+    storedProfileId != null && profiles?.some((p) => p.id === storedProfileId)
+      ? storedProfileId
+      : profiles?.[0]?.id;
+  const storedFolderPath = inst?.defaultRootFolderPath;
+  const defaultFolderPath =
+    storedFolderPath != null && folders?.some((f) => f.path === storedFolderPath)
+      ? storedFolderPath
+      : folders?.[0]?.path;
+
+  const effectiveQualityProfileId = qualityProfileId ?? defaultProfileId;
+  const effectiveRootFolderPath = rootFolderPath ?? defaultFolderPath;
 
   const poster = result?.images.find((i) => i.coverType === "poster");
   const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, serviceId);

--- a/components/lidarr/add-artist-sheet.tsx
+++ b/components/lidarr/add-artist-sheet.tsx
@@ -3,6 +3,7 @@ import { Mic2 } from "lucide-react-native";
 import { Select } from "@/components/ui/select";
 import { toast, toastError } from "@/components/ui/toast";
 import { AddMediaSheet } from "@/components/common/add-media-sheet";
+import { useTargetInstance } from "@/hooks/use-instance-target";
 import {
   useAddArtist,
   useLidarrQualityProfiles,
@@ -41,7 +42,17 @@ export function AddArtistSheet({ result, visible, onClose }: AddArtistSheetProps
   const [metadataProfileId, setMetadataProfileId] = useState<number | undefined>();
   const [monitor, setMonitor] = useState<LidarrMonitorOption>("all");
 
-  const effectiveMetadataProfileId = metadataProfileId ?? metadataProfiles?.[0]?.id;
+  // Mirror AddMediaSheet's default resolution for Lidarr's extra Metadata
+  // Profile picker: the instance's stored default (Settings → Add Defaults),
+  // falling back to first-in-list when unset or stale.
+  const inst = useTargetInstance("lidarr");
+  const storedMetadataProfileId = inst?.defaultMetadataProfileId;
+  const defaultMetadataProfileId =
+    storedMetadataProfileId != null &&
+    metadataProfiles?.some((p) => p.id === storedMetadataProfileId)
+      ? storedMetadataProfileId
+      : metadataProfiles?.[0]?.id;
+  const effectiveMetadataProfileId = metadataProfileId ?? defaultMetadataProfileId;
 
   return (
     <AddMediaSheet

--- a/components/radarr/add-movie-sheet.tsx
+++ b/components/radarr/add-movie-sheet.tsx
@@ -67,6 +67,7 @@ export function AddMovieSheet({
       onClose={onClose}
       result={result}
       serviceId="radarr"
+      instanceId={instanceId}
       sheetTitle="Add Movie"
       submitLabel="Add Movie"
       placeholderIcon={Film}

--- a/components/settings/arr-defaults-card.tsx
+++ b/components/settings/arr-defaults-card.tsx
@@ -1,0 +1,212 @@
+import { View, Text } from "react-native";
+import { Card } from "@/components/ui/card";
+import { Select } from "@/components/ui/select";
+import { formatBytes } from "@/lib/utils";
+import { useConfigStore } from "@/store/config-store";
+import { useTargetInstance } from "@/hooks/use-instance-target";
+import {
+  useRadarrQualityProfiles,
+  useRadarrRootFolders,
+} from "@/hooks/use-radarr";
+import {
+  useSonarrQualityProfiles,
+  useSonarrRootFolders,
+} from "@/hooks/use-sonarr";
+import {
+  useLidarrQualityProfiles,
+  useLidarrRootFolders,
+  useLidarrMetadataProfiles,
+} from "@/hooks/use-lidarr";
+import type { ServiceId } from "@/lib/constants";
+
+// arr profile/metadata ids are always >= 1 and root-folder paths are non-empty,
+// so these sentinels safely mean "no stored default — use first in list".
+const FIRST_IN_LIST_ID = -1;
+const FIRST_IN_LIST_PATH = "";
+
+interface Profile {
+  id: number;
+  name: string;
+}
+interface Folder {
+  path: string;
+  freeSpace: number;
+}
+
+/**
+ * Per-instance defaults for the Radarr/Sonarr/Lidarr add flows (#287): the
+ * Quality Profile, Root Folder, and (Lidarr) Metadata Profile that get
+ * preselected in the add sheet. Renders nothing for other service kinds so the
+ * caller can drop it in unconditionally. Each field persists on change via
+ * `updateInstance`, matching the connection toggles above it — no dirty state.
+ */
+export function ArrDefaultsCard({
+  serviceId,
+  instanceId,
+}: {
+  serviceId: ServiceId;
+  instanceId: string;
+}) {
+  switch (serviceId) {
+    case "radarr":
+      return <RadarrDefaults instanceId={instanceId} />;
+    case "sonarr":
+      return <SonarrDefaults instanceId={instanceId} />;
+    case "lidarr":
+      return <LidarrDefaults instanceId={instanceId} />;
+    default:
+      return null;
+  }
+}
+
+// One thin wrapper per kind so the (conditionally-called) service hooks stay at
+// the top level. Each resolves its instance-scoped profiles/folders and hands
+// them to the shared body.
+function RadarrDefaults({ instanceId }: { instanceId: string }) {
+  const { data: profiles } = useRadarrQualityProfiles(instanceId);
+  const { data: folders } = useRadarrRootFolders(instanceId);
+  return (
+    <DefaultsCardBody
+      serviceId="radarr"
+      instanceId={instanceId}
+      profiles={profiles}
+      folders={folders}
+    />
+  );
+}
+
+function SonarrDefaults({ instanceId }: { instanceId: string }) {
+  const { data: profiles } = useSonarrQualityProfiles(instanceId);
+  const { data: folders } = useSonarrRootFolders(instanceId);
+  return (
+    <DefaultsCardBody
+      serviceId="sonarr"
+      instanceId={instanceId}
+      profiles={profiles}
+      folders={folders}
+    />
+  );
+}
+
+function LidarrDefaults({ instanceId }: { instanceId: string }) {
+  const { data: profiles } = useLidarrQualityProfiles(instanceId);
+  const { data: folders } = useLidarrRootFolders(instanceId);
+  const { data: metadataProfiles } = useLidarrMetadataProfiles(instanceId);
+  return (
+    <DefaultsCardBody
+      serviceId="lidarr"
+      instanceId={instanceId}
+      profiles={profiles}
+      folders={folders}
+      metadataProfiles={metadataProfiles}
+    />
+  );
+}
+
+function DefaultsCardBody({
+  serviceId,
+  instanceId,
+  profiles,
+  folders,
+  metadataProfiles,
+}: {
+  serviceId: ServiceId;
+  instanceId: string;
+  profiles: Profile[] | undefined;
+  folders: Folder[] | undefined;
+  metadataProfiles?: Profile[] | undefined;
+}) {
+  const inst = useTargetInstance(serviceId, instanceId);
+  const updateInstance = useConfigStore((s) => s.updateInstance);
+
+  const hasProfiles = !!profiles?.length;
+  const hasFolders = !!folders?.length;
+  const hasMetadata = !!metadataProfiles?.length;
+  const showMetadata = serviceId === "lidarr";
+  // Nothing came back from the server — disabled instance, missing credentials,
+  // or unreachable. Show the fields (as sentinel "First in list") plus a hint.
+  const nothingLoaded = !hasProfiles && !hasFolders && (!showMetadata || !hasMetadata);
+
+  return (
+    <Card className="gap-4 mb-4">
+      <View className="gap-1">
+        <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+          Add Defaults
+        </Text>
+        <Text className="text-zinc-500 text-xs">
+          Preselected when adding new content from this instance.
+        </Text>
+      </View>
+
+      <Select<number>
+        label="Quality Profile"
+        value={inst?.defaultQualityProfileId ?? FIRST_IN_LIST_ID}
+        disabled={!hasProfiles}
+        options={[
+          {
+            value: FIRST_IN_LIST_ID,
+            label: "First in list",
+            description: "Use the server's first profile (default)",
+          },
+          ...(profiles?.map((p) => ({ value: p.id, label: p.name })) ?? []),
+        ]}
+        onChange={(v) =>
+          updateInstance(serviceId, instanceId, {
+            defaultQualityProfileId: v === FIRST_IN_LIST_ID ? undefined : v,
+          })
+        }
+      />
+
+      {showMetadata ? (
+        <Select<number>
+          label="Metadata Profile"
+          value={inst?.defaultMetadataProfileId ?? FIRST_IN_LIST_ID}
+          disabled={!hasMetadata}
+          options={[
+            {
+              value: FIRST_IN_LIST_ID,
+              label: "First in list",
+              description: "Use the server's first profile (default)",
+            },
+            ...(metadataProfiles?.map((p) => ({ value: p.id, label: p.name })) ?? []),
+          ]}
+          onChange={(v) =>
+            updateInstance(serviceId, instanceId, {
+              defaultMetadataProfileId: v === FIRST_IN_LIST_ID ? undefined : v,
+            })
+          }
+        />
+      ) : null}
+
+      <Select<string>
+        label="Root Folder"
+        value={inst?.defaultRootFolderPath ?? FIRST_IN_LIST_PATH}
+        disabled={!hasFolders}
+        options={[
+          {
+            value: FIRST_IN_LIST_PATH,
+            label: "First in list",
+            description: "Use the server's first folder (default)",
+          },
+          ...(folders?.map((f) => ({
+            value: f.path,
+            label: f.path,
+            description: `${formatBytes(f.freeSpace)} free`,
+          })) ?? []),
+        ]}
+        onChange={(v) =>
+          updateInstance(serviceId, instanceId, {
+            defaultRootFolderPath: v === FIRST_IN_LIST_PATH ? undefined : v,
+          })
+        }
+      />
+
+      {nothingLoaded ? (
+        <Text className="text-zinc-500 text-xs">
+          Profiles and folders load from the server. Save the connection above,
+          then make sure this instance is enabled and reachable.
+        </Text>
+      ) : null}
+    </Card>
+  );
+}

--- a/hooks/use-instance-target.ts
+++ b/hooks/use-instance-target.ts
@@ -49,3 +49,24 @@ export function useInstanceTarget(
   });
   return { instanceId: targetId, enabled };
 }
+
+/**
+ * The full ServiceInstance a sheet or settings card is targeting: the explicit
+ * `instanceId` when given, otherwise the workspace-resolved active instance for
+ * the kind. Used to read per-instance preferences (e.g. the arr add-flow
+ * defaults) alongside the instance-scoped profile/folder hooks.
+ *
+ * Returns a stable array-element reference from the store, so no `useShallow`
+ * is needed — the selector only signals a change when the resolved instance
+ * object itself changes.
+ */
+export function useTargetInstance(
+  serviceId: ServiceId,
+  instanceId?: string,
+): ServiceInstance | undefined {
+  return useConfigStore((s) => {
+    const targetId = instanceId ?? s.activeInstance[serviceId] ?? null;
+    if (!targetId) return undefined;
+    return (s.serviceInstances[serviceId] ?? []).find((i) => i.id === targetId);
+  });
+}

--- a/store/config-migrations.test.ts
+++ b/store/config-migrations.test.ts
@@ -1601,3 +1601,48 @@ describe("migrateWidgetSlotSettings (v25 stream-monitor split)", () => {
     expect(migrateWidgetSlotSettings("stream-monitor", settings)).toBe(settings);
   });
 });
+
+describe("v35 → v36 (arr add-flow defaults stamp)", () => {
+  it("just stamps the version and preserves any already-set defaults", () => {
+    const result: any = migrateConfig({
+      version: 35,
+      services: {
+        radarr: [
+          {
+            id: "r1",
+            enabled: true,
+            name: "Radarr",
+            localUrl: "",
+            remoteUrl: "",
+            useRemote: false,
+            defaultQualityProfileId: 4,
+            defaultRootFolderPath: "/movies",
+          },
+        ],
+      },
+      secrets: {},
+      activeInstance: { radarr: "r1" },
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.services.radarr[0].defaultQualityProfileId).toBe(4);
+    expect(result.services.radarr[0].defaultRootFolderPath).toBe("/movies");
+  });
+
+  it("leaves the defaults absent when the source payload omitted them", () => {
+    const result: any = migrateConfig({
+      version: 35,
+      services: {
+        radarr: [{ id: "r1", enabled: true, name: "Radarr", localUrl: "", remoteUrl: "", useRemote: false }],
+      },
+      secrets: {},
+      activeInstance: { radarr: "r1" },
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.services.radarr[0].defaultQualityProfileId).toBeUndefined();
+    expect(result.services.radarr[0].defaultRootFolderPath).toBeUndefined();
+  });
+});

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -137,8 +137,13 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         defaultInstances() iterates SERVICE_IDS and backfills a disabled
  *         unraid instance at import time, so older exports just need the
  *         version field bumped.
+ *   v36 — optional per-instance arr add-flow defaults on ServiceConfig
+ *         (defaultQualityProfileId / defaultRootFolderPath /
+ *         defaultMetadataProfileId, #287). Pure version stamp — the fields are
+ *         optional, absence means "first in list", and coerceServiceInstance
+ *         validates them on import.
  */
-export const CURRENT_CONFIG_VERSION = 35;
+export const CURRENT_CONFIG_VERSION = 36;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -637,6 +642,11 @@ const migrations: Record<number, (payload: any) => any> = {
   // v34 → v35: added the unraid service entry. Pure version stamp —
   // defaultInstances() backfills a disabled unraid instance at import.
   34: (payload) => ({ ...payload, version: 35 }),
+  // v35 → v36: optional per-instance arr add-flow defaults on ServiceConfig
+  // (defaultQualityProfileId / defaultRootFolderPath / defaultMetadataProfileId,
+  // #287). Pure version stamp — the fields are optional and absence means
+  // "first in list".
+  35: (payload) => ({ ...payload, version: 36 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -265,6 +265,44 @@ describe("validateExportPayload — service instance coercion", () => {
     expect(result.services.radarr[0].ignoreCertErrors).toBe(false);
     expect(result.services.sonarr[0].ignoreCertErrors).toBe(false);
   });
+
+  it("round-trips arr add-flow defaults (v36)", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      services: {
+        lidarr: [
+          validInstance({
+            defaultQualityProfileId: 4,
+            defaultRootFolderPath: "/movies",
+            defaultMetadataProfileId: 1,
+          }),
+        ],
+      },
+    });
+    expect(result.services.lidarr[0].defaultQualityProfileId).toBe(4);
+    expect(result.services.lidarr[0].defaultRootFolderPath).toBe("/movies");
+    expect(result.services.lidarr[0].defaultMetadataProfileId).toBe(1);
+  });
+
+  it("drops invalid arr defaults without rejecting the instance", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      services: {
+        radarr: [
+          validInstance({
+            defaultQualityProfileId: "4",
+            defaultRootFolderPath: 42,
+            defaultMetadataProfileId: -1,
+          }),
+        ],
+      },
+    });
+    // The instance survives; only the garbage default fields are stripped.
+    expect(result.services.radarr).toHaveLength(1);
+    expect(result.services.radarr[0].defaultQualityProfileId).toBeUndefined();
+    expect(result.services.radarr[0].defaultRootFolderPath).toBeUndefined();
+    expect(result.services.radarr[0].defaultMetadataProfileId).toBeUndefined();
+  });
 });
 
 describe("validateExportPayload — service IDs (forward-compat silent drop)", () => {

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -71,7 +71,7 @@ function coerceServiceInstance(v: unknown): ServiceInstance | null {
   if (!isHttpUrlOrEmpty(v.localUrl)) return null;
   if (!isHttpUrlOrEmpty(v.remoteUrl)) return null;
   if (typeof v.useRemote !== "boolean") return null;
-  return {
+  const out: ServiceInstance = {
     id: v.id,
     enabled: v.enabled,
     name: v.name,
@@ -82,6 +82,27 @@ function coerceServiceInstance(v: unknown): ServiceInstance | null {
     // (older exports, hand-edited files) lands on the secure default.
     ignoreCertErrors: v.ignoreCertErrors === true,
   };
+  // v36 (#287): optional per-instance arr add-flow defaults. Drop invalid
+  // values rather than rejecting the whole instance — absence just falls back
+  // to first-in-list at add time.
+  if (isPositiveInt(v.defaultQualityProfileId)) {
+    out.defaultQualityProfileId = v.defaultQualityProfileId;
+  }
+  if (isPositiveInt(v.defaultMetadataProfileId)) {
+    out.defaultMetadataProfileId = v.defaultMetadataProfileId;
+  }
+  if (
+    typeof v.defaultRootFolderPath === "string" &&
+    v.defaultRootFolderPath.length > 0 &&
+    v.defaultRootFolderPath.length <= 1024
+  ) {
+    out.defaultRootFolderPath = v.defaultRootFolderPath;
+  }
+  return out;
+}
+
+function isPositiveInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v > 0;
 }
 
 function coerceServiceSecrets(v: unknown): ServiceSecrets | null {

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -84,6 +84,14 @@ export interface ServiceConfig {
   // lib/insecure-tls.ts), which bypasses trust evaluation for exactly those
   // hosts. Absent/undefined behaves like false.
   ignoreCertErrors?: boolean;
+  // v36 (#287): per-instance defaults preselected in the arr add flows
+  // (components/common/add-media-sheet.tsx). Absent/undefined keeps the
+  // previous "first in the server's list" behavior; a stale value (profile or
+  // folder deleted upstream) also falls back to first-in-list at add time.
+  // defaultMetadataProfileId is Lidarr-only.
+  defaultQualityProfileId?: number;
+  defaultRootFolderPath?: string;
+  defaultMetadataProfileId?: number;
 }
 
 // A configured service instance: a ServiceConfig plus a stable UUID `id` that


### PR DESCRIPTION
Refs #287

Per-instance defaults for the Radarr/Sonarr/Lidarr add flows: a preferred Quality Profile, Root Folder, and (Lidarr) Metadata Profile that preselect in the add sheet. Absent = previous first-in-list behavior; a stale value (deleted upstream) also falls back to first-in-list.

- New "Add Defaults" card in the instance settings editor (`components/settings/arr-defaults-card.tsx`), saved on change via `updateInstance`
- `add-media-sheet` resolves the stored default via a new `useTargetInstance` helper; in-sheet picks still override
- Config v36: optional fields on `ServiceConfig` + migration stamp + import validation

## Test plan
- `pnpm exec tsc --noEmit`: clean
- `pnpm jest`: 764 pass (added v35->v36 migration + schema round-trip/drop tests)
- Manual (device verification unavailable in this env): set a non-first Quality Profile/Root Folder on a Radarr instance -> Add Movie preselects them; reset to "First in list" restores default; Lidarr metadata profile preselects; export/import round-trips