### PR TITLE
feat(dashboard): per-widget hide-when-empty toggle (Refs #282)

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -8,6 +8,7 @@ import {
   Copy,
   Pencil,
   Check,
+  EyeOff,
   Search,
   Settings,
   SlidersHorizontal,
@@ -22,6 +23,7 @@ import Animated, { FadeInDown } from "react-native-reanimated";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { useConfigStore } from "@/store/config-store";
+import { useWidgetVisibilityStore } from "@/store/widget-visibility-store";
 import { CardErrorBoundary } from "@/components/common/error-boundary";
 import { ICON, type WidgetId } from "@/lib/constants";
 import {
@@ -90,6 +92,10 @@ export default function DashboardScreen() {
   // ActionSheet below; null when closed.
   const [copySlotId, setCopySlotId] = useState<string | null>(null);
   const [revealCount, setRevealCount] = useState(REVEAL_INITIAL);
+  // Slots whose widget reported "empty + hide when empty enabled" (#282).
+  // Only changes when such a widget's emptiness actually flips, so this
+  // subscription rarely re-renders the screen.
+  const hiddenSlots = useWidgetVisibilityStore((s) => s.hiddenSlots);
 
   // Entering edit mode mounts a per-widget control row (several SVG icons each)
   // for every visible widget at once — heavy enough to stall the tap. So show
@@ -362,12 +368,22 @@ export default function DashboardScreen() {
             const { label, settingsComponent } = widget;
             const isFirst = visibleIndex === 0;
             const isLast = visibleIndex === visibleSlots.length - 1;
+            const hidesWhenEmpty = slot.settings?.hideWhenEmpty === true;
+            // display:none (not unmount) so the widget's queries keep polling
+            // and it reappears the moment content shows up. Edit mode always
+            // shows the card so the toggle stays reachable. Yoga excludes
+            // display:none nodes from the parent gap, so no stray spacing.
+            const hiddenWhenEmpty = !editMode && !!hiddenSlots[slot.id];
 
             return (
               // No per-index delay: progressive mounting already staggers the
               // reveal (each widget springs in as its batch mounts), so an
               // index-based delay would make late widgets wait ~1s to appear.
-              <Animated.View key={slot.id} entering={FadeInDown.springify()}>
+              <Animated.View
+                key={slot.id}
+                entering={FadeInDown.springify()}
+                style={hiddenWhenEmpty ? { display: "none" } : undefined}
+              >
                 {showEditControls && (
                   <View className="flex-row items-center justify-between mb-1 px-1">
                     <View className="flex-row items-center gap-1.5 flex-1">
@@ -375,6 +391,9 @@ export default function DashboardScreen() {
                       <Text className="text-zinc-500 text-xs font-medium" numberOfLines={1}>
                         {label}
                       </Text>
+                      {hidesWhenEmpty && (
+                        <Icon icon={EyeOff} size={ICON.SM} color="#52525b" />
+                      )}
                     </View>
                     <View className="flex-row items-center gap-1">
                       <TouchableOpacity

--- a/components/dashboard/arr-queue-card.tsx
+++ b/components/dashboard/arr-queue-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   ARR_QUEUE_DEFAULT_SETTINGS,
@@ -76,6 +77,14 @@ export function ArrQueueCard({ slotId, adapter }: Props) {
   );
   const display = records.slice(0, settings.maxItems);
   const hasMore = records.length > settings.maxItems;
+
+  // A nonzero Missing badge is real content, so it keeps the card visible.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty:
+      instances.length === 0 || (records.length === 0 && missingCount === 0),
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/bazarr-wanted-card.tsx
+++ b/components/dashboard/bazarr-wanted-card.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { getWantedMovies, getWantedEpisodes } from "@/services/bazarr-api";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useBazarrPosters } from "@/hooks/use-bazarr-posters";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
@@ -99,6 +100,12 @@ export function BazarrWantedCard({ slotId }: WidgetComponentProps) {
 
   const display = previewItems.slice(0, MAX_PREVIEW);
   const hasMore = totalMissing > display.length;
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: instances.length === 0 || display.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
@@ -194,6 +195,14 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
 
   const headerCount = items.length;
   const headerNoun = headerCount === 1 ? "release" : "releases";
+
+  // The no-sources misconfiguration hint stays visible so the user can find
+  // their way back to the widget settings.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: !noSources && grouped.length === 0,
+    isLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/combined-now-playing-card.tsx
+++ b/components/dashboard/combined-now-playing-card.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { getSessions as getPlexSessions } from "@/services/plex-api";
 import { getSessions as getMediaServerSessions } from "@/services/jellyfin-api";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
@@ -96,6 +97,12 @@ export function CombinedNowPlayingCard({ slotId }: WidgetComponentProps) {
   const display = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;
   const viewAllRoute = `/(tabs)/${(display[0] ?? filtered[0])?.serviceId ?? sources[0]?.serviceId ?? "dashboard"}`;
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: sources.length === 0 || display.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/download-card.tsx
+++ b/components/dashboard/download-card.tsx
@@ -17,6 +17,7 @@ import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { lightHaptic } from "@/lib/haptics";
 import { formatSpeed, formatEta } from "@/lib/utils";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   DOWNLOADS_DEFAULT_SETTINGS,
@@ -313,6 +314,16 @@ export function DownloadCard({ slotId }: WidgetComponentProps) {
   const hasMore = filtered.length > settings.maxItems;
   const allHidden = allowedGroups.size === 0;
   const showMultiInstanceLabel = totalInstances > 1;
+
+  // The all-errored and all-states-hidden branches stay visible: one is a
+  // problem the user should see, the other points back to the settings.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty:
+      totalInstances === 0 ||
+      (!allHidden && !isAllErrored && filtered.length === 0),
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/overseerr-requests-card.tsx
+++ b/components/dashboard/overseerr-requests-card.tsx
@@ -13,6 +13,7 @@ import {
   getPosterUrl,
 } from "@/services/overseerr-api";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import type {
@@ -109,6 +110,12 @@ export function OverseerrRequestsCard({ slotId }: WidgetComponentProps) {
   );
 
   const goToRequests = () => router.push("/(tabs)/requests?tab=requests");
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: instances.length === 0 || filtered.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/plex-now-playing-card.tsx
+++ b/components/dashboard/plex-now-playing-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getSessions } from "@/services/plex-api";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
@@ -57,6 +58,12 @@ export function PlexNowPlayingCard({ slotId }: WidgetComponentProps) {
 
   const display = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: instances.length === 0 || display.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/prowlarr-stats-card.tsx
+++ b/components/dashboard/prowlarr-stats-card.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
 import { getIndexers, getIndexerStatuses } from "@/services/prowlarr-api";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
@@ -66,6 +67,12 @@ export function ProwlarrStatsCard({ slotId }: WidgetComponentProps) {
     ({ indexer, instanceId }) =>
       failedByInstance.get(instanceId)?.has(indexer.id) ?? false,
   ).length;
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: instances.length === 0 || enabled.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card onPress={() => router.push("/(tabs)/indexers")}>

--- a/components/dashboard/recently-downloaded-card.tsx
+++ b/components/dashboard/recently-downloaded-card.tsx
@@ -8,6 +8,7 @@ import { getHistory as getRadarrHistory, getRadarrPoster } from "@/services/rada
 import { getHistory as getSonarrHistory, getSonarrPoster } from "@/services/sonarr-api";
 import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { formatEpisodeCode, relativeDate } from "@/lib/utils";
@@ -131,6 +132,14 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
   // The combined now-playing card uses a logo badge only when more than one
   // kind is active — same here, so a single-source feed isn't cluttered.
   const showSourceBadge = showSonarr && showRadarr;
+
+  // The no-sources misconfiguration hint stays visible so the user can find
+  // their way back to the widget settings.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: !noSources && display.length === 0,
+    isLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
@@ -200,6 +201,14 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
 
   const noSources = !showSonarr && !showRadarr;
   const noServicesEnabled = !sonarrEnabled && !radarrEnabled;
+
+  // The no-sources misconfiguration hint stays visible so the user can find
+  // their way back to the widget settings.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: !noSources && grouped.length === 0,
+    isLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/stream-monitor-card.tsx
+++ b/components/dashboard/stream-monitor-card.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { getMonitorAdapter, type MonitorKind } from "@/lib/monitor-adapter";
@@ -73,6 +74,12 @@ export function StreamMonitorCard({ slotId }: WidgetComponentProps) {
   const bandwidthLabels = queries
     .map((q) => q.data?.bandwidthLabel)
     .filter((l): l is string => !!l);
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: sources.length === 0 || display.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/usenet-queue-card.tsx
+++ b/components/dashboard/usenet-queue-card.tsx
@@ -8,6 +8,7 @@ import { ProgressBar } from "@/components/ui/progress-bar";
 import { EmptyState } from "@/components/ui/empty-state";
 import { downloadStatusColor } from "@/lib/download-status";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import { SkeletonCardContent } from "@/components/ui/skeleton";
@@ -85,6 +86,14 @@ export function UsenetQueueCard({ slotId, adapter }: Props) {
   const display = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;
   const allHidden = allowedStatuses.size === 0;
+
+  // The "all states hidden" misconfiguration hint stays visible so the user
+  // can find their way back to the widget settings.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: instances.length === 0 || (!allHidden && filtered.length === 0),
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/components/dashboard/widget-settings/arr-queue-settings.tsx
+++ b/components/dashboard/widget-settings/arr-queue-settings.tsx
@@ -6,17 +6,22 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
-import { MaxItemsSelector } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import {
+  HideWhenEmptyToggle,
+  MaxItemsSelector,
+} from "@/components/dashboard/widget-settings/widget-settings-blocks";
 import type { ServiceId } from "@/lib/constants";
 
 export interface ArrQueueSettingsValue extends Record<string, unknown> {
   instanceIds: InstanceBindingValue;
   maxItems: number;
+  hideWhenEmpty: boolean;
 }
 
 export const ARR_QUEUE_DEFAULT_SETTINGS: ArrQueueSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
   maxItems: 5,
+  hideWhenEmpty: false,
 };
 
 interface Props extends WidgetSettingsComponentProps {
@@ -42,6 +47,10 @@ export function ArrQueueSettings({ slotId, serviceId }: Props) {
       <MaxItemsSelector
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
+      />
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/bazarr-wanted-settings.tsx
+++ b/components/dashboard/widget-settings/bazarr-wanted-settings.tsx
@@ -6,13 +6,16 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { HideWhenEmptyToggle } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export interface BazarrWantedSettingsValue extends Record<string, unknown> {
   instanceIds: InstanceBindingValue;
+  hideWhenEmpty: boolean;
 }
 
 export const BAZARR_WANTED_DEFAULT_SETTINGS: BazarrWantedSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
+  hideWhenEmpty: false,
 };
 
 export function BazarrWantedSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -27,6 +30,10 @@ export function BazarrWantedSettings({ slotId }: WidgetSettingsComponentProps) {
         serviceId="bazarr"
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
+      />
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/calendar-settings.tsx
+++ b/components/dashboard/widget-settings/calendar-settings.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
   ChipGroup,
+  HideWhenEmptyToggle,
   SettingsSection,
   ToggleCard,
 } from "@/components/dashboard/widget-settings/widget-settings-blocks";
@@ -24,6 +25,7 @@ export interface CalendarSettingsValue extends Record<string, unknown> {
   includeRadarr: boolean;
   daysAhead: number;
   radarrReleaseType: "cinemas" | "digital" | "physical" | "any";
+  hideWhenEmpty: boolean;
 }
 
 export const CALENDAR_DEFAULT_SETTINGS: CalendarSettingsValue = {
@@ -35,6 +37,7 @@ export const CALENDAR_DEFAULT_SETTINGS: CalendarSettingsValue = {
   // Default to "any" so movies show up regardless of which release Radarr
   // marks them with — matches how Radarr's calendar groups by default.
   radarrReleaseType: "any",
+  hideWhenEmpty: false,
 };
 
 const DAYS_OPTIONS: { value: number; label: string }[] = [
@@ -124,6 +127,11 @@ export function CalendarSettings({ slotId }: WidgetSettingsComponentProps) {
           onChange={(radarrReleaseType) => update({ radarrReleaseType })}
         />
       )}
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/combined-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/combined-now-playing-settings.tsx
@@ -10,6 +10,7 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -24,6 +25,7 @@ export interface CombinedNowPlayingSettingsValue extends Record<string, unknown>
   hideUsers: string;
   showTranscoding: boolean;
   showUserAndDevice: boolean;
+  hideWhenEmpty: boolean;
 }
 
 export const COMBINED_NOW_PLAYING_DEFAULT_SETTINGS: CombinedNowPlayingSettingsValue = {
@@ -35,6 +37,7 @@ export const COMBINED_NOW_PLAYING_DEFAULT_SETTINGS: CombinedNowPlayingSettingsVa
   hideUsers: "",
   showTranscoding: true,
   showUserAndDevice: true,
+  hideWhenEmpty: false,
 };
 
 const MAX_OPTIONS: { value: number; label: string }[] = [
@@ -124,6 +127,11 @@ export function CombinedNowPlayingSettings({ slotId }: WidgetSettingsComponentPr
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
         options={MAX_OPTIONS}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/downloads-settings.tsx
+++ b/components/dashboard/widget-settings/downloads-settings.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
   ChipGroup,
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -26,6 +27,7 @@ export interface DownloadsSettingsValue extends Record<string, unknown> {
   showPaused: boolean;
   showErrored: boolean;
   sortBy: DownloadsSortBy;
+  hideWhenEmpty: boolean;
 }
 
 export const DOWNLOADS_DEFAULT_SETTINGS: DownloadsSettingsValue = {
@@ -36,6 +38,7 @@ export const DOWNLOADS_DEFAULT_SETTINGS: DownloadsSettingsValue = {
   showPaused: false,
   showErrored: false,
   sortBy: "speed",
+  hideWhenEmpty: false,
 };
 
 const SORT_OPTIONS: { value: DownloadsSortBy; label: string }[] = [
@@ -100,6 +103,11 @@ export function DownloadsSettings({ slotId }: WidgetSettingsComponentProps) {
         options={SORT_OPTIONS}
         value={settings.sortBy}
         onChange={(sortBy) => update({ sortBy })}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/overseerr-requests-settings.tsx
+++ b/components/dashboard/widget-settings/overseerr-requests-settings.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
   ChipGroup,
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -21,6 +22,7 @@ export interface OverseerrRequestsSettingsValue extends Record<string, unknown> 
   statusFilter: OverseerrStatusFilter;
   maxItems: number;
   showRequester: boolean;
+  hideWhenEmpty: boolean;
 }
 
 export const OVERSEERR_REQUESTS_DEFAULT_SETTINGS: OverseerrRequestsSettingsValue = {
@@ -28,6 +30,7 @@ export const OVERSEERR_REQUESTS_DEFAULT_SETTINGS: OverseerrRequestsSettingsValue
   statusFilter: "pending",
   maxItems: 5,
   showRequester: true,
+  hideWhenEmpty: false,
 };
 
 const STATUS_OPTIONS: { value: OverseerrStatusFilter; label: string }[] = [
@@ -70,6 +73,11 @@ export function OverseerrRequestsSettings({ slotId }: WidgetSettingsComponentPro
       <MaxItemsSelector
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/prowlarr-stats-settings.tsx
+++ b/components/dashboard/widget-settings/prowlarr-stats-settings.tsx
@@ -6,13 +6,16 @@ import {
   INSTANCE_BINDING_ALL,
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
+import { HideWhenEmptyToggle } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 
 export interface ProwlarrStatsSettingsValue extends Record<string, unknown> {
   instanceIds: InstanceBindingValue;
+  hideWhenEmpty: boolean;
 }
 
 export const PROWLARR_STATS_DEFAULT_SETTINGS: ProwlarrStatsSettingsValue = {
   instanceIds: INSTANCE_BINDING_ALL,
+  hideWhenEmpty: false,
 };
 
 export function ProwlarrStatsSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -27,6 +30,10 @@ export function ProwlarrStatsSettings({ slotId }: WidgetSettingsComponentProps) 
         serviceId="prowlarr"
         value={settings.instanceIds}
         onChange={(instanceIds) => update({ instanceIds })}
+      />
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/recently-downloaded-settings.tsx
+++ b/components/dashboard/widget-settings/recently-downloaded-settings.tsx
@@ -9,6 +9,7 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -23,6 +24,7 @@ export interface RecentlyDownloadedSettingsValue extends Record<string, unknown>
   includeSonarr: boolean;
   includeRadarr: boolean;
   maxItems: number;
+  hideWhenEmpty: boolean;
 }
 
 export const RECENTLY_DOWNLOADED_DEFAULT_SETTINGS: RecentlyDownloadedSettingsValue = {
@@ -31,6 +33,7 @@ export const RECENTLY_DOWNLOADED_DEFAULT_SETTINGS: RecentlyDownloadedSettingsVal
   includeSonarr: true,
   includeRadarr: true,
   maxItems: 10,
+  hideWhenEmpty: false,
 };
 
 export function RecentlyDownloadedSettings({ slotId }: WidgetSettingsComponentProps) {
@@ -91,6 +94,11 @@ export function RecentlyDownloadedSettings({ slotId }: WidgetSettingsComponentPr
       <MaxItemsSelector
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/still-pending-settings.tsx
+++ b/components/dashboard/widget-settings/still-pending-settings.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
   ChipGroup,
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -27,6 +28,7 @@ export interface StillPendingSettingsValue extends Record<string, unknown> {
   // too (they also appear under "Today" in the Releasing Soon widget). Off by
   // default so the two cards never list the same item.
   includeToday: boolean;
+  hideWhenEmpty: boolean;
 }
 
 export const STILL_PENDING_DEFAULT_SETTINGS: StillPendingSettingsValue = {
@@ -39,6 +41,7 @@ export const STILL_PENDING_DEFAULT_SETTINGS: StillPendingSettingsValue = {
   lookbackDays: 14,
   maxItems: 5,
   includeToday: false,
+  hideWhenEmpty: false,
 };
 
 const LOOKBACK_OPTIONS: { value: number; label: string }[] = [
@@ -125,6 +128,11 @@ export function StillPendingSettings({ slotId }: WidgetSettingsComponentProps) {
           />
         </ToggleCard>
       </SettingsSection>
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/stream-monitor-settings.tsx
+++ b/components/dashboard/widget-settings/stream-monitor-settings.tsx
@@ -10,6 +10,7 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -23,6 +24,7 @@ export interface StreamMonitorSettingsValue extends Record<string, unknown> {
   showTranscoding: boolean;
   showUserAndDevice: boolean;
   showBandwidthSummary: boolean;
+  hideWhenEmpty: boolean;
 }
 
 export const STREAM_MONITOR_DEFAULT_SETTINGS: StreamMonitorSettingsValue = {
@@ -33,6 +35,7 @@ export const STREAM_MONITOR_DEFAULT_SETTINGS: StreamMonitorSettingsValue = {
   showTranscoding: true,
   showUserAndDevice: true,
   showBandwidthSummary: true,
+  hideWhenEmpty: false,
 };
 
 const MAX_OPTIONS: { value: number; label: string }[] = [
@@ -109,6 +112,11 @@ export function StreamMonitorSettings({ slotId }: WidgetSettingsComponentProps) 
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
         options={MAX_OPTIONS}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/streaming-now-playing-settings.tsx
+++ b/components/dashboard/widget-settings/streaming-now-playing-settings.tsx
@@ -9,6 +9,7 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -23,6 +24,7 @@ export interface StreamingNowPlayingSettingsValue extends Record<string, unknown
   showBitrate: boolean;
   showTranscoding: boolean;
   showUserAndDevice: boolean;
+  hideWhenEmpty: boolean;
 }
 
 export const STREAMING_NOW_PLAYING_DEFAULT_SETTINGS: StreamingNowPlayingSettingsValue = {
@@ -33,6 +35,7 @@ export const STREAMING_NOW_PLAYING_DEFAULT_SETTINGS: StreamingNowPlayingSettings
   showBitrate: false,
   showTranscoding: true,
   showUserAndDevice: true,
+  hideWhenEmpty: false,
 };
 
 const MAX_OPTIONS: { value: number; label: string }[] = [
@@ -109,6 +112,11 @@ export function StreamingNowPlayingSettings({
         value={settings.maxItems}
         onChange={(maxItems) => update({ maxItems })}
         options={MAX_OPTIONS}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/usenet-queue-settings.tsx
+++ b/components/dashboard/widget-settings/usenet-queue-settings.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
   ChipGroup,
+  HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
   ToggleCard,
@@ -24,6 +25,7 @@ export interface UsenetQueueSettingsValue extends Record<string, unknown> {
   showPaused: boolean;
   showQueued: boolean;
   sortBy: UsenetQueueSortBy;
+  hideWhenEmpty: boolean;
 }
 
 export const USENET_QUEUE_DEFAULT_SETTINGS: UsenetQueueSettingsValue = {
@@ -33,6 +35,7 @@ export const USENET_QUEUE_DEFAULT_SETTINGS: UsenetQueueSettingsValue = {
   showPaused: true,
   showQueued: true,
   sortBy: "progress",
+  hideWhenEmpty: false,
 };
 
 const SORT_OPTIONS: { value: UsenetQueueSortBy; label: string }[] = [
@@ -90,6 +93,11 @@ export function UsenetQueueSettings({ slotId, serviceId }: Props) {
         options={SORT_OPTIONS}
         value={settings.sortBy}
         onChange={(sortBy) => update({ sortBy })}
+      />
+
+      <HideWhenEmptyToggle
+        value={settings.hideWhenEmpty}
+        onChange={(hideWhenEmpty) => update({ hideWhenEmpty })}
       />
     </View>
   );

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -3,6 +3,7 @@ import { View, Text, Pressable } from "react-native";
 import { Check } from "lucide-react-native";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { Icon } from "@/components/ui/icon";
+import { Toggle } from "@/components/ui/toggle";
 
 /**
  * Section header + body wrapper used by every widget-settings panel. Keeps
@@ -115,6 +116,31 @@ export function SelectRow({
         ) : null}
       </View>
     </Pressable>
+  );
+}
+
+/**
+ * "Hide when empty" toggle (#282). Rendered as the last section of a widget's
+ * settings form; the widget wires the value into `useHideWhenEmpty`.
+ */
+export function HideWhenEmptyToggle({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <SettingsSection label="Visibility">
+      <ToggleCard>
+        <Toggle
+          label="Hide when empty"
+          description="Hide this widget from the dashboard when there is nothing to show"
+          value={value}
+          onValueChange={onChange}
+        />
+      </ToggleCard>
+    </SettingsSection>
   );
 }
 

--- a/components/media-server/media-server-now-playing-card.tsx
+++ b/components/media-server/media-server-now-playing-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { getSessions } from "@/services/jellyfin-api";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import type { MediaServerId } from "@/lib/media-server-config";
@@ -62,6 +63,12 @@ export function MediaServerNowPlayingCard({
 
   const display = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;
+
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenEmpty,
+    isEmpty: instances.length === 0 || display.length === 0,
+    isLoading: isInitialLoading,
+  });
 
   return (
     <Card>

--- a/hooks/use-hide-when-empty.ts
+++ b/hooks/use-hide-when-empty.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useWidgetVisibilityStore } from "@/store/widget-visibility-store";
+
+/**
+ * Reports a widget slot's "hide when empty" outcome to the visibility store
+ * (#282). The dashboard collapses the slot's wrapper; the widget itself stays
+ * mounted so its queries keep polling and it can reappear when content shows
+ * up. Never pass `isEmpty: true` while data is still loading — hand the
+ * widget's `isInitialLoading` in via `isLoading` so the initial fetch renders
+ * its skeleton instead of flashing hidden.
+ */
+export function useHideWhenEmpty(
+  slotId: string,
+  opts: { enabled: boolean; isEmpty: boolean; isLoading: boolean },
+): void {
+  const setSlotHidden = useWidgetVisibilityStore((s) => s.setSlotHidden);
+  const hidden = opts.enabled && opts.isEmpty && !opts.isLoading;
+
+  useEffect(() => {
+    setSlotHidden(slotId, hidden);
+  }, [slotId, hidden, setSlotHidden]);
+
+  // Clear on unmount: slot removed, dashboard switched, or the widget crashed
+  // into its error boundary — in every case the slot must not stay hidden.
+  useEffect(
+    () => () => setSlotHidden(slotId, false),
+    [slotId, setSlotHidden],
+  );
+}

--- a/store/widget-visibility-store.test.ts
+++ b/store/widget-visibility-store.test.ts
@@ -1,0 +1,46 @@
+import { useWidgetVisibilityStore } from "./widget-visibility-store";
+
+describe("widget-visibility-store", () => {
+  beforeEach(() => {
+    useWidgetVisibilityStore.setState({ hiddenSlots: {} });
+  });
+
+  it("marks and unmarks a slot as hidden", () => {
+    const { setSlotHidden } = useWidgetVisibilityStore.getState();
+
+    setSlotHidden("slot-1", true);
+    expect(useWidgetVisibilityStore.getState().hiddenSlots).toEqual({
+      "slot-1": true,
+    });
+
+    setSlotHidden("slot-1", false);
+    expect(useWidgetVisibilityStore.getState().hiddenSlots).toEqual({});
+  });
+
+  it("tracks multiple slots independently", () => {
+    const { setSlotHidden } = useWidgetVisibilityStore.getState();
+
+    setSlotHidden("slot-1", true);
+    setSlotHidden("slot-2", true);
+    setSlotHidden("slot-1", false);
+
+    expect(useWidgetVisibilityStore.getState().hiddenSlots).toEqual({
+      "slot-2": true,
+    });
+  });
+
+  it("does not produce a new hiddenSlots reference for a same-value report", () => {
+    const { setSlotHidden } = useWidgetVisibilityStore.getState();
+
+    // The common case during progressive reveal: widgets with the toggle off
+    // (or with content) report `false` on mount. Must not churn the store.
+    const before = useWidgetVisibilityStore.getState().hiddenSlots;
+    setSlotHidden("slot-1", false);
+    expect(useWidgetVisibilityStore.getState().hiddenSlots).toBe(before);
+
+    setSlotHidden("slot-1", true);
+    const hidden = useWidgetVisibilityStore.getState().hiddenSlots;
+    setSlotHidden("slot-1", true);
+    expect(useWidgetVisibilityStore.getState().hiddenSlots).toBe(hidden);
+  });
+});

--- a/store/widget-visibility-store.ts
+++ b/store/widget-visibility-store.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+// Slots whose widget currently has nothing to show AND has "Hide when empty"
+// enabled (#282). Ephemeral by design: every mounted widget re-reports its
+// emptiness via useHideWhenEmpty, so persisting this would only risk stale
+// hides across launches. The dashboard collapses hidden slots' wrappers while
+// keeping the widgets mounted, so their queries keep polling and the widget
+// reappears the moment content arrives.
+interface WidgetVisibilityStore {
+  hiddenSlots: Record<string, true>;
+  setSlotHidden: (slotId: string, hidden: boolean) => void;
+}
+
+export const useWidgetVisibilityStore = create<WidgetVisibilityStore>(
+  (set, get) => ({
+    hiddenSlots: {},
+    setSlotHidden: (slotId, hidden) => {
+      // No-op when unchanged: widgets with the toggle off (the common case)
+      // report `false` on every mount during the dashboard's progressive
+      // reveal, and a fresh object per report would re-render the screen for
+      // each batch.
+      if (!!get().hiddenSlots[slotId] === hidden) return;
+      set((s) => {
+        const next = { ...s.hiddenSlots };
+        if (hidden) next[slotId] = true;
+        else delete next[slotId];
+        return { hiddenSlots: next };
+      });
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- Adds a "Hide when empty" toggle to each widget's settings sheet; when on, the widget hides from the dashboard when there is nothing to show and reappears as soon as content arrives (Refs #282)
- Widgets stay mounted (slot wrapper collapses via display:none) so polling continues; never hides during initial load or on error states, and edit mode always shows the card so the toggle stays reachable
- Covers 14 widgets (queues, now playing, requests, calendar, still pending, recently downloaded, indexers, Bazarr); unRAID and Health Alerts are deliberately out of scope

## Test plan
- tsc --noEmit clean, jest 38 suites / 781 tests pass (new widget-visibility-store test)
- Manual: enable toggle on an empty queue widget (card disappears, no stray gap), enter edit mode (card returns with chrome + EyeOff hint), start a download/stream (card reappears on next poll)