### PR TITLE
feat(calendar): week starts on device's first day, with Sunday/Monday override

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -140,6 +140,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "expo-router",
     "expo-secure-store",
     "expo-web-browser",
+    "expo-localization",
     "./plugins/withAndroidSigning",
     "./plugins/withCleartextTraffic",
     "./plugins/withDevVariant",

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -28,6 +28,13 @@ import {
   getCalendar as getRadarrCalendar,
   getQueue as getRadarrQueue,
 } from "@/services/radarr-api";
+import {
+  getCalendarGrid,
+  getFetchRange,
+  orderedWeekdays,
+} from "@/lib/calendar-grid";
+import { resolveWeekStartDow } from "@/lib/week-start";
+import { useConfigStore } from "@/store/config-store";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
@@ -74,62 +81,10 @@ type CalendarItem =
       instanceId: string;
     };
 
-const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
 const MONTH_NAMES = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
 ];
-
-// Fetch the full visible grid (incl. prev/next-month padding cells) padded
-// ±1 day, mirroring Sonarr's web UI. The padding keeps boundary episodes
-// whose UTC day differs from the local day inside the server-side range
-// filter; the extra day on `end` also matters because the *arr APIs treat a
-// date-only end as midnight (exclusive of that day's airings).
-function getFetchRange(year: number, month: number) {
-  const first = new Date(year, month, 1);
-  const last = new Date(year, month + 1, 0);
-  const start = new Date(year, month, 1 - first.getDay() - 1);
-  const end = new Date(year, month, last.getDate() + (6 - last.getDay()) + 1);
-  return {
-    start: localDateKey(start),
-    end: localDateKey(end),
-  };
-}
-
-function getCalendarGrid(year: number, month: number) {
-  const firstDay = new Date(year, month, 1);
-  const lastDay = new Date(year, month + 1, 0);
-  const startDow = firstDay.getDay();
-  const daysInMonth = lastDay.getDate();
-
-  const cells: { day: number; dateKey: string; inMonth: boolean }[] = [];
-
-  // Previous month padding
-  const prevLast = new Date(year, month, 0).getDate();
-  for (let i = startDow - 1; i >= 0; i--) {
-    const d = prevLast - i;
-    const date = new Date(year, month - 1, d);
-    cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
-  }
-
-  // Current month
-  for (let d = 1; d <= daysInMonth; d++) {
-    const date = new Date(year, month, d);
-    cells.push({ day: d, dateKey: localDateKey(date), inMonth: true });
-  }
-
-  // Next month padding
-  const remaining = 7 - (cells.length % 7);
-  if (remaining < 7) {
-    for (let d = 1; d <= remaining; d++) {
-      const date = new Date(year, month + 1, d);
-      cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
-    }
-  }
-
-  return cells;
-}
 
 export default function CalendarScreen() {
   const today = new Date();
@@ -145,6 +100,12 @@ export default function CalendarScreen() {
     setIncludeUnmonitoredState(value);
     setBoolean(INCLUDE_UNMONITORED_KEY, value);
   };
+
+  // First day of week (0 = Sunday … 6 = Saturday): device-derived by default,
+  // overridable in Settings > Appearance (#320).
+  const weekStart = useConfigStore((s) => s.weekStart);
+  const firstDow = useMemo(() => resolveWeekStartDow(weekStart), [weekStart]);
+  const weekdays = useMemo(() => orderedWeekdays(firstDow), [firstDow]);
 
   const attachedInstances = useAttachedInstances();
   const sonarrAllRaw = useEnabledInstances("sonarr");
@@ -199,7 +160,7 @@ export default function CalendarScreen() {
     [radarrAll, radarrFilter],
   );
 
-  const { start, end } = getFetchRange(year, month);
+  const { start, end } = getFetchRange(year, month, firstDow);
 
   // Fan out the calendar query across every selected Sonarr/Radarr instance.
   // Each instance contributes its own slice of dates; we flatten and dedupe
@@ -383,7 +344,10 @@ export default function CalendarScreen() {
     return { itemsByDate: map, allItems: all };
   }, [taggedEpisodes, taggedMovies, filter]);
 
-  const grid = useMemo(() => getCalendarGrid(year, month), [year, month]);
+  const grid = useMemo(
+    () => getCalendarGrid(year, month, firstDow),
+    [year, month, firstDow],
+  );
   const todayKey = localDateKey(today);
   const selectedItems = itemsByDate.get(selectedDate) ?? [];
 
@@ -549,7 +513,7 @@ export default function CalendarScreen() {
       <Card>
         {/* Weekday headers */}
         <View className="flex-row">
-          {WEEKDAYS.map((d) => (
+          {weekdays.map((d) => (
             <View key={d} className="flex-1 items-center pb-2">
               <Text className="text-zinc-500 text-xs font-medium">{d}</Text>
             </View>

--- a/app/settings/appearance.tsx
+++ b/app/settings/appearance.tsx
@@ -3,6 +3,7 @@ import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { Select } from "@/components/ui/select";
 import { APP_THEMES, type AppThemeId } from "@/lib/app-themes";
+import { type WeekStart } from "@/lib/week-start";
 import { SettingsGroup } from "@/components/settings/settings-group";
 import { SettingsToggleRow } from "@/components/settings/settings-toggle-row";
 import { useConfigStore } from "@/store/config-store";
@@ -15,6 +16,8 @@ export default function AppearanceSettingsScreen() {
   const setAppTheme = useConfigStore((s) => s.setAppTheme);
   const hapticsEnabled = useConfigStore((s) => s.hapticsEnabled);
   const setHapticsEnabled = useConfigStore((s) => s.setHapticsEnabled);
+  const weekStart = useConfigStore((s) => s.weekStart);
+  const setWeekStart = useConfigStore((s) => s.setWeekStart);
 
   return (
     <ScreenWrapper>
@@ -43,6 +46,22 @@ export default function AppearanceSettingsScreen() {
               description: t.description,
             }))}
             onChange={setAppTheme}
+          />
+        </View>
+        <View className="px-4 py-3">
+          <Select<WeekStart>
+            label="First day of week"
+            value={weekStart}
+            options={[
+              {
+                value: "auto",
+                label: "Auto",
+                description: "Match the device's week start",
+              },
+              { value: "sunday", label: "Sunday" },
+              { value: "monday", label: "Monday" },
+            ]}
+            onChange={setWeekStart}
           />
         </View>
         <SettingsToggleRow

--- a/lib/calendar-grid.test.ts
+++ b/lib/calendar-grid.test.ts
@@ -1,0 +1,104 @@
+import {
+  getCalendarGrid,
+  getFetchRange,
+  orderedWeekdays,
+} from "./calendar-grid";
+
+// August 2026: Aug 1 is a Saturday, Aug 31 is a Monday, 31 days.
+const YEAR = 2026;
+const AUG = 7;
+
+describe("orderedWeekdays", () => {
+  it("keeps Sunday first for firstDow=0", () => {
+    expect(orderedWeekdays(0)).toEqual([
+      "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+    ]);
+  });
+
+  it("rotates to Monday first for firstDow=1", () => {
+    expect(orderedWeekdays(1)).toEqual([
+      "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+    ]);
+  });
+
+  it("rotates to Saturday first for firstDow=6", () => {
+    expect(orderedWeekdays(6)).toEqual([
+      "Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
+    ]);
+  });
+});
+
+describe("getCalendarGrid", () => {
+  it("pads a Sunday-start grid so Aug 1 (Saturday) lands in column 6", () => {
+    const grid = getCalendarGrid(YEAR, AUG, 0);
+    expect(grid.length % 7).toBe(0);
+    // 6 padding cells from July (Sun Jul 26 – Fri Jul 31)
+    expect(grid[0]).toEqual({ day: 26, dateKey: "2026-07-26", inMonth: false });
+    expect(grid[6]).toEqual({ day: 1, dateKey: "2026-08-01", inMonth: true });
+    // Aug 31 is a Monday → 5 trailing September cells close the last week
+    expect(grid[grid.length - 1]).toEqual({
+      day: 5,
+      dateKey: "2026-09-05",
+      inMonth: false,
+    });
+    expect(grid.length).toBe(42);
+  });
+
+  it("pads a Monday-start grid so Aug 1 (Saturday) lands in column 5", () => {
+    const grid = getCalendarGrid(YEAR, AUG, 1);
+    expect(grid.length % 7).toBe(0);
+    // 5 padding cells from July (Mon Jul 27 – Fri Jul 31)
+    expect(grid[0]).toEqual({ day: 27, dateKey: "2026-07-27", inMonth: false });
+    expect(grid[5]).toEqual({ day: 1, dateKey: "2026-08-01", inMonth: true });
+    // Aug 31 is a Monday → it opens the last row, 6 September cells follow
+    expect(grid[grid.length - 7]).toEqual({
+      day: 31,
+      dateKey: "2026-08-31",
+      inMonth: true,
+    });
+    expect(grid[grid.length - 1]).toEqual({
+      day: 6,
+      dateKey: "2026-09-06",
+      inMonth: false,
+    });
+    expect(grid.length).toBe(42);
+  });
+
+  it("adds no leading padding when the month starts on the week's first day", () => {
+    // June 2026 starts on a Monday
+    const grid = getCalendarGrid(2026, 5, 1);
+    expect(grid[0]).toEqual({ day: 1, dateKey: "2026-06-01", inMonth: true });
+  });
+
+  it("adds no trailing padding when the month ends on the week's last day", () => {
+    // May 2026 ends on Sunday May 31 — last cell of a Monday-start grid
+    const grid = getCalendarGrid(2026, 4, 1);
+    expect(grid[grid.length - 1]).toEqual({
+      day: 31,
+      dateKey: "2026-05-31",
+      inMonth: true,
+    });
+  });
+
+  it("handles a Saturday-start week", () => {
+    const grid = getCalendarGrid(YEAR, AUG, 6);
+    // Aug 1 is a Saturday → no leading padding at all
+    expect(grid[0]).toEqual({ day: 1, dateKey: "2026-08-01", inMonth: true });
+  });
+});
+
+describe("getFetchRange", () => {
+  it("covers the Sunday-start grid ±1 day", () => {
+    const { start, end } = getFetchRange(YEAR, AUG, 0);
+    // Grid runs Jul 26 – Sep 5; range pads one day each side
+    expect(start).toBe("2026-07-25");
+    expect(end).toBe("2026-09-06");
+  });
+
+  it("covers the Monday-start grid ±1 day", () => {
+    const { start, end } = getFetchRange(YEAR, AUG, 1);
+    // Grid runs Jul 27 – Sep 6; range pads one day each side
+    expect(start).toBe("2026-07-26");
+    expect(end).toBe("2026-09-07");
+  });
+});

--- a/lib/calendar-grid.ts
+++ b/lib/calendar-grid.ts
@@ -1,0 +1,81 @@
+import { localDateKey } from "@/lib/utils";
+
+// Month-grid math for the Calendar tab, parameterized by the first day of
+// the week (0 = Sunday … 6 = Saturday, matching Date.getDay()) so the grid
+// can start on Monday for locales/settings that want it (#320).
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** Weekday header labels, rotated so index 0 is the week's first day. */
+export function orderedWeekdays(firstDow: number): string[] {
+  return WEEKDAY_LABELS.map((_, i) => WEEKDAY_LABELS[(firstDow + i) % 7]);
+}
+
+/** Column offset of a date within a week that starts on `firstDow`. */
+function weekColumn(dow: number, firstDow: number): number {
+  return (dow - firstDow + 7) % 7;
+}
+
+// Fetch the full visible grid (incl. prev/next-month padding cells) padded
+// ±1 day, mirroring Sonarr's web UI. The padding keeps boundary episodes
+// whose UTC day differs from the local day inside the server-side range
+// filter; the extra day on `end` also matters because the *arr APIs treat a
+// date-only end as midnight (exclusive of that day's airings).
+export function getFetchRange(year: number, month: number, firstDow: number) {
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+  const start = new Date(year, month, 1 - weekColumn(first.getDay(), firstDow) - 1);
+  const end = new Date(
+    year,
+    month,
+    last.getDate() + (6 - weekColumn(last.getDay(), firstDow)) + 1,
+  );
+  return {
+    start: localDateKey(start),
+    end: localDateKey(end),
+  };
+}
+
+export interface CalendarGridCell {
+  day: number;
+  dateKey: string;
+  inMonth: boolean;
+}
+
+export function getCalendarGrid(
+  year: number,
+  month: number,
+  firstDow: number,
+): CalendarGridCell[] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const startCol = weekColumn(firstDay.getDay(), firstDow);
+  const daysInMonth = lastDay.getDate();
+
+  const cells: CalendarGridCell[] = [];
+
+  // Previous month padding
+  const prevLast = new Date(year, month, 0).getDate();
+  for (let i = startCol - 1; i >= 0; i--) {
+    const d = prevLast - i;
+    const date = new Date(year, month - 1, d);
+    cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
+  }
+
+  // Current month
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = new Date(year, month, d);
+    cells.push({ day: d, dateKey: localDateKey(date), inMonth: true });
+  }
+
+  // Next month padding
+  const remaining = 7 - (cells.length % 7);
+  if (remaining < 7) {
+    for (let d = 1; d <= remaining; d++) {
+      const date = new Date(year, month + 1, d);
+      cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
+    }
+  }
+
+  return cells;
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -213,6 +213,7 @@ export const STORAGE_KEYS = {
   globalCustomHeaders: "app.globalCustomHeaders",
   uiScale: "app.uiScale",
   appTheme: "app.appTheme",
+  weekStart: "app.weekStart",
   // v17: user-defined display order for the Services tab tiles. Stored as a
   // ServiceId[]; unknown ids in this list are ignored at render time, and
   // any SERVICE_IDS missing from the list are appended in their canonical

--- a/lib/week-start.ts
+++ b/lib/week-start.ts
@@ -1,0 +1,28 @@
+import { getCalendars } from "expo-localization";
+
+// First-day-of-week preference for the calendar grid (#320). "auto" follows
+// the device — on iOS that's Settings > General > Language & Region > First
+// Day of Week; on Android it's derived from the locale.
+export const WEEK_STARTS = ["auto", "sunday", "monday"] as const;
+export type WeekStart = (typeof WEEK_STARTS)[number];
+
+export const DEFAULT_WEEK_START: WeekStart = "auto";
+
+export function isValidWeekStart(value: unknown): value is WeekStart {
+  return (WEEK_STARTS as readonly unknown[]).includes(value);
+}
+
+/**
+ * Resolve the preference to a JS day-of-week number (0 = Sunday … 6 =
+ * Saturday, matching Date.getDay()). "auto" can yield any day — e.g. 6
+ * (Saturday) in locales that start the week there — and the grid math in
+ * lib/calendar-grid.ts handles the general case.
+ */
+export function resolveWeekStartDow(setting: WeekStart): number {
+  if (setting === "sunday") return 0;
+  if (setting === "monday") return 1;
+  // expo-localization firstWeekday: 1 = Sunday … 7 = Saturday (may be null
+  // on some Android devices — fall back to Sunday).
+  const firstWeekday = getCalendars()[0]?.firstWeekday;
+  return typeof firstWeekday === "number" ? (firstWeekday - 1 + 7) % 7 : 0;
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "expo-linear-gradient": "^15.0.8",
     "expo-linking": "~8.0.11",
     "expo-local-authentication": "~17.0.8",
+    "expo-localization": "~17.0.9",
     "expo-location": "~19.0.8",
     "expo-notifications": "^0.32.16",
     "expo-router": "~6.0.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       expo-local-authentication:
         specifier: ~17.0.8
         version: 17.0.8(expo@54.0.33)
+      expo-localization:
+        specifier: ~17.0.9
+        version: 17.0.9(expo@54.0.33)(react@19.1.0)
       expo-location:
         specifier: ~19.0.8
         version: 19.0.8(expo@54.0.33)
@@ -2515,6 +2518,12 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-localization@17.0.9:
+    resolution: {integrity: sha512-k5eYHr7iLMob3M8cHH6bgDrDRmqnZG8xKGLhpx8ST+LsFXmSgYpJ/t0VwWm0gz64C/K669XhObdG3D6QwCGqhw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+
   expo-location@19.0.8:
     resolution: {integrity: sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==}
     peerDependencies:
@@ -4292,6 +4301,9 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  rtl-detect@1.1.2:
+    resolution: {integrity: sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -7671,6 +7683,12 @@ snapshots:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       invariant: 2.2.4
 
+  expo-localization@17.0.9(expo@54.0.33)(react@19.1.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      rtl-detect: 1.1.2
+
   expo-location@19.0.8(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -9916,6 +9934,8 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rtl-detect@1.1.2: {}
 
   run-parallel@1.2.0:
     dependencies:

--- a/store/config-migrations.test.ts
+++ b/store/config-migrations.test.ts
@@ -1706,3 +1706,30 @@ describe("v37 → v38 (appTheme stamp)", () => {
     expect(result.appTheme).toBeUndefined();
   });
 });
+
+describe("v39 → v40 (weekStart stamp)", () => {
+  it("just stamps the version and preserves an already-set weekStart", () => {
+    const result: any = migrateConfig({
+      version: 39,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+      weekStart: "monday",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.weekStart).toBe("monday");
+  });
+
+  it("leaves weekStart absent when the source payload omitted it", () => {
+    const result: any = migrateConfig({
+      version: 39,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.weekStart).toBeUndefined();
+  });
+});

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -153,8 +153,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         defaultInstances() iterates SERVICE_IDS and backfills a disabled
  *         jackett instance at import time, so older exports just need the
  *         version field bumped.
+ *   v40 — optional `weekStart` calendar first-day-of-week preference (#320).
+ *         Pure version stamp — absence means "auto" (follow the device), and
+ *         importConfig whitelists the value.
  */
-export const CURRENT_CONFIG_VERSION = 39;
+export const CURRENT_CONFIG_VERSION = 40;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -667,6 +670,9 @@ const migrations: Record<number, (payload: any) => any> = {
   // v38 → v39: added the jackett service entry (#300). Pure version stamp —
   // defaultInstances() backfills a disabled jackett instance at import.
   38: (payload) => ({ ...payload, version: 39 }),
+  // v39 → v40: optional `weekStart` first-day-of-week preference (#320).
+  // Pure version stamp — absence means "auto" (follow the device).
+  39: (payload) => ({ ...payload, version: 40 }),
 };
 
 /**

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -37,6 +37,11 @@ import {
   type AppThemeId,
 } from "@/lib/app-themes";
 import {
+  DEFAULT_WEEK_START,
+  isValidWeekStart,
+  type WeekStart,
+} from "@/lib/week-start";
+import {
   DEFAULT_DASHBOARD_ICON,
   type DashboardIconName,
 } from "@/lib/dashboard-icons";
@@ -375,6 +380,8 @@ interface ConfigState {
   uiScale: UiScale;
   // Global chrome tint preset applied via NativeWind CSS vars (ThemeRoot).
   appTheme: AppThemeId;
+  // Calendar first day of week: follow the device or force Sunday/Monday.
+  weekStart: WeekStart;
   notificationSettings: NotificationSettings;
 }
 
@@ -410,6 +417,8 @@ export interface ExportPayload {
   treatVpnAsHome?: boolean;
   // v38 — global app theme preset.
   appTheme?: AppThemeId;
+  // v40 — calendar first-day-of-week preference (#320).
+  weekStart?: WeekStart;
 }
 
 export type ExportStage = "preparing" | "encrypting" | "finalizing";
@@ -529,6 +538,7 @@ interface ConfigActions {
   setGlobalCustomHeaders: (headers: Record<string, string>) => void;
   setUiScale: (scale: UiScale) => void;
   setAppTheme: (theme: AppThemeId) => void;
+  setWeekStart: (weekStart: WeekStart) => void;
   setNotificationSetting: <K extends keyof NotificationSettings>(
     key: K,
     value: NotificationSettings[K],
@@ -996,6 +1006,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   globalCustomHeaders: {},
   uiScale: DEFAULT_UI_SCALE,
   appTheme: DEFAULT_APP_THEME,
+  weekStart: DEFAULT_WEEK_START,
   notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
 
   hydrate: async () => {
@@ -1456,6 +1467,11 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       ? storedAppTheme
       : DEFAULT_APP_THEME;
 
+    const storedWeekStart = getString(STORAGE_KEYS.weekStart);
+    const weekStart: WeekStart = isValidWeekStart(storedWeekStart)
+      ? storedWeekStart
+      : DEFAULT_WEEK_START;
+
     // Notification settings persisted under their own AsyncStorage key since
     // v2 (originally owned by a standalone notifications-store). Merge over
     // defaults so a partially-stored payload (older app picking up newer
@@ -1551,6 +1567,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders,
       uiScale,
       appTheme,
+      weekStart,
       notificationSettings,
       hydrated: true,
     });
@@ -2460,6 +2477,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     set({ appTheme: theme });
   },
 
+  setWeekStart: (weekStart) => {
+    if (!isValidWeekStart(weekStart)) return;
+    setString(STORAGE_KEYS.weekStart, weekStart);
+    set({ weekStart });
+  },
+
   setNotificationSetting: (key, value) => {
     const next = { ...get().notificationSettings, [key]: value };
     setJSON(STORAGE_KEYS.notificationSettings, next);
@@ -2668,6 +2691,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders,
       uiScale,
       appTheme,
+      weekStart,
       notificationSettings: notifSettings,
     } = get();
     const { url, sharedSecret, deviceId } = useBackendStore.getState();
@@ -2692,6 +2716,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders,
       uiScale,
       appTheme,
+      weekStart,
     };
 
     onStage?.("encrypting");
@@ -2867,6 +2892,10 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       ? payload.appTheme
       : DEFAULT_APP_THEME;
     setString(STORAGE_KEYS.appTheme, importedAppTheme);
+    const importedWeekStart: WeekStart = isValidWeekStart(payload.weekStart)
+      ? payload.weekStart
+      : DEFAULT_WEEK_START;
+    setString(STORAGE_KEYS.weekStart, importedWeekStart);
     const importedServicesOrder = sanitizeServicesOrder(payload.servicesOrder);
     setJSON(STORAGE_KEYS.servicesOrder, importedServicesOrder);
 
@@ -2922,6 +2951,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders: importedGlobalCustomHeaders,
       uiScale: importedUiScale,
       appTheme: importedAppTheme,
+      weekStart: importedWeekStart,
       notificationSettings: importedNotificationSettings,
     });
 


### PR DESCRIPTION
Refs #320

The calendar grid hardcoded Sunday as the first weekday. Now it follows the device's first day of week by default (iOS Settings > General > Language & Region > First Day of Week, locale-derived on Android) via expo-localization, with an Auto/Sunday/Monday override in Settings > Appearance.

- Grid/fetch-range math moved to `lib/calendar-grid.ts`, parameterized by week start (handles any start day, incl. Saturday locales) with unit tests
- `weekStart` persisted in config store, exported in backups (v40 pure-stamp migration)
- Adds the expo-localization native module: new fingerprint, so it ships with the next store build, not as an OTA to the current runtime

## Test plan
- `npx tsc --noEmit` clean, all 848 jest tests pass (10 new)
- Manual: calendar tab with setting on Auto (Monday-region device), Sunday, and Monday; month navigation and day selection across padded cells