### PR TITLE
fix(releases): cancelable interactive search with in-flight retry and clearer timeout (Refs #290)

### DIFF
--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -22,7 +22,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { lightHaptic } from "@/lib/haptics";
-import { getHttpErrorMessage } from "@/lib/http-client";
+import { getHttpErrorMessage, isAbortError } from "@/lib/http-client";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import { useSortStore, type ReleasesSortKey } from "@/store/sort-store";
 import {
@@ -260,18 +260,19 @@ export function ReleasesPicker({
   // Loading-time progression: skeletons until 8s, then contextual empty state
   // with a "this can take up to a minute" hint, then a "still searching" hint
   // past 30s.
+  // searchEpoch bumps on a manual restart so the ticker resets even though
+  // isFetching never flips across the cancel-and-refetch.
   const [elapsed, setElapsed] = useState(0);
+  const [searchEpoch, setSearchEpoch] = useState(0);
   useEffect(() => {
-    if (!isLoading && !isFetching) {
-      setElapsed(0);
-      return;
-    }
+    setElapsed(0);
+    if (!isLoading && !isFetching) return;
     const start = Date.now();
     const id = setInterval(() => {
       setElapsed(Math.round((Date.now() - start) / 1000));
     }, 1000);
     return () => clearInterval(id);
-  }, [isLoading, isFetching]);
+  }, [isLoading, isFetching, searchEpoch]);
 
   // "Tick" so the relative-time string in the status bar stays fresh once
   // results are in.
@@ -335,9 +336,12 @@ export function ReleasesPicker({
     }
   }, [data, prefHideRejected]);
 
+  // No isFetching guard: with the queryFn consuming the abort signal, v5's
+  // refetch (cancelRefetch defaults true) aborts an in-flight search and starts
+  // a fresh one — the in-app recovery for a hung search (#290).
   function handleRefresh() {
-    if (isFetching) return;
     lightHaptic();
+    setSearchEpoch((e) => e + 1);
     refetch();
   }
 
@@ -486,6 +490,15 @@ export function ReleasesPicker({
                   ? "Still searching. Some indexers are slower than others."
                   : "This can take up to a minute."
               }
+              action={
+                showLongSearchingHint ? (
+                  <Button
+                    label="Restart search"
+                    variant="outline"
+                    onPress={handleRefresh}
+                  />
+                ) : undefined
+              }
             />
           ) : (
             <View className="gap-2">
@@ -499,7 +512,13 @@ export function ReleasesPicker({
         <EmptyState
           icon={<Icon icon={AlertTriangle} size={28} color="#ef4444" />}
           title="Search failed"
-          message={getHttpErrorMessage(error) ?? error?.message ?? "Unknown error"}
+          message={
+            // A TanStack-initiated cancel reverts the query instead of erroring,
+            // so an AbortError landing here is always the fetch timeout.
+            isAbortError(error)
+              ? "Search timed out. Indexers may be slow or unreachable. Try again."
+              : (getHttpErrorMessage(error) ?? error?.message ?? "Unknown error")
+          }
           action={<Button label="Retry" onPress={handleRefresh} />}
         />
       ) : (

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -438,13 +438,16 @@ export function useRadarrTags(instanceId?: string) {
 }
 
 // Interactive search is expensive (live indexer hit, often 30s+) — don't
-// auto-retry on transient failure, and keep the cache warm long enough that
-// back-navigation doesn't re-trigger.
+// auto-retry on transient failure, and keep completed results cached long
+// enough that back-navigation doesn't re-trigger. Consuming the queryFn signal
+// means an in-flight search aborts when the user backs out or restarts it —
+// without it a hung fetch becomes a zombie the query dedupes onto forever
+// (the "no results until app restart" symptom, #290).
 export function useRadarrReleases(movieId: number, instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
     queryKey: ["radarr", id, "releases", movieId],
-    queryFn: () => getReleasesForMovie(movieId, id ?? undefined),
+    queryFn: ({ signal }) => getReleasesForMovie(movieId, id ?? undefined, signal),
     enabled: enabled && movieId > 0 && !!id,
     staleTime: 60_000,
     gcTime: 5 * 60_000,

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -486,7 +486,8 @@ export function useSonarrReleasesForEpisode(
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "releases", "episode", episodeId],
-    queryFn: () => getReleasesForEpisode(episodeId, id ?? undefined),
+    queryFn: ({ signal }) =>
+      getReleasesForEpisode(episodeId, id ?? undefined, signal),
     enabled: enabled && episodeId > 0 && !!id,
     staleTime: 60_000,
     gcTime: 5 * 60_000,
@@ -503,8 +504,8 @@ export function useSonarrReleasesForSeason(
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "releases", "season", seriesId, seasonNumber],
-    queryFn: () =>
-      getReleasesForSeason(seriesId, seasonNumber, id ?? undefined),
+    queryFn: ({ signal }) =>
+      getReleasesForSeason(seriesId, seasonNumber, id ?? undefined, signal),
     enabled: enabled && seriesId > 0 && seasonNumber >= 0 && !!id,
     staleTime: 60_000,
     gcTime: 5 * 60_000,

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -3,6 +3,8 @@ import {
   pingService,
   testServiceConnection,
   AuthProxyResponseError,
+  HttpError,
+  isAbortError,
 } from "./http-client";
 
 // jest.mock factories run before module-scope code; the only refs allowed
@@ -492,5 +494,105 @@ describe("testServiceConnection — auth-proxy detection (#239)", () => {
       apiKey: "k",
     });
     expect(result.kind).toBe("ok");
+  });
+});
+
+// External signal (TanStack Query's queryFn signal) composed with the internal
+// timeout controller — either firing must abort the fetch (#290).
+describe("serviceRequest — signal composition (#290)", () => {
+  let originalFetch: typeof global.fetch;
+  let fetchSpy: jest.Mock;
+
+  // A fetch that never resolves on its own and rejects the way RN does when
+  // its signal aborts: a plain Error named "AbortError" (no DOMException).
+  function hangingFetch(): jest.Mock {
+    return jest.fn(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          const fail = () =>
+            reject(Object.assign(new Error("Aborted"), { name: "AbortError" }));
+          if (init.signal.aborted) fail();
+          else init.signal.addEventListener("abort", fail);
+        }),
+    );
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    mockStateRef.current = makeState();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it("aborts the fetch when the external signal fires mid-flight", async () => {
+    fetchSpy = hangingFetch();
+    global.fetch = fetchSpy as any;
+    const external = new AbortController();
+    const promise = serviceRequest("radarr", "/release", {
+      signal: external.signal,
+    });
+    const expectation = expect(promise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    external.abort();
+    await expectation;
+  });
+
+  it("rejects immediately when the external signal is already aborted", async () => {
+    fetchSpy = hangingFetch();
+    global.fetch = fetchSpy as any;
+    const external = new AbortController();
+    external.abort();
+    await expect(
+      serviceRequest("radarr", "/release", { signal: external.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("still times out with an unfired external signal attached", async () => {
+    jest.useFakeTimers();
+    fetchSpy = hangingFetch();
+    global.fetch = fetchSpy as any;
+    const external = new AbortController();
+    const promise = serviceRequest("radarr", "/release", {
+      timeout: 5000,
+      signal: external.signal,
+    });
+    const expectation = expect(promise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    jest.advanceTimersByTime(5001);
+    await expectation;
+  });
+
+  it("resolves normally with an external signal attached; a later abort is a no-op", async () => {
+    fetchSpy = fetchMock();
+    global.fetch = fetchSpy as any;
+    const external = new AbortController();
+    await expect(
+      serviceRequest("radarr", "/system/status", { signal: external.signal }),
+    ).resolves.toEqual({});
+    // The abort listener was removed in the finally — firing it now must not
+    // surface an unhandled rejection or throw.
+    external.abort();
+  });
+});
+
+describe("isAbortError", () => {
+  it("matches RN's abort rejection shape", () => {
+    expect(
+      isAbortError(Object.assign(new Error("Aborted"), { name: "AbortError" })),
+    ).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    expect(isAbortError(new Error("boom"))).toBe(false);
+    expect(isAbortError(new HttpError(500, "Internal", "http://x.local"))).toBe(
+      false,
+    );
+    expect(isAbortError("AbortError")).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
   });
 });

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -49,6 +49,9 @@ interface RequestOptions extends Omit<RequestInit, "signal"> {
   // explicitly from the hooks layer so multi-instance setups can route each
   // request to the right server.
   instanceId?: string;
+  // External abort signal (e.g. TanStack Query's queryFn signal). Composed
+  // with the internal timeout controller: the fetch aborts when either fires.
+  signal?: AbortSignal;
 }
 
 const REDACT_PARAMS = ["x-plex-token", "apikey", "api_key", "token"];
@@ -139,6 +142,13 @@ export function getHttpErrorMessage(err: unknown): string | undefined {
   return undefined;
 }
 
+// RN/Hermes has no DOMException global; aborted fetches reject with a plain
+// Error named "AbortError". True for both the internal timeout abort and an
+// external (query-cancellation) abort.
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
 // Produce a verbose, paste-friendly representation of any caught error.
 // Used as the clipboard payload for error toasts so users can share or
 // search the underlying cause even when the toast shows a friendly summary.
@@ -180,7 +190,13 @@ export async function serviceRequest<T>(
   path: string,
   options: RequestOptions = {},
 ): Promise<T> {
-  const { timeout = DEFAULT_TIMEOUT, params, instanceId, ...fetchOptions } = options;
+  const {
+    timeout = DEFAULT_TIMEOUT,
+    params,
+    instanceId,
+    signal: externalSignal,
+    ...fetchOptions
+  } = options;
   const store = useConfigStore.getState();
 
   if (store.demoMode) {
@@ -303,8 +319,15 @@ export async function serviceRequest<T>(
     headers.set("Content-Type", "application/json");
   }
 
+  // No AbortSignal.any on RN/Hermes — compose the external signal with the
+  // timeout controller by hand. Double-abort is a spec no-op.
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const onExternalAbort = () => controller.abort();
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort();
+    else externalSignal.addEventListener("abort", onExternalAbort);
+  }
 
   try {
     const response = await fetch(url, {
@@ -357,6 +380,7 @@ export async function serviceRequest<T>(
     return body as unknown as T;
   } finally {
     clearTimeout(timeoutId);
+    externalSignal?.removeEventListener("abort", onExternalAbort);
   }
 }
 
@@ -560,11 +584,8 @@ export async function testServiceConnection(
     }
     return result;
   } catch (err) {
-    // AbortError = our 8s timeout fired. Note: don't reference `DOMException`
-    // here — it isn't a global in React Native's Hermes engine, so
-    // `err instanceof DOMException` throws "Property 'DOMException' doesn't
-    // exist". RN rejects aborted fetches with an Error named "AbortError".
-    if (err instanceof Error && err.name === "AbortError") {
+    // AbortError = our 8s timeout fired.
+    if (isAbortError(err)) {
       return { kind: "unreachable", message: "Request timed out" };
     }
     return {

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -249,11 +249,13 @@ export function searchAllMissingMovies(instanceId?: string): Promise<void> {
 export function getReleasesForMovie(
   movieId: number,
   instanceId?: string,
+  signal?: AbortSignal,
 ): Promise<RadarrRelease[]> {
   return serviceRequest<RadarrRelease[]>("radarr", "/release", {
     params: { movieId },
     timeout: INTERACTIVE_SEARCH_TIMEOUT,
     instanceId,
+    signal,
   });
 }
 

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -396,11 +396,13 @@ export function searchAllMissingEpisodes(instanceId?: string): Promise<void> {
 export function getReleasesForEpisode(
   episodeId: number,
   instanceId?: string,
+  signal?: AbortSignal,
 ): Promise<SonarrRelease[]> {
   return serviceRequest<SonarrRelease[]>("sonarr", "/release", {
     params: { episodeId },
     timeout: INTERACTIVE_SEARCH_TIMEOUT,
     instanceId,
+    signal,
   });
 }
 
@@ -408,11 +410,13 @@ export function getReleasesForSeason(
   seriesId: number,
   seasonNumber: number,
   instanceId?: string,
+  signal?: AbortSignal,
 ): Promise<SonarrRelease[]> {
   return serviceRequest<SonarrRelease[]>("sonarr", "/release", {
     params: { seriesId, seasonNumber },
     timeout: INTERACTIVE_SEARCH_TIMEOUT,
     instanceId,
+    signal,
   });
 }
 


### PR DESCRIPTION
## Summary
- Thread TanStack Query's abort signal through the Radarr/Sonarr release search so a hung request is cancelled on back-out or refetch instead of becoming a zombie the query re-attaches to (the no-results-until-restart symptom in #290)
- Pull-to-refresh now cancels and restarts an in-flight search; a Restart search button appears after 30s
- Timeouts show a clear message instead of "Aborted"

## Test plan
- 6 new unit tests for signal composition and isAbortError in lib/http-client.test.ts; full suite 770 passing
- Manual on iOS: back out mid-search and re-enter, pull-to-refresh mid-search, 30s+ Restart button, cached results survive back-and-return within 60s