### PR TITLE
fix(seerr): Recently Added slider never showed content (Refs #293)

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -966,6 +966,28 @@ export interface OverseerrSearchResponse {
   results: OverseerrMediaResult[];
 }
 
+// One row from GET /media — a bare Media entity (ids + status only, no title or
+// artwork). Used by the Recently Added slider, which hydrates each entry via
+// the movie/tv details endpoints.
+export interface OverseerrMediaEntity {
+  id: number;
+  mediaType: OverseerrMediaType;
+  tmdbId: number;
+  tvdbId?: number;
+  status: OverseerrMediaStatus;
+  status4k?: OverseerrMediaStatus;
+}
+
+export interface OverseerrMediaListResponse {
+  pageInfo: {
+    pages: number;
+    pageSize: number;
+    results: number;
+    page: number;
+  };
+  results: OverseerrMediaEntity[];
+}
+
 // One entry from /discover/genreslider/{movie,tv}: a genre plus a few backdrop
 // paths used to illustrate the genre tile.
 export interface OverseerrGenreSliderItem {
@@ -995,8 +1017,11 @@ export interface OverseerrRelatedVideo {
 export interface OverseerrMovieDetails {
   id: number;
   title: string;
+  overview?: string;
   posterPath?: string;
+  backdropPath?: string;
   releaseDate?: string;
+  voteAverage?: number;
   relatedVideos?: OverseerrRelatedVideo[];
   mediaInfo?: {
     id: number;
@@ -1016,8 +1041,11 @@ export interface OverseerrSeasonInfo {
 export interface OverseerrTVDetails {
   id: number;
   name: string;
+  overview?: string;
   posterPath?: string;
+  backdropPath?: string;
   firstAirDate?: string;
+  voteAverage?: number;
   seasons?: OverseerrSeasonInfo[];
   relatedVideos?: OverseerrRelatedVideo[];
   mediaInfo?: {

--- a/services/overseerr-api.ts
+++ b/services/overseerr-api.ts
@@ -1,6 +1,8 @@
 import { serviceRequest } from "@/lib/http-client";
 import type {
   OverseerrMediaType,
+  OverseerrMediaListResponse,
+  OverseerrMediaResult,
   OverseerrRequestsResponse,
   OverseerrSearchResponse,
   OverseerrGenreSliderItem,
@@ -117,12 +119,61 @@ export function getUpcomingMovies(
   });
 }
 
-export function getRecentlyAdded(
+// Seerr has no /discover/recently-added endpoint (verified against both the
+// Overseerr and Jellyseerr route sources) — the web UI's Recently Added slider
+// reads GET /media sorted by mediaAddedAt and hydrates each bare Media entity
+// (ids + status only) from the movie/tv details endpoints. We do the same and
+// shape the result as a search response so the row renders like any other
+// slider. Entries whose details fetch fails are dropped rather than failing
+// the whole row.
+export async function getRecentlyAdded(
   instanceId?: string,
 ): Promise<OverseerrSearchResponse> {
-  return serviceRequest<OverseerrSearchResponse>("overseerr", "/discover/recently-added", {
+  const media = await serviceRequest<OverseerrMediaListResponse>("overseerr", "/media", {
+    params: { filter: "allavailable", take: 20, sort: "mediaAdded" },
     instanceId,
   });
+  const hydrated = await Promise.allSettled(
+    (media.results ?? []).map(async (entity): Promise<OverseerrMediaResult> => {
+      if (entity.mediaType === "movie") {
+        const d = await getMovieDetails(entity.tmdbId, instanceId);
+        return {
+          id: d.id,
+          mediaType: "movie",
+          title: d.title,
+          overview: d.overview ?? "",
+          posterPath: d.posterPath,
+          backdropPath: d.backdropPath,
+          releaseDate: d.releaseDate,
+          voteAverage: d.voteAverage ?? 0,
+          mediaInfo: d.mediaInfo ?? { status: entity.status, status4k: entity.status4k },
+        };
+      }
+      const d = await getTVDetails(entity.tmdbId, instanceId);
+      return {
+        id: d.id,
+        mediaType: "tv",
+        name: d.name,
+        overview: d.overview ?? "",
+        posterPath: d.posterPath,
+        backdropPath: d.backdropPath,
+        firstAirDate: d.firstAirDate,
+        voteAverage: d.voteAverage ?? 0,
+        mediaInfo: d.mediaInfo ?? { status: entity.status, status4k: entity.status4k },
+      };
+    }),
+  );
+  const results = hydrated
+    .filter(
+      (r): r is PromiseFulfilledResult<OverseerrMediaResult> => r.status === "fulfilled",
+    )
+    .map((r) => r.value);
+  return {
+    page: 1,
+    totalPages: 1,
+    totalResults: results.length,
+    results,
+  };
 }
 
 // --- Browse by network / studio / genre ---


### PR DESCRIPTION
## Summary
- Seerr has no `/discover/recently-added` endpoint (verified against Overseerr and Jellyseerr route sources), so the Recently Added row was always empty
- Do what the Seerr web UI does: fetch `GET /media?filter=allavailable&take=20&sort=mediaAdded` and hydrate each bare Media entity via the movie/tv details endpoints, mapped into `OverseerrMediaResult` so the row renders like any other slider
- Failed detail fetches drop that entry instead of failing the whole row

## Test plan
- `tsc --noEmit` clean
- Endpoint and params verified against the Overseerr `/media` route source (same request the official web UI makes)