### PR TITLE
feat(theme): global app theme presets (Refs #288)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -10,6 +10,7 @@ import { useActiveDashboard, useAttachedKinds } from "@/hooks/use-active-dashboa
 import { resolveDashboardIcon } from "@/lib/dashboard-icons";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 import { resolveTabIcon } from "@/lib/tab-icons";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import {
   ALL_PICKABLE_TABS,
   visiblePinnedTabs,
@@ -40,6 +41,7 @@ export default function TabLayout() {
 
   const dashIcon = resolveDashboardIcon(activeDashboard?.icon);
   const accent = resolveDashboardColor(activeDashboard?.color);
+  const theme = useAppTheme();
 
   // If the focused tab is no longer pinned (because the user switched to a
   // dashboard that doesn't include it, or unattached its underlying service),
@@ -81,8 +83,8 @@ export default function TabLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
-          backgroundColor: HAS_GLASS_TAB_BAR ? "transparent" : "#18181b",
-          borderTopColor: HAS_GLASS_TAB_BAR ? "transparent" : "#3f3f46",
+          backgroundColor: HAS_GLASS_TAB_BAR ? "transparent" : theme.surface,
+          borderTopColor: HAS_GLASS_TAB_BAR ? "transparent" : theme.border,
           borderTopWidth: HAS_GLASS_TAB_BAR ? 0 : 0.5,
           height: 52 + bottom,
           paddingBottom: 4 + bottom,

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -35,6 +35,7 @@ import { AddWidgetSheet } from "@/components/dashboard/add-widget-sheet";
 import { WidgetSettingsSheet } from "@/components/dashboard/widget-settings-sheet";
 import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sheet";
 import { useAttachedKinds } from "@/hooks/use-active-dashboard";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import { hasSearchableKind } from "@/lib/global-search";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 import { resolveDashboardIcon } from "@/lib/dashboard-icons";
@@ -75,6 +76,7 @@ const WidgetSlotBody = memo(function WidgetSlotBody({
 
 export default function DashboardScreen() {
   const { refreshing, onRefresh } = usePullToRefresh();
+  const theme = useAppTheme();
   const services = useConfigStore((s) => s.services);
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
   const dashboards = useConfigStore((s) => s.dashboards);
@@ -448,7 +450,7 @@ export default function DashboardScreen() {
                   style={editMode ? {
                     borderWidth: 1,
                     borderStyle: "dashed",
-                    borderColor: "#3f3f46",
+                    borderColor: theme.border,
                     borderRadius: 16,
                     opacity: 0.85,
                   } : undefined}

--- a/app/(tabs)/plex.tsx
+++ b/app/(tabs)/plex.tsx
@@ -52,6 +52,7 @@ import { useUiScale } from "@/hooks/use-ui-scale";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { truncateText } from "@/lib/utils";
 import type { PlexSession, PlexMediaItem, PlexLibrary } from "@/lib/types";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 type Tab = "playing" | "recent" | "ondeck" | "libraries";
 
@@ -96,6 +97,7 @@ export default function PlexScreen() {
 
 function PlexScreenInner() {
   const [tab, setTab] = useState<Tab>("playing");
+  const theme = useAppTheme();
   const recentSort = useSortStore((s) => s.plexRecent);
   const setRecentSort = useSortStore((s) => s.setPlexRecent);
   const [recentSortOpen, setRecentSortOpen] = useState(false);
@@ -119,7 +121,7 @@ function PlexScreenInner() {
       onRefresh={onRefresh}
       tintColor="#3b82f6"
       colors={["#3b82f6"]}
-      progressBackgroundColor="#18181b"
+      progressBackgroundColor={theme.surface}
     />
   );
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -35,6 +35,7 @@ import { TextInput } from "@/components/ui/text-input";
 import { Button } from "@/components/ui/button";
 import { Toggle } from "@/components/ui/toggle";
 import { Select } from "@/components/ui/select";
+import { APP_THEMES, type AppThemeId } from "@/lib/app-themes";
 import { HeaderListEditor } from "@/components/ui/header-list-editor";
 import { useConfigStore } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
@@ -212,6 +213,8 @@ export default function SettingsScreen() {
   const setHapticsEnabled = useConfigStore((s) => s.setHapticsEnabled);
   const uiScale = useConfigStore((s) => s.uiScale);
   const setUiScale = useConfigStore((s) => s.setUiScale);
+  const appTheme = useConfigStore((s) => s.appTheme);
+  const setAppTheme = useConfigStore((s) => s.setAppTheme);
 
   // GitHub logo is an SVG (lucide v1 dropped brand icons), so size it manually
   // to match the lucide icons in other rows (size=20 with rem scale).
@@ -560,6 +563,18 @@ export default function SettingsScreen() {
               { value: 1.3, label: "Extra Large", description: "+30% fonts, spacing, and icons" },
             ]}
             onChange={(v) => setUiScale(v as 1 | 1.15 | 1.3)}
+          />
+        </View>
+        <View className="px-4 py-3">
+          <Select<AppThemeId>
+            label="Theme"
+            value={appTheme}
+            options={APP_THEMES.map((t) => ({
+              value: t.id,
+              label: t.label,
+              description: t.description,
+            }))}
+            onChange={setAppTheme}
           />
         </View>
         <SettingsToggleRow

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,14 +1,16 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import { Stack, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { QueryClientProvider, focusManager } from "@tanstack/react-query";
-import { AppState } from "react-native";
+import { AppState, View } from "react-native";
 import type { AppStateStatus } from "react-native";
 import * as Notifications from "expo-notifications";
 import { SafeAreaProvider, initialWindowMetrics } from "react-native-safe-area-context";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
-import { rem } from "nativewind";
+import { rem, vars } from "nativewind";
+import { hexToRgbChannels } from "@/lib/app-themes";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import { useConfigStore } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
 import { useSortStore } from "@/store/sort-store";
@@ -198,6 +200,26 @@ function UiScaleBridge() {
   return null;
 }
 
+// Applies the selected app theme by overriding the chrome-token CSS variables
+// (see tailwind.config.ts / global.css). vars() propagates through React
+// context, so everything below — Stack screens, overlays, toasts, and Modal
+// content (Modals stay in the React tree) — re-resolves bg-background /
+// bg-surface / bg-surface-light / border-border against the active theme.
+function ThemeRoot({ children }: { children: ReactNode }) {
+  const theme = useAppTheme();
+  const themeVars = useMemo(
+    () =>
+      vars({
+        "--color-background": hexToRgbChannels(theme.background),
+        "--color-surface": hexToRgbChannels(theme.surface),
+        "--color-surface-light": hexToRgbChannels(theme.surfaceLight),
+        "--color-border": hexToRgbChannels(theme.border),
+      }),
+    [theme],
+  );
+  return <View style={[{ flex: 1 }, themeVars]}>{children}</View>;
+}
+
 // Keeps the native TLS-bypass allowlist in lockstep with config: which hosts
 // the user opted out of certificate validation for. Pushes once on hydrate and
 // again on every config change (the sync itself dedupes, so unrelated changes
@@ -264,6 +286,7 @@ export default function RootLayout() {
   const introSeen = useIntroStore((s) => s.workspaceIntroSeen);
   const introReplayVersion = useIntroStore((s) => s.showRequestVersion);
   const markIntroSeen = useIntroStore((s) => s.markWorkspaceIntroSeen);
+  const theme = useAppTheme();
 
   useEffect(() => {
     hydrate();
@@ -309,57 +332,59 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <KeyboardProvider>
-        <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-          <QueryClientProvider client={queryClient}>
-            <ErrorBoundary>
-              {/* Invisible root subscribers — isolated so a single failing
-                  watcher (e.g. a service returning an unexpected payload) can't
-                  unmount the navigator and trap the user on the fallback. */}
-              <SilentErrorBoundary label="notification-watchers">
-                <NotificationWatchers />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="notification-router">
-                <NotificationRouter />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="backend-health">
-                <BackendHealthPoller />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="network-auto-switch">
-                <NetworkAutoSwitcher />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="config-sync">
-                <ConfigSyncBridge />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="insecure-tls">
-                <InsecureTlsBridge />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="widget-refresh">
-                <WidgetRefreshBridge />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="ui-scale">
-                <UiScaleBridge />
-              </SilentErrorBoundary>
-              <SilentErrorBoundary label="app-update-checker">
-                <AppUpdateChecker />
-              </SilentErrorBoundary>
-              <StatusBar style="light" />
-              <Stack
-                screenOptions={{
-                  headerShown: false,
-                  contentStyle: { backgroundColor: "#09090b" },
-                  animation: "slide_from_right",
-                }}
-              />
-              <WorkspaceIntroOverlay
-                visible={showIntro}
-                onDismiss={markIntroSeen}
-              />
-              <ToastContainer />
-            </ErrorBoundary>
-          </QueryClientProvider>
-        </SafeAreaProvider>
-      </KeyboardProvider>
+      <ThemeRoot>
+        <KeyboardProvider>
+          <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+            <QueryClientProvider client={queryClient}>
+              <ErrorBoundary>
+                {/* Invisible root subscribers — isolated so a single failing
+                    watcher (e.g. a service returning an unexpected payload) can't
+                    unmount the navigator and trap the user on the fallback. */}
+                <SilentErrorBoundary label="notification-watchers">
+                  <NotificationWatchers />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="notification-router">
+                  <NotificationRouter />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="backend-health">
+                  <BackendHealthPoller />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="network-auto-switch">
+                  <NetworkAutoSwitcher />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="config-sync">
+                  <ConfigSyncBridge />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="insecure-tls">
+                  <InsecureTlsBridge />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="widget-refresh">
+                  <WidgetRefreshBridge />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="ui-scale">
+                  <UiScaleBridge />
+                </SilentErrorBoundary>
+                <SilentErrorBoundary label="app-update-checker">
+                  <AppUpdateChecker />
+                </SilentErrorBoundary>
+                <StatusBar style="light" />
+                <Stack
+                  screenOptions={{
+                    headerShown: false,
+                    contentStyle: { backgroundColor: theme.background },
+                    animation: "slide_from_right",
+                  }}
+                />
+                <WorkspaceIntroOverlay
+                  visible={showIntro}
+                  onDismiss={markIntroSeen}
+                />
+                <ToastContainer />
+              </ErrorBoundary>
+            </QueryClientProvider>
+          </SafeAreaProvider>
+        </KeyboardProvider>
+      </ThemeRoot>
     </GestureHandlerRootView>
   );
 }

--- a/app/dashboard-edit/[id].tsx
+++ b/app/dashboard-edit/[id].tsx
@@ -25,6 +25,7 @@ import { ConfirmModal } from "@/components/common/confirm-modal";
 import { TextInput } from "@/components/ui/text-input";
 import { useConfigStore, type ServiceInstance } from "@/store/config-store";
 import { useModalFlow } from "@/hooks/use-modal-flow";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import {
   ICON,
   SERVICE_DEFAULTS,
@@ -929,13 +930,14 @@ const SegmentButton = memo(function SegmentButton({
   color,
   onPress,
 }: SegmentButtonProps) {
+  const theme = useAppTheme();
   return (
     <Pressable
       onPress={onPress}
       className="flex-1 rounded-xl py-2.5 items-center border active:opacity-80"
       style={{
         backgroundColor: active ? `${color}1A` : "transparent",
-        borderColor: active ? color : "#3f3f46",
+        borderColor: active ? color : theme.border,
       }}
     >
       <Text
@@ -955,12 +957,13 @@ interface CheckboxProps {
 }
 
 const Checkbox = memo(function Checkbox({ on, color, disabled }: CheckboxProps) {
+  const theme = useAppTheme();
   return (
     <View
       className="w-5 h-5 rounded items-center justify-center border"
       style={{
         backgroundColor: on ? color : "transparent",
-        borderColor: on ? color : disabled ? "#3f3f46" : "#52525b",
+        borderColor: on ? color : disabled ? theme.border : "#52525b",
       }}
     >
       {on && <Icon icon={Check} size={14} color="#ffffff" />}

--- a/components/common/arr-history-list.tsx
+++ b/components/common/arr-history-list.tsx
@@ -15,6 +15,7 @@ import {
   HISTORY_TONE_COLOR,
   type ArrHistoryEntry,
 } from "@/lib/arr-history";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 interface ArrHistoryListProps<T> {
   query: UseQueryResult<T[], Error>;
@@ -111,6 +112,7 @@ export function ArrHistoryList<T>({ query, normalize }: ArrHistoryListProps<T>) 
     () => (data ?? []).map(normalize),
     [data, normalize],
   );
+  const theme = useAppTheme();
 
   const handleRefresh = useCallback(() => {
     if (isFetching) return;
@@ -152,7 +154,7 @@ export function ArrHistoryList<T>({ query, normalize }: ArrHistoryListProps<T>) 
           onRefresh={handleRefresh}
           tintColor="#3b82f6"
           colors={["#3b82f6"]}
-          progressBackgroundColor="#18181b"
+          progressBackgroundColor={theme.surface}
         />
       }
       ListEmptyComponent={

--- a/components/common/releases-picker.tsx
+++ b/components/common/releases-picker.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/store/releases-filter-store";
 import { useArrCustomFilters } from "@/hooks/use-arr-custom-filters";
 import { applyArrCustomFilter } from "@/lib/arr-custom-filters";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 type Release = ArrRelease | SonarrRelease;
 
@@ -127,6 +128,7 @@ function ReleaseFlatList({
     ),
     [onSelect],
   );
+  const theme = useAppTheme();
 
   const keyExtractor = useCallback((r: Release) => r.guid, []);
 
@@ -147,7 +149,7 @@ function ReleaseFlatList({
           onRefresh={onRefresh}
           tintColor="#3b82f6"
           colors={["#3b82f6"]}
-          progressBackgroundColor="#18181b"
+          progressBackgroundColor={theme.surface}
         />
       }
       ListEmptyComponent={

--- a/components/common/screen-wrapper.tsx
+++ b/components/common/screen-wrapper.tsx
@@ -1,12 +1,14 @@
 import { useContext } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { RefreshControl, Platform } from "react-native";
+import { RefreshControl, Platform, StyleSheet } from "react-native";
 import type { ViewProps } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 import { cssInterop } from "nativewind";
+import { LinearGradient } from "expo-linear-gradient";
 import { BottomTabBarHeightContext } from "@react-navigation/bottom-tabs";
 import { DemoBanner } from "@/components/common/demo-banner";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 cssInterop(KeyboardAwareScrollView, {
   className: "style",
@@ -77,14 +79,28 @@ export function ScreenWrapper({
   const usesFloatingTabBar = HAS_GLASS_TAB_BAR && tabBarHeight !== undefined;
   const safeAreaEdges = useScreenSafeAreaEdges(edgeToEdge);
   const scrollPaddingBottom = useScreenBottomPadding();
+  const theme = useAppTheme();
+
+  // Full-bleed theme backdrop: a soft top glow fading into the flat
+  // background color. SafeAreaView is padding-based, so absoluteFill covers
+  // the status-bar region too; pointerEvents="none" keeps scroll and
+  // pull-to-refresh untouched.
+  const backdrop = (
+    <LinearGradient
+      colors={theme.gradient}
+      style={StyleSheet.absoluteFill}
+      pointerEvents="none"
+    />
+  );
 
   if (scrollable) {
     return (
       <SafeAreaView
         edges={safeAreaEdges}
-        className={`flex-1 bg-background ${className}`}
+        className={`flex-1 ${className}`}
         {...props}
       >
+        {backdrop}
         <DemoBanner />
         <KeyboardAwareScrollView
           className="flex-1"
@@ -101,7 +117,7 @@ export function ScreenWrapper({
                 onRefresh={onRefresh}
                 tintColor="#3b82f6"
                 colors={["#3b82f6"]}
-                progressBackgroundColor="#18181b"
+                progressBackgroundColor={theme.surface}
               />
             ) : undefined
           }
@@ -116,9 +132,10 @@ export function ScreenWrapper({
     <SafeAreaView
       edges={safeAreaEdges}
       style={usesFloatingTabBar ? { paddingBottom: tabBarHeight } : undefined}
-      className={`flex-1 bg-background ${edgeToEdge ? "" : "px-4"} ${className}`}
+      className={`flex-1 ${edgeToEdge ? "" : "px-4"} ${className}`}
       {...props}
     >
+      {backdrop}
       <DemoBanner />
       {children}
     </SafeAreaView>

--- a/components/dashboard/dashboard-icon-picker-sheet.tsx
+++ b/components/dashboard/dashboard-icon-picker-sheet.tsx
@@ -28,6 +28,7 @@ import * as Haptics from "expo-haptics";
 import { Icon } from "@/components/ui/icon";
 import { GlassSurface } from "@/components/ui/glass-surface";
 import { ICON } from "@/lib/constants";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import {
   LUCIDE_BY_NAME,
   LUCIDE_ICON_NAMES,
@@ -202,6 +203,7 @@ const IconCell = memo(function IconCell({
   index,
   onPress,
 }: IconCellProps) {
+  const theme = useAppTheme();
   const Comp = LUCIDE_BY_NAME[name];
   // Cap the cascade delay — past ~30 cells the stagger should be effectively
   // simultaneous so the bottom of the grid doesn't look like it's still
@@ -214,8 +216,8 @@ const IconCell = memo(function IconCell({
         hitSlop={4}
         className="w-12 h-12 rounded-xl items-center justify-center"
         style={{
-          backgroundColor: selected ? `${color}26` : "#27272a",
-          borderColor: selected ? color : "#3f3f46",
+          backgroundColor: selected ? `${color}26` : theme.surfaceLight,
+          borderColor: selected ? color : theme.border,
           borderWidth: selected ? 2 : 1,
         }}
       >

--- a/components/dashboard/server-stats-card.tsx
+++ b/components/dashboard/server-stats-card.tsx
@@ -20,6 +20,7 @@ import { getCpu, getMem, getFs, getGpu, getNet, getLoad, selectInterfaces, type 
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { useUiScale } from "@/hooks/use-ui-scale";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import {
   SERVER_STATS_DEFAULT_SETTINGS,
   type ServerStatsSettingsValue,
@@ -56,6 +57,7 @@ const MetricRing = memo(function MetricRing({ percent, label, sublabel, icon }: 
   // Use numeric pixel size scaled by uiScale so the ring resizes with
   // accessibility scaling — react-native-svg props are numeric, not rem.
   const scale = useUiScale();
+  const theme = useAppTheme();
   const size = Math.round(RING_BASE * scale);
   const stroke = Math.max(4, Math.round(STROKE_WIDTH * scale));
   const radius = (size - stroke) / 2;
@@ -73,7 +75,7 @@ const MetricRing = memo(function MetricRing({ percent, label, sublabel, icon }: 
             cx={size / 2}
             cy={size / 2}
             r={radius}
-            stroke="#27272a"
+            stroke={theme.surfaceLight}
             strokeWidth={stroke}
             fill="none"
           />

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -61,6 +61,7 @@ import {
   type TorrentFilterType,
   type UnifiedTorrent,
 } from "@/lib/torrent-adapter";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 const FILTER_OPTIONS: { key: TorrentFilterType; label: string }[] = [
   { key: "all", label: "All" },
@@ -110,6 +111,7 @@ export function TorrentDownloadsView({
   onMagnetConsumed,
 }: ViewProps) {
   const [filter, setFilter] = useState<TorrentFilterType>("all");
+  const theme = useAppTheme();
   const [category, setCategory] = useState<string>(ALL_CATEGORIES);
   const sort = useSortStore((s) => s.downloads);
   const setSort = useSortStore((s) => s.setDownloads);
@@ -502,7 +504,7 @@ export function TorrentDownloadsView({
             onRefresh={onRefresh}
             tintColor="#3b82f6"
             colors={["#3b82f6"]}
-            progressBackgroundColor="#18181b"
+            progressBackgroundColor={theme.surface}
           />
         }
         keyboardShouldPersistTaps="handled"

--- a/components/lidarr/music-view.tsx
+++ b/components/lidarr/music-view.tsx
@@ -56,6 +56,7 @@ import {
   lidarrAlbumIsMissing,
 } from "@/lib/arr-poster-status";
 import type { LidarrArtist, LidarrAlbum, LidarrQueueItem } from "@/lib/types";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 // MonitoredLibraryGrid keys on `title`; Lidarr artists use `artistName`, so we
 // project a `title` field on before handing them to the grid.
@@ -110,6 +111,7 @@ export const MusicView = memo(function MusicView({
   embedded?: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("library");
+  const theme = useAppTheme();
   const [monitorFilter, setMonitorFilter] = useState<MonitorFilter>("monitored");
   const sort = useSortStore((s) => s.music);
   const setSort = useSortStore((s) => s.setMusic);
@@ -245,7 +247,7 @@ export const MusicView = memo(function MusicView({
       onRefresh={onRefresh}
       tintColor="#3b82f6"
       colors={["#3b82f6"]}
-      progressBackgroundColor="#18181b"
+      progressBackgroundColor={theme.surface}
     />
   );
 

--- a/components/media-server/media-server-screen.tsx
+++ b/components/media-server/media-server-screen.tsx
@@ -45,6 +45,7 @@ import { useUiScale } from "@/hooks/use-ui-scale";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { truncateText } from "@/lib/utils";
 import type { JellyfinItem, JellyfinLibrary, JellyfinSession } from "@/lib/types";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 // One hook set per media-server kind, stamped once at module scope. Selecting
 // from this map by serviceId (which is fixed per mounted screen) keeps hook
@@ -101,6 +102,7 @@ function compareRecent(
 export function MediaServerScreen({ serviceId }: { serviceId: MediaServerId }) {
   const { displayName } = getMediaServerConfig(serviceId);
   const [tab, setTab] = useState<Tab>("playing");
+  const theme = useAppTheme();
 
   // Sort preference is per-kind so the two tabs keep independent state.
   const jellyfinSort = useSortStore((s) => s.jellyfinRecent);
@@ -131,7 +133,7 @@ export function MediaServerScreen({ serviceId }: { serviceId: MediaServerId }) {
       onRefresh={onRefresh}
       tintColor="#3b82f6"
       colors={["#3b82f6"]}
-      progressBackgroundColor="#18181b"
+      progressBackgroundColor={theme.surface}
     />
   );
 

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -56,6 +56,7 @@ import {
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { radarrReleaseTime } from "@/lib/radarr-release-date";
 import type { RadarrMovie, RadarrQueueItem } from "@/lib/types";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 type MovieSheetTarget =
   | { kind: "movie"; item: RadarrMovie }
@@ -167,6 +168,7 @@ export const MoviesView = memo(function MoviesView({
   embedded?: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("library");
+  const theme = useAppTheme();
   const [monitorFilter, setMonitorFilter] = useState<MonitorFilter>("monitored");
   const sort = useSortStore((s) => s.movies);
   const setSort = useSortStore((s) => s.setMovies);
@@ -292,7 +294,7 @@ export const MoviesView = memo(function MoviesView({
       onRefresh={onRefresh}
       tintColor="#3b82f6"
       colors={["#3b82f6"]}
-      progressBackgroundColor="#18181b"
+      progressBackgroundColor={theme.surface}
     />
   );
 

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -78,6 +78,7 @@ import {
 } from "@/lib/utils";
 import { mediumHaptic } from "@/lib/haptics";
 import type { SonarrSeries, SonarrCalendarEntry } from "@/lib/types";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 type SeriesSheetTarget =
   | { kind: "series"; item: SonarrSeries }
@@ -155,6 +156,7 @@ export const TvView = memo(function TvView({
   embedded?: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("library");
+  const theme = useAppTheme();
   const [monitorFilter, setMonitorFilter] =
     useState<MonitorFilter>("monitored");
   const sort = useSortStore((s) => s.series);
@@ -302,7 +304,7 @@ export const TvView = memo(function TvView({
       onRefresh={onRefresh}
       tintColor="#3b82f6"
       colors={["#3b82f6"]}
-      progressBackgroundColor="#18181b"
+      progressBackgroundColor={theme.surface}
     />
   );
 

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -8,6 +8,7 @@ import Animated, {
   Easing,
   ReduceMotion,
 } from "react-native-reanimated";
+import { useAppTheme } from "@/hooks/use-app-theme";
 
 interface SkeletonProps {
   width?: number | string;
@@ -23,6 +24,7 @@ export function Skeleton({
   className,
 }: SkeletonProps) {
   const translateX = useSharedValue(-1);
+  const theme = useAppTheme();
 
   useEffect(() => {
     // ReduceMotion.Never: the shimmer is a loading affordance, so keep it moving
@@ -53,7 +55,7 @@ export function Skeleton({
         width: width as any,
         height,
         borderRadius,
-        backgroundColor: "#27272a",
+        backgroundColor: theme.surfaceLight,
         overflow: "hidden",
       }}
     >
@@ -64,7 +66,7 @@ export function Skeleton({
             top: 0,
             bottom: 0,
             width: "40%",
-            backgroundColor: "#3f3f46",
+            backgroundColor: theme.border,
             borderRadius,
             opacity: 0.5,
           },

--- a/global.css
+++ b/global.css
@@ -1,3 +1,16 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Default (zinc) values for the themeable chrome tokens, as space-separated
+   RGB channels — see tailwind.config.ts. ThemeRoot in app/_layout.tsx
+   overrides these at runtime via NativeWind vars() when a non-default
+   app theme is selected. */
+@layer base {
+  :root {
+    --color-background: 9 9 11;
+    --color-surface: 24 24 27;
+    --color-surface-light: 39 39 42;
+    --color-border: 63 63 70;
+  }
+}

--- a/hooks/use-app-theme.ts
+++ b/hooks/use-app-theme.ts
@@ -1,0 +1,6 @@
+import { resolveAppTheme, type AppTheme } from "@/lib/app-themes";
+import { useConfigStore } from "@/store/config-store";
+
+export function useAppTheme(): AppTheme {
+  return resolveAppTheme(useConfigStore((s) => s.appTheme));
+}

--- a/lib/app-themes.ts
+++ b/lib/app-themes.ts
@@ -1,0 +1,86 @@
+// Global app theme presets (issue #288). Each theme tints the four chrome
+// tokens (background / surface / surface-light / border) together; accents
+// (primary + per-dashboard colors) are unaffected. Hex strings so the id
+// round-trips through JSON export/import unchanged. Pure data — no
+// react-native/nativewind imports, since store tests import this transitively
+// via config-schema. Runtime application happens through NativeWind CSS
+// variables set in app/_layout.tsx (ThemeRoot).
+export const APP_THEMES = [
+  {
+    id: "default",
+    label: "Default",
+    description: "Neutral zinc",
+    background: "#09090b",
+    surface: "#18181b",
+    surfaceLight: "#27272a",
+    border: "#3f3f46",
+    gradient: ["#131316", "#09090b"],
+  },
+  {
+    id: "ember",
+    label: "Ember",
+    description: "Warm red-brown",
+    background: "#140b09",
+    surface: "#241512",
+    surfaceLight: "#362019",
+    border: "#4f3128",
+    gradient: ["#2e1712", "#140b09"],
+  },
+  {
+    id: "midnight",
+    label: "Midnight",
+    description: "Deep navy blue",
+    background: "#0a0e1a",
+    surface: "#131a2b",
+    surfaceLight: "#1e2840",
+    border: "#354362",
+    gradient: ["#16203a", "#0a0e1a"],
+  },
+  {
+    id: "forest",
+    label: "Forest",
+    description: "Dark green",
+    background: "#0a120d",
+    surface: "#13211a",
+    surfaceLight: "#1d3126",
+    border: "#31523f",
+    gradient: ["#152a1e", "#0a120d"],
+  },
+  {
+    id: "violet",
+    label: "Violet",
+    description: "Dark purple",
+    background: "#0f0a17",
+    surface: "#1a1226",
+    surfaceLight: "#281c3a",
+    border: "#443059",
+    gradient: ["#241536", "#0f0a17"],
+  },
+] as const;
+
+export type AppTheme = (typeof APP_THEMES)[number];
+export type AppThemeId = AppTheme["id"];
+
+export const DEFAULT_APP_THEME: AppThemeId = "default";
+
+const THEMES_BY_ID = new Map<string, AppTheme>(
+  APP_THEMES.map((t) => [t.id, t]),
+);
+
+export function isValidAppTheme(value: unknown): value is AppThemeId {
+  return typeof value === "string" && THEMES_BY_ID.has(value);
+}
+
+export function resolveAppTheme(id: string | undefined): AppTheme {
+  return (id && THEMES_BY_ID.get(id)) || THEMES_BY_ID.get(DEFAULT_APP_THEME)!;
+}
+
+// "#140b09" -> "20 11 9" — the space-separated channel triplet format the
+// Tailwind tokens expect (rgb(var(--color-x) / <alpha-value>)).
+export function hexToRgbChannels(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `${r} ${g} ${b}`;
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -198,6 +198,7 @@ export const STORAGE_KEYS = {
   hapticsEnabled: "app.hapticsEnabled",
   globalCustomHeaders: "app.globalCustomHeaders",
   uiScale: "app.uiScale",
+  appTheme: "app.appTheme",
   // v17: user-defined display order for the Services tab tiles. Stored as a
   // ServiceId[]; unknown ids in this list are ignored at render time, and
   // any SERVICE_IDS missing from the list are appended in their canonical

--- a/store/config-migrations.test.ts
+++ b/store/config-migrations.test.ts
@@ -1679,3 +1679,30 @@ describe("v36 → v37 (per-workspace tabIcons stamp)", () => {
     expect(result.dashboards[0].tabIcons).toBeUndefined();
   });
 });
+
+describe("v37 → v38 (appTheme stamp)", () => {
+  it("just stamps the version and preserves an already-set appTheme", () => {
+    const result: any = migrateConfig({
+      version: 37,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+      appTheme: "ember",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.appTheme).toBe("ember");
+  });
+
+  it("leaves appTheme absent when the source payload omitted it", () => {
+    const result: any = migrateConfig({
+      version: 37,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.appTheme).toBeUndefined();
+  });
+});

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -146,8 +146,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         TabRouteId → lucide icon name overriding the bottom-tab icon.
  *         Pure version stamp — absence means default tab icons, and
  *         coerceDashboard validates entries on import.
+ *   v38 — optional global `appTheme` preset id (#288). Pure version stamp —
+ *         absence means the default zinc theme, and validateExportPayload
+ *         whitelists the id on import.
  */
-export const CURRENT_CONFIG_VERSION = 37;
+export const CURRENT_CONFIG_VERSION = 38;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -654,6 +657,9 @@ const migrations: Record<number, (payload: any) => any> = {
   // v36 → v37: optional per-workspace `tabIcons` bottom-tab icon overrides on
   // Dashboard (#195). Pure version stamp — absence means default tab icons.
   36: (payload) => ({ ...payload, version: 37 }),
+  // v37 → v38: optional global `appTheme` preset id (#288). Pure version
+  // stamp — absence falls back to the default theme.
+  37: (payload) => ({ ...payload, version: 38 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -1379,6 +1379,30 @@ describe("validateExportPayload — uiScale", () => {
   });
 });
 
+describe("validateExportPayload — appTheme", () => {
+  it("accepts a whitelisted appTheme id", () => {
+    const result = validateExportPayload({ ...baseValid(), appTheme: "ember" });
+    expect(result.appTheme).toBe("ember");
+  });
+
+  it("omits appTheme from the result when absent in input", () => {
+    const result = validateExportPayload(baseValid());
+    expect(result.appTheme).toBeUndefined();
+  });
+
+  it("rejects an unknown appTheme id", () => {
+    expect(() =>
+      validateExportPayload({ ...baseValid(), appTheme: "hotpink" as any }),
+    ).toThrow(/appTheme/);
+  });
+
+  it("rejects a non-string appTheme", () => {
+    expect(() =>
+      validateExportPayload({ ...baseValid(), appTheme: 3 as any }),
+    ).toThrow(/appTheme/);
+  });
+});
+
 describe("validateExportPayload — slot settings", () => {
   it("preserves a slot's settings object verbatim", () => {
     const result = validateExportPayload({

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/store/config-store";
 import type { NotificationSettings, NotifCategory, AppriseConfig } from "@/store/config-store";
 import { NOTIF_CATEGORIES } from "@/lib/notification-categories";
+import { isValidAppTheme } from "@/lib/app-themes";
 import { ALL_PICKABLE_TABS, MAX_PINNED_TABS } from "@/lib/tab-routes";
 
 const NOTIF_CATEGORY_SET: ReadonlySet<string> = new Set(NOTIF_CATEGORIES);
@@ -546,6 +547,13 @@ export function validateExportPayload(raw: unknown): ExportPayload {
       throw new Error("Config uiScale is invalid");
     }
     payload.uiScale = raw.uiScale as ExportPayload["uiScale"];
+  }
+
+  if (raw.appTheme !== undefined) {
+    if (!isValidAppTheme(raw.appTheme)) {
+      throw new Error("Config appTheme is invalid");
+    }
+    payload.appTheme = raw.appTheme;
   }
 
   if (raw.servicesOrder !== undefined && raw.servicesOrder !== null) {

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -32,6 +32,11 @@ import {
 } from "@/lib/constants";
 import type { UiScale } from "@/lib/constants";
 import {
+  DEFAULT_APP_THEME,
+  isValidAppTheme,
+  type AppThemeId,
+} from "@/lib/app-themes";
+import {
   DEFAULT_DASHBOARD_ICON,
   type DashboardIconName,
 } from "@/lib/dashboard-icons";
@@ -368,6 +373,8 @@ interface ConfigState {
   globalCustomHeaders: Record<string, string>;
   // Accessibility multiplier applied app-wide via NativeWind's rem observable.
   uiScale: UiScale;
+  // Global chrome tint preset applied via NativeWind CSS vars (ThemeRoot).
+  appTheme: AppThemeId;
   notificationSettings: NotificationSettings;
 }
 
@@ -401,6 +408,8 @@ export interface ExportPayload {
   servicesOrder?: ServiceId[];
   // v32 — opt-in "VPN connected counts as home" (#185).
   treatVpnAsHome?: boolean;
+  // v38 — global app theme preset.
+  appTheme?: AppThemeId;
 }
 
 export type ExportStage = "preparing" | "encrypting" | "finalizing";
@@ -519,6 +528,7 @@ interface ConfigActions {
   setHapticsEnabled: (enabled: boolean) => void;
   setGlobalCustomHeaders: (headers: Record<string, string>) => void;
   setUiScale: (scale: UiScale) => void;
+  setAppTheme: (theme: AppThemeId) => void;
   setNotificationSetting: <K extends keyof NotificationSettings>(
     key: K,
     value: NotificationSettings[K],
@@ -985,6 +995,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   hapticsEnabled: true,
   globalCustomHeaders: {},
   uiScale: DEFAULT_UI_SCALE,
+  appTheme: DEFAULT_APP_THEME,
   notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
 
   hydrate: async () => {
@@ -1440,6 +1451,11 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         ? (storedUiScale as UiScale)
         : DEFAULT_UI_SCALE;
 
+    const storedAppTheme = getString(STORAGE_KEYS.appTheme);
+    const appTheme: AppThemeId = isValidAppTheme(storedAppTheme)
+      ? storedAppTheme
+      : DEFAULT_APP_THEME;
+
     // Notification settings persisted under their own AsyncStorage key since
     // v2 (originally owned by a standalone notifications-store). Merge over
     // defaults so a partially-stored payload (older app picking up newer
@@ -1534,6 +1550,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       hapticsEnabled,
       globalCustomHeaders,
       uiScale,
+      appTheme,
       notificationSettings,
       hydrated: true,
     });
@@ -2437,6 +2454,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     set({ uiScale: scale });
   },
 
+  setAppTheme: (theme) => {
+    if (!isValidAppTheme(theme)) return;
+    setString(STORAGE_KEYS.appTheme, theme);
+    set({ appTheme: theme });
+  },
+
   setNotificationSetting: (key, value) => {
     const next = { ...get().notificationSettings, [key]: value };
     setJSON(STORAGE_KEYS.notificationSettings, next);
@@ -2644,6 +2667,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       hapticsEnabled,
       globalCustomHeaders,
       uiScale,
+      appTheme,
       notificationSettings: notifSettings,
     } = get();
     const { url, sharedSecret, deviceId } = useBackendStore.getState();
@@ -2667,6 +2691,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       hapticsEnabled,
       globalCustomHeaders,
       uiScale,
+      appTheme,
     };
 
     onStage?.("encrypting");
@@ -2838,6 +2863,10 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
         ? payload.uiScale
         : DEFAULT_UI_SCALE;
     setJSON(STORAGE_KEYS.uiScale, importedUiScale);
+    const importedAppTheme: AppThemeId = isValidAppTheme(payload.appTheme)
+      ? payload.appTheme
+      : DEFAULT_APP_THEME;
+    setString(STORAGE_KEYS.appTheme, importedAppTheme);
     const importedServicesOrder = sanitizeServicesOrder(payload.servicesOrder);
     setJSON(STORAGE_KEYS.servicesOrder, importedServicesOrder);
 
@@ -2892,6 +2921,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       hapticsEnabled: importedHapticsEnabled,
       globalCustomHeaders: importedGlobalCustomHeaders,
       uiScale: importedUiScale,
+      appTheme: importedAppTheme,
       notificationSettings: importedNotificationSettings,
     });
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,10 +10,15 @@ export default {
   theme: {
     extend: {
       colors: {
-        background: "#09090b",
-        surface: "#18181b",
-        "surface-light": "#27272a",
-        border: "#3f3f46",
+        // Chrome tokens resolve through CSS variables so the app theme
+        // (lib/app-themes.ts, applied by ThemeRoot in app/_layout.tsx) can
+        // retint them at runtime. Channel-triplet + <alpha-value> form keeps
+        // opacity modifiers (bg-surface-light/70 etc.) working. Defaults live
+        // in global.css :root.
+        background: "rgb(var(--color-background) / <alpha-value>)",
+        surface: "rgb(var(--color-surface) / <alpha-value>)",
+        "surface-light": "rgb(var(--color-surface-light) / <alpha-value>)",
+        border: "rgb(var(--color-border) / <alpha-value>)",
         primary: "#3b82f6",
         success: "#22c55e",
         warning: "#f59e0b",


### PR DESCRIPTION
## Summary
- 5 dark theme presets (Default, Ember, Midnight, Forest, Violet) that tint background, surfaces, and borders together, with a subtle top gradient per screen (Refs #288)
- Chrome tokens now resolve through NativeWind CSS variables; ThemeRoot in the root layout applies the selected theme at runtime, existing Tailwind classes untouched
- Theme select in Settings > Appearance, persisted and included in config export/import (config v38)
- Raw-hex chrome made theme-aware: root Stack, tab bar, refresh bubbles, skeleton shimmer, inline card/border styles

## Test plan
- tsc --noEmit clean, all 787 jest tests pass (new schema + migration tests)
- Tailwind compile verified: variable tokens and opacity modifiers emit correctly
- Manual on device: Default should look identical to current build; switching themes should retint screens, cards, tab bar, and sheets/dialogs