### PR TITLE
feat(sonarr): monitor/unmonitor and delete files from the season menu

### DIFF
--- a/app/series/[id].tsx
+++ b/app/series/[id].tsx
@@ -9,6 +9,7 @@ import {
   UserSearch,
   Trash2,
   Bookmark,
+  BookmarkX,
   MoreHorizontal,
   Award,
   Tv,
@@ -44,7 +45,9 @@ import {
   useSonarrEpisodeFiles,
   useSonarrQueue,
   useToggleEpisodeMonitored,
+  useToggleSeasonMonitored,
   useDeleteEpisodeFile,
+  useDeleteEpisodeFiles,
   useSearchForEpisodes,
   useSearchForSeason,
   useSearchForSeries,
@@ -739,8 +742,10 @@ function SeasonAccordion({
 }) {
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
-  const flow = useModalFlow<{ menu: void }>();
+  const flow = useModalFlow<{ menu: void; confirmDeleteFiles: void }>();
   const searchSeason = useSearchForSeason(instanceId);
+  const toggleSeason = useToggleSeasonMonitored(instanceId);
+  const deleteSeasonFiles = useDeleteEpisodeFiles(instanceId);
   const stats = season.statistics;
   const progress = stats ? stats.percentOfEpisodes / 100 : 0;
   // Any episode of this season currently grabbing turns the season bar purple.
@@ -754,6 +759,13 @@ function SeasonAccordion({
   const releasesQuery = `seasonNumber=${season.seasonNumber}${
     instanceId ? `&instanceId=${instanceId}` : ""
   }`;
+
+  // Every downloaded file in this season — what "Delete Files" removes in one
+  // bulk request. Empty while the episode list is still loading, which also
+  // keeps us from sending Sonarr an empty id list (it throws on that).
+  const seasonFileIds = (episodes ?? [])
+    .map((ep) => ep.episodeFileId)
+    .filter((fileId): fileId is number => !!fileId);
 
   // Mirrors the episode "⋯" menu: automatic vs interactive search read clearly
   // as labeled rows instead of a bare magnifier icon.
@@ -772,6 +784,39 @@ function SeasonAccordion({
           router.push(`/series/releases/${seriesId}?${releasesQuery}`),
         ),
     },
+    {
+      label: season.monitored ? "Unmonitor Season" : "Monitor Season",
+      // Sonarr cascades a season's monitored flag onto its episodes server-side
+      // — worth saying, since the episode rows below carry their own toggles.
+      subtitle: "Includes all episodes",
+      icon: (
+        <Icon
+          icon={season.monitored ? BookmarkX : Bookmark}
+          size={20}
+          color={season.monitored ? "#a1a1aa" : "#3b82f6"}
+        />
+      ),
+      disabled: toggleSeason.isPending,
+      onPress: () =>
+        toggleSeason.mutate({
+          seriesId,
+          seasonNumber: season.seasonNumber,
+          monitored: !season.monitored,
+        }),
+    },
+    ...(seasonFileIds.length > 0
+      ? [
+          {
+            label: "Delete Files",
+            subtitle: `${seasonFileIds.length} file${
+              seasonFileIds.length !== 1 ? "s" : ""
+            }${stats?.sizeOnDisk ? ` · ${formatBytes(stats.sizeOnDisk)}` : ""}`,
+            icon: <Icon icon={Trash2} size={20} color="#ef4444" />,
+            variant: "danger" as const,
+            onPress: () => flow.open("confirmDeleteFiles"),
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -797,15 +842,47 @@ function SeasonAccordion({
               {stats.episodeFileCount}/{stats.episodeCount}
             </Text>
           )}
-          <Pressable
-            onPress={() => flow.open("menu")}
-            hitSlop={8}
-            className="p-1 active:opacity-70"
-            accessibilityRole="button"
-            accessibilityLabel={`${seasonLabel} actions`}
-          >
-            <Icon icon={MoreHorizontal} size={16} color="#a1a1aa" />
-          </Pressable>
+          <View className="flex-row items-center gap-1">
+            {/* Mirrors the per-episode bookmark: without it the menu's
+                Monitor/Unmonitor row would be the only way to see — or notice a
+                change in — the season's monitored state. */}
+            <Pressable
+              onPress={() =>
+                toggleSeason.mutate({
+                  seriesId,
+                  seasonNumber: season.seasonNumber,
+                  monitored: !season.monitored,
+                })
+              }
+              disabled={toggleSeason.isPending}
+              hitSlop={8}
+              className={`p-1 active:opacity-70 ${
+                toggleSeason.isPending ? "opacity-50" : ""
+              }`}
+              accessibilityRole="button"
+              accessibilityLabel={
+                season.monitored
+                  ? `${seasonLabel} monitored — tap to unmonitor`
+                  : `${seasonLabel} not monitored — tap to monitor`
+              }
+            >
+              <Icon
+                icon={Bookmark}
+                size={16}
+                color={season.monitored ? "#3b82f6" : "#52525b"}
+                fill={season.monitored ? "#3b82f6" : "transparent"}
+              />
+            </Pressable>
+            <Pressable
+              onPress={() => flow.open("menu")}
+              hitSlop={8}
+              className="p-1 active:opacity-70"
+              accessibilityRole="button"
+              accessibilityLabel={`${seasonLabel} actions`}
+            >
+              <Icon icon={MoreHorizontal} size={16} color="#a1a1aa" />
+            </Pressable>
+          </View>
         </View>
       </View>
 
@@ -843,6 +920,21 @@ function SeasonAccordion({
         {...flow.bind("menu")}
         title={seasonLabel}
         actions={seasonActions}
+      />
+
+      <ConfirmModal
+        {...flow.bind("confirmDeleteFiles")}
+        title="Delete Season Files"
+        message={`Delete ${seasonFileIds.length} episode file${
+          seasonFileIds.length !== 1 ? "s" : ""
+        } for ${seasonLabel}? The episodes stay in the library but will be marked missing.`}
+        icon={Trash2}
+        tone="danger"
+        confirmLabel="Delete"
+        onConfirm={() => {
+          flow.close();
+          if (seasonFileIds.length > 0) deleteSeasonFiles.mutate(seasonFileIds);
+        }}
       />
     </Card>
   );

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -5,6 +5,7 @@ import {
   getEpisodes,
   getEpisodeFiles,
   deleteEpisodeFile,
+  deleteEpisodeFiles,
   getCalendar,
   getQueue,
   getHistory,
@@ -183,16 +184,42 @@ export function useDeleteEpisodeFile(instanceId?: string) {
     mutationFn: (episodeFileId: number) =>
       deleteEpisodeFile(episodeFileId, id ?? undefined),
     onSuccess: () => {
-      // Refresh the episode list, file map, and series stats (file counts).
-      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "episodes"] });
-      queryClient.invalidateQueries({
-        queryKey: ["sonarr", id, "episodeFiles"],
-      });
-      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
+      invalidateAfterFileDelete(queryClient, id);
       toast("Episode file deleted");
     },
     onError: (err) => toastError("Delete failed", err),
   });
+}
+
+// Season-level "delete files": one bulk request for every file in the season.
+// The episodes stay in the library and flip back to missing, same as the
+// single-file delete.
+export function useDeleteEpisodeFiles(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
+  return useMutation({
+    mutationFn: (episodeFileIds: number[]) =>
+      deleteEpisodeFiles(episodeFileIds, id ?? undefined),
+    onSuccess: (_data, episodeFileIds) => {
+      invalidateAfterFileDelete(queryClient, id);
+      toast(
+        `${episodeFileIds.length} episode file${
+          episodeFileIds.length !== 1 ? "s" : ""
+        } deleted`,
+      );
+    },
+    onError: (err) => toastError("Delete failed", err),
+  });
+}
+
+// Refresh the episode list, file map, and series stats (file counts).
+function invalidateAfterFileDelete(
+  queryClient: ReturnType<typeof useQueryClient>,
+  id: string | null,
+) {
+  queryClient.invalidateQueries({ queryKey: ["sonarr", id, "episodes"] });
+  queryClient.invalidateQueries({ queryKey: ["sonarr", id, "episodeFiles"] });
+  queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
 }
 
 export function useSearchForSeries(instanceId?: string) {
@@ -380,6 +407,58 @@ export function useUpdateSeriesFields(instanceId?: string) {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "series"] });
     },
   });
+}
+
+/**
+ * Season monitoring lives on the series resource, so the toggle is the same
+ * full series PUT as any other field edit — Sonarr's own web UI flips
+ * `seasons[n].monitored` and PUTs /series/{id}. Server-side,
+ * `SeriesService.UpdateSeries` notices the changed season and calls
+ * `SetEpisodeMonitoredBySeason`, so every episode in that season follows and
+ * the episode list has to be refetched on top of the usual series caches.
+ */
+export function useToggleSeasonMonitored(instanceId?: string) {
+  const queryClient = useQueryClient();
+  const { instanceId: id } = useInstanceTarget("sonarr", instanceId);
+  const update = useUpdateSeriesFields(instanceId);
+
+  return {
+    isPending: update.isPending,
+    mutate: ({
+      seriesId,
+      seasonNumber,
+      monitored,
+    }: {
+      seriesId: number;
+      seasonNumber: number;
+      monitored: boolean;
+    }) => {
+      const cached = queryClient.getQueryData<SonarrSeries>([
+        "sonarr",
+        id,
+        "series",
+        seriesId,
+      ]);
+      if (!cached) return;
+      update.mutate(
+        {
+          seriesId,
+          fields: {
+            seasons: cached.seasons.map((s) =>
+              s.seasonNumber === seasonNumber ? { ...s, monitored } : s,
+            ),
+          },
+          errorLabel: "Failed to update monitoring",
+        },
+        {
+          onSettled: () =>
+            queryClient.invalidateQueries({
+              queryKey: ["sonarr", id, "episodes", seriesId],
+            }),
+        },
+      );
+    },
+  };
 }
 
 export function useUpdateSeriesRootFolder(instanceId?: string) {

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -99,6 +99,23 @@ export function deleteEpisodeFile(
   });
 }
 
+// Bulk file delete — the endpoint behind Sonarr's own "delete selected files",
+// used here to clear a whole season in one request instead of N per-file
+// DELETEs. Present since Sonarr v3 (Sonarr.Api.V3 EpisodeFileModule:
+// `Delete("/bulk")` reading an EpisodeFileListResource).
+// Never call with an empty list: Sonarr resolves the series from
+// `episodeFiles.First()` and throws on an empty match.
+export function deleteEpisodeFiles(
+  episodeFileIds: number[],
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("sonarr", "/episodefile/bulk", {
+    method: "DELETE",
+    body: JSON.stringify({ episodeFileIds }),
+    instanceId,
+  });
+}
+
 // --- Calendar ---
 
 export function getCalendar(


### PR DESCRIPTION
Adds the two season-level actions from #311 to the season "..." menu on the series detail screen.

- **Monitor / Unmonitor Season** - flips `seasons[n].monitored` and PUTs the series, same as Sonarr web. Sonarr cascades it to the season's episodes server-side (`SetEpisodeMonitoredBySeason`), so the episode list is invalidated too.
- **Delete Files** - one `DELETE /episodefile/bulk` for the season, behind a `ConfirmModal`. Hidden when the season has no files (Sonarr throws on an empty id list).

Also adds a tappable monitored bookmark to the season header, mirroring the episode rows, so the toggle has visible state and feedback.

Refs #311

## Test plan
- `tsc --noEmit` clean
- `jest` 854/854 passing
- Not verified on device