### PR TITLE
feat(sonarr): series status filter on TV library (Refs #283)

### DIFF
--- a/components/common/monitored-library-grid.tsx
+++ b/components/common/monitored-library-grid.tsx
@@ -65,6 +65,12 @@ interface MonitoredLibraryGridProps<T extends MonitoredItem, S extends string> {
    * fields the generic item type doesn't know (hasFile / episode counts).
    */
   isMissing: (item: T) => boolean;
+  /**
+   * Additional screen-level predicate ANDed with the monitor filter (e.g. the
+   * TV library's series-status filter). Pass undefined when inactive so the
+   * empty state can tell "library is empty" from "nothing matches filters".
+   */
+  extraFilter?: (item: T) => boolean;
   sort: S;
   compare: (a: T, b: T, sort: S) => number;
   serviceId: "radarr" | "sonarr" | "lidarr";
@@ -109,6 +115,7 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
   error,
   monitorFilter,
   isMissing,
+  extraFilter,
   sort,
   compare,
   serviceId,
@@ -132,13 +139,14 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
     // keep the call site itself safe against any non-array data.
     if (!Array.isArray(data)) return [];
     const filtered = data.filter((item) => {
+      if (extraFilter && !extraFilter(item)) return false;
       if (monitorFilter === "monitored") return item.monitored;
       if (monitorFilter === "unmonitored") return !item.monitored;
       if (monitorFilter === "missing") return isMissing(item);
       return true;
     });
     return [...filtered].sort((a, b) => compare(a, b, sort));
-  }, [data, monitorFilter, isMissing, sort, compare]);
+  }, [data, monitorFilter, isMissing, extraFilter, sort, compare]);
 
   const emptyState = useMemo(() => {
     if (isLoading) {
@@ -164,8 +172,9 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
         />
       );
     }
-    const title =
-      monitorFilter === "monitored"
+    const title = extraFilter
+      ? `No ${nounPlural} match filters`
+      : monitorFilter === "monitored"
         ? `No monitored ${nounPlural}`
         : monitorFilter === "unmonitored"
           ? `No unmonitored ${nounPlural}`
@@ -178,7 +187,7 @@ export function MonitoredLibraryGrid<T extends MonitoredItem, S extends string>(
         title={title}
       />
     );
-  }, [isLoading, error, data, nounPlural, monitorFilter, placeholderIcon, cellWidth, gap]);
+  }, [isLoading, error, data, nounPlural, monitorFilter, extraFilter, placeholderIcon, cellWidth, gap]);
 
   return (
     <FlatList

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -86,6 +86,16 @@ type SeriesSheetTarget =
 
 type Tab = "library" | "calendar";
 
+type SeriesStatusFilter = "all" | "continuing" | "ended" | "upcoming" | "deleted";
+
+const STATUS_FILTER_OPTIONS: { key: SeriesStatusFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "continuing", label: "Continuing" },
+  { key: "ended", label: "Ended" },
+  { key: "upcoming", label: "Upcoming" },
+  { key: "deleted", label: "Deleted" },
+];
+
 const SORT_OPTIONS: { key: SeriesSortKey; label: string }[] = [
   { key: "added-desc", label: "Recently Added" },
   { key: "next-airing-asc", label: "Next Airing" },
@@ -157,6 +167,7 @@ export const TvView = memo(function TvView({
   const [tab, setTab] = useState<Tab>("library");
   const [monitorFilter, setMonitorFilter] =
     useState<MonitorFilter>("monitored");
+  const [statusFilter, setStatusFilter] = useState<SeriesStatusFilter>("all");
   const sort = useSortStore((s) => s.series);
   const setSort = useSortStore((s) => s.setSeries);
   const [filterSortOpen, setFilterSortOpen] = useState(false);
@@ -355,10 +366,22 @@ export const TvView = memo(function TvView({
       {tab === "library" && (
         <View className="mb-4">
           <FilterSortButton
-            summary={`${MONITOR_FILTER_OPTIONS.find((f) => f.value === monitorFilter)?.label ?? ""} · ${SORT_OPTIONS.find((o) => o.key === sort)?.label ?? ""}`}
+            summary={[
+              MONITOR_FILTER_OPTIONS.find((f) => f.value === monitorFilter)
+                ?.label ?? "",
+              statusFilter !== "all"
+                ? (STATUS_FILTER_OPTIONS.find((o) => o.key === statusFilter)
+                    ?.label ?? "")
+                : null,
+              SORT_OPTIONS.find((o) => o.key === sort)?.label ?? "",
+            ]
+              .filter(Boolean)
+              .join(" · ")}
             onPress={() => setFilterSortOpen(true)}
             active={
-              monitorFilter !== "monitored" || sort !== SORT_DEFAULTS.series
+              monitorFilter !== "monitored" ||
+              statusFilter !== "all" ||
+              sort !== SORT_DEFAULTS.series
             }
           />
         </View>
@@ -371,6 +394,7 @@ export const TvView = memo(function TvView({
       {tab === "library" && (
         <SeriesLibrary
           monitorFilter={monitorFilter}
+          statusFilter={statusFilter}
           sort={sort}
           onLongPress={openSeriesSheet}
           listHeader={header}
@@ -407,6 +431,14 @@ export const TvView = memo(function TvView({
         }))}
         filterValue={monitorFilter}
         onFilterChange={setMonitorFilter}
+        extraSections={[
+          {
+            label: "Status",
+            options: STATUS_FILTER_OPTIONS,
+            value: statusFilter,
+            onChange: (v) => setStatusFilter(v as SeriesStatusFilter),
+          },
+        ]}
         sortOptions={SORT_OPTIONS.map((o) => ({ key: o.key, label: o.label }))}
         sortValue={sort}
         onSortChange={setSort}
@@ -458,6 +490,7 @@ export const TvView = memo(function TvView({
 
 function SeriesLibrary({
   monitorFilter,
+  statusFilter,
   sort,
   onLongPress,
   listHeader,
@@ -465,6 +498,7 @@ function SeriesLibrary({
   contentContainerStyle,
 }: {
   monitorFilter: MonitorFilter;
+  statusFilter: SeriesStatusFilter;
   sort: SeriesSortKey;
   onLongPress: (series: SonarrSeries) => void;
   listHeader: React.ReactElement;
@@ -482,12 +516,21 @@ function SeriesLibrary({
     [queue],
   );
 
+  const statusPredicate = useMemo(
+    () =>
+      statusFilter === "all"
+        ? undefined
+        : (s: SonarrSeries) => s.status === statusFilter,
+    [statusFilter],
+  );
+
   return (
     <MonitoredLibraryGrid
       data={series}
       isLoading={isLoading}
       error={error}
       monitorFilter={monitorFilter}
+      extraFilter={statusPredicate}
       isMissing={sonarrIsMissing}
       sort={sort}
       compare={compareSeries}


### PR DESCRIPTION
Adds a Status section (All / Continuing / Ended / Upcoming / Deleted) to the TV library's Filter & sort sheet, filtering on Sonarr's series status. Refs #283.

Test plan:
- tsc --noEmit clean, jest 781 tests pass
- TV tab: pick Ended in the sheet, only ended series remain; summary pill shows the active status; All restores; empty match shows "No shows match filters"
- Movies/Lidarr grids unchanged (no extraFilter passed)