### PR TITLE
feat: queue issue alerts, grouped recent downloads, Services auto-hide

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -31,6 +31,7 @@ import {
   isWidgetServiceAttached,
   isWidgetServiceEnabled,
 } from "@/components/dashboard/widget-registry";
+import { slotAutoHides } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 import { AddWidgetSheet } from "@/components/dashboard/add-widget-sheet";
 import { WidgetSettingsSheet } from "@/components/dashboard/widget-settings-sheet";
 import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sheet";
@@ -370,13 +371,10 @@ export default function DashboardScreen() {
             const { label, settingsComponent } = widget;
             const isFirst = visibleIndex === 0;
             const isLast = visibleIndex === visibleSlots.length - 1;
-            // Any of the per-widget auto-hide settings: the standard
-            // "hide when empty" (#282) or Service Health's "hide when all
-            // healthy" (#303). Only drives the edit-mode EyeOff marker — the
-            // collapse itself is widget-agnostic via the visibility store.
-            const autoHides =
-              slot.settings?.hideWhenEmpty === true ||
-              slot.settings?.hideWhenAllHealthy === true;
+            // Only drives the edit-mode EyeOff marker — the collapse itself is
+            // widget-agnostic via the visibility store. The key list lives next
+            // to AutoHideToggle so the two can't drift.
+            const autoHides = slotAutoHides(slot.settings);
             // display:none (not unmount) so the widget's queries keep polling
             // and it reappears the moment content shows up. Edit mode always
             // shows the card so the toggle stays reachable. Yoga excludes

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -370,7 +370,13 @@ export default function DashboardScreen() {
             const { label, settingsComponent } = widget;
             const isFirst = visibleIndex === 0;
             const isLast = visibleIndex === visibleSlots.length - 1;
-            const hidesWhenEmpty = slot.settings?.hideWhenEmpty === true;
+            // Any of the per-widget auto-hide settings: the standard
+            // "hide when empty" (#282) or Service Health's "hide when all
+            // healthy" (#303). Only drives the edit-mode EyeOff marker — the
+            // collapse itself is widget-agnostic via the visibility store.
+            const autoHides =
+              slot.settings?.hideWhenEmpty === true ||
+              slot.settings?.hideWhenAllHealthy === true;
             // display:none (not unmount) so the widget's queries keep polling
             // and it reappears the moment content shows up. Edit mode always
             // shows the card so the toggle stays reachable. Yoga excludes
@@ -393,7 +399,7 @@ export default function DashboardScreen() {
                       <Text className="text-zinc-500 text-xs font-medium" numberOfLines={1}>
                         {label}
                       </Text>
-                      {hidesWhenEmpty && (
+                      {autoHides && (
                         <Icon icon={EyeOff} size={ICON.SM} color="#52525b" />
                       )}
                     </View>

--- a/components/dashboard/recently-downloaded-card.tsx
+++ b/components/dashboard/recently-downloaded-card.tsx
@@ -4,15 +4,27 @@ import { useQueries } from "@tanstack/react-query";
 import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ServiceLogo } from "@/components/ui/service-logo";
+import {
+  ActionSheet,
+  type ActionSheetAction,
+} from "@/components/ui/action-sheet";
 import { getHistory as getRadarrHistory, getRadarrPoster } from "@/services/radarr-api";
 import { getHistory as getSonarrHistory, getSonarrPoster } from "@/services/sonarr-api";
 import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
+import { useModalFlow } from "@/hooks/use-modal-flow";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { POLLING_INTERVALS } from "@/lib/constants";
-import { formatEpisodeCode, relativeDate } from "@/lib/utils";
+import { formatBytes, formatEpisodeCode, relativeDate } from "@/lib/utils";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import { normalizeSonarrHistory } from "@/lib/arr-history";
+import { BAR_KIND_COLOR } from "@/lib/arr-poster-status";
+import {
+  groupRecentDownloads,
+  type RecentGroup,
+  type RecentItem,
+} from "@/lib/recently-downloaded";
 import {
   RECENTLY_DOWNLOADED_DEFAULT_SETTINGS,
   type RecentlyDownloadedSettingsValue,
@@ -21,28 +33,6 @@ import type { WidgetComponentProps } from "@/components/dashboard/widget-registr
 import { MediaPosterTile } from "@/components/dashboard/media-poster-tile";
 import { PosterSkeletonRow } from "@/components/dashboard/poster-skeleton-row";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
-import type {
-  RadarrHistoryRecord,
-  SonarrHistoryRecord,
-} from "@/lib/types";
-
-// One imported entry from either Sonarr or Radarr, tagged with its source
-// instance so the per-tile router push targets the right id space (movie /
-// series ids aren't globally unique across instances of the same kind).
-type RecentItem =
-  | {
-      kind: "episode";
-      record: SonarrHistoryRecord;
-      instanceId: string;
-      // Pulled out for sorting — `date` is optional on the record type.
-      date: string;
-    }
-  | {
-      kind: "movie";
-      record: RadarrHistoryRecord;
-      instanceId: string;
-      date: string;
-    };
 
 // Radarr/Sonarr expose the import event under this name. Grab events fire too,
 // but the issue asks for "recently downloaded" — only completed imports count.
@@ -56,6 +46,10 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
   );
   const sonarrEnabled = useConfigStore((s) => s.services.sonarr.enabled);
   const radarrEnabled = useConfigStore((s) => s.services.radarr.enabled);
+
+  // A grouped tile opens a sheet whose rows navigate — a modal-into-navigation
+  // chain, so it goes through the flow rather than plain state (see CLAUDE.md).
+  const flow = useModalFlow<{ episodes: RecentGroup }>();
 
   const showSonarr = settings.includeSonarr && sonarrEnabled;
   const showRadarr = settings.includeRadarr && radarrEnabled;
@@ -123,9 +117,12 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
     });
   }
 
-  // Sort descending by import timestamp so the freshest download is leftmost.
-  items.sort((a, b) => b.date.localeCompare(a.date));
-  const display = items.slice(0, settings.maxItems);
+  // Sorted newest-first and collapsed by series (issue #307), so the cap counts
+  // tiles: a season batch no longer pushes the rest of the feed off screen.
+  const display = groupRecentDownloads(items, settings.groupEpisodes).slice(
+    0,
+    settings.maxItems,
+  );
 
   const noSources = !showSonarr && !showRadarr;
   const noServicesEnabled = !sonarrEnabled && !radarrEnabled;
@@ -139,6 +136,39 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
     enabled: settings.hideWhenEmpty,
     isEmpty: !noSources && display.length === 0,
     isLoading,
+  });
+
+  const openSeries = (item: Extract<RecentItem, { kind: "episode" }>) => {
+    const seriesId = item.record.seriesId ?? item.record.series?.id;
+    if (!seriesId) return;
+    router.push(`/series/${seriesId}?instanceId=${item.instanceId}`);
+  };
+
+  // Payload stays readable while the sheet animates out, so the rows don't
+  // blank mid-dismiss.
+  const openGroup = flow.payload("episodes");
+  const openGroupItems = (openGroup?.items ?? []).filter(
+    (i): i is Extract<RecentItem, { kind: "episode" }> => i.kind === "episode",
+  );
+
+  const episodeActions: ActionSheetAction[] = openGroupItems.map((item) => {
+    const entry = normalizeSonarrHistory(item.record);
+    const episode = item.record.episode;
+    const code = episode
+      ? formatEpisodeCode(episode.seasonNumber ?? 0, episode.episodeNumber ?? 0)
+      : null;
+    return {
+      label: [code, episode?.title].filter(Boolean).join(" · ") || entry.title,
+      subtitle:
+        [
+          entry.qualityName,
+          entry.sizeBytes ? formatBytes(entry.sizeBytes) : null,
+          relativeDate(item.date),
+        ]
+          .filter(Boolean)
+          .join(" · ") || undefined,
+      onPress: () => flow.whenClear(() => openSeries(item)),
+    };
   });
 
   return (
@@ -177,40 +207,77 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={{ gap: 12 }}
         >
-          {display.map((item) =>
-            item.kind === "episode" ? (
-              <EpisodeTile
-                key={`ep-${item.instanceId}-${item.record.id}`}
-                item={item}
+          {display.map((group) => {
+            const first = group.items[0];
+            if (first.kind === "movie") {
+              return (
+                <MovieTile
+                  key={group.key}
+                  item={first}
+                  showSourceBadge={showSourceBadge}
+                  onPress={() => {
+                    const movieId = first.record.movieId ?? first.record.movie?.id;
+                    if (!movieId) return;
+                    router.push(
+                      `/movie/${movieId}?instanceId=${first.instanceId}`,
+                    );
+                  }}
+                />
+              );
+            }
+            if (group.items.length === 1) {
+              return (
+                <EpisodeTile
+                  key={group.key}
+                  item={first}
+                  showSourceBadge={showSourceBadge}
+                  onPress={() => openSeries(first)}
+                />
+              );
+            }
+            return (
+              <EpisodeGroupTile
+                key={group.key}
+                group={group}
                 showSourceBadge={showSourceBadge}
-                onPress={() => {
-                  const seriesId =
-                    item.record.seriesId ?? item.record.series?.id;
-                  if (!seriesId) return;
-                  router.push(
-                    `/series/${seriesId}?instanceId=${item.instanceId}`,
-                  );
-                }}
+                onPress={() => flow.open("episodes", group)}
               />
-            ) : (
-              <MovieTile
-                key={`mv-${item.instanceId}-${item.record.id}`}
-                item={item}
-                showSourceBadge={showSourceBadge}
-                onPress={() => {
-                  const movieId = item.record.movieId ?? item.record.movie?.id;
-                  if (!movieId) return;
-                  router.push(
-                    `/movie/${movieId}?instanceId=${item.instanceId}`,
-                  );
-                }}
-              />
-            ),
-          )}
+            );
+          })}
         </ScrollView>
       )}
+
+      <ActionSheet
+        {...flow.bind("episodes")}
+        title={openGroup ? seriesTitleOf(openGroup) : undefined}
+        subtitle={openGroup ? groupSubtitle(openGroup) : undefined}
+        actions={episodeActions}
+      />
     </Card>
   );
+}
+
+// Every record in a series group names the same show, but `series` is only
+// populated when Sonarr echoed it back — fall back to the first one that did.
+function seriesTitleOf(group: RecentGroup): string {
+  for (const item of group.items) {
+    if (item.kind !== "episode") continue;
+    const title = item.record.series?.title ?? item.record.sourceTitle;
+    if (title) return title;
+  }
+  return "Episodes";
+}
+
+function seriesImagesOf(group: RecentGroup) {
+  for (const item of group.items) {
+    if (item.kind !== "episode") continue;
+    if (item.record.series?.images?.length) return item.record.series.images;
+  }
+  return undefined;
+}
+
+function groupSubtitle(group: RecentGroup): string {
+  return `${group.items.length} episodes · ${relativeDate(group.date)}`;
 }
 
 function EpisodeTile({
@@ -239,6 +306,36 @@ function EpisodeTile({
       title={title}
       subtitle={subtitle}
       mediaType="tv"
+      topLeftBadge={
+        showSourceBadge ? <ServiceLogo id="sonarr" size={14} /> : undefined
+      }
+      onPress={onPress}
+    />
+  );
+}
+
+// Several episodes of one series collapsed into a single tile (issue #307).
+// The count pill is the at-a-glance signal; the sheet behind the tap lists
+// which episodes actually landed.
+function EpisodeGroupTile({
+  group,
+  showSourceBadge,
+  onPress,
+}: {
+  group: RecentGroup;
+  showSourceBadge: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <MediaPosterTile
+      posterUrl={getSonarrPoster(seriesImagesOf(group))}
+      title={seriesTitleOf(group)}
+      subtitle={groupSubtitle(group)}
+      mediaType="tv"
+      cornerBadge={{
+        label: String(group.items.length),
+        color: BAR_KIND_COLOR.primary,
+      }}
       topLeftBadge={
         showSourceBadge ? <ServiceLogo id="sonarr" size={14} /> : undefined
       }

--- a/components/dashboard/recently-downloaded-card.tsx
+++ b/components/dashboard/recently-downloaded-card.tsx
@@ -66,6 +66,17 @@ export function RecentlyDownloadedCard({ slotId }: WidgetComponentProps) {
   // Fan history across each resolved instance. Query keys match the watchers
   // in use-notification-watchers.tsx so we share the same cached page instead
   // of issuing a second request per instance.
+  //
+  // 50 raw records covering every event type (grab, import, rename, delete) is
+  // the shared budget, so with grouping on the row can hold fewer than
+  // `maxItems` tiles: a 20-episode season eats much of the window and collapses
+  // to one tile. That's the #307 trade-off working as intended — you did
+  // download fewer distinct things. Don't "fix" it by raising the page size
+  // here: this response embeds a full series/movie object per record and is
+  // polled every 30s, so a bigger page is a real recurring cost for every user,
+  // paid to fill one widget. Narrowing to import events only would be the
+  // cheaper lever, but the key is shared — useTorrentPosterMap backfills poster
+  // lookups from grab events on it too.
   const sonarrQueries = useQueries({
     queries: showSonarr
       ? sonarrInstances.map((inst) => ({

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -194,15 +194,23 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   const allHealthy = entries.every((e) => e.awayBlocked || e.status === "ok");
   // Must run before the early return below — rules of hooks.
   //
-  // isPending, not `determining`: the latter also flips on every pull-to-refresh
-  // and on re-keyed refetches, which would pop a hidden card back into view
-  // mid-refresh and collapse it again. On a cold start every entry falls back to
-  // "offline" (see status above), so the card is visible anyway; this guard only
-  // covers the vacuously-true empty-entries case.
+  // `isEmpty: allHealthy || isPending` with no isLoading gate, which inverts the
+  // usual useHideWhenEmpty contract on purpose. That contract ("never report
+  // empty while loading") exists so an emptiness-driven widget shows its
+  // skeleton instead of flashing hidden. Here the signal is inverted: until the
+  // first probe returns, `status` falls back to "offline" for every entry, so
+  // gating on isPending would render a full card of pulsing tiles on every cold
+  // start and collapse it a second later — layout shift on every launch, for a
+  // card the user asked to see only when something breaks. Nothing is known to
+  // be wrong yet, so start hidden and appear when a probe says otherwise.
+  //
+  // isPending specifically, not `determining`: the latter also flips on
+  // pull-to-refresh and re-keyed refetches, which would hide an already-visible
+  // card mid-refresh and pop it back.
   useHideWhenEmpty(slotId, {
     enabled: settings.hideWhenAllHealthy,
-    isEmpty: allHealthy,
-    isLoading: isPending,
+    isEmpty: allHealthy || isPending,
+    isLoading: false,
   });
 
   if (entries.length === 0) return null;

--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -9,6 +9,7 @@ import { StatusDot } from "@/components/ui/status-dot";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useServiceTileLayout } from "@/hooks/use-service-tile-cell";
 import { useManualRefresh } from "@/store/manual-refresh-store";
 import { ICON, type ServiceId } from "@/lib/constants";
@@ -186,6 +187,23 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
       });
     }
   }
+
+  // Away-blocked instances are offline by configuration (remote-only with no
+  // remote URL, #168), not by failure, so they don't count as "something is
+  // wrong". auth_failed does — a rejected key is actionable, keep the card up.
+  const allHealthy = entries.every((e) => e.awayBlocked || e.status === "ok");
+  // Must run before the early return below — rules of hooks.
+  //
+  // isPending, not `determining`: the latter also flips on every pull-to-refresh
+  // and on re-keyed refetches, which would pop a hidden card back into view
+  // mid-refresh and collapse it again. On a cold start every entry falls back to
+  // "offline" (see status above), so the card is visible anyway; this guard only
+  // covers the vacuously-true empty-entries case.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenAllHealthy,
+    isEmpty: allHealthy,
+    isLoading: isPending,
+  });
 
   if (entries.length === 0) return null;
 

--- a/components/dashboard/widget-settings/recently-downloaded-settings.tsx
+++ b/components/dashboard/widget-settings/recently-downloaded-settings.tsx
@@ -23,6 +23,8 @@ export interface RecentlyDownloadedSettingsValue extends Record<string, unknown>
   radarrInstanceIds: InstanceBindingValue;
   includeSonarr: boolean;
   includeRadarr: boolean;
+  // Collapse every import of the same series into one tile (issue #307).
+  groupEpisodes: boolean;
   maxItems: number;
   hideWhenEmpty: boolean;
 }
@@ -32,6 +34,7 @@ export const RECENTLY_DOWNLOADED_DEFAULT_SETTINGS: RecentlyDownloadedSettingsVal
   radarrInstanceIds: INSTANCE_BINDING_ALL,
   includeSonarr: true,
   includeRadarr: true,
+  groupEpisodes: true,
   maxItems: 10,
   hideWhenEmpty: false,
 };
@@ -89,6 +92,20 @@ export function RecentlyDownloadedSettings({ slotId }: WidgetSettingsComponentPr
           value={settings.radarrInstanceIds}
           onChange={(radarrInstanceIds) => update({ radarrInstanceIds })}
         />
+      )}
+
+      {/* Grouping only ever affects episodes, so the toggle follows Sonarr. */}
+      {settings.includeSonarr && sonarrEnabled && (
+        <SettingsSection label="Episodes">
+          <ToggleCard>
+            <Toggle
+              label="Group by series"
+              description="Collapse episodes of the same series into one tile"
+              value={settings.groupEpisodes}
+              onValueChange={(groupEpisodes) => update({ groupEpisodes })}
+            />
+          </ToggleCard>
+        </SettingsSection>
       )}
 
       <MaxItemsSelector

--- a/components/dashboard/widget-settings/service-health-settings.tsx
+++ b/components/dashboard/widget-settings/service-health-settings.tsx
@@ -9,6 +9,7 @@ import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { lightHaptic, mediumHaptic } from "@/lib/haptics";
 import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+import { AutoHideToggle } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 import {
   InstancePickerRow,
   INSTANCE_BINDING_ALL,
@@ -37,6 +38,12 @@ export interface ServiceHealthSettingsValue extends Record<string, unknown> {
   // (away from home, or a workspace pinned to always-remote) while it has only a
   // local URL — the #168 case. Defaults on; merged for legacy slots like above.
   showAwayBadge: boolean;
+  // This widget's take on "hide when empty" (#303). The grid is never empty
+  // while services are configured, so the useful signal is "nothing is wrong":
+  // hide while every tile is online, reappear the moment one isn't. Away-blocked
+  // instances (#168) don't count as wrong — they're offline by configuration, so
+  // they'd otherwise pin the widget open for the whole time the user is away.
+  hideWhenAllHealthy: boolean;
 }
 
 export const SERVICE_HEALTH_DEFAULT_SETTINGS: ServiceHealthSettingsValue = {
@@ -44,6 +51,7 @@ export const SERVICE_HEALTH_DEFAULT_SETTINGS: ServiceHealthSettingsValue = {
   instances: {},
   showUrlBadge: true,
   showAwayBadge: true,
+  hideWhenAllHealthy: false,
 };
 
 export function ServiceHealthSettings({
@@ -226,6 +234,14 @@ export function ServiceHealthSettings({
       ) : (
         renderRow(configuredKinds[0])
       )}
+      {/* Last section, like every other widget's Visibility block — only the
+          wording differs, since this grid is never literally empty (#303). */}
+      <AutoHideToggle
+        label="Hide when all healthy"
+        description="Hide this widget from the dashboard when every service shown is online"
+        value={settings.hideWhenAllHealthy}
+        onChange={(hideWhenAllHealthy) => update({ hideWhenAllHealthy })}
+      />
     </View>
   );
 }

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -153,6 +153,19 @@ export function AutoHideToggle({
 }
 
 /**
+ * Every slot-settings key written by an `AutoHideToggle`. Edit mode marks a slot
+ * carrying one of these with the crossed-out-eye icon, so a "vanished" widget is
+ * findable. Add a new auto-hide toggle's key here or its widget will disappear
+ * with nothing in edit mode explaining why.
+ */
+const AUTO_HIDE_SETTING_KEYS = ["hideWhenEmpty", "hideWhenAllHealthy"] as const;
+
+/** Whether this slot is configured to hide itself under some condition. */
+export function slotAutoHides(settings?: Record<string, unknown>): boolean {
+  return AUTO_HIDE_SETTING_KEYS.some((key) => settings?.[key] === true);
+}
+
+/**
  * "Hide when empty" toggle (#282) — the standard wording, used by every widget
  * whose emptiness is the signal.
  */

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -120,8 +120,41 @@ export function SelectRow({
 }
 
 /**
- * "Hide when empty" toggle (#282). Rendered as the last section of a widget's
- * settings form; the widget wires the value into `useHideWhenEmpty`.
+ * Visibility section for a widget's "hide itself when there's nothing worth
+ * showing" toggle (#282). Rendered as the last section of a widget's settings
+ * form; the widget wires the value into `useHideWhenEmpty`. Most widgets use
+ * the `HideWhenEmptyToggle` wrapper below — pass your own copy only when
+ * "nothing worth showing" isn't emptiness (e.g. Service Health, whose grid is
+ * never empty but is uninteresting while every service is healthy, #303).
+ */
+export function AutoHideToggle({
+  label,
+  description,
+  value,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <SettingsSection label="Visibility">
+      <ToggleCard>
+        <Toggle
+          label={label}
+          description={description}
+          value={value}
+          onValueChange={onChange}
+        />
+      </ToggleCard>
+    </SettingsSection>
+  );
+}
+
+/**
+ * "Hide when empty" toggle (#282) — the standard wording, used by every widget
+ * whose emptiness is the signal.
  */
 export function HideWhenEmptyToggle({
   value,
@@ -131,16 +164,12 @@ export function HideWhenEmptyToggle({
   onChange: (value: boolean) => void;
 }) {
   return (
-    <SettingsSection label="Visibility">
-      <ToggleCard>
-        <Toggle
-          label="Hide when empty"
-          description="Hide this widget from the dashboard when there is nothing to show"
-          value={value}
-          onValueChange={onChange}
-        />
-      </ToggleCard>
-    </SettingsSection>
+    <AutoHideToggle
+      label="Hide when empty"
+      description="Hide this widget from the dashboard when there is nothing to show"
+      value={value}
+      onChange={onChange}
+    />
   );
 }
 

--- a/components/lidarr/music-view.tsx
+++ b/components/lidarr/music-view.tsx
@@ -13,6 +13,8 @@ import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
 import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
+import { QueueIssuesBanner } from "@/components/services/queue-issues-banner";
+import { lidarrArrQueueAdapter } from "@/lib/arr-queue-adapters/lidarr";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -278,6 +280,7 @@ export const MusicView = memo(function MusicView({
       </View>
 
       <HealthIssuesBanner serviceId="lidarr" className="mb-4" />
+      <QueueIssuesBanner adapter={lidarrArrQueueAdapter} className="mb-4" />
 
       <ScrollView
         horizontal

--- a/components/radarr/movies-view.tsx
+++ b/components/radarr/movies-view.tsx
@@ -13,6 +13,8 @@ import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper, useScreenBottomPadding } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
 import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
+import { QueueIssuesBanner } from "@/components/services/queue-issues-banner";
+import { radarrArrQueueAdapter } from "@/lib/arr-queue-adapters/radarr";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -325,6 +327,7 @@ export const MoviesView = memo(function MoviesView({
       </View>
 
       <HealthIssuesBanner serviceId="radarr" className="mb-4" />
+      <QueueIssuesBanner adapter={radarrArrQueueAdapter} className="mb-4" />
 
       <ScrollView
         horizontal

--- a/components/services/health-issues-banner.tsx
+++ b/components/services/health-issues-banner.tsx
@@ -29,53 +29,58 @@ export function HealthIssuesBanner({
 
   const issues = (data ?? []).filter((i) => i.type !== "ok");
   const severity = worstSeverity(issues);
-  if (!severity) return null;
 
   const isError = severity === "error";
   const serviceName = SERVICE_DEFAULTS[serviceId].name;
   const label =
     issues.length === 1 ? "1 health issue" : `${issues.length} health issues`;
 
+  // Only the banner is conditional; the sheet stays mounted even once the
+  // instance is healthy again. A poll that clears the last issue while the
+  // sheet is open would otherwise unmount a Modal mid-dismiss, which is the
+  // iOS/Fabric freeze from issue #83.
   return (
     <>
-      <Pressable
-        onPress={() => {
-          lightHaptic();
-          setOpen(true);
-        }}
-        className={`flex-row items-center gap-2.5 rounded-xl border px-3 py-2.5 active:opacity-70 ${
-          isError
-            ? "border-red-600/40 bg-red-600/10"
-            : "border-amber-500/40 bg-amber-500/10"
-        } ${className}`}
-      >
-        <Icon
-          icon={AlertTriangle}
-          size={16}
-          color={isError ? "#f87171" : "#fbbf24"}
-        />
-        <View className="flex-1">
-          <Text
-            className={`text-sm font-semibold ${
-              isError ? "text-red-300" : "text-amber-200"
-            }`}
-          >
-            {label}
-          </Text>
-          <Text
-            className={`text-xs ${
-              isError ? "text-red-200/80" : "text-amber-100/80"
-            }`}
-          >
-            {`Tap to view ${serviceName} System Health`}
-          </Text>
-        </View>
-        <Icon
-          icon={ChevronRight}
-          size={16}
-          color={isError ? "#fca5a5" : "#fcd34d"}
-        />
-      </Pressable>
+      {severity ? (
+        <Pressable
+          onPress={() => {
+            lightHaptic();
+            setOpen(true);
+          }}
+          className={`flex-row items-center gap-2.5 rounded-xl border px-3 py-2.5 active:opacity-70 ${
+            isError
+              ? "border-red-600/40 bg-red-600/10"
+              : "border-amber-500/40 bg-amber-500/10"
+          } ${className}`}
+        >
+          <Icon
+            icon={AlertTriangle}
+            size={16}
+            color={isError ? "#f87171" : "#fbbf24"}
+          />
+          <View className="flex-1">
+            <Text
+              className={`text-sm font-semibold ${
+                isError ? "text-red-300" : "text-amber-200"
+              }`}
+            >
+              {label}
+            </Text>
+            <Text
+              className={`text-xs ${
+                isError ? "text-red-200/80" : "text-amber-100/80"
+              }`}
+            >
+              {`Tap to view ${serviceName} System Health`}
+            </Text>
+          </View>
+          <Icon
+            icon={ChevronRight}
+            size={16}
+            color={isError ? "#fca5a5" : "#fcd34d"}
+          />
+        </Pressable>
+      ) : null}
 
       <HealthIssuesSheet
         visible={open}

--- a/components/services/health-issues-sheet.tsx
+++ b/components/services/health-issues-sheet.tsx
@@ -1,6 +1,7 @@
 import { Modal, View, Text, Pressable, ScrollView, Linking } from "react-native";
-import { AlertTriangle, Info, ExternalLink } from "lucide-react-native";
+import { AlertTriangle, Info, ExternalLink, CheckCircle2 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { EmptyState } from "@/components/ui/empty-state";
 import { SheetHeader } from "@/components/ui/sheet-header";
 import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
 import { lightHaptic } from "@/lib/haptics";
@@ -51,6 +52,17 @@ export function HealthIssuesSheet({
           contentContainerStyle={scrollPadding}
           showsVerticalScrollIndicator={false}
         >
+          {/* The callers keep this sheet mounted while it dismisses, so a poll
+              that resolves the last issue can empty it out from under an open
+              sheet. Say so rather than showing a blank pane. */}
+          {instances?.every((inst) => inst.issues.length === 0) ? (
+            <EmptyState
+              icon={<Icon icon={CheckCircle2} size={28} color="#22c55e" />}
+              title="All clear"
+              message={`${serviceName} has no health issues right now`}
+            />
+          ) : null}
+
           {instances?.map((inst) => (
             <View key={inst.instanceId} className="gap-2">
               {showInstanceNames ? (

--- a/components/services/queue-issues-banner.tsx
+++ b/components/services/queue-issues-banner.tsx
@@ -1,0 +1,208 @@
+import { View, Text, Pressable } from "react-native";
+import { AlertTriangle, ChevronRight, Ban, Search, Trash2 } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
+import { ConfirmModal } from "@/components/common/confirm-modal";
+import { QueueIssuesSheet } from "@/components/services/queue-issues-sheet";
+import { useModalFlow } from "@/hooks/use-modal-flow";
+import {
+  useArrQueueIssues,
+  useRemoveFromArrQueue,
+  type ArrQueueRemoveMode,
+} from "@/hooks/use-arr-queue-issues";
+import { lightHaptic, mediumHaptic } from "@/lib/haptics";
+import type { ArrQueueAdapter, ArrQueueItem } from "@/lib/arr-queue-adapter";
+
+interface QueueIssuesBannerProps {
+  adapter: ArrQueueAdapter;
+  // Follows the screen's active instance when omitted.
+  instanceId?: string;
+  className?: string;
+}
+
+interface PendingRemoval {
+  item: ArrQueueItem;
+  mode: ArrQueueRemoveMode;
+}
+
+// Copy per removal mode. "Blocklist" here means *arr marks the grab as failed so
+// the release is never picked up again; the search variant additionally kicks
+// off a hunt for a replacement (issue #285).
+const REMOVAL_COPY: Record<
+  ArrQueueRemoveMode,
+  { title: string; confirmLabel: string; describe: (service: string) => string }
+> = {
+  remove: {
+    title: "Remove from queue?",
+    confirmLabel: "Remove",
+    describe: (service) =>
+      `${service} drops this grab and deletes it from the download client. The release stays eligible, so it can be grabbed again.`,
+  },
+  blocklistAndSearch: {
+    title: "Blocklist and search?",
+    confirmLabel: "Blocklist & Search",
+    describe: (service) =>
+      `${service} removes this grab, blocks the release so it is never grabbed again, and starts searching for a replacement.`,
+  },
+  blocklist: {
+    title: "Blocklist release?",
+    confirmLabel: "Blocklist",
+    describe: (service) =>
+      `${service} removes this grab and blocks the release so it is never grabbed again. No replacement search runs.`,
+  },
+};
+
+/**
+ * Top-of-screen banner for an *arr view: when the active instance has grabs
+ * stuck with a warning or error (a blocked import, a failed download), it shows
+ * a tappable summary that opens the issue list, where each item can be removed
+ * or blocklisted (#285). Renders null when the queue is healthy.
+ *
+ * Owns the whole modal chain — sheet → actions → confirm — through a single
+ * useModalFlow, per the sequencing rules in CLAUDE.md.
+ */
+export function QueueIssuesBanner({
+  adapter,
+  instanceId,
+  className = "",
+}: QueueIssuesBannerProps) {
+  const { issues, severity } = useArrQueueIssues(adapter, instanceId);
+  const removeMutation = useRemoveFromArrQueue(adapter, instanceId);
+
+  const flow = useModalFlow<{
+    issues: void;
+    itemActions: ArrQueueItem;
+    confirmRemove: PendingRemoval;
+  }>();
+
+  const sheetItem = flow.payload("itemActions");
+  const pending = flow.payload("confirmRemove");
+
+  const actions: ActionSheetAction[] = sheetItem
+    ? [
+        {
+          label: "Remove from queue",
+          icon: <Icon icon={Trash2} size={18} color="#a1a1aa" />,
+          onPress: () =>
+            flow.open("confirmRemove", { item: sheetItem, mode: "remove" }),
+        },
+        {
+          label: "Blocklist & Search",
+          icon: <Icon icon={Search} size={18} color="#ef4444" />,
+          variant: "danger",
+          onPress: () =>
+            flow.open("confirmRemove", {
+              item: sheetItem,
+              mode: "blocklistAndSearch",
+            }),
+        },
+        {
+          label: "Blocklist only",
+          icon: <Icon icon={Ban} size={18} color="#ef4444" />,
+          variant: "danger",
+          onPress: () =>
+            flow.open("confirmRemove", { item: sheetItem, mode: "blocklist" }),
+        },
+      ]
+    : [];
+
+  const confirmRemove = () => {
+    if (!pending) return;
+    flow.close();
+    removeMutation.mutate(
+      { queueId: pending.item.id, mode: pending.mode },
+      {
+        // Back to the list so several stuck grabs can be cleared in a row. The
+        // just-handled item is filtered out; when it was the last one the list
+        // is empty and there is nothing to return to.
+        onSuccess: () => {
+          if (issues.some((i) => i.id !== pending.item.id)) flow.open("issues");
+        },
+      },
+    );
+  };
+
+  const isError = severity === "error";
+  const label =
+    issues.length === 1 ? "1 import issue" : `${issues.length} import issues`;
+
+  // Only the banner itself is conditional. The modals stay mounted even once
+  // the queue is clean — clearing the last issue resolves the query mid-dismiss,
+  // and unmounting a modal that is still animating out is the iOS freeze from
+  // issue #83.
+  return (
+    <>
+      {severity ? (
+        <Pressable
+          onPress={() => {
+            lightHaptic();
+            flow.open("issues");
+          }}
+          className={`flex-row items-center gap-2.5 rounded-xl border px-3 py-2.5 active:opacity-70 ${
+            isError
+              ? "border-red-600/40 bg-red-600/10"
+              : "border-amber-500/40 bg-amber-500/10"
+          } ${className}`}
+        >
+          <Icon
+            icon={AlertTriangle}
+            size={16}
+            color={isError ? "#f87171" : "#fbbf24"}
+          />
+          <View className="flex-1">
+            <Text
+              className={`text-sm font-semibold ${
+                isError ? "text-red-300" : "text-amber-200"
+              }`}
+            >
+              {label}
+            </Text>
+            <Text
+              className={`text-xs ${
+                isError ? "text-red-200/80" : "text-amber-100/80"
+              }`}
+            >
+              {`Tap to review stuck ${adapter.displayName} downloads`}
+            </Text>
+          </View>
+          <Icon
+            icon={ChevronRight}
+            size={16}
+            color={isError ? "#fca5a5" : "#fcd34d"}
+          />
+        </Pressable>
+      ) : null}
+
+      <QueueIssuesSheet
+        {...flow.bind("issues")}
+        serviceName={adapter.displayName}
+        issues={issues}
+        onSelect={(item) => {
+          mediumHaptic();
+          flow.open("itemActions", item);
+        }}
+      />
+
+      <ActionSheet
+        {...flow.bind("itemActions")}
+        title={sheetItem?.title}
+        subtitle={sheetItem?.statusLabel}
+        actions={actions}
+      />
+
+      <ConfirmModal
+        {...flow.bind("confirmRemove")}
+        title={pending ? REMOVAL_COPY[pending.mode].title : ""}
+        message={
+          pending
+            ? `${REMOVAL_COPY[pending.mode].describe(adapter.displayName)}\n\n${pending.item.releaseTitle}`
+            : ""
+        }
+        icon={pending?.mode === "remove" ? Trash2 : Ban}
+        tone="danger"
+        confirmLabel={pending ? REMOVAL_COPY[pending.mode].confirmLabel : undefined}
+        onConfirm={confirmRemove}
+      />
+    </>
+  );
+}

--- a/components/services/queue-issues-banner.tsx
+++ b/components/services/queue-issues-banner.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { AlertTriangle, ChevronRight, Ban, Search, Trash2 } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
@@ -10,6 +11,7 @@ import {
   useRemoveFromArrQueue,
   type ArrQueueRemoveMode,
 } from "@/hooks/use-arr-queue-issues";
+import { worstQueueSeverity } from "@/lib/arr-queue-issues";
 import { lightHaptic, mediumHaptic } from "@/lib/haptics";
 import type { ArrQueueAdapter, ArrQueueItem } from "@/lib/arr-queue-adapter";
 
@@ -54,9 +56,11 @@ const REMOVAL_COPY: Record<
 
 /**
  * Top-of-screen banner for an *arr view: when the active instance has grabs
- * stuck with a warning or error (a blocked import, a failed download), it shows
- * a tappable summary that opens the issue list, where each item can be removed
- * or blocklisted (#285). Renders null when the queue is healthy.
+ * stuck with a warning or error (a blocked import, a stalled or failed
+ * download), it shows a tappable summary that opens the issue list, where each
+ * item can be removed or blocklisted (#285). Renders null when the queue is
+ * healthy. See lib/arr-queue-issues.ts for why the copy says "queue issues"
+ * rather than "import issues" — the detection is deliberately broader.
  *
  * Owns the whole modal chain — sheet → actions → confirm — through a single
  * useModalFlow, per the sequencing rules in CLAUDE.md.
@@ -66,8 +70,29 @@ export function QueueIssuesBanner({
   instanceId,
   className = "",
 }: QueueIssuesBannerProps) {
-  const { issues, severity } = useArrQueueIssues(adapter, instanceId);
+  const { issues: fetched } = useArrQueueIssues(adapter, instanceId);
   const removeMutation = useRemoveFromArrQueue(adapter, instanceId);
+
+  // Queue ids already removed on the service but still in the cached response
+  // until the invalidated refetch lands. Without this the list reopens with the
+  // row the user just handled still on it, and tapping it again fires a DELETE
+  // for an id the service no longer has (404 → error toast).
+  const [removedIds, setRemovedIds] = useState<number[]>([]);
+
+  // Forget an id once the refetch confirms it's gone, so the set can't grow
+  // unbounded across a long session.
+  useEffect(() => {
+    setRemovedIds((prev) => {
+      const next = prev.filter((id) => fetched.some((i) => i.id === id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [fetched]);
+
+  const issues = useMemo(
+    () => fetched.filter((i) => !removedIds.includes(i.id)),
+    [fetched, removedIds],
+  );
+  const severity = worstQueueSeverity(issues);
 
   const flow = useModalFlow<{
     issues: void;
@@ -108,15 +133,17 @@ export function QueueIssuesBanner({
 
   const confirmRemove = () => {
     if (!pending) return;
+    const { id } = pending.item;
     flow.close();
     removeMutation.mutate(
-      { queueId: pending.item.id, mode: pending.mode },
+      { queueId: id, mode: pending.mode },
       {
         // Back to the list so several stuck grabs can be cleared in a row. The
-        // just-handled item is filtered out; when it was the last one the list
-        // is empty and there is nothing to return to.
+        // just-handled item is hidden immediately; when it was the last one the
+        // list is empty and there is nothing to return to.
         onSuccess: () => {
-          if (issues.some((i) => i.id !== pending.item.id)) flow.open("issues");
+          setRemovedIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+          if (issues.some((i) => i.id !== id)) flow.open("issues");
         },
       },
     );
@@ -124,7 +151,7 @@ export function QueueIssuesBanner({
 
   const isError = severity === "error";
   const label =
-    issues.length === 1 ? "1 import issue" : `${issues.length} import issues`;
+    issues.length === 1 ? "1 queue issue" : `${issues.length} queue issues`;
 
   // Only the banner itself is conditional. The modals stay mounted even once
   // the queue is clean — clearing the last issue resolves the query mid-dismiss,

--- a/components/services/queue-issues-sheet.tsx
+++ b/components/services/queue-issues-sheet.tsx
@@ -21,7 +21,8 @@ interface QueueIssuesSheetProps {
   onClosed?: () => void;
 }
 
-// The blocked/failed grabs for one *arr instance, one tappable row each.
+// The stuck grabs for one *arr instance — blocked imports, stalled or failed
+// downloads — one tappable row each.
 // Unlike HealthIssuesSheet this one IS a modal-flow step: picking a row opens
 // the removal ActionSheet, so it wires `onClosed` and must only ever be
 // opened/closed through the flow.
@@ -45,7 +46,7 @@ export function QueueIssuesSheet({
       onDismiss={handleDismiss}
     >
       <View className="flex-1 bg-background">
-        <SheetHeader title={`${serviceName} Import Issues`} onClose={onClose} />
+        <SheetHeader title={`${serviceName} Queue Issues`} onClose={onClose} />
 
         <ScrollView
           contentContainerClassName="px-4 py-4 gap-2"
@@ -56,7 +57,7 @@ export function QueueIssuesSheet({
             <EmptyState
               icon={<Icon icon={CheckCircle2} size={28} color="#22c55e" />}
               title="Nothing stuck"
-              message={`${serviceName} has no blocked or failed grabs right now`}
+              message={`${serviceName} has no stuck grabs right now`}
             />
           ) : null}
 

--- a/components/services/queue-issues-sheet.tsx
+++ b/components/services/queue-issues-sheet.tsx
@@ -1,0 +1,118 @@
+import { Modal, View, Text, Pressable, ScrollView } from "react-native";
+import { AlertTriangle, ChevronRight, CheckCircle2 } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
+import { useModalClosed } from "@/hooks/use-modal-closed";
+import type { ArrQueueItem } from "@/lib/arr-queue-adapter";
+
+interface QueueIssuesSheetProps {
+  visible: boolean;
+  // Display name of the owning service kind (e.g. "Sonarr").
+  serviceName: string;
+  issues: ArrQueueItem[];
+  onSelect: (item: ArrQueueItem) => void;
+  onClose: () => void;
+  /**
+   * Fired once the native `<Modal>` is fully gone. Required here because this
+   * sheet chains into an ActionSheet — see hooks/use-modal-flow.ts.
+   */
+  onClosed?: () => void;
+}
+
+// The blocked/failed grabs for one *arr instance, one tappable row each.
+// Unlike HealthIssuesSheet this one IS a modal-flow step: picking a row opens
+// the removal ActionSheet, so it wires `onClosed` and must only ever be
+// opened/closed through the flow.
+export function QueueIssuesSheet({
+  visible,
+  serviceName,
+  issues,
+  onSelect,
+  onClose,
+  onClosed,
+}: QueueIssuesSheetProps) {
+  const handleDismiss = useModalClosed(visible, onClosed);
+  const scrollPadding = useSheetBottomPadding(16);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+      onDismiss={handleDismiss}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title={`${serviceName} Import Issues`} onClose={onClose} />
+
+        <ScrollView
+          contentContainerClassName="px-4 py-4 gap-2"
+          contentContainerStyle={scrollPadding}
+          showsVerticalScrollIndicator={false}
+        >
+          {issues.length === 0 ? (
+            <EmptyState
+              icon={<Icon icon={CheckCircle2} size={28} color="#22c55e" />}
+              title="Nothing stuck"
+              message={`${serviceName} has no blocked or failed grabs right now`}
+            />
+          ) : null}
+
+          {issues.map((item) => {
+            const isError = item.severity === "error";
+            return (
+              <Pressable
+                key={item.id}
+                onPress={() => onSelect(item)}
+                className="flex-row gap-3 bg-surface border border-border rounded-2xl p-3 active:opacity-70"
+              >
+                <View className="pt-0.5">
+                  <Icon
+                    icon={AlertTriangle}
+                    size={18}
+                    color={isError ? "#f87171" : "#fbbf24"}
+                  />
+                </View>
+
+                <View className="flex-1 gap-1">
+                  <Text className="text-zinc-200 text-sm font-semibold" numberOfLines={2}>
+                    {item.title}
+                  </Text>
+                  {item.subtitle ? (
+                    <Text className="text-zinc-500 text-xs">{item.subtitle}</Text>
+                  ) : null}
+
+                  <Text
+                    className={`text-xs font-semibold ${
+                      isError ? "text-red-300" : "text-amber-200"
+                    }`}
+                  >
+                    {item.statusLabel}
+                  </Text>
+
+                  {item.messages.map((message, idx) => (
+                    <Text key={idx} className="text-zinc-400 text-sm">
+                      {message}
+                    </Text>
+                  ))}
+
+                  {/* The release name is what the removal actions act on, so it
+                      stays visible even though the media title leads the row. */}
+                  <Text className="text-zinc-600 text-xs mt-1" numberOfLines={2}>
+                    {item.releaseTitle}
+                  </Text>
+                </View>
+
+                <View className="justify-center">
+                  <Icon icon={ChevronRight} size={16} color="#71717a" />
+                </View>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/components/common/screen-wrapper";
 import { ServiceHeader } from "@/components/common/service-header";
 import { HealthIssuesBanner } from "@/components/services/health-issues-banner";
+import { QueueIssuesBanner } from "@/components/services/queue-issues-banner";
+import { sonarrArrQueueAdapter } from "@/lib/arr-queue-adapters/sonarr";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterChip } from "@/components/ui/filter-chip";
@@ -348,6 +350,7 @@ export const TvView = memo(function TvView({
       </View>
 
       <HealthIssuesBanner serviceId="sonarr" className="mb-4" />
+      <QueueIssuesBanner adapter={sonarrArrQueueAdapter} className="mb-4" />
 
       <ScrollView
         horizontal

--- a/components/ui/action-sheet.tsx
+++ b/components/ui/action-sheet.tsx
@@ -38,6 +38,8 @@ export type ActionSheetVariant = "default" | "danger";
 
 export interface ActionSheetAction {
   label: string;
+  /** Secondary line under the label, for rows that need metadata. */
+  subtitle?: string;
   icon?: React.ReactNode;
   variant?: ActionSheetVariant;
   disabled?: boolean;
@@ -260,16 +262,23 @@ function ActionRow({ action, onPress }: ActionRowProps) {
             {action.icon}
           </View>
         )}
-        <Text
-          className={`flex-1 text-base ${
-            isDanger
-              ? "text-danger font-semibold"
-              : "text-zinc-100 font-medium"
-          }`}
-          numberOfLines={1}
-        >
-          {action.label}
-        </Text>
+        <View className="flex-1">
+          <Text
+            className={`text-base ${
+              isDanger
+                ? "text-danger font-semibold"
+                : "text-zinc-100 font-medium"
+            }`}
+            numberOfLines={1}
+          >
+            {action.label}
+          </Text>
+          {action.subtitle && (
+            <Text className="text-zinc-500 text-xs mt-0.5" numberOfLines={1}>
+              {action.subtitle}
+            </Text>
+          )}
+        </View>
       </Pressable>
     </Animated.View>
   );

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -626,8 +626,11 @@
         <p>
           Most settings sheets include a <strong>Visibility, "Hide when empty"</strong> toggle. Cards
           hidden that way still appear in edit mode, marked with a crossed-out-eye icon, so a
-          "vanished" widget is easy to find. Widgets for services that support several instances also
-          expose an instance chip row with an <strong>All instances</strong> chip.
+          "vanished" widget is easy to find. Service Health has the same toggle worded
+          <strong>"Hide when all healthy"</strong>, since its grid is never empty: it hides while every
+          service it shows is online and comes back the moment one goes down. Widgets for services
+          that support several instances also expose an instance chip row with an
+          <strong>All instances</strong> chip.
         </p>
 
         <h3>Attached instances and auto-attach</h3>
@@ -1009,8 +1012,8 @@
         <h3>A widget disappeared from the dashboard.</h3>
         <p>
           Either its service was disabled or un-attached (it is hidden, not deleted, and returns when
-          you restore it), or it has "Hide when empty" on. Enter widget edit mode to see hidden cards,
-          marked with a crossed-out-eye icon.
+          you restore it), or it has "Hide when empty" on, or, for Service Health, "Hide when all
+          healthy". Enter widget edit mode to see hidden cards, marked with a crossed-out-eye icon.
         </p>
 
         <h3>qBittorrent says wrong username or password.</h3>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -619,6 +619,13 @@
           Jackett Indexers, Bazarr Wanted, Wake-on-LAN, Disk Space, Health Alerts, unRAID Array.
         </p>
         <p>
+          <strong>Recently Downloaded</strong> collapses episodes of the same series into one tile,
+          badged with how many arrived, so a batch of episodes cannot push everything else out of the
+          row. Tapping that tile lists the individual episodes with their quality, size and import
+          date, and any of them opens the series. Turn it off with
+          <strong>Episodes, "Group by series"</strong> in the widget settings.
+        </p>
+        <p>
           The same widget can be placed more than once on one dashboard, each copy with its own
           settings, which is how you show two download clients or two Radarrs side by side. Three
           widgets have no options and therefore no gear: Wake-on-LAN, Health Alerts and unRAID Array.

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -723,14 +723,15 @@
           <li><strong>Services</strong>: a two-column grid of your enabled, attached services with a status dot each. Long-press a tile to drag-reorder, and the order saves per dashboard. When a tile is not green the reason is printed under its name rather than leaving a silent red dot.</li>
         </ul>
 
-        <h3>Import issues (Radarr, Sonarr, Lidarr)</h3>
+        <h3>Queue issues (Radarr, Sonarr, Lidarr)</h3>
         <p>
-          Sometimes a grab finishes downloading but the *arr refuses to import it: non-media files
-          in the release, a sample-only folder, episodes missing from the pack, no matching movie or
-          series. When that happens the Movies, TV and Music screens show an
-          <strong>import issues</strong> banner above the chip row. Amber means a warning, red means
-          the download failed outright. It only appears when something is actually stuck, and it
-          follows the instance you currently have selected.
+          Sometimes a grab gets stuck. Most often it finished downloading but the *arr refuses to
+          import it: non-media files in the release, a sample-only folder, episodes missing from the
+          pack, no matching movie or series. It can also be the download itself going wrong, such as
+          a torrent stalled with no connections. When that happens the Movies, TV and Music screens
+          show a <strong>queue issues</strong> banner above the chip row. Amber means a warning, red
+          means the download failed outright. It only appears when something is actually stuck, and
+          it follows the instance you currently have selected.
         </p>
         <p>
           Tapping it lists every stuck grab with the reason the service gave and the release name.

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -723,6 +723,29 @@
           <li><strong>Services</strong>: a two-column grid of your enabled, attached services with a status dot each. Long-press a tile to drag-reorder, and the order saves per dashboard. When a tile is not green the reason is printed under its name rather than leaving a silent red dot.</li>
         </ul>
 
+        <h3>Import issues (Radarr, Sonarr, Lidarr)</h3>
+        <p>
+          Sometimes a grab finishes downloading but the *arr refuses to import it: non-media files
+          in the release, a sample-only folder, episodes missing from the pack, no matching movie or
+          series. When that happens the Movies, TV and Music screens show an
+          <strong>import issues</strong> banner above the chip row. Amber means a warning, red means
+          the download failed outright. It only appears when something is actually stuck, and it
+          follows the instance you currently have selected.
+        </p>
+        <p>
+          Tapping it lists every stuck grab with the reason the service gave and the release name.
+          Tap one for three actions:
+        </p>
+        <ul>
+          <li><strong>Remove from queue</strong>: drops the grab and deletes it from the download client. The release stays eligible, so the same copy can be grabbed again.</li>
+          <li><strong>Blocklist &amp; Search</strong>: also blocks the release so it is never grabbed again, then starts a search for a replacement. This is the one you want for a bad copy.</li>
+          <li><strong>Blocklist only</strong>: blocks the release with no replacement search.</li>
+        </ul>
+        <p>
+          All three ask for confirmation first, and blocklisted releases show up under
+          <em>System &rarr; Blocklist</em> in Radarr, Sonarr or Lidarr itself.
+        </p>
+
         <h3>Global search</h3>
         <p>
           The magnifier in the Dashboard header opens <strong>Search</strong>. It needs two characters

--- a/hooks/use-arr-queue-issues.ts
+++ b/hooks/use-arr-queue-issues.ts
@@ -3,17 +3,21 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 import { toast, toastError } from "@/components/ui/toast";
 import { POLLING_INTERVALS } from "@/lib/constants";
-import { worstQueueSeverity, type ArrQueueSeverity } from "@/lib/arr-queue-issues";
 import type { ArrQueueAdapter, ArrQueueItem } from "@/lib/arr-queue-adapter";
 
 /**
  * The active instance's stuck queue items (#285) — grabs Radarr/Sonarr/Lidarr
- * flagged with a warning or error, typically a blocked import.
+ * flagged with a warning or error. A blocked import is the common case but not
+ * the only one; see lib/arr-queue-issues.ts.
  *
  * The query deliberately reuses the adapter's own key + fetcher, so it shares
  * the single cache entry `useRadarrQueue` / `ArrQueueCard` already own: mounting
  * the banner costs no extra requests. Normalization stays outside the queryFn
  * for the same reason (see lib/arr-queue-adapter.ts).
+ *
+ * Returns the raw list only — callers that hide rows (e.g. a removal awaiting
+ * its refetch) derive the summary severity from what they actually render, via
+ * `worstQueueSeverity`, so the badge can't disagree with the list.
  */
 export function useArrQueueIssues(adapter: ArrQueueAdapter, instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget(
@@ -33,9 +37,7 @@ export function useArrQueueIssues(adapter: ArrQueueAdapter, instanceId?: string)
     return adapter.toItems(data, id).filter((item) => item.severity !== null);
   }, [adapter, data, id]);
 
-  const severity: ArrQueueSeverity | null = worstQueueSeverity(issues);
-
-  return { issues, severity, instanceId: id };
+  return { issues, instanceId: id };
 }
 
 /** How a stuck grab is disposed of. See ArrQueueRemoveOptions for the flags. */

--- a/hooks/use-arr-queue-issues.ts
+++ b/hooks/use-arr-queue-issues.ts
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { toast, toastError } from "@/components/ui/toast";
+import { POLLING_INTERVALS } from "@/lib/constants";
+import { worstQueueSeverity, type ArrQueueSeverity } from "@/lib/arr-queue-issues";
+import type { ArrQueueAdapter, ArrQueueItem } from "@/lib/arr-queue-adapter";
+
+/**
+ * The active instance's stuck queue items (#285) — grabs Radarr/Sonarr/Lidarr
+ * flagged with a warning or error, typically a blocked import.
+ *
+ * The query deliberately reuses the adapter's own key + fetcher, so it shares
+ * the single cache entry `useRadarrQueue` / `ArrQueueCard` already own: mounting
+ * the banner costs no extra requests. Normalization stays outside the queryFn
+ * for the same reason (see lib/arr-queue-adapter.ts).
+ */
+export function useArrQueueIssues(adapter: ArrQueueAdapter, instanceId?: string) {
+  const { instanceId: id, enabled } = useInstanceTarget(
+    adapter.serviceId,
+    instanceId,
+  );
+
+  const { data } = useQuery({
+    queryKey: adapter.queueQueryKey(id!),
+    queryFn: () => adapter.fetchQueue(id!),
+    refetchInterval: POLLING_INTERVALS.queue,
+    enabled: enabled && !!id,
+  });
+
+  const issues = useMemo<ArrQueueItem[]>(() => {
+    if (!data || !id) return [];
+    return adapter.toItems(data, id).filter((item) => item.severity !== null);
+  }, [adapter, data, id]);
+
+  const severity: ArrQueueSeverity | null = worstQueueSeverity(issues);
+
+  return { issues, severity, instanceId: id };
+}
+
+/** How a stuck grab is disposed of. See ArrQueueRemoveOptions for the flags. */
+export type ArrQueueRemoveMode = "remove" | "blocklistAndSearch" | "blocklist";
+
+const REMOVE_OPTIONS: Record<
+  ArrQueueRemoveMode,
+  { blocklist: boolean; skipRedownload: boolean }
+> = {
+  remove: { blocklist: false, skipRedownload: false },
+  blocklistAndSearch: { blocklist: true, skipRedownload: false },
+  blocklist: { blocklist: true, skipRedownload: true },
+};
+
+const REMOVE_TOAST: Record<ArrQueueRemoveMode, string> = {
+  remove: "Removed from queue",
+  blocklistAndSearch: "Blocklisted, searching for a replacement",
+  blocklist: "Release blocklisted",
+};
+
+export function useRemoveFromArrQueue(
+  adapter: ArrQueueAdapter,
+  instanceId?: string,
+) {
+  const { instanceId: id } = useInstanceTarget(adapter.serviceId, instanceId);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      queueId,
+      mode,
+    }: {
+      queueId: number;
+      mode: ArrQueueRemoveMode;
+    }) => adapter.removeFromQueue(id!, queueId, REMOVE_OPTIONS[mode]),
+    onSuccess: (_data, { mode }) => {
+      toast(REMOVE_TOAST[mode]);
+      if (!id) return;
+      queryClient.invalidateQueries({ queryKey: adapter.queueQueryKey(id) });
+      // Prefix match — also refreshes the full ["<service>", id, "wanted", "all"]
+      // list, since a blocklisted grab puts its media back in wanted/missing.
+      queryClient.invalidateQueries({ queryKey: adapter.wantedQueryKey(id) });
+    },
+    onError: (err) => toastError("Failed to update queue", err),
+  });
+}

--- a/hooks/use-hide-when-empty.ts
+++ b/hooks/use-hide-when-empty.ts
@@ -8,6 +8,13 @@ import { useWidgetVisibilityStore } from "@/store/widget-visibility-store";
  * up. Never pass `isEmpty: true` while data is still loading — hand the
  * widget's `isInitialLoading` in via `isLoading` so the initial fetch renders
  * its skeleton instead of flashing hidden.
+ *
+ * The one deliberate exception is a widget whose signal is inverted — it hides
+ * when nothing is *wrong* rather than when nothing is *there* (Service Health's
+ * "hide when all healthy", #303). There the loading state means "nothing known
+ * to be wrong yet", so it reports empty during the first probe and passes
+ * `isLoading: false`; gating it the normal way would flash the card open on
+ * every cold start. See components/dashboard/service-health-card.tsx.
  */
 export function useHideWhenEmpty(
   slotId: string,

--- a/hooks/use-lidarr.ts
+++ b/hooks/use-lidarr.ts
@@ -81,7 +81,7 @@ export function useLidarrQueue(instanceId?: string) {
   return useQuery({
     queryKey: ["lidarr", id, "queue"],
     // Args must stay identical to lidarrArrQueueAdapter.fetchQueue — the
-    // dashboard widget and the import-issues banner share this cache entry.
+    // dashboard widget and the queue-issues banner share this cache entry.
     queryFn: () => getQueue(1, 100, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,

--- a/hooks/use-lidarr.ts
+++ b/hooks/use-lidarr.ts
@@ -80,7 +80,9 @@ export function useLidarrQueue(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("lidarr", instanceId);
   return useQuery({
     queryKey: ["lidarr", id, "queue"],
-    queryFn: () => getQueue(1, 20, id ?? undefined),
+    // Args must stay identical to lidarrArrQueueAdapter.fetchQueue — the
+    // dashboard widget and the import-issues banner share this cache entry.
+    queryFn: () => getQueue(1, 100, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
   });

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -84,7 +84,7 @@ export function useRadarrQueue(instanceId?: string) {
   return useQuery({
     queryKey: ["radarr", id, "queue"],
     // Args must stay identical to radarrArrQueueAdapter.fetchQueue — the
-    // dashboard widget and the import-issues banner share this cache entry.
+    // dashboard widget and the queue-issues banner share this cache entry.
     queryFn: () => getQueue(1, 100, true, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -83,7 +83,9 @@ export function useRadarrQueue(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
     queryKey: ["radarr", id, "queue"],
-    queryFn: () => getQueue(1, 20, true, id ?? undefined),
+    // Args must stay identical to radarrArrQueueAdapter.fetchQueue — the
+    // dashboard widget and the import-issues banner share this cache entry.
+    queryFn: () => getQueue(1, 100, true, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
   });

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -91,7 +91,7 @@ export function useSonarrQueue(instanceId?: string) {
   return useQuery({
     queryKey: ["sonarr", id, "queue"],
     // Args must stay identical to sonarrArrQueueAdapter.fetchQueue — the
-    // dashboard widget and the import-issues banner share this cache entry.
+    // dashboard widget and the queue-issues banner share this cache entry.
     queryFn: () => getQueue(1, 100, true, true, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -90,7 +90,9 @@ export function useSonarrQueue(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
     queryKey: ["sonarr", id, "queue"],
-    queryFn: () => getQueue(1, 20, true, true, id ?? undefined),
+    // Args must stay identical to sonarrArrQueueAdapter.fetchQueue — the
+    // dashboard widget and the import-issues banner share this cache entry.
+    queryFn: () => getQueue(1, 100, true, true, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.queue,
     enabled: enabled && !!id,
   });

--- a/lib/arr-queue-adapter.ts
+++ b/lib/arr-queue-adapter.ts
@@ -20,11 +20,11 @@ export interface ArrQueueItem {
   // underlying media record id is unavailable (then the tile doesn't navigate).
   detailPath: string | null;
 
-  // --- Import/download trouble (#285) ---
+  // --- Stuck-grab trouble (#285) ---
   // The raw release name. `title` above prefers the media title, which for a
   // blocked grab hides which release is actually stuck.
   releaseTitle: string;
-  // null when the grab is healthy — the import-issues banner filters on this.
+  // null when the grab is healthy — the queue-issues banner filters on this.
   severity: ArrQueueSeverity | null;
   // Short state label, e.g. "Import blocked" / "Downloading".
   statusLabel: string;

--- a/lib/arr-queue-adapter.ts
+++ b/lib/arr-queue-adapter.ts
@@ -1,5 +1,7 @@
 import type { LucideIcon } from "lucide-react-native";
 import type { ServiceId } from "@/lib/constants";
+import type { ArrQueueSeverity } from "@/lib/arr-queue-issues";
+import type { ArrQueueRemoveOptions } from "@/lib/types";
 
 // A single queue row, normalized so the shared ArrQueueCard renders with no
 // service-specific knowledge. Radarr/Sonarr/Lidarr adapters map their raw
@@ -17,6 +19,17 @@ export interface ArrQueueItem {
   // Detail-screen deep link already carrying `?instanceId=`, or null when the
   // underlying media record id is unavailable (then the tile doesn't navigate).
   detailPath: string | null;
+
+  // --- Import/download trouble (#285) ---
+  // The raw release name. `title` above prefers the media title, which for a
+  // blocked grab hides which release is actually stuck.
+  releaseTitle: string;
+  // null when the grab is healthy — the import-issues banner filters on this.
+  severity: ArrQueueSeverity | null;
+  // Short state label, e.g. "Import blocked" / "Downloading".
+  statusLabel: string;
+  // Every reason *arr gave, deduped. Empty when it gave none.
+  messages: string[];
 }
 
 // Shared adapter: every *arr service that exposes a download queue implements
@@ -55,4 +68,12 @@ export interface ArrQueueAdapter {
   // Fetch the raw wanted/missing response; the header badge reads its total.
   fetchWanted: (instanceId: string) => Promise<unknown>;
   wantedCount: (data: unknown) => number;
+
+  // DELETE /queue/{id} — drop a stuck grab, optionally blocklisting the release
+  // so it is never picked up again (#285).
+  removeFromQueue: (
+    instanceId: string,
+    queueId: number,
+    opts: ArrQueueRemoveOptions,
+  ) => Promise<void>;
 }

--- a/lib/arr-queue-adapters/lidarr.ts
+++ b/lib/arr-queue-adapters/lidarr.ts
@@ -1,7 +1,17 @@
 import { Disc3 } from "lucide-react-native";
-import { getQueue, getWantedMissing, getLidarrAlbumCover } from "@/services/lidarr-api";
+import {
+  getQueue,
+  getWantedMissing,
+  getLidarrAlbumCover,
+  removeFromQueue,
+} from "@/services/lidarr-api";
 import type { LidarrQueue, LidarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
+import {
+  queueIssueMessages,
+  queueIssueSeverity,
+  queueStatusLabel,
+} from "@/lib/arr-queue-issues";
 
 export const lidarrArrQueueAdapter: ArrQueueAdapter = {
   serviceId: "lidarr",
@@ -15,7 +25,7 @@ export const lidarrArrQueueAdapter: ArrQueueAdapter = {
   wantedQueryKey: (instanceId) => ["lidarr", instanceId, "wanted"] as const,
 
   // Same key + args as useLidarrQueue, so the widget shares its cache entry.
-  fetchQueue: (instanceId) => getQueue(1, 20, instanceId),
+  fetchQueue: (instanceId) => getQueue(1, 100, instanceId),
 
   toItems: (data, instanceId) =>
     ((data as LidarrQueue).records ?? []).map((item) => ({
@@ -33,8 +43,15 @@ export const lidarrArrQueueAdapter: ArrQueueAdapter = {
       detailPath: item.albumId
         ? `/album/${item.albumId}?instanceId=${instanceId}`
         : null,
+      releaseTitle: item.title,
+      severity: queueIssueSeverity(item),
+      statusLabel: queueStatusLabel(item),
+      messages: queueIssueMessages(item),
     })),
 
   fetchWanted: (instanceId) => getWantedMissing(1, 1, instanceId),
   wantedCount: (data) => (data as LidarrWantedMissing).totalRecords ?? 0,
+
+  removeFromQueue: (instanceId, queueId, opts) =>
+    removeFromQueue(queueId, opts, instanceId),
 };

--- a/lib/arr-queue-adapters/radarr.ts
+++ b/lib/arr-queue-adapters/radarr.ts
@@ -1,6 +1,16 @@
-import { getQueue, getWantedMissing, getRadarrPoster } from "@/services/radarr-api";
+import {
+  getQueue,
+  getWantedMissing,
+  getRadarrPoster,
+  removeFromQueue,
+} from "@/services/radarr-api";
 import type { RadarrQueue, RadarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
+import {
+  queueIssueMessages,
+  queueIssueSeverity,
+  queueStatusLabel,
+} from "@/lib/arr-queue-issues";
 
 export const radarrArrQueueAdapter: ArrQueueAdapter = {
   serviceId: "radarr",
@@ -14,7 +24,7 @@ export const radarrArrQueueAdapter: ArrQueueAdapter = {
   wantedQueryKey: (instanceId) => ["radarr", instanceId, "wanted"] as const,
 
   // Same key + args as useRadarrQueue, so the widget shares its cache entry.
-  fetchQueue: (instanceId) => getQueue(1, 20, true, instanceId),
+  fetchQueue: (instanceId) => getQueue(1, 100, true, instanceId),
 
   toItems: (data, instanceId) =>
     ((data as RadarrQueue).records ?? []).map((item) => {
@@ -32,9 +42,16 @@ export const radarrArrQueueAdapter: ArrQueueAdapter = {
         detailPath: movieId
           ? `/movie/${movieId}?instanceId=${instanceId}`
           : null,
+        releaseTitle: item.title,
+        severity: queueIssueSeverity(item),
+        statusLabel: queueStatusLabel(item),
+        messages: queueIssueMessages(item),
       };
     }),
 
   fetchWanted: (instanceId) => getWantedMissing(1, 1, instanceId),
   wantedCount: (data) => (data as RadarrWantedMissing).totalRecords ?? 0,
+
+  removeFromQueue: (instanceId, queueId, opts) =>
+    removeFromQueue(queueId, opts, instanceId),
 };

--- a/lib/arr-queue-adapters/sonarr.ts
+++ b/lib/arr-queue-adapters/sonarr.ts
@@ -1,6 +1,16 @@
-import { getQueue, getWantedMissing, getSonarrPoster } from "@/services/sonarr-api";
+import {
+  getQueue,
+  getWantedMissing,
+  getSonarrPoster,
+  removeFromQueue,
+} from "@/services/sonarr-api";
 import type { SonarrQueue, SonarrQueueItem, SonarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
+import {
+  queueIssueMessages,
+  queueIssueSeverity,
+  queueStatusLabel,
+} from "@/lib/arr-queue-issues";
 
 // "S02E05" when the episode is known, else the ETA, else nothing. Gives the
 // poster tile the episode context a series poster alone can't convey.
@@ -26,7 +36,7 @@ export const sonarrArrQueueAdapter: ArrQueueAdapter = {
   wantedQueryKey: (instanceId) => ["sonarr", instanceId, "wanted"] as const,
 
   // Same key + args as useSonarrQueue, so the widget shares its cache entry.
-  fetchQueue: (instanceId) => getQueue(1, 20, true, true, instanceId),
+  fetchQueue: (instanceId) => getQueue(1, 100, true, true, instanceId),
 
   toItems: (data, instanceId) =>
     ((data as SonarrQueue).records ?? []).map((item) => {
@@ -44,9 +54,16 @@ export const sonarrArrQueueAdapter: ArrQueueAdapter = {
         detailPath: seriesId
           ? `/series/${seriesId}?instanceId=${instanceId}`
           : null,
+        releaseTitle: item.title,
+        severity: queueIssueSeverity(item),
+        statusLabel: queueStatusLabel(item),
+        messages: queueIssueMessages(item),
       };
     }),
 
   fetchWanted: (instanceId) => getWantedMissing(1, 1, instanceId),
   wantedCount: (data) => (data as SonarrWantedMissing).totalRecords ?? 0,
+
+  removeFromQueue: (instanceId, queueId, opts) =>
+    removeFromQueue(queueId, opts, instanceId),
 };

--- a/lib/arr-queue-issues.test.ts
+++ b/lib/arr-queue-issues.test.ts
@@ -107,9 +107,6 @@ describe("queueStatusLabel", () => {
   });
 
   it("labels the failure states", () => {
-    expect(
-      queueStatusLabel(record({ trackedDownloadState: "importFailed" })),
-    ).toBe("Import failed");
     expect(queueStatusLabel(record({ trackedDownloadState: "failed" }))).toBe(
       "Download failed",
     );
@@ -121,7 +118,17 @@ describe("queueStatusLabel", () => {
     );
   });
 
+  // A state upstream doesn't have (or a future one) must not fall through to a
+  // healthy-looking label when the record is flagged.
   it("falls back to severity when the state is unknown or absent", () => {
+    expect(
+      queueStatusLabel(
+        record({
+          trackedDownloadState: "someFutureState",
+          trackedDownloadStatus: "error",
+        }),
+      ),
+    ).toBe("Download failed");
     expect(queueStatusLabel({ trackedDownloadStatus: "warning" })).toBe(
       "Download warning",
     );

--- a/lib/arr-queue-issues.test.ts
+++ b/lib/arr-queue-issues.test.ts
@@ -1,0 +1,186 @@
+import {
+  queueIssueSeverity,
+  queueIssueMessages,
+  queueStatusLabel,
+  worstQueueSeverity,
+  type ArrQueueIssueRecord,
+} from "@/lib/arr-queue-issues";
+
+function record(over: Partial<ArrQueueIssueRecord> = {}): ArrQueueIssueRecord {
+  return { status: "downloading", trackedDownloadStatus: "ok", ...over };
+}
+
+describe("queueIssueSeverity", () => {
+  it("returns null for a healthy record", () => {
+    expect(queueIssueSeverity(record())).toBeNull();
+  });
+
+  it("returns null when the tracked status is missing", () => {
+    expect(queueIssueSeverity({})).toBeNull();
+    expect(queueIssueSeverity({ status: "downloading" })).toBeNull();
+  });
+
+  it("maps tracked status to severity", () => {
+    expect(queueIssueSeverity(record({ trackedDownloadStatus: "warning" }))).toBe(
+      "warning",
+    );
+    expect(queueIssueSeverity(record({ trackedDownloadStatus: "error" }))).toBe(
+      "error",
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(queueIssueSeverity(record({ trackedDownloadStatus: "Warning" }))).toBe(
+      "warning",
+    );
+    expect(queueIssueSeverity(record({ trackedDownloadStatus: "ERROR" }))).toBe(
+      "error",
+    );
+  });
+
+  it("falls back to the queue status for pending releases", () => {
+    expect(
+      queueIssueSeverity({ status: "warning", trackedDownloadStatus: undefined }),
+    ).toBe("warning");
+    expect(
+      queueIssueSeverity({ status: "failed", trackedDownloadStatus: undefined }),
+    ).toBe("error");
+  });
+
+  it("lets error outrank warning", () => {
+    expect(
+      queueIssueSeverity({ status: "warning", trackedDownloadStatus: "error" }),
+    ).toBe("error");
+    expect(
+      queueIssueSeverity({ status: "failed", trackedDownloadStatus: "warning" }),
+    ).toBe("error");
+  });
+});
+
+describe("worstQueueSeverity", () => {
+  it("returns null for an empty list or a clean list", () => {
+    expect(worstQueueSeverity([])).toBeNull();
+    expect(worstQueueSeverity([{ severity: null }, { severity: undefined }])).toBeNull();
+  });
+
+  it("prefers error over warning regardless of order", () => {
+    expect(
+      worstQueueSeverity([{ severity: "warning" }, { severity: "error" }]),
+    ).toBe("error");
+    expect(
+      worstQueueSeverity([{ severity: "error" }, { severity: "warning" }]),
+    ).toBe("error");
+  });
+
+  it("returns warning when that is the worst", () => {
+    expect(worstQueueSeverity([{ severity: null }, { severity: "warning" }])).toBe(
+      "warning",
+    );
+  });
+});
+
+describe("queueStatusLabel", () => {
+  it("labels a healthy download", () => {
+    expect(queueStatusLabel(record({ trackedDownloadState: "downloading" }))).toBe(
+      "Downloading",
+    );
+  });
+
+  it("labels importBlocked regardless of severity", () => {
+    expect(
+      queueStatusLabel(record({ trackedDownloadState: "importBlocked" })),
+    ).toBe("Import blocked");
+  });
+
+  it("distinguishes a pending import from a blocked one", () => {
+    expect(
+      queueStatusLabel(record({ trackedDownloadState: "importPending" })),
+    ).toBe("Waiting to import");
+    expect(
+      queueStatusLabel(
+        record({
+          trackedDownloadState: "importPending",
+          trackedDownloadStatus: "warning",
+        }),
+      ),
+    ).toBe("Import blocked");
+  });
+
+  it("labels the failure states", () => {
+    expect(
+      queueStatusLabel(record({ trackedDownloadState: "importFailed" })),
+    ).toBe("Import failed");
+    expect(queueStatusLabel(record({ trackedDownloadState: "failed" }))).toBe(
+      "Download failed",
+    );
+    expect(
+      queueStatusLabel(record({ trackedDownloadState: "failedPending" })),
+    ).toBe("Download failed");
+    expect(queueStatusLabel(record({ trackedDownloadState: "ignored" }))).toBe(
+      "Ignored",
+    );
+  });
+
+  it("falls back to severity when the state is unknown or absent", () => {
+    expect(queueStatusLabel({ trackedDownloadStatus: "warning" })).toBe(
+      "Download warning",
+    );
+    expect(queueStatusLabel({ trackedDownloadStatus: "error" })).toBe(
+      "Download failed",
+    );
+    expect(queueStatusLabel({})).toBe("Downloading");
+  });
+});
+
+describe("queueIssueMessages", () => {
+  it("returns nothing when there is nothing to report", () => {
+    expect(queueIssueMessages({})).toEqual([]);
+    expect(queueIssueMessages({ statusMessages: [] })).toEqual([]);
+  });
+
+  it("puts errorMessage first", () => {
+    expect(
+      queueIssueMessages({
+        errorMessage: "Download client reported an error",
+        statusMessages: [{ title: "Release", messages: ["Sample file"] }],
+      }),
+    ).toEqual(["Download client reported an error", "Sample file"]);
+  });
+
+  it("flattens messages from every status message entry", () => {
+    expect(
+      queueIssueMessages({
+        statusMessages: [
+          { title: "Release.A", messages: ["No files eligible for import", "Sample"] },
+          { title: "Release.B", messages: ["Unknown movie"] },
+        ],
+      }),
+    ).toEqual(["No files eligible for import", "Sample", "Unknown movie"]);
+  });
+
+  it("uses the title when an entry carries no messages", () => {
+    expect(
+      queueIssueMessages({
+        statusMessages: [
+          { title: "One or more episodes expected in this release were not imported" },
+          { title: "Ignored", messages: [] },
+        ],
+      }),
+    ).toEqual([
+      "One or more episodes expected in this release were not imported",
+      "Ignored",
+    ]);
+  });
+
+  it("dedupes and trims", () => {
+    expect(
+      queueIssueMessages({
+        errorMessage: " Sample file ",
+        statusMessages: [
+          { title: "A", messages: ["Sample file"] },
+          { title: "B", messages: ["Sample file", "   "] },
+        ],
+      }),
+    ).toEqual(["Sample file"]);
+  });
+});

--- a/lib/arr-queue-issues.ts
+++ b/lib/arr-queue-issues.ts
@@ -1,7 +1,7 @@
 import type { ArrQueueStatusMessage } from "@/lib/types";
 
 /**
- * Import-blocked / failed queue detection for Radarr, Sonarr and Lidarr (issue #285).
+ * Stuck-grab detection for the Radarr, Sonarr and Lidarr queues (issue #285).
  *
  * All three *arr APIs describe a stuck grab the same way, so this module is
  * structural: any queue record with these fields works, no per-service branch.
@@ -10,7 +10,16 @@ import type { ArrQueueStatusMessage } from "@/lib/types";
  *   trackedDownloadState   downloading | importPending | importBlocked |
  *                          importing | imported | failedPending | failed |
  *                          ignored                     — where it is stuck
+ *   status                 the *download client's* item status, not *arr's
  *   statusMessages / errorMessage                      — why
+ *
+ * A blocked import is the common case, but NOT the only one this catches, which
+ * is why everything user-facing says "queue issues" rather than "import issues":
+ * `status` is copied straight off the download client item
+ * (QueueService.cs: `trackedDownload.DownloadItem.Status`, whose enum is
+ * Queued/Paused/Downloading/Completed/Failed/Warning), so a stalled torrent or a
+ * client-side error surfaces here too. Both are things the user wants to act on,
+ * and both are fixed by the same remove/blocklist actions.
  *
  * Verified against Radarr's Queue/QueueController.cs + TrackedDownload model and
  * mirrored on Rudarr's QueueItem.swift (`hasIssue` = trackedDownloadStatus != ok).
@@ -61,6 +70,10 @@ export function worstQueueSeverity(
  * `importPending` is the interesting one: on its own it just means "waiting for
  * the client to finish", but paired with a warning/error it is the state
  * Sonarr/Radarr surface as "Import blocked" in their own queue UI.
+ *
+ * The cases below are the whole TrackedDownloadState enum (TrackedDownload.cs in
+ * Sonarr and Radarr, QueueItem in Lidarr) minus the healthy in-flight ones —
+ * there is deliberately no `importFailed`, that state does not exist upstream.
  */
 export function queueStatusLabel(item: ArrQueueIssueRecord): string {
   const severity = queueIssueSeverity(item);
@@ -71,8 +84,6 @@ export function queueStatusLabel(item: ArrQueueIssueRecord): string {
       return "Import blocked";
     case "importpending":
       return severity ? "Import blocked" : "Waiting to import";
-    case "importfailed":
-      return "Import failed";
     case "failed":
     case "failedpending":
       return "Download failed";

--- a/lib/arr-queue-issues.ts
+++ b/lib/arr-queue-issues.ts
@@ -1,0 +1,108 @@
+import type { ArrQueueStatusMessage } from "@/lib/types";
+
+/**
+ * Import-blocked / failed queue detection for Radarr, Sonarr and Lidarr (issue #285).
+ *
+ * All three *arr APIs describe a stuck grab the same way, so this module is
+ * structural: any queue record with these fields works, no per-service branch.
+ *
+ *   trackedDownloadStatus  ok | warning | error       — how bad it is
+ *   trackedDownloadState   downloading | importPending | importBlocked |
+ *                          importing | imported | failedPending | failed |
+ *                          ignored                     — where it is stuck
+ *   statusMessages / errorMessage                      — why
+ *
+ * Verified against Radarr's Queue/QueueController.cs + TrackedDownload model and
+ * mirrored on Rudarr's QueueItem.swift (`hasIssue` = trackedDownloadStatus != ok).
+ */
+
+export type ArrQueueSeverity = "warning" | "error";
+
+/** The subset of a queue record this module needs. */
+export interface ArrQueueIssueRecord {
+  status?: string;
+  trackedDownloadStatus?: string;
+  trackedDownloadState?: string;
+  statusMessages?: ArrQueueStatusMessage[];
+  errorMessage?: string;
+}
+
+/**
+ * `error` outranks `warning`; anything else (including `ok` and a missing
+ * field, which older/partial responses do emit) is not an issue. `status` is
+ * checked too because a pending release that never reached the client reports
+ * its trouble there with no tracked status at all.
+ */
+export function queueIssueSeverity(
+  item: ArrQueueIssueRecord,
+): ArrQueueSeverity | null {
+  const tracked = (item.trackedDownloadStatus ?? "").toLowerCase();
+  const status = (item.status ?? "").toLowerCase();
+
+  if (tracked === "error" || status === "failed") return "error";
+  if (tracked === "warning" || status === "warning") return "warning";
+  return null;
+}
+
+/** Worst severity in a list, or null when nothing is wrong. */
+export function worstQueueSeverity(
+  items: readonly { severity?: ArrQueueSeverity | null }[],
+): ArrQueueSeverity | null {
+  let worst: ArrQueueSeverity | null = null;
+  for (const item of items) {
+    if (item.severity === "error") return "error";
+    if (item.severity === "warning") worst = "warning";
+  }
+  return worst;
+}
+
+/**
+ * Short human label for the row/pill, derived from where the grab is stuck.
+ * `importPending` is the interesting one: on its own it just means "waiting for
+ * the client to finish", but paired with a warning/error it is the state
+ * Sonarr/Radarr surface as "Import blocked" in their own queue UI.
+ */
+export function queueStatusLabel(item: ArrQueueIssueRecord): string {
+  const severity = queueIssueSeverity(item);
+  const state = (item.trackedDownloadState ?? "").toLowerCase();
+
+  switch (state) {
+    case "importblocked":
+      return "Import blocked";
+    case "importpending":
+      return severity ? "Import blocked" : "Waiting to import";
+    case "importfailed":
+      return "Import failed";
+    case "failed":
+    case "failedpending":
+      return "Download failed";
+    case "ignored":
+      return "Ignored";
+  }
+
+  if (severity === "error") return "Download failed";
+  if (severity === "warning") return "Download warning";
+  return "Downloading";
+}
+
+/**
+ * Every reason *arr gives, flattened and deduped, most important first.
+ *
+ * A `statusMessages` entry normally names the release in `title` and lists the
+ * reasons in `messages`, but a bare reason arrives as a title with no messages
+ * — so an entry contributes its messages when it has any, else its title.
+ */
+export function queueIssueMessages(item: ArrQueueIssueRecord): string[] {
+  const out: string[] = [];
+  const push = (line?: string) => {
+    const trimmed = line?.trim();
+    if (trimmed && !out.includes(trimmed)) out.push(trimmed);
+  };
+
+  push(item.errorMessage);
+  for (const entry of item.statusMessages ?? []) {
+    if (entry.messages?.length) entry.messages.forEach(push);
+    else push(entry.title);
+  }
+  return out;
+}

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -739,8 +739,8 @@ const DEMO_LIDARR_TRACKS = [
 
 const DEMO_LIDARR_QUEUE = {
   page: 1,
-  pageSize: 20,
-  totalRecords: 1,
+  pageSize: 100,
+  totalRecords: 2,
   records: [
     {
       id: 401,
@@ -760,6 +760,33 @@ const DEMO_LIDARR_QUEUE = {
       quality: { quality: { name: "FLAC" } },
       artist: DEMO_LIDARR_ARTISTS[1],
       album: DEMO_LIDARR_ALBUMS[3],
+    },
+    // Finished downloading but Lidarr refuses to import it — drives the queue
+    // issues banner (#285) on the Music screen, matching Radarr and Sonarr.
+    {
+      id: 402,
+      artistId: 1,
+      albumId: 11,
+      title: "Radiohead.OK.Computer.1997.24bit.96kHz.FLAC",
+      status: "completed",
+      trackedDownloadStatus: "warning",
+      trackedDownloadState: "importPending",
+      statusMessages: [
+        {
+          title: "Radiohead.OK.Computer.1997.24bit.96kHz.FLAC",
+          messages: [
+            "No files found are eligible for import in /downloads/complete/Radiohead.OK.Computer.1997.24bit.96kHz.FLAC",
+          ],
+        },
+      ],
+      size: 1_073_741_824,
+      sizeleft: 0,
+      timeleft: null,
+      protocol: "torrent",
+      downloadClient: "qBittorrent",
+      quality: { quality: { name: "FLAC 24bit" } },
+      artist: DEMO_LIDARR_ARTISTS[0],
+      album: DEMO_LIDARR_ALBUMS[0],
     },
   ],
 };
@@ -1726,9 +1753,18 @@ export function getDemoResponse(
   path: string,
   params?: Record<string, string | number | boolean>,
   body?: string,
+  method?: string,
 ): unknown {
   const basePath = path.split("?")[0]!;
   const normalized = basePath.replace(/\/\d+(\.\d+)*$/, "/:id");
+
+  // Demo fixtures are static, so every mutation is a no-op — but a DELETE must
+  // not fall through to the read route for the same path. `DELETE /queue/103`
+  // would match `startsWith("/queue")` and hand the caller the whole queue back
+  // as its "void" result. Return nothing instead, so a demo delete resolves the
+  // way the real one does. POST/PUT are deliberately excluded: NZBGet,
+  // Transmission and rtorrent dispatch their reads off a POST body.
+  if (method === "DELETE") return undefined;
 
   switch (serviceId) {
     case "radarr": {

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -429,8 +429,8 @@ const DEMO_RADARR_MOVIES = [
 
 const DEMO_RADARR_QUEUE = {
   page: 1,
-  pageSize: 20,
-  totalRecords: 2,
+  pageSize: 100,
+  totalRecords: 3,
   records: [
     {
       id: 101,
@@ -464,6 +464,31 @@ const DEMO_RADARR_QUEUE = {
       downloadClient: "qBittorrent",
       quality: { quality: { name: "WEBDL-1080p" } },
       movie: makeMovie(8, "Kingdom of the Planet of the Apes", 2024, 653346, false),
+    },
+    // Finished downloading but Radarr refuses to import it — drives the import
+    // issues banner (#285).
+    {
+      id: 103,
+      movieId: 11,
+      title: "Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP",
+      status: "completed",
+      trackedDownloadStatus: "warning",
+      trackedDownloadState: "importPending",
+      statusMessages: [
+        {
+          title: "Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP",
+          messages: [
+            "No files found are eligible for import in /downloads/complete/Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP",
+          ],
+        },
+      ],
+      size: 62277025792,
+      sizeleft: 0,
+      timeleft: null,
+      protocol: "torrent",
+      downloadClient: "qBittorrent",
+      quality: { quality: { name: "Bluray-2160p" } },
+      movie: makeMovie(11, "Furiosa: A Mad Max Saga", 2024, 786892, false),
     },
   ],
 };
@@ -574,8 +599,8 @@ const DEMO_SONARR_CALENDAR = [
 
 const DEMO_SONARR_QUEUE = {
   page: 1,
-  pageSize: 20,
-  totalRecords: 1,
+  pageSize: 100,
+  totalRecords: 2,
   records: [
     {
       id: 301,
@@ -589,6 +614,31 @@ const DEMO_SONARR_QUEUE = {
       sizeleft: 1610612736,
       timeleft: "00:35:00",
       estimatedCompletionTime: daysFromNowFull(0.03),
+      protocol: "torrent",
+      quality: { quality: { name: "WEBDL-1080p" } },
+      series: makeSeries(3, "Fallout", 2024, 456789),
+    },
+    // Finished downloading but Sonarr refuses to import it — drives the import
+    // issues banner (#285).
+    {
+      id: 302,
+      seriesId: 3,
+      episodeId: 204,
+      title: "Fallout.S01E07.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb",
+      status: "completed",
+      trackedDownloadStatus: "warning",
+      trackedDownloadState: "importBlocked",
+      statusMessages: [
+        {
+          title: "Fallout.S01E07.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb",
+          messages: [
+            "One or more episodes expected in this release were not imported or missing",
+          ],
+        },
+      ],
+      size: 2952790016,
+      sizeleft: 0,
+      timeleft: null,
       protocol: "torrent",
       quality: { quality: { name: "WEBDL-1080p" } },
       series: makeSeries(3, "Fallout", 2024, 456789),

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -205,7 +205,8 @@ export async function serviceRequest<T>(
     // the path or query params — pass body through so the demo router can read
     // it. Other services ignore the third arg.
     const body = typeof fetchOptions.body === "string" ? fetchOptions.body : undefined;
-    return (getDemoResponse(serviceId, path, params, body) ?? undefined) as T;
+    return (getDemoResponse(serviceId, path, params, body, fetchOptions.method) ??
+      undefined) as T;
   }
 
   const targetId = instanceId ?? store.getActiveInstanceId(serviceId);

--- a/lib/recently-downloaded.test.ts
+++ b/lib/recently-downloaded.test.ts
@@ -1,0 +1,191 @@
+import { groupRecentDownloads, type RecentItem } from "./recently-downloaded";
+
+// Import records carry far more than the grouper reads; these factories keep
+// the fixtures to the fields that actually decide a group.
+function episode(
+  id: number,
+  date: string,
+  seriesId: number | undefined,
+  instanceId = "sonarr-a",
+): RecentItem {
+  return {
+    kind: "episode",
+    instanceId,
+    date,
+    record: {
+      id,
+      eventType: "downloadFolderImported",
+      date,
+      ...(seriesId === undefined ? {} : { seriesId }),
+    },
+  };
+}
+
+function movie(id: number, date: string, instanceId = "radarr-a"): RecentItem {
+  return {
+    kind: "movie",
+    instanceId,
+    date,
+    record: { id, eventType: "downloadFolderImported", date },
+  };
+}
+
+describe("groupRecentDownloads", () => {
+  it("sorts newest first", () => {
+    const groups = groupRecentDownloads(
+      [
+        movie(1, "2026-07-20T10:00:00Z"),
+        movie(2, "2026-07-24T10:00:00Z"),
+        movie(3, "2026-07-22T10:00:00Z"),
+      ],
+      true,
+    );
+    expect(groups.map((g) => g.items[0].record.id)).toEqual([2, 3, 1]);
+  });
+
+  // The point of issue #307: a batch of episodes must occupy one slot, not
+  // three, so the rest of the feed stays visible.
+  it("collapses several imports of the same series into one group", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-24T10:00:00Z", 5),
+        episode(11, "2026-07-24T11:00:00Z", 5),
+        episode(12, "2026-07-24T12:00:00Z", 5),
+      ],
+      true,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items.map((i) => i.record.id)).toEqual([12, 11, 10]);
+    expect(groups[0].date).toBe("2026-07-24T12:00:00Z");
+    expect(groups[0].key).toBe("series:sonarr-a:5");
+  });
+
+  // Grouping collapses follow-ups into the tile that was already there; it
+  // never promotes a series ahead of a newer unrelated import.
+  it("keeps a group at the feed position of its newest episode", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-20T10:00:00Z", 5),
+        movie(20, "2026-07-22T10:00:00Z"),
+        episode(11, "2026-07-24T10:00:00Z", 5),
+      ],
+      true,
+    );
+    expect(groups.map((g) => g.key)).toEqual([
+      "series:sonarr-a:5",
+      "movie:radarr-a:20",
+    ]);
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  it("keeps different series apart", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-24T10:00:00Z", 5),
+        episode(11, "2026-07-24T11:00:00Z", 6),
+      ],
+      true,
+    );
+    expect(groups.map((g) => g.key)).toEqual([
+      "series:sonarr-a:6",
+      "series:sonarr-a:5",
+    ]);
+  });
+
+  // Series ids are only unique within an instance, so two Sonarrs sharing an
+  // id are still two different shows.
+  it("keeps the same series id on different instances apart", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-24T10:00:00Z", 5, "sonarr-a"),
+        episode(11, "2026-07-24T11:00:00Z", 5, "sonarr-b"),
+      ],
+      true,
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.key)).toEqual([
+      "series:sonarr-b:5",
+      "series:sonarr-a:5",
+    ]);
+  });
+
+  it("never groups movies, even two imports of the same movie", () => {
+    const groups = groupRecentDownloads(
+      [movie(20, "2026-07-24T10:00:00Z"), movie(21, "2026-07-24T11:00:00Z")],
+      true,
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.key)).toEqual([
+      "movie:radarr-a:21",
+      "movie:radarr-a:20",
+    ]);
+  });
+
+  it("falls back to the embedded series id when the record omits the top-level one", () => {
+    const withEmbedded: RecentItem = {
+      kind: "episode",
+      instanceId: "sonarr-a",
+      date: "2026-07-24T11:00:00Z",
+      record: {
+        id: 11,
+        eventType: "downloadFolderImported",
+        date: "2026-07-24T11:00:00Z",
+        series: { id: 5 } as never,
+      },
+    };
+    const groups = groupRecentDownloads(
+      [episode(10, "2026-07-24T10:00:00Z", 5), withEmbedded],
+      true,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  // Nothing to group on — but the tile still has to render, so it becomes its
+  // own group rather than being dropped or merged with other unknowns.
+  it("gives every series-less episode its own group", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-24T10:00:00Z", undefined),
+        episode(11, "2026-07-24T11:00:00Z", undefined),
+      ],
+      true,
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.key)).toEqual([
+      "episode:sonarr-a:11",
+      "episode:sonarr-a:10",
+    ]);
+  });
+
+  it("leaves every import in its own group when grouping is off", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-24T10:00:00Z", 5),
+        episode(11, "2026-07-24T11:00:00Z", 5),
+        episode(12, "2026-07-24T12:00:00Z", 5),
+      ],
+      false,
+    );
+    expect(groups).toHaveLength(3);
+    expect(groups.map((g) => g.items[0].record.id)).toEqual([12, 11, 10]);
+    expect(groups.map((g) => g.key)).toEqual([
+      "episode:sonarr-a:12",
+      "episode:sonarr-a:11",
+      "episode:sonarr-a:10",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [
+      movie(1, "2026-07-20T10:00:00Z"),
+      movie(2, "2026-07-24T10:00:00Z"),
+    ];
+    groupRecentDownloads(items, true);
+    expect(items.map((i) => i.record.id)).toEqual([1, 2]);
+  });
+
+  it("returns nothing for an empty feed", () => {
+    expect(groupRecentDownloads([], true)).toEqual([]);
+  });
+});

--- a/lib/recently-downloaded.test.ts
+++ b/lib/recently-downloaded.test.ts
@@ -7,6 +7,7 @@ function episode(
   date: string,
   seriesId: number | undefined,
   instanceId = "sonarr-a",
+  episodeId?: number,
 ): RecentItem {
   return {
     kind: "episode",
@@ -17,6 +18,7 @@ function episode(
       eventType: "downloadFolderImported",
       date,
       ...(seriesId === undefined ? {} : { seriesId }),
+      ...(episodeId === undefined ? {} : { episodeId }),
     },
   };
 }
@@ -76,6 +78,56 @@ describe("groupRecentDownloads", () => {
       "movie:radarr-a:20",
     ]);
     expect(groups[0].items).toHaveLength(2);
+  });
+
+  // A quality upgrade re-imports an episode already in the window. Counting
+  // both would badge one episode as "2 episodes" and list it twice.
+  it("keeps only the newest import of a repeated episode", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-20T10:00:00Z", 5, "sonarr-a", 900),
+        episode(11, "2026-07-24T10:00:00Z", 5, "sonarr-a", 900),
+        episode(12, "2026-07-22T10:00:00Z", 5, "sonarr-a", 901),
+      ],
+      true,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items.map((i) => i.record.id)).toEqual([11, 12]);
+  });
+
+  it("does not dedupe the same episode id across different series", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-24T10:00:00Z", 5, "sonarr-a", 900),
+        episode(11, "2026-07-24T11:00:00Z", 6, "sonarr-a", 900),
+      ],
+      true,
+    );
+    expect(groups).toHaveLength(2);
+  });
+
+  // Nothing to match on, so a duplicate is preferable to a dropped import.
+  it("keeps repeated imports when the episode id is missing", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-20T10:00:00Z", 5),
+        episode(11, "2026-07-24T10:00:00Z", 5),
+      ],
+      true,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  it("leaves repeated episodes alone when grouping is off", () => {
+    const groups = groupRecentDownloads(
+      [
+        episode(10, "2026-07-20T10:00:00Z", 5, "sonarr-a", 900),
+        episode(11, "2026-07-24T10:00:00Z", 5, "sonarr-a", 900),
+      ],
+      false,
+    );
+    expect(groups).toHaveLength(2);
   });
 
   it("keeps different series apart", () => {

--- a/lib/recently-downloaded.ts
+++ b/lib/recently-downloaded.ts
@@ -1,0 +1,86 @@
+import type { RadarrHistoryRecord, SonarrHistoryRecord } from "@/lib/types";
+
+// One imported entry from either Sonarr or Radarr, tagged with its source
+// instance so the per-tile router push targets the right id space (movie /
+// series ids aren't globally unique across instances of the same kind).
+export type RecentItem =
+  | {
+      kind: "episode";
+      record: SonarrHistoryRecord;
+      instanceId: string;
+      // Pulled out for sorting — `date` is optional on the record type.
+      date: string;
+    }
+  | {
+      kind: "movie";
+      record: RadarrHistoryRecord;
+      instanceId: string;
+      date: string;
+    };
+
+/**
+ * One tile in the Recently Downloaded widget. Usually a single import; with
+ * episode grouping on, every import of the same series collapses into one tile
+ * (issue #307) so a season batch can't push the rest of the feed off screen.
+ */
+export interface RecentGroup {
+  /** Grouping identity — also the React key. */
+  key: string;
+  /** Newest import in the group; drives sort order and the tile subtitle. */
+  date: string;
+  /** Newest first, same order as the flat feed. */
+  items: RecentItem[];
+}
+
+// Sonarr puts the series id at the top level on modern history records but
+// leaves it out on some older ones, where only the embedded series carries it.
+function seriesIdOf(record: SonarrHistoryRecord): number | undefined {
+  return record.seriesId ?? record.series?.id;
+}
+
+/**
+ * Merge a flat import feed into the tiles the widget renders, newest first.
+ *
+ * A series group takes the feed position of its newest episode, so grouping
+ * never reorders the feed relative to what an ungrouped view would show — it
+ * only collapses the follow-up episodes into the tile that was already there.
+ */
+export function groupRecentDownloads(
+  items: RecentItem[],
+  groupEpisodes: boolean,
+): RecentGroup[] {
+  // Newest first. Array.prototype.sort is stable, so records sharing a
+  // timestamp keep the order their service returned them in.
+  const sorted = [...items].sort((a, b) => b.date.localeCompare(a.date));
+
+  const groups: RecentGroup[] = [];
+  const bySeries = new Map<string, RecentGroup>();
+
+  for (const item of sorted) {
+    const seriesId =
+      item.kind === "episode" ? seriesIdOf(item.record) : undefined;
+
+    // Movies are one import each, and an episode whose series id is missing
+    // has nothing to group on — both get a singleton keyed by record id.
+    if (seriesId === undefined || !groupEpisodes) {
+      groups.push({
+        key: `${item.kind}:${item.instanceId}:${item.record.id}`,
+        date: item.date,
+        items: [item],
+      });
+      continue;
+    }
+
+    const key = `series:${item.instanceId}:${seriesId}`;
+    const existing = bySeries.get(key);
+    if (existing) {
+      existing.items.push(item);
+      continue;
+    }
+    const group: RecentGroup = { key, date: item.date, items: [item] };
+    bySeries.set(key, group);
+    groups.push(group);
+  }
+
+  return groups;
+}

--- a/lib/recently-downloaded.ts
+++ b/lib/recently-downloaded.ts
@@ -38,12 +38,22 @@ function seriesIdOf(record: SonarrHistoryRecord): number | undefined {
   return record.seriesId ?? record.series?.id;
 }
 
+function episodeIdOf(record: SonarrHistoryRecord): number | undefined {
+  return record.episodeId ?? record.episode?.id;
+}
+
 /**
  * Merge a flat import feed into the tiles the widget renders, newest first.
  *
  * A series group takes the feed position of its newest episode, so grouping
  * never reorders the feed relative to what an ungrouped view would show — it
  * only collapses the follow-up episodes into the tile that was already there.
+ *
+ * Within a group each episode appears once. A quality upgrade emits a second
+ * `downloadFolderImported` for an episode already in the window, and counting
+ * both would badge a single episode as "2 episodes" and list it twice in the
+ * sheet. Iteration is newest-first, so the survivor is the latest import — the
+ * one whose quality and size are actually on disk.
  */
 export function groupRecentDownloads(
   items: RecentItem[],
@@ -55,6 +65,8 @@ export function groupRecentDownloads(
 
   const groups: RecentGroup[] = [];
   const bySeries = new Map<string, RecentGroup>();
+  // "<groupKey>:<episodeId>" for every episode already placed in a group.
+  const seenEpisodes = new Set<string>();
 
   for (const item of sorted) {
     const seriesId =
@@ -72,6 +84,17 @@ export function groupRecentDownloads(
     }
 
     const key = `series:${item.instanceId}:${seriesId}`;
+
+    // An episode Sonarr didn't identify can't be matched against anything, so
+    // it's kept rather than guessed at — better a duplicate than a lost import.
+    const episodeId =
+      item.kind === "episode" ? episodeIdOf(item.record) : undefined;
+    if (episodeId !== undefined) {
+      const seenKey = `${key}:${episodeId}`;
+      if (seenEpisodes.has(seenKey)) continue;
+      seenEpisodes.add(seenKey);
+    }
+
     const existing = bySeries.get(key);
     if (existing) {
       existing.items.push(item);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -361,6 +361,26 @@ export interface RadarrImage {
   remoteUrl: string;
 }
 
+// A single queue status message as *arr reports it: `title` is usually the
+// release/file it applies to and `messages` the reasons, but a bare reason
+// arrives as a title with an empty `messages` array. Shared by every *arr queue.
+export interface ArrQueueStatusMessage {
+  title: string;
+  messages?: string[];
+}
+
+/**
+ * Query params for `DELETE /queue/{id}`, identical across Radarr v3, Sonarr v3
+ * and Lidarr v1. `blocklist` marks the grab as failed so the release is never
+ * picked up again; `skipRedownload` then suppresses the replacement search that
+ * failure would otherwise trigger (it has no effect without `blocklist`).
+ */
+export interface ArrQueueRemoveOptions {
+  removeFromClient?: boolean;
+  blocklist?: boolean;
+  skipRedownload?: boolean;
+}
+
 export interface RadarrQueueItem {
   id: number;
   movieId: number;
@@ -368,7 +388,10 @@ export interface RadarrQueueItem {
   status: string;
   trackedDownloadStatus?: string;
   trackedDownloadState?: string;
-  statusMessages: { title: string; messages: string[] }[];
+  // Why the grab is stuck, when it is. Radarr omits both on a healthy record
+  // and `statusMessages` entirely on some responses, so both are optional.
+  statusMessages?: ArrQueueStatusMessage[];
+  errorMessage?: string;
   size: number;
   sizeleft: number;
   timeleft?: string;
@@ -376,6 +399,8 @@ export interface RadarrQueueItem {
   protocol: string;
   downloadId?: string;
   downloadClient?: string;
+  indexer?: string;
+  added?: string;
   quality: { quality: { name: string } };
   movie?: RadarrMovie;
 }
@@ -678,12 +703,17 @@ export interface SonarrQueueItem {
   status: string;
   trackedDownloadStatus?: string;
   trackedDownloadState?: string;
+  statusMessages?: ArrQueueStatusMessage[];
+  errorMessage?: string;
   size: number;
   sizeleft: number;
   timeleft?: string;
   estimatedCompletionTime?: string;
   protocol: string;
   downloadId?: string;
+  downloadClient?: string;
+  indexer?: string;
+  added?: string;
   quality: { quality: { name: string } };
   series?: SonarrSeries;
   episode?: SonarrEpisode;
@@ -841,7 +871,8 @@ export interface LidarrQueueItem {
   status: string;
   trackedDownloadStatus?: string;
   trackedDownloadState?: string;
-  statusMessages?: { title: string; messages: string[] }[];
+  statusMessages?: ArrQueueStatusMessage[];
+  errorMessage?: string;
   size: number;
   sizeleft: number;
   timeleft?: string;
@@ -849,6 +880,8 @@ export interface LidarrQueueItem {
   protocol: string;
   downloadId?: string;
   downloadClient?: string;
+  indexer?: string;
+  added?: string;
   quality: { quality: { name: string } };
   artist?: LidarrArtist;
   album?: LidarrAlbum;

--- a/services/lidarr-api.ts
+++ b/services/lidarr-api.ts
@@ -83,7 +83,7 @@ export function getTracks(
 
 // --- Queue ---
 
-// `includeUnknownArtistItems` matters for the import-blocked banner (#285): a
+// `includeUnknownArtistItems` matters for the queue-issues banner (#285): a
 // grab whose artist was deleted from the library is exactly the kind that gets
 // stuck, and Lidarr hides those by default. The page size is generous for the
 // same reason — blocked items have no `timeleft` and sort last under the

--- a/services/lidarr-api.ts
+++ b/services/lidarr-api.ts
@@ -7,6 +7,7 @@ import type {
   LidarrWantedMissing,
   LidarrImage,
   LidarrArtistSearchResult,
+  ArrQueueRemoveOptions,
 } from "@/lib/types";
 
 // --- Image helpers ---
@@ -82,13 +83,44 @@ export function getTracks(
 
 // --- Queue ---
 
+// `includeUnknownArtistItems` matters for the import-blocked banner (#285): a
+// grab whose artist was deleted from the library is exactly the kind that gets
+// stuck, and Lidarr hides those by default. The page size is generous for the
+// same reason — blocked items have no `timeleft` and sort last under the
+// default sort, so a small page would clip them off.
 export function getQueue(
   page = 1,
-  pageSize = 20,
+  pageSize = 100,
   instanceId?: string,
 ): Promise<LidarrQueue> {
   return serviceRequest<LidarrQueue>("lidarr", "/queue", {
-    params: { page, pageSize, includeArtist: true, includeAlbum: true },
+    params: {
+      page,
+      pageSize,
+      includeArtist: true,
+      includeAlbum: true,
+      includeUnknownArtistItems: true,
+    },
+    instanceId,
+  });
+}
+
+/**
+ * Removes a queue item. See ArrQueueRemoveOptions for what the flags do; the
+ * defaults match Lidarr's own (`removeFromClient=true`, no blocklist).
+ */
+export function removeFromQueue(
+  queueId: number,
+  opts: ArrQueueRemoveOptions = {},
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("lidarr", `/queue/${queueId}`, {
+    method: "DELETE",
+    params: {
+      removeFromClient: opts.removeFromClient ?? true,
+      blocklist: opts.blocklist ?? false,
+      skipRedownload: opts.skipRedownload ?? false,
+    },
     instanceId,
   });
 }

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -71,7 +71,7 @@ export function getCollectionByTmdbId(
 
 // --- Queue ---
 
-// `includeUnknownMovieItems` matters for the import-blocked banner (#285): a
+// `includeUnknownMovieItems` matters for the queue-issues banner (#285): a
 // grab whose movie was deleted from the library is exactly the kind that gets
 // stuck, and Radarr hides those by default. The page size is generous for the
 // same reason — blocked items have no `timeleft` and sort last under the

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -9,6 +9,7 @@ import type {
   RadarrImage,
   RadarrRelease,
   RadarrCollection,
+  ArrQueueRemoveOptions,
 } from "@/lib/types";
 
 // Interactive search hits indexers live and frequently exceeds the 15s
@@ -70,14 +71,39 @@ export function getCollectionByTmdbId(
 
 // --- Queue ---
 
+// `includeUnknownMovieItems` matters for the import-blocked banner (#285): a
+// grab whose movie was deleted from the library is exactly the kind that gets
+// stuck, and Radarr hides those by default. The page size is generous for the
+// same reason — blocked items have no `timeleft` and sort last under the
+// default sort, so a small page would clip them off.
 export function getQueue(
   page = 1,
-  pageSize = 20,
+  pageSize = 100,
   includeMovie = true,
   instanceId?: string,
 ): Promise<RadarrQueue> {
   return serviceRequest<RadarrQueue>("radarr", "/queue", {
-    params: { page, pageSize, includeMovie },
+    params: { page, pageSize, includeMovie, includeUnknownMovieItems: true },
+    instanceId,
+  });
+}
+
+/**
+ * Removes a queue item. See ArrQueueRemoveOptions for what the flags do; the
+ * defaults match Radarr's own (`removeFromClient=true`, no blocklist).
+ */
+export function removeFromQueue(
+  queueId: number,
+  opts: ArrQueueRemoveOptions = {},
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("radarr", `/queue/${queueId}`, {
+    method: "DELETE",
+    params: {
+      removeFromClient: opts.removeFromClient ?? true,
+      blocklist: opts.blocklist ?? false,
+      skipRedownload: opts.skipRedownload ?? false,
+    },
     instanceId,
   });
 }

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -12,6 +12,7 @@ import type {
   SonarrImage,
   SonarrRelease,
   SonarrWantedMissing,
+  ArrQueueRemoveOptions,
 } from "@/lib/types";
 
 const INTERACTIVE_SEARCH_TIMEOUT = 90_000;
@@ -143,15 +144,46 @@ export function getWantedMissing(
 
 // --- Queue ---
 
+// `includeUnknownSeriesItems` matters for the import-blocked banner (#285): a
+// grab whose series was deleted from the library is exactly the kind that gets
+// stuck, and Sonarr hides those by default. The page size is generous for the
+// same reason — blocked items have no `timeleft` and sort last under the
+// default sort, so a small page would clip them off.
 export function getQueue(
   page = 1,
-  pageSize = 20,
+  pageSize = 100,
   includeSeries = true,
   includeEpisode = true,
   instanceId?: string,
 ): Promise<SonarrQueue> {
   return serviceRequest<SonarrQueue>("sonarr", "/queue", {
-    params: { page, pageSize, includeSeries, includeEpisode },
+    params: {
+      page,
+      pageSize,
+      includeSeries,
+      includeEpisode,
+      includeUnknownSeriesItems: true,
+    },
+    instanceId,
+  });
+}
+
+/**
+ * Removes a queue item. See ArrQueueRemoveOptions for what the flags do; the
+ * defaults match Sonarr's own (`removeFromClient=true`, no blocklist).
+ */
+export function removeFromQueue(
+  queueId: number,
+  opts: ArrQueueRemoveOptions = {},
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("sonarr", `/queue/${queueId}`, {
+    method: "DELETE",
+    params: {
+      removeFromClient: opts.removeFromClient ?? true,
+      blocklist: opts.blocklist ?? false,
+      skipRedownload: opts.skipRedownload ?? false,
+    },
     instanceId,
   });
 }

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -144,7 +144,7 @@ export function getWantedMissing(
 
 // --- Queue ---
 
-// `includeUnknownSeriesItems` matters for the import-blocked banner (#285): a
+// `includeUnknownSeriesItems` matters for the queue-issues banner (#285): a
 // grab whose series was deleted from the library is exactly the kind that gets
 // stuck, and Sonarr hides those by default. The page size is generous for the
 // same reason — blocked items have no `timeleft` and sort last under the


### PR DESCRIPTION
Refs #285, #307, #303

## Summary

- **Queue issues banner (Radarr, Sonarr, Lidarr).** Movies, TV and Music show a banner when the active instance has a stuck grab (blocked import, stalled or failed download). Tap to list each one with the reason the service gave, then remove, blocklist, or blocklist and search. Detection is shared across all three services via `trackedDownloadStatus` / `trackedDownloadState`. Queue fetches now use page size 100 and include unknown-media items, since a grab whose movie was deleted is exactly the kind that sticks.
- **Recently Downloaded groups by series.** A season batch collapses into one tile with a count badge instead of flooding the row; tapping it lists the episodes. Toggle under Episodes, "Group by series", on by default.
- **Services widget "Hide when all healthy".** The grid is never empty, so it gets its own wording: hidden while everything is online, back the moment something breaks. Away-blocked instances do not count as unhealthy. Off by default.

Also fixes a pre-existing unmount-while-dismissing hazard in the health issues banner (the #83 modal class).

## Test plan

- `tsc --noEmit` clean, 836 tests pass (42 suites), including new coverage for stuck-grab detection and series grouping.
- Demo mode: all three services show a stuck grab and the full sheet, actions and confirm chain.
- Real stack: verified against live Radarr/Sonarr/Lidarr, including removal and blocklist writing through to the service.
- iOS: ran the three-deep modal chain (sheet, actions, confirm, back to sheet) repeatedly, no freeze.
- Services widget stays hidden across a cold start with the toggle on.