### PR TITLE
fix(backend): patch fast-uri and find-my-way CVEs, release v1.2.8

### DIFF
--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1118,9 +1118,9 @@
       "license": "MIT"
     },
     "node_modules/find-my-way": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
-      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboarr-backend",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/rate-limit": "^10.2.1",

--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Self-hosted companion backend for Dashboarr — polls your *arr stack and sends real Expo push notifications",
   "license": "GPL-3.0",
   "private": true,

--- a/backend/dashboarr-backend/pnpm-lock.yaml
+++ b/backend/dashboarr-backend/pnpm-lock.yaml
@@ -350,8 +350,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -365,8 +365,8 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
-  find-my-way@9.6.0:
-    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@4.1.0:
@@ -733,7 +733,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
 
   '@fastify/error@4.2.0': {}
 
@@ -783,7 +783,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -900,7 +900,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -908,7 +908,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -921,7 +921,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 6.4.0
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -936,7 +936,7 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2


### PR DESCRIPTION
Patches both HIGH CVEs in the backend image.

- `fast-uri` 3.1.3 -> 3.1.5 (CVE-2026-16221) - code-scanning alert #44
- `find-my-way` 9.5.0 -> 9.7.0 (CVE-2026-47219) - not yet an alert, but postdates the scan behind #44 and would open one on the next push to main

Both are transitive fastify deps whose existing ranges (`^3.0.0`/`^3.0.1`, `^9.0.0`) already admit the patched versions, so no `overrides` and no major bumps. Same shape as 8416ec0.

Note: neither would have been caught by the current Dependabot config, which runs version updates only. Transitive CVEs need Dependabot security updates, a repo-settings toggle.

## Test plan

- [x] `npm ci` clean; `npm ls` shows fast-uri 3.1.5 deduped across all three dependents, find-my-way 9.7.0
- [x] `npm run typecheck` clean, 26/26 tests pass, `npm run build` clean
- [x] Docker image rebuilt and scanned with Trivy (fresh DB, same `HIGH,CRITICAL --ignore-unfixed` settings as CI): 0 findings, alpine and node-pkg
- [x] `npm audit` HIGH count 1 -> 0 (remaining low is esbuild via tsx, a dev dep stripped by `npm prune --omit=dev`)

Refs #44