### PR TITLE
feat(dashboard): "Hide when all healthy" for Health Alerts

### DIFF
--- a/components/dashboard/arr-health-card.tsx
+++ b/components/dashboard/arr-health-card.tsx
@@ -12,6 +12,12 @@ import {
   useArrHealthSections,
   type ArrInstanceHealth,
 } from "@/hooks/use-arr-health";
+import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import {
+  ARR_HEALTH_DEFAULT_SETTINGS,
+  type ArrHealthSettingsValue,
+} from "@/components/dashboard/widget-settings/arr-health-settings";
 import { useManualRefresh } from "@/store/manual-refresh-store";
 import { SERVICE_DEFAULTS } from "@/lib/constants";
 import { lightHaptic } from "@/lib/haptics";
@@ -23,6 +29,10 @@ import type { WidgetComponentProps } from "@/components/dashboard/widget-registr
 // healthy" state otherwise so the widget is reassuring, not just an alarm.
 export function ArrHealthCard({ slotId }: WidgetComponentProps) {
   const { sections, isLoading, isFetching } = useArrHealthSections();
+  const { settings } = useWidgetSettings<ArrHealthSettingsValue>(
+    slotId,
+    ARR_HEALTH_DEFAULT_SETTINGS,
+  );
   // Mirror the Services widget: show the "Checking…" indicator on the first
   // load and during a user pull-to-refresh, but stay silent on the routine 30s
   // background poll (which also flips isFetching) so the header doesn't blink (#196).
@@ -35,6 +45,18 @@ export function ArrHealthCard({ slotId }: WidgetComponentProps) {
 
   const totalIssues = sections.reduce((acc, s) => acc + s.count, 0);
   const anyError = sections.some((s) => s.severity === "error");
+
+  // Inverted signal, so `isLoading: false` on purpose — same reasoning as the
+  // Services widget (#303). useHideWhenEmpty's usual "never report empty while
+  // loading" rule protects emptiness-driven widgets from flashing hidden before
+  // their first fetch; here it would do the opposite, rendering the skeleton on
+  // every cold start and collapsing it a second later. No alerts are known yet,
+  // so start hidden and appear when a /health response says otherwise.
+  useHideWhenEmpty(slotId, {
+    enabled: settings.hideWhenAllHealthy,
+    isEmpty: sections.length === 0,
+    isLoading: false,
+  });
 
   return (
     <Card>

--- a/components/dashboard/widget-registry.tsx
+++ b/components/dashboard/widget-registry.tsx
@@ -167,6 +167,11 @@ import {
   DISK_SPACE_DEFAULT_SETTINGS,
   type DiskSpaceSettingsValue,
 } from "@/components/dashboard/widget-settings/disk-space-settings";
+import {
+  ArrHealthSettings,
+  ARR_HEALTH_DEFAULT_SETTINGS,
+  type ArrHealthSettingsValue,
+} from "@/components/dashboard/widget-settings/arr-health-settings";
 import { DASHBOARD_WIDGET_IDS, type ServiceId, type WidgetId } from "@/lib/constants";
 
 // Every widget component receives the id of its slot in the active dashboard.
@@ -488,6 +493,8 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetDefinition> = {
     icon: ShieldAlert,
     service: ["radarr", "sonarr", "prowlarr", "lidarr"],
     component: ArrHealthCard,
+    settingsComponent: ArrHealthSettings,
+    defaultSettings: ARR_HEALTH_DEFAULT_SETTINGS,
   },
   "unraid-array": {
     id: "unraid-array",
@@ -531,4 +538,5 @@ export type {
   JackettIndexersSettingsValue,
   BazarrWantedSettingsValue,
   DiskSpaceSettingsValue,
+  ArrHealthSettingsValue,
 };

--- a/components/dashboard/widget-settings/arr-health-settings.tsx
+++ b/components/dashboard/widget-settings/arr-health-settings.tsx
@@ -1,0 +1,35 @@
+import { View } from "react-native";
+import { useWidgetSettings } from "@/hooks/use-widget-settings";
+import type { WidgetSettingsComponentProps } from "@/components/dashboard/widget-registry";
+import { AutoHideToggle } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+
+export interface ArrHealthSettingsValue extends Record<string, unknown> {
+  // Health Alerts' take on "hide when empty" (#303). The card is never blank —
+  // with nothing wrong it renders a reassuring "All services healthy" row — so
+  // the useful signal is the absence of alerts: hide while every *arr instance
+  // reports clean, reappear the moment one raises a warning or error. Shares
+  // the Services widget's key so `slotAutoHides` marks the slot in edit mode.
+  hideWhenAllHealthy: boolean;
+}
+
+export const ARR_HEALTH_DEFAULT_SETTINGS: ArrHealthSettingsValue = {
+  hideWhenAllHealthy: false,
+};
+
+export function ArrHealthSettings({ slotId }: WidgetSettingsComponentProps) {
+  const { settings, update } = useWidgetSettings<ArrHealthSettingsValue>(
+    slotId,
+    ARR_HEALTH_DEFAULT_SETTINGS,
+  );
+
+  return (
+    <View className="px-4 py-2 gap-5">
+      <AutoHideToggle
+        label="Hide when all healthy"
+        description="Hide this widget from the dashboard when Sonarr, Radarr, Prowlarr and Lidarr report no health issues"
+        value={settings.hideWhenAllHealthy}
+        onChange={(hideWhenAllHealthy) => update({ hideWhenAllHealthy })}
+      />
+    </View>
+  );
+}

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -627,17 +627,18 @@
         </p>
         <p>
           The same widget can be placed more than once on one dashboard, each copy with its own
-          settings, which is how you show two download clients or two Radarrs side by side. Three
-          widgets have no options and therefore no gear: Wake-on-LAN, Health Alerts and unRAID Array.
+          settings, which is how you show two download clients or two Radarrs side by side. Two
+          widgets have no options and therefore no gear: Wake-on-LAN and unRAID Array.
         </p>
         <p>
           Most settings sheets include a <strong>Visibility, "Hide when empty"</strong> toggle. Cards
           hidden that way still appear in edit mode, marked with a crossed-out-eye icon, so a
-          "vanished" widget is easy to find. Service Health has the same toggle worded
-          <strong>"Hide when all healthy"</strong>, since its grid is never empty: it hides while every
-          service it shows is online and comes back the moment one goes down. Widgets for services
-          that support several instances also expose an instance chip row with an
-          <strong>All instances</strong> chip.
+          "vanished" widget is easy to find. Service Health and Health Alerts have the same toggle
+          worded <strong>"Hide when all healthy"</strong>, since neither is ever literally empty:
+          Service Health hides while every service it shows is online, Health Alerts hides while
+          Sonarr, Radarr, Prowlarr and Lidarr report no health issues, and both come back the moment
+          something goes wrong. Widgets for services that support several instances also expose an
+          instance chip row with an <strong>All instances</strong> chip.
         </p>
 
         <h3>Attached instances and auto-attach</h3>
@@ -1043,8 +1044,9 @@
         <h3>A widget disappeared from the dashboard.</h3>
         <p>
           Either its service was disabled or un-attached (it is hidden, not deleted, and returns when
-          you restore it), or it has "Hide when empty" on, or, for Service Health, "Hide when all
-          healthy". Enter widget edit mode to see hidden cards, marked with a crossed-out-eye icon.
+          you restore it), or it has "Hide when empty" on, or, for Service Health and Health Alerts,
+          "Hide when all healthy". Enter widget edit mode to see hidden cards, marked with a
+          crossed-out-eye icon.
         </p>
 
         <h3>qBittorrent says wrong username or password.</h3>
@@ -1087,7 +1089,11 @@
         </p>
 
         <h3>The Health Alerts widget is empty.</h3>
-        <p>That is correct. It only renders when there is a problem to report.</p>
+        <p>
+          That is correct. With nothing wrong it shows "All services healthy". To drop the card off
+          the dashboard entirely while everything is clean, turn on
+          <strong>Visibility, "Hide when all healthy"</strong> in its widget settings.
+        </p>
 
         <h3>Filing a bug.</h3>
         <p>


### PR DESCRIPTION
Refs #303

## Summary

#312 put "Hide when all healthy" on the **Services** widget. Per the follow-up comment on #303, the ask was the **Health Alerts** widget (the aggregated Sonarr/Radarr/Prowlarr/Lidarr System > Health card), which had no settings at all.

It gets its first gear now, with a single Visibility toggle: hidden while every *arr reports clean, back the moment one raises a warning or error. Off by default. Like the Services widget it reports empty during the first probe rather than gating on loading, so a cold start does not render the card and collapse it a second later.

## Test plan

- `tsc --noEmit` clean, 836 tests pass (42 suites).
- Not yet exercised on a device: toggle on with a healthy stack, reappearance when an *arr raises a health issue, and the cold-start path. Worth a pass before release.