### PR TITLE
fix(indexers): release card overflow and stuck Jackett search

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -140,6 +140,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "expo-router",
     "expo-secure-store",
     "expo-web-browser",
+    "expo-localization",
     "./plugins/withAndroidSigning",
     "./plugins/withCleartextTraffic",
     "./plugins/withDevVariant",

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -28,6 +28,13 @@ import {
   getCalendar as getRadarrCalendar,
   getQueue as getRadarrQueue,
 } from "@/services/radarr-api";
+import {
+  getCalendarGrid,
+  getFetchRange,
+  orderedWeekdays,
+} from "@/lib/calendar-grid";
+import { resolveWeekStartDow } from "@/lib/week-start";
+import { useConfigStore } from "@/store/config-store";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
@@ -74,62 +81,10 @@ type CalendarItem =
       instanceId: string;
     };
 
-const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
 const MONTH_NAMES = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
 ];
-
-// Fetch the full visible grid (incl. prev/next-month padding cells) padded
-// ±1 day, mirroring Sonarr's web UI. The padding keeps boundary episodes
-// whose UTC day differs from the local day inside the server-side range
-// filter; the extra day on `end` also matters because the *arr APIs treat a
-// date-only end as midnight (exclusive of that day's airings).
-function getFetchRange(year: number, month: number) {
-  const first = new Date(year, month, 1);
-  const last = new Date(year, month + 1, 0);
-  const start = new Date(year, month, 1 - first.getDay() - 1);
-  const end = new Date(year, month, last.getDate() + (6 - last.getDay()) + 1);
-  return {
-    start: localDateKey(start),
-    end: localDateKey(end),
-  };
-}
-
-function getCalendarGrid(year: number, month: number) {
-  const firstDay = new Date(year, month, 1);
-  const lastDay = new Date(year, month + 1, 0);
-  const startDow = firstDay.getDay();
-  const daysInMonth = lastDay.getDate();
-
-  const cells: { day: number; dateKey: string; inMonth: boolean }[] = [];
-
-  // Previous month padding
-  const prevLast = new Date(year, month, 0).getDate();
-  for (let i = startDow - 1; i >= 0; i--) {
-    const d = prevLast - i;
-    const date = new Date(year, month - 1, d);
-    cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
-  }
-
-  // Current month
-  for (let d = 1; d <= daysInMonth; d++) {
-    const date = new Date(year, month, d);
-    cells.push({ day: d, dateKey: localDateKey(date), inMonth: true });
-  }
-
-  // Next month padding
-  const remaining = 7 - (cells.length % 7);
-  if (remaining < 7) {
-    for (let d = 1; d <= remaining; d++) {
-      const date = new Date(year, month + 1, d);
-      cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
-    }
-  }
-
-  return cells;
-}
 
 export default function CalendarScreen() {
   const today = new Date();
@@ -145,6 +100,12 @@ export default function CalendarScreen() {
     setIncludeUnmonitoredState(value);
     setBoolean(INCLUDE_UNMONITORED_KEY, value);
   };
+
+  // First day of week (0 = Sunday … 6 = Saturday): device-derived by default,
+  // overridable in Settings > Appearance (#320).
+  const weekStart = useConfigStore((s) => s.weekStart);
+  const firstDow = useMemo(() => resolveWeekStartDow(weekStart), [weekStart]);
+  const weekdays = useMemo(() => orderedWeekdays(firstDow), [firstDow]);
 
   const attachedInstances = useAttachedInstances();
   const sonarrAllRaw = useEnabledInstances("sonarr");
@@ -199,7 +160,7 @@ export default function CalendarScreen() {
     [radarrAll, radarrFilter],
   );
 
-  const { start, end } = getFetchRange(year, month);
+  const { start, end } = getFetchRange(year, month, firstDow);
 
   // Fan out the calendar query across every selected Sonarr/Radarr instance.
   // Each instance contributes its own slice of dates; we flatten and dedupe
@@ -383,7 +344,10 @@ export default function CalendarScreen() {
     return { itemsByDate: map, allItems: all };
   }, [taggedEpisodes, taggedMovies, filter]);
 
-  const grid = useMemo(() => getCalendarGrid(year, month), [year, month]);
+  const grid = useMemo(
+    () => getCalendarGrid(year, month, firstDow),
+    [year, month, firstDow],
+  );
   const todayKey = localDateKey(today);
   const selectedItems = itemsByDate.get(selectedDate) ?? [];
 
@@ -549,7 +513,7 @@ export default function CalendarScreen() {
       <Card>
         {/* Weekday headers */}
         <View className="flex-row">
-          {WEEKDAYS.map((d) => (
+          {weekdays.map((d) => (
             <View key={d} className="flex-1 items-center pb-2">
               <Text className="text-zinc-500 text-xs font-medium">{d}</Text>
             </View>

--- a/app/settings/appearance.tsx
+++ b/app/settings/appearance.tsx
@@ -3,6 +3,7 @@ import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { Select } from "@/components/ui/select";
 import { APP_THEMES, type AppThemeId } from "@/lib/app-themes";
+import { type WeekStart } from "@/lib/week-start";
 import { SettingsGroup } from "@/components/settings/settings-group";
 import { SettingsToggleRow } from "@/components/settings/settings-toggle-row";
 import { useConfigStore } from "@/store/config-store";
@@ -15,6 +16,8 @@ export default function AppearanceSettingsScreen() {
   const setAppTheme = useConfigStore((s) => s.setAppTheme);
   const hapticsEnabled = useConfigStore((s) => s.hapticsEnabled);
   const setHapticsEnabled = useConfigStore((s) => s.setHapticsEnabled);
+  const weekStart = useConfigStore((s) => s.weekStart);
+  const setWeekStart = useConfigStore((s) => s.setWeekStart);
 
   return (
     <ScreenWrapper>
@@ -43,6 +46,22 @@ export default function AppearanceSettingsScreen() {
               description: t.description,
             }))}
             onChange={setAppTheme}
+          />
+        </View>
+        <View className="px-4 py-3">
+          <Select<WeekStart>
+            label="First day of week"
+            value={weekStart}
+            options={[
+              {
+                value: "auto",
+                label: "Auto",
+                description: "Match the device's week start",
+              },
+              { value: "sunday", label: "Sunday" },
+              { value: "monday", label: "Monday" },
+            ]}
+            onChange={setWeekStart}
           />
         </View>
         <SettingsToggleRow

--- a/components/indexers/release-card.tsx
+++ b/components/indexers/release-card.tsx
@@ -19,9 +19,13 @@ export function ReleaseCard({
         <Text className="text-zinc-200 text-sm" numberOfLines={2}>
           {release.title}
         </Text>
-        <View className="flex-row items-center gap-3 mt-1.5">
+        {/* Yoga defaults flexShrink to 0 (web CSS defaults it to 1), so without a
+            flexible child the indexer name lays out at full intrinsic width and shoves
+            the stats + protocol pill past the card's content box — #314. Making the
+            indexer the one `flex-1` element is the same fix ReleaseListItem uses. */}
+        <View className="flex-row items-center gap-2 mt-1.5">
           <Text className="text-zinc-500 text-xs">{formatBytes(release.sizeBytes)}</Text>
-          <Text className="text-zinc-500 text-xs" numberOfLines={1}>
+          <Text className="text-zinc-500 text-xs flex-1 min-w-0" numberOfLines={1}>
             {release.indexer}
           </Text>
           {release.seeders !== undefined && (

--- a/components/indexers/release-search.tsx
+++ b/components/indexers/release-search.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { View, Text } from "react-native";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBanner } from "@/components/common/error-banner";
 import { ReleaseCard } from "@/components/indexers/release-card";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import type { IndexerSearchAdapter, UnifiedRelease } from "@/lib/indexer-adapter";
 
 // Shared release-search sub-tab of the Indexers screen. The adapter supplies
@@ -11,7 +13,12 @@ import type { IndexerSearchAdapter, UnifiedRelease } from "@/lib/indexer-adapter
 export function ReleaseSearch({ adapter }: { adapter: IndexerSearchAdapter }) {
   const [query, setQuery] = useState("");
   const [pendingGrab, setPendingGrab] = useState<UnifiedRelease | null>(null);
-  const { data: results, isLoading } = adapter.useSearch(query);
+  // Un-debounced, every keystroke started a fresh all-indexers fan-out under its
+  // own queryKey, so nothing deduped or cancelled and the slowest one won — the
+  // "searches as soon as you type, then sits on Searching..." report in #314.
+  // 300ms matches global search (app/search.tsx).
+  const debounced = useDebouncedValue(query.trim(), 300);
+  const { data: results, isLoading, isError, error } = adapter.useSearch(debounced);
 
   return (
     <View>
@@ -25,7 +32,14 @@ export function ReleaseSearch({ adapter }: { adapter: IndexerSearchAdapter }) {
 
       {isLoading && <Text className="text-zinc-500">Searching...</Text>}
 
-      {results && results.length === 0 && query.length >= 2 && (
+      {isError && (
+        <ErrorBanner
+          error={error}
+          title={`Couldn't search ${adapter.displayName}`}
+        />
+      )}
+
+      {!isError && results && results.length === 0 && debounced.length >= 2 && (
         <EmptyState title="No results" />
       )}
 

--- a/hooks/use-jackett.ts
+++ b/hooks/use-jackett.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getIndexers, searchAll } from "@/services/jackett-api";
+import { getIndexers } from "@/services/jackett-api";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
 export function useJackettIndexers(instanceId?: string) {
@@ -15,11 +15,5 @@ export function useJackettIndexers(instanceId?: string) {
   });
 }
 
-export function useJackettSearch(query: string, instanceId?: string) {
-  const { instanceId: id, enabled } = useInstanceTarget("jackett", instanceId);
-  return useQuery({
-    queryKey: ["jackett", id, "search", query],
-    queryFn: () => searchAll(query, id ?? undefined),
-    enabled: enabled && query.length >= 2 && !!id,
-  });
-}
+// Release search lives in lib/indexer-adapters/jackett.ts, not here — it needs
+// the abort/retry/timeout contract the shared ReleaseSearch view relies on.

--- a/hooks/use-prowlarr.ts
+++ b/hooks/use-prowlarr.ts
@@ -3,7 +3,6 @@ import {
   getIndexers,
   getIndexerStatuses,
   getIndexerStats,
-  searchAll,
   toggleIndexer,
   grabRelease,
 } from "@/services/prowlarr-api";
@@ -40,18 +39,8 @@ export function useProwlarrStats(instanceId?: string) {
   });
 }
 
-export function useProwlarrSearch(
-  query: string,
-  indexerIds?: number[],
-  instanceId?: string,
-) {
-  const { instanceId: id, enabled } = useInstanceTarget("prowlarr", instanceId);
-  return useQuery({
-    queryKey: ["prowlarr", id, "search", query, indexerIds],
-    queryFn: () => searchAll(query, indexerIds, undefined, id ?? undefined),
-    enabled: enabled && query.length >= 2 && !!id,
-  });
-}
+// Release search lives in lib/indexer-adapters/prowlarr.ts, not here — it needs
+// the abort/retry/timeout contract the shared ReleaseSearch view relies on.
 
 export function useToggleIndexer(instanceId?: string) {
   const queryClient = useQueryClient();

--- a/lib/calendar-grid.test.ts
+++ b/lib/calendar-grid.test.ts
@@ -1,0 +1,104 @@
+import {
+  getCalendarGrid,
+  getFetchRange,
+  orderedWeekdays,
+} from "./calendar-grid";
+
+// August 2026: Aug 1 is a Saturday, Aug 31 is a Monday, 31 days.
+const YEAR = 2026;
+const AUG = 7;
+
+describe("orderedWeekdays", () => {
+  it("keeps Sunday first for firstDow=0", () => {
+    expect(orderedWeekdays(0)).toEqual([
+      "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+    ]);
+  });
+
+  it("rotates to Monday first for firstDow=1", () => {
+    expect(orderedWeekdays(1)).toEqual([
+      "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+    ]);
+  });
+
+  it("rotates to Saturday first for firstDow=6", () => {
+    expect(orderedWeekdays(6)).toEqual([
+      "Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri",
+    ]);
+  });
+});
+
+describe("getCalendarGrid", () => {
+  it("pads a Sunday-start grid so Aug 1 (Saturday) lands in column 6", () => {
+    const grid = getCalendarGrid(YEAR, AUG, 0);
+    expect(grid.length % 7).toBe(0);
+    // 6 padding cells from July (Sun Jul 26 – Fri Jul 31)
+    expect(grid[0]).toEqual({ day: 26, dateKey: "2026-07-26", inMonth: false });
+    expect(grid[6]).toEqual({ day: 1, dateKey: "2026-08-01", inMonth: true });
+    // Aug 31 is a Monday → 5 trailing September cells close the last week
+    expect(grid[grid.length - 1]).toEqual({
+      day: 5,
+      dateKey: "2026-09-05",
+      inMonth: false,
+    });
+    expect(grid.length).toBe(42);
+  });
+
+  it("pads a Monday-start grid so Aug 1 (Saturday) lands in column 5", () => {
+    const grid = getCalendarGrid(YEAR, AUG, 1);
+    expect(grid.length % 7).toBe(0);
+    // 5 padding cells from July (Mon Jul 27 – Fri Jul 31)
+    expect(grid[0]).toEqual({ day: 27, dateKey: "2026-07-27", inMonth: false });
+    expect(grid[5]).toEqual({ day: 1, dateKey: "2026-08-01", inMonth: true });
+    // Aug 31 is a Monday → it opens the last row, 6 September cells follow
+    expect(grid[grid.length - 7]).toEqual({
+      day: 31,
+      dateKey: "2026-08-31",
+      inMonth: true,
+    });
+    expect(grid[grid.length - 1]).toEqual({
+      day: 6,
+      dateKey: "2026-09-06",
+      inMonth: false,
+    });
+    expect(grid.length).toBe(42);
+  });
+
+  it("adds no leading padding when the month starts on the week's first day", () => {
+    // June 2026 starts on a Monday
+    const grid = getCalendarGrid(2026, 5, 1);
+    expect(grid[0]).toEqual({ day: 1, dateKey: "2026-06-01", inMonth: true });
+  });
+
+  it("adds no trailing padding when the month ends on the week's last day", () => {
+    // May 2026 ends on Sunday May 31 — last cell of a Monday-start grid
+    const grid = getCalendarGrid(2026, 4, 1);
+    expect(grid[grid.length - 1]).toEqual({
+      day: 31,
+      dateKey: "2026-05-31",
+      inMonth: true,
+    });
+  });
+
+  it("handles a Saturday-start week", () => {
+    const grid = getCalendarGrid(YEAR, AUG, 6);
+    // Aug 1 is a Saturday → no leading padding at all
+    expect(grid[0]).toEqual({ day: 1, dateKey: "2026-08-01", inMonth: true });
+  });
+});
+
+describe("getFetchRange", () => {
+  it("covers the Sunday-start grid ±1 day", () => {
+    const { start, end } = getFetchRange(YEAR, AUG, 0);
+    // Grid runs Jul 26 – Sep 5; range pads one day each side
+    expect(start).toBe("2026-07-25");
+    expect(end).toBe("2026-09-06");
+  });
+
+  it("covers the Monday-start grid ±1 day", () => {
+    const { start, end } = getFetchRange(YEAR, AUG, 1);
+    // Grid runs Jul 27 – Sep 6; range pads one day each side
+    expect(start).toBe("2026-07-26");
+    expect(end).toBe("2026-09-07");
+  });
+});

--- a/lib/calendar-grid.ts
+++ b/lib/calendar-grid.ts
@@ -1,0 +1,81 @@
+import { localDateKey } from "@/lib/utils";
+
+// Month-grid math for the Calendar tab, parameterized by the first day of
+// the week (0 = Sunday … 6 = Saturday, matching Date.getDay()) so the grid
+// can start on Monday for locales/settings that want it (#320).
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** Weekday header labels, rotated so index 0 is the week's first day. */
+export function orderedWeekdays(firstDow: number): string[] {
+  return WEEKDAY_LABELS.map((_, i) => WEEKDAY_LABELS[(firstDow + i) % 7]);
+}
+
+/** Column offset of a date within a week that starts on `firstDow`. */
+function weekColumn(dow: number, firstDow: number): number {
+  return (dow - firstDow + 7) % 7;
+}
+
+// Fetch the full visible grid (incl. prev/next-month padding cells) padded
+// ±1 day, mirroring Sonarr's web UI. The padding keeps boundary episodes
+// whose UTC day differs from the local day inside the server-side range
+// filter; the extra day on `end` also matters because the *arr APIs treat a
+// date-only end as midnight (exclusive of that day's airings).
+export function getFetchRange(year: number, month: number, firstDow: number) {
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+  const start = new Date(year, month, 1 - weekColumn(first.getDay(), firstDow) - 1);
+  const end = new Date(
+    year,
+    month,
+    last.getDate() + (6 - weekColumn(last.getDay(), firstDow)) + 1,
+  );
+  return {
+    start: localDateKey(start),
+    end: localDateKey(end),
+  };
+}
+
+export interface CalendarGridCell {
+  day: number;
+  dateKey: string;
+  inMonth: boolean;
+}
+
+export function getCalendarGrid(
+  year: number,
+  month: number,
+  firstDow: number,
+): CalendarGridCell[] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const startCol = weekColumn(firstDay.getDay(), firstDow);
+  const daysInMonth = lastDay.getDate();
+
+  const cells: CalendarGridCell[] = [];
+
+  // Previous month padding
+  const prevLast = new Date(year, month, 0).getDate();
+  for (let i = startCol - 1; i >= 0; i--) {
+    const d = prevLast - i;
+    const date = new Date(year, month - 1, d);
+    cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
+  }
+
+  // Current month
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = new Date(year, month, d);
+    cells.push({ day: d, dateKey: localDateKey(date), inMonth: true });
+  }
+
+  // Next month padding
+  const remaining = 7 - (cells.length % 7);
+  if (remaining < 7) {
+    for (let d = 1; d <= remaining; d++) {
+      const date = new Date(year, month + 1, d);
+      cells.push({ day: d, dateKey: localDateKey(date), inMonth: false });
+    }
+  }
+
+  return cells;
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -130,6 +130,12 @@ export const POLLING_INTERVALS = {
   diskSpace: 60000,
 } as const;
 
+// Live indexer searches (Sonarr/Radarr interactive search, Prowlarr and Jackett
+// all-indexer fan-outs) query every configured tracker synchronously and often
+// run past 30s. They need a far longer ceiling than http-client's 15s default,
+// which otherwise aborts a search that was going to succeed.
+export const INTERACTIVE_SEARCH_TIMEOUT = 90_000;
+
 export const DASHBOARD_WIDGET_IDS = [
   "server-stats",
   "speed-stats",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -213,6 +213,7 @@ export const STORAGE_KEYS = {
   globalCustomHeaders: "app.globalCustomHeaders",
   uiScale: "app.uiScale",
   appTheme: "app.appTheme",
+  weekStart: "app.weekStart",
   // v17: user-defined display order for the Services tab tiles. Stored as a
   // ServiceId[]; unknown ids in this list are ignored at render time, and
   // any SERVICE_IDS missing from the list are appended in their canonical

--- a/lib/indexer-adapters/jackett.ts
+++ b/lib/indexer-adapters/jackett.ts
@@ -27,12 +27,20 @@ export const jackettIndexerAdapter: IndexerSearchAdapter = {
   serviceId: "jackett",
   displayName: "Jackett",
 
+  // Interactive indexer searches are slow and expensive: don't auto-retry a
+  // transient failure (it multiplies a 90s timeout by three before the user
+  // sees anything), consume the queryFn signal so backing out aborts the
+  // in-flight fetch, and cache a completed search long enough that returning
+  // to the tab doesn't re-run it. Same contract as useRadarrReleases (#290).
   useSearch: (query: string, instanceId?: string) => {
     const { instanceId: id, enabled } = useInstanceTarget("jackett", instanceId);
     return useQuery({
       queryKey: ["jackett", id, "search", query],
-      queryFn: () => searchAll(query, id ?? undefined),
+      queryFn: ({ signal }) => searchAll(query, id ?? undefined, signal),
       enabled: enabled && query.length >= 2 && !!id,
+      staleTime: 60_000,
+      gcTime: 5 * 60_000,
+      retry: false,
       // Jackett returns results in per-tracker arrival order and the UI slices
       // the top of the list, so sorting by seeders is load-bearing.
       select: (resp: JackettResultsResponse) =>

--- a/lib/indexer-adapters/prowlarr.ts
+++ b/lib/indexer-adapters/prowlarr.ts
@@ -26,15 +26,25 @@ export const prowlarrIndexerAdapter: IndexerSearchAdapter = {
   serviceId: "prowlarr",
   displayName: "Prowlarr",
 
-  // Same queryKey shape as useProwlarrSearch (trailing undefined = no indexer
-  // filter) so both surfaces share one cache entry; `select` maps to the
-  // unified shape without touching the cached raw results.
+  // The trailing `undefined` in the queryKey is the indexer filter, kept so a
+  // filtered search can never collide with this unfiltered one; `select` maps
+  // to the unified shape without touching the cached raw results.
+  //
+  // Interactive indexer searches are slow and expensive: don't auto-retry a
+  // transient failure (it multiplies a 90s timeout by three before the user
+  // sees anything), consume the queryFn signal so backing out aborts the
+  // in-flight fetch, and cache a completed search long enough that returning
+  // to the tab doesn't re-run it. Same contract as useRadarrReleases (#290).
   useSearch: (query: string, instanceId?: string) => {
     const { instanceId: id, enabled } = useInstanceTarget("prowlarr", instanceId);
     return useQuery({
       queryKey: ["prowlarr", id, "search", query, undefined],
-      queryFn: () => searchAll(query, undefined, undefined, id ?? undefined),
+      queryFn: ({ signal }) =>
+        searchAll(query, undefined, undefined, id ?? undefined, signal),
       enabled: enabled && query.length >= 2 && !!id,
+      staleTime: 60_000,
+      gcTime: 5 * 60_000,
+      retry: false,
       select: (results: ProwlarrSearchResult[]) => results.map(prowlarrToUnified),
     });
   },

--- a/lib/week-start.ts
+++ b/lib/week-start.ts
@@ -1,0 +1,28 @@
+import { getCalendars } from "expo-localization";
+
+// First-day-of-week preference for the calendar grid (#320). "auto" follows
+// the device — on iOS that's Settings > General > Language & Region > First
+// Day of Week; on Android it's derived from the locale.
+export const WEEK_STARTS = ["auto", "sunday", "monday"] as const;
+export type WeekStart = (typeof WEEK_STARTS)[number];
+
+export const DEFAULT_WEEK_START: WeekStart = "auto";
+
+export function isValidWeekStart(value: unknown): value is WeekStart {
+  return (WEEK_STARTS as readonly unknown[]).includes(value);
+}
+
+/**
+ * Resolve the preference to a JS day-of-week number (0 = Sunday … 6 =
+ * Saturday, matching Date.getDay()). "auto" can yield any day — e.g. 6
+ * (Saturday) in locales that start the week there — and the grid math in
+ * lib/calendar-grid.ts handles the general case.
+ */
+export function resolveWeekStartDow(setting: WeekStart): number {
+  if (setting === "sunday") return 0;
+  if (setting === "monday") return 1;
+  // expo-localization firstWeekday: 1 = Sunday … 7 = Saturday (may be null
+  // on some Android devices — fall back to Sunday).
+  const firstWeekday = getCalendars()[0]?.firstWeekday;
+  return typeof firstWeekday === "number" ? (firstWeekday - 1 + 7) % 7 : 0;
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "expo-linear-gradient": "^15.0.8",
     "expo-linking": "~8.0.11",
     "expo-local-authentication": "~17.0.8",
+    "expo-localization": "~17.0.9",
     "expo-location": "~19.0.8",
     "expo-notifications": "^0.32.16",
     "expo-router": "~6.0.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       expo-local-authentication:
         specifier: ~17.0.8
         version: 17.0.8(expo@54.0.33)
+      expo-localization:
+        specifier: ~17.0.9
+        version: 17.0.9(expo@54.0.33)(react@19.1.0)
       expo-location:
         specifier: ~19.0.8
         version: 19.0.8(expo@54.0.33)
@@ -2515,6 +2518,12 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-localization@17.0.9:
+    resolution: {integrity: sha512-k5eYHr7iLMob3M8cHH6bgDrDRmqnZG8xKGLhpx8ST+LsFXmSgYpJ/t0VwWm0gz64C/K669XhObdG3D6QwCGqhw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+
   expo-location@19.0.8:
     resolution: {integrity: sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==}
     peerDependencies:
@@ -4292,6 +4301,9 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  rtl-detect@1.1.2:
+    resolution: {integrity: sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -7671,6 +7683,12 @@ snapshots:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       invariant: 2.2.4
 
+  expo-localization@17.0.9(expo@54.0.33)(react@19.1.0):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      rtl-detect: 1.1.2
+
   expo-location@19.0.8(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -9916,6 +9934,8 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rtl-detect@1.1.2: {}
 
   run-parallel@1.2.0:
     dependencies:

--- a/services/jackett-api.test.ts
+++ b/services/jackett-api.test.ts
@@ -6,7 +6,14 @@ jest.mock("@/lib/http-client", () => ({
 }));
 
 import { serviceRequest } from "@/lib/http-client";
-import { getIndexers, parseIndexersXml, searchAll } from "@/services/jackett-api";
+import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
+import {
+  assertIndexersUsable,
+  getIndexers,
+  parseIndexersXml,
+  searchAll,
+} from "@/services/jackett-api";
+import type { JackettResultsResponse } from "@/lib/types";
 
 const mockRequest = serviceRequest as jest.Mock;
 
@@ -109,7 +116,95 @@ describe("searchAll", () => {
     await expect(searchAll("ubuntu", "inst-2")).resolves.toBe(payload);
     expect(mockRequest).toHaveBeenCalledWith("jackett", "/indexers/all/results", {
       params: { Query: "ubuntu" },
+      timeout: INTERACTIVE_SEARCH_TIMEOUT,
       instanceId: "inst-2",
+      signal: undefined,
     });
+  });
+
+  // The 15s default aborts a fan-out that was going to succeed (#314), and
+  // without the signal a hung fetch outlives the search that started it.
+  it("uses the interactive-search timeout and forwards the abort signal", async () => {
+    mockRequest.mockResolvedValue({ Results: [], Indexers: [] });
+    const controller = new AbortController();
+    await searchAll("ubuntu", "inst-2", controller.signal);
+    const opts = mockRequest.mock.calls[0][2];
+    expect(opts.timeout).toBe(INTERACTIVE_SEARCH_TIMEOUT);
+    expect(opts.signal).toBe(controller.signal);
+  });
+
+  it("rejects when the 200 body says every indexer failed", async () => {
+    mockRequest.mockResolvedValue(response(0, [{ Name: "1337x", Error: "boom" }]));
+    await expect(searchAll("ubuntu")).rejects.toThrow(
+      "1 of 1 indexer failed. 1337x: boom",
+    );
+  });
+});
+
+function response(
+  results: number,
+  indexers: Array<{ Name: string; Error: string | null }>,
+): JackettResultsResponse {
+  return {
+    Results: Array.from({ length: results }, (_, i) => ({
+      Guid: `g${i}`,
+      Title: `Release ${i}`,
+      Tracker: "1337x",
+      TrackerId: "1337x",
+      CategoryDesc: null,
+      PublishDate: "2026-01-01T00:00:00Z",
+      Size: 1,
+      Seeders: 1,
+      Peers: 0,
+      Grabs: null,
+      Link: null,
+      MagnetUri: "magnet:?xt=1",
+      Details: null,
+    })),
+    Indexers: indexers.map((i, n) => ({
+      ID: `id${n}`,
+      Name: i.Name,
+      Status: i.Error ? 1 : 0,
+      Results: 0,
+      Error: i.Error,
+    })),
+  };
+}
+
+describe("assertIndexersUsable", () => {
+  // A search where every tracker errored decodes as `Results: []`, which the UI
+  // otherwise renders as a plain "No results" (#314).
+  it("throws when there are no results and every indexer errored", () => {
+    const resp = response(0, [
+      { Name: "1337x", Error: "Connection timed out" },
+      { Name: "Nyaa", Error: "403 Forbidden" },
+    ]);
+    expect(() => assertIndexersUsable(resp)).toThrow(
+      "2 of 2 indexers failed. 1337x: Connection timed out",
+    );
+  });
+
+  // A partial failure still has something to show, so it must not become an
+  // error banner that hides the working trackers' releases.
+  it("stays silent when some indexers errored but results came back", () => {
+    const resp = response(3, [
+      { Name: "1337x", Error: null },
+      { Name: "Nyaa", Error: "403 Forbidden" },
+    ]);
+    expect(() => assertIndexersUsable(resp)).not.toThrow();
+  });
+
+  it("stays silent on a genuine no-match", () => {
+    const resp = response(0, [
+      { Name: "1337x", Error: null },
+      { Name: "Nyaa", Error: null },
+    ]);
+    expect(() => assertIndexersUsable(resp)).not.toThrow();
+  });
+
+  it("tolerates a response with no Indexers array", () => {
+    expect(() =>
+      assertIndexersUsable({ Results: [] } as unknown as JackettResultsResponse),
+    ).not.toThrow();
   });
 });

--- a/services/jackett-api.ts
+++ b/services/jackett-api.ts
@@ -1,6 +1,7 @@
 import { XMLParser } from "fast-xml-parser";
 
 import { serviceRequest } from "@/lib/http-client";
+import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
 import type { JackettIndexer, JackettResultsResponse } from "@/lib/types";
 
 // Jackett API notes:
@@ -20,14 +21,46 @@ import type { JackettIndexer, JackettResultsResponse } from "@/lib/types";
 
 // JSON manual-search endpoint (the one Jackett's own web UI uses). Returns
 // releases across every configured indexer plus per-indexer status rows.
-export function searchAll(
+// Jackett queries every tracker synchronously before responding, which blows
+// past the 15s default on any real setup — hence the interactive-search
+// timeout. `signal` is the caller's cancel channel: without it a hung fetch
+// outlives the search that started it and later searches dedupe onto the
+// zombie, the "stuck on Searching... forever" report in #314.
+export async function searchAll(
   query: string,
   instanceId?: string,
+  signal?: AbortSignal,
 ): Promise<JackettResultsResponse> {
-  return serviceRequest<JackettResultsResponse>("jackett", "/indexers/all/results", {
-    params: { Query: query },
-    instanceId,
-  });
+  const resp = await serviceRequest<JackettResultsResponse>(
+    "jackett",
+    "/indexers/all/results",
+    {
+      params: { Query: query },
+      timeout: INTERACTIVE_SEARCH_TIMEOUT,
+      instanceId,
+      signal,
+    },
+  );
+  assertIndexersUsable(resp);
+  return resp;
+}
+
+// Jackett answers 200 with `Results: []` whether nothing matched or every
+// tracker blew up, so a broken setup is indistinguishable from a bad query and
+// renders as a bare "No results" (#314). Promote its own per-indexer Error
+// strings to a thrown error the UI can show. Only when there is nothing at all
+// to display: a partial failure still renders what the working trackers
+// returned. Exported for tests.
+export function assertIndexersUsable(resp: JackettResultsResponse): void {
+  if (resp.Results.length > 0) return;
+  const indexers = resp.Indexers ?? [];
+  const failed = indexers.filter((i) => !!i.Error);
+  if (failed.length === 0) return;
+  throw new Error(
+    `${failed.length} of ${indexers.length} indexer` +
+      `${indexers.length === 1 ? "" : "s"} failed. ` +
+      `${failed[0].Name}: ${failed[0].Error}`,
+  );
 }
 
 // --- Indexers ---

--- a/services/prowlarr-api.ts
+++ b/services/prowlarr-api.ts
@@ -1,4 +1,5 @@
 import { serviceRequest } from "@/lib/http-client";
+import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
 import type {
   ProwlarrIndexer,
   ProwlarrIndexerStatus,
@@ -49,11 +50,16 @@ export function toggleIndexer(
 
 // --- Search ---
 
+// Fans out to every configured indexer, so it gets the interactive-search
+// timeout rather than the 15s default. `signal` is the caller's (TanStack
+// Query's) cancel channel — without it a hung fetch outlives the search that
+// started it and later searches dedupe onto the zombie (#290, #314).
 export function searchAll(
   query: string,
   indexerIds?: number[],
   categories?: number[],
   instanceId?: string,
+  signal?: AbortSignal,
 ): Promise<ProwlarrSearchResult[]> {
   const params: Record<string, string | number | boolean> = {
     query,
@@ -67,7 +73,9 @@ export function searchAll(
   }
   return serviceRequest<ProwlarrSearchResult[]>("prowlarr", "/search", {
     params,
+    timeout: INTERACTIVE_SEARCH_TIMEOUT,
     instanceId,
+    signal,
   });
 }
 

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -1,4 +1,5 @@
 import { serviceRequest } from "@/lib/http-client";
+import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
 import type {
   RadarrMovie,
   RadarrQueue,
@@ -11,11 +12,6 @@ import type {
   RadarrCollection,
   ArrQueueRemoveOptions,
 } from "@/lib/types";
-
-// Interactive search hits indexers live and frequently exceeds the 15s
-// default timeout. Bump per-call to keep slow indexers from short-circuiting
-// the whole search.
-const INTERACTIVE_SEARCH_TIMEOUT = 90_000;
 
 // --- Image helpers ---
 

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -1,4 +1,5 @@
 import { serviceRequest } from "@/lib/http-client";
+import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
 import type {
   SonarrSeries,
   SonarrEpisode,
@@ -14,8 +15,6 @@ import type {
   SonarrWantedMissing,
   ArrQueueRemoveOptions,
 } from "@/lib/types";
-
-const INTERACTIVE_SEARCH_TIMEOUT = 90_000;
 
 // --- Image helpers ---
 

--- a/store/config-migrations.test.ts
+++ b/store/config-migrations.test.ts
@@ -1706,3 +1706,30 @@ describe("v37 → v38 (appTheme stamp)", () => {
     expect(result.appTheme).toBeUndefined();
   });
 });
+
+describe("v39 → v40 (weekStart stamp)", () => {
+  it("just stamps the version and preserves an already-set weekStart", () => {
+    const result: any = migrateConfig({
+      version: 39,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+      weekStart: "monday",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.weekStart).toBe("monday");
+  });
+
+  it("leaves weekStart absent when the source payload omitted it", () => {
+    const result: any = migrateConfig({
+      version: 39,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.weekStart).toBeUndefined();
+  });
+});

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -153,8 +153,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         defaultInstances() iterates SERVICE_IDS and backfills a disabled
  *         jackett instance at import time, so older exports just need the
  *         version field bumped.
+ *   v40 — optional `weekStart` calendar first-day-of-week preference (#320).
+ *         Pure version stamp — absence means "auto" (follow the device), and
+ *         importConfig whitelists the value.
  */
-export const CURRENT_CONFIG_VERSION = 39;
+export const CURRENT_CONFIG_VERSION = 40;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -667,6 +670,9 @@ const migrations: Record<number, (payload: any) => any> = {
   // v38 → v39: added the jackett service entry (#300). Pure version stamp —
   // defaultInstances() backfills a disabled jackett instance at import.
   38: (payload) => ({ ...payload, version: 39 }),
+  // v39 → v40: optional `weekStart` first-day-of-week preference (#320).
+  // Pure version stamp — absence means "auto" (follow the device).
+  39: (payload) => ({ ...payload, version: 40 }),
 };
 
 /**

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -37,6 +37,11 @@ import {
   type AppThemeId,
 } from "@/lib/app-themes";
 import {
+  DEFAULT_WEEK_START,
+  isValidWeekStart,
+  type WeekStart,
+} from "@/lib/week-start";
+import {
   DEFAULT_DASHBOARD_ICON,
   type DashboardIconName,
 } from "@/lib/dashboard-icons";
@@ -375,6 +380,8 @@ interface ConfigState {
   uiScale: UiScale;
   // Global chrome tint preset applied via NativeWind CSS vars (ThemeRoot).
   appTheme: AppThemeId;
+  // Calendar first day of week: follow the device or force Sunday/Monday.
+  weekStart: WeekStart;
   notificationSettings: NotificationSettings;
 }
 
@@ -410,6 +417,8 @@ export interface ExportPayload {
   treatVpnAsHome?: boolean;
   // v38 — global app theme preset.
   appTheme?: AppThemeId;
+  // v40 — calendar first-day-of-week preference (#320).
+  weekStart?: WeekStart;
 }
 
 export type ExportStage = "preparing" | "encrypting" | "finalizing";
@@ -529,6 +538,7 @@ interface ConfigActions {
   setGlobalCustomHeaders: (headers: Record<string, string>) => void;
   setUiScale: (scale: UiScale) => void;
   setAppTheme: (theme: AppThemeId) => void;
+  setWeekStart: (weekStart: WeekStart) => void;
   setNotificationSetting: <K extends keyof NotificationSettings>(
     key: K,
     value: NotificationSettings[K],
@@ -996,6 +1006,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
   globalCustomHeaders: {},
   uiScale: DEFAULT_UI_SCALE,
   appTheme: DEFAULT_APP_THEME,
+  weekStart: DEFAULT_WEEK_START,
   notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
 
   hydrate: async () => {
@@ -1456,6 +1467,11 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       ? storedAppTheme
       : DEFAULT_APP_THEME;
 
+    const storedWeekStart = getString(STORAGE_KEYS.weekStart);
+    const weekStart: WeekStart = isValidWeekStart(storedWeekStart)
+      ? storedWeekStart
+      : DEFAULT_WEEK_START;
+
     // Notification settings persisted under their own AsyncStorage key since
     // v2 (originally owned by a standalone notifications-store). Merge over
     // defaults so a partially-stored payload (older app picking up newer
@@ -1551,6 +1567,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders,
       uiScale,
       appTheme,
+      weekStart,
       notificationSettings,
       hydrated: true,
     });
@@ -2460,6 +2477,12 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     set({ appTheme: theme });
   },
 
+  setWeekStart: (weekStart) => {
+    if (!isValidWeekStart(weekStart)) return;
+    setString(STORAGE_KEYS.weekStart, weekStart);
+    set({ weekStart });
+  },
+
   setNotificationSetting: (key, value) => {
     const next = { ...get().notificationSettings, [key]: value };
     setJSON(STORAGE_KEYS.notificationSettings, next);
@@ -2668,6 +2691,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders,
       uiScale,
       appTheme,
+      weekStart,
       notificationSettings: notifSettings,
     } = get();
     const { url, sharedSecret, deviceId } = useBackendStore.getState();
@@ -2692,6 +2716,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders,
       uiScale,
       appTheme,
+      weekStart,
     };
 
     onStage?.("encrypting");
@@ -2867,6 +2892,10 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       ? payload.appTheme
       : DEFAULT_APP_THEME;
     setString(STORAGE_KEYS.appTheme, importedAppTheme);
+    const importedWeekStart: WeekStart = isValidWeekStart(payload.weekStart)
+      ? payload.weekStart
+      : DEFAULT_WEEK_START;
+    setString(STORAGE_KEYS.weekStart, importedWeekStart);
     const importedServicesOrder = sanitizeServicesOrder(payload.servicesOrder);
     setJSON(STORAGE_KEYS.servicesOrder, importedServicesOrder);
 
@@ -2922,6 +2951,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       globalCustomHeaders: importedGlobalCustomHeaders,
       uiScale: importedUiScale,
       appTheme: importedAppTheme,
+      weekStart: importedWeekStart,
       notificationSettings: importedNotificationSettings,
     });
 


### PR DESCRIPTION
Refs #314

## Summary

**Badge overflow.** Yoga defaults `flexShrink` to 0, so `numberOfLines={1}` on the indexer name never truncated: the Text laid out at full intrinsic width and pushed the seeders/leechers and protocol pill past the card's content box. The indexer name is now the one `flex-1` element. Prowlarr shares this card and gets the same fix.

**Stuck search** (reported in the issue comments as "just said searching", nothing came up):

- The Indexers tab had no debounce, so every keystroke started a fresh all-indexers fan-out under its own queryKey. Now debounced 300ms, matching global search.
- Jackett and Prowlarr `searchAll` inherited the 15s HTTP default, which aborts a fan-out that was going to succeed. Both now use the 90s interactive-search timeout, hoisted to `lib/constants.ts` from the duplicate definitions in the Sonarr and Radarr services.
- Neither threaded the queryFn abort signal and both inherited 2 retries, so a hung fetch became a zombie later searches deduped onto and a failure took ~48s to surface. Both adapters now match the `useRadarrReleases` contract from #290: signal, `retry: false`, `staleTime`/`gcTime`.
- A failed search rendered nothing at all. `ReleaseSearch` now shows `ErrorBanner`, and Jackett's per-indexer `Error` strings are promoted to a thrown error so "every tracker errored" no longer reads as "No results".

Also removes `useJackettSearch` and `useProwlarrSearch`, which had no callers and were unhardened copies of the live path.

## Test plan

- `tsc --noEmit` clean
- `jest`: 854 passing, including 5 new Jackett cases covering the timeout, the abort signal, and the all-indexers-failed error
- Not yet verified on a device