### PR TITLE
feat(search): rank library matches first in Radarr/Sonarr/Lidarr search

### DIFF
--- a/app/artist/search.tsx
+++ b/app/artist/search.tsx
@@ -1,32 +1,28 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { View, Text } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { Mic2 } from "lucide-react-native";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
+import { ErrorBanner } from "@/components/common/error-banner";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AddArtistSheet } from "@/components/lidarr/add-artist-sheet";
+import { ArrLibraryRow } from "@/components/search/arr-library-row";
 import { LidarrSearchRow } from "@/components/search/lidarr-search-row";
-import { useLidarrSearch, useLidarrArtists } from "@/hooks/use-lidarr";
+import { useLidarrSearchRows } from "@/hooks/use-arr-search-rows";
 import type { LidarrArtistSearchResult } from "@/lib/types";
 
 export default function ArtistSearchScreen() {
   const router = useRouter();
   const { q } = useLocalSearchParams<{ q?: string }>();
   const [query, setQuery] = useState(q ?? "");
-  const { data: results, isLoading } = useLidarrSearch(query);
-  const { data: existing } = useLidarrArtists();
+  // Artists already in Lidarr match locally and render on the keystroke; only the
+  // MusicBrainz lookup underneath waits on the network (#304).
+  const { rows, isLoading, isError, error } = useLidarrSearchRows(query);
   const [advancedTarget, setAdvancedTarget] = useState<LidarrArtistSearchResult | null>(
     null,
   );
-
-  const existingByForeignId = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const a of existing ?? []) {
-      map.set(a.foreignArtistId, a.id);
-    }
-    return map;
-  }, [existing]);
 
   return (
     <ScreenWrapper>
@@ -40,28 +36,41 @@ export default function ArtistSearchScreen() {
         containerClassName="mb-4"
       />
 
-      {isLoading && <Text className="text-zinc-500">Searching...</Text>}
+      {isLoading && <Text className="text-zinc-500 mb-3">Searching...</Text>}
 
-      {results && results.length === 0 && query.length >= 2 && (
+      {/* The lookup can fail while library matches still render, so the failure
+          needs to be visible rather than read as "no results". */}
+      {isError && (
+        <ErrorBanner error={error} title="Couldn't search Lidarr" className="mb-4" />
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && query.trim().length >= 2 && (
         <EmptyState title="No results" message={`No artists found for "${query}"`} />
       )}
 
-      {results && results.length > 0 && (
+      {rows.length > 0 && (
         <View className="gap-3">
-          {results.map((result) => {
-            const existingId = existingByForeignId.get(result.foreignArtistId);
-            return (
+          {rows.map((row) =>
+            row.kind === "library" ? (
+              <ArrLibraryRow
+                key={row.key}
+                serviceId="lidarr"
+                fallbackIcon={Mic2}
+                display={row.display}
+                onOpen={() => router.push(`/artist/${row.id}`)}
+              />
+            ) : (
               <LidarrSearchRow
-                key={result.foreignArtistId}
-                result={result}
-                existingArtistId={existingId}
-                onAdvanced={() => setAdvancedTarget(result)}
+                key={row.key}
+                result={row.result}
+                existingArtistId={row.existingId}
+                onAdvanced={() => setAdvancedTarget(row.result)}
                 onOpenExisting={() =>
-                  existingId !== undefined && router.push(`/artist/${existingId}`)
+                  row.existingId !== undefined && router.push(`/artist/${row.existingId}`)
                 }
               />
-            );
-          })}
+            ),
+          )}
         </View>
       )}
 

--- a/app/movie/search.tsx
+++ b/app/movie/search.tsx
@@ -1,30 +1,26 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { View, Text } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { Film } from "lucide-react-native";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
+import { ErrorBanner } from "@/components/common/error-banner";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AddMovieSheet } from "@/components/radarr/add-movie-sheet";
+import { ArrLibraryRow } from "@/components/search/arr-library-row";
 import { RadarrSearchRow } from "@/components/search/radarr-search-row";
-import { useRadarrSearch, useRadarrMovies } from "@/hooks/use-radarr";
+import { useRadarrSearchRows } from "@/hooks/use-arr-search-rows";
 import type { RadarrSearchResult } from "@/lib/types";
 
 export default function MovieSearchScreen() {
   const router = useRouter();
   const { q } = useLocalSearchParams<{ q?: string }>();
   const [query, setQuery] = useState(q ?? "");
-  const { data: results, isLoading } = useRadarrSearch(query);
-  const { data: existing } = useRadarrMovies();
+  // Movies already in Radarr match locally and render on the keystroke; only the
+  // TMDB lookup underneath waits on the network (#304).
+  const { rows, isLoading, isError, error } = useRadarrSearchRows(query);
   const [advancedTarget, setAdvancedTarget] = useState<RadarrSearchResult | null>(null);
-
-  const existingByTmdbId = useMemo(() => {
-    const map = new Map<number, number>();
-    for (const m of existing ?? []) {
-      map.set(m.tmdbId, m.id);
-    }
-    return map;
-  }, [existing]);
 
   return (
     <ScreenWrapper>
@@ -38,28 +34,41 @@ export default function MovieSearchScreen() {
         containerClassName="mb-4"
       />
 
-      {isLoading && <Text className="text-zinc-500">Searching...</Text>}
+      {isLoading && <Text className="text-zinc-500 mb-3">Searching...</Text>}
 
-      {results && results.length === 0 && query.length >= 2 && (
+      {/* The lookup can fail while library matches still render, so the failure
+          needs to be visible rather than read as "no results". */}
+      {isError && (
+        <ErrorBanner error={error} title="Couldn't search Radarr" className="mb-4" />
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && query.trim().length >= 2 && (
         <EmptyState title="No results" message={`No movies found for "${query}"`} />
       )}
 
-      {results && results.length > 0 && (
+      {rows.length > 0 && (
         <View className="gap-3">
-          {results.map((result) => {
-            const existingId = existingByTmdbId.get(result.tmdbId);
-            return (
+          {rows.map((row) =>
+            row.kind === "library" ? (
+              <ArrLibraryRow
+                key={row.key}
+                serviceId="radarr"
+                fallbackIcon={Film}
+                display={row.display}
+                onOpen={() => router.push(`/movie/${row.id}`)}
+              />
+            ) : (
               <RadarrSearchRow
-                key={result.tmdbId}
-                result={result}
-                existingMovieId={existingId}
-                onAdvanced={() => setAdvancedTarget(result)}
+                key={row.key}
+                result={row.result}
+                existingMovieId={row.existingId}
+                onAdvanced={() => setAdvancedTarget(row.result)}
                 onOpenExisting={() =>
-                  existingId !== undefined && router.push(`/movie/${existingId}`)
+                  row.existingId !== undefined && router.push(`/movie/${row.existingId}`)
                 }
               />
-            );
-          })}
+            ),
+          )}
         </View>
       )}
 

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -26,7 +26,8 @@ const MIN_QUERY = 2;
  */
 export default function GlobalSearchScreen() {
   const [query, setQuery] = useState("");
-  const debounced = useDebouncedValue(query.trim(), 300);
+  const trimmed = query.trim();
+  const debounced = useDebouncedValue(trimmed, 300);
   const attachedKinds = useAttachedKinds();
 
   const hasRadarr = attachedKinds.has("radarr");
@@ -65,9 +66,11 @@ export default function GlobalSearchScreen() {
         />
       ) : (
         <>
-          {hasRadarr && <RadarrSearchSection query={debounced} />}
-          {hasSonarr && <SonarrSearchSection query={debounced} />}
-          {hasLidarr && <LidarrSearchSection query={debounced} />}
+          {/* The *arr sections take the raw query: their library half matches on
+              the keystroke and they debounce their own lookup (#304). */}
+          {hasRadarr && <RadarrSearchSection query={trimmed} />}
+          {hasSonarr && <SonarrSearchSection query={trimmed} />}
+          {hasLidarr && <LidarrSearchSection query={trimmed} />}
           {hasOverseerr && <OverseerrSearchSection query={debounced} />}
           {hasProwlarr && (
             <ReleaseSearchSection adapter={prowlarrIndexerAdapter} query={debounced} />

--- a/app/series/search.tsx
+++ b/app/series/search.tsx
@@ -1,30 +1,26 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { View, Text } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { Tv } from "lucide-react-native";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
+import { ErrorBanner } from "@/components/common/error-banner";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { AddSeriesSheet } from "@/components/sonarr/add-series-sheet";
+import { ArrLibraryRow } from "@/components/search/arr-library-row";
 import { SonarrSearchRow } from "@/components/search/sonarr-search-row";
-import { useSonarrSearch, useSonarrSeries } from "@/hooks/use-sonarr";
+import { useSonarrSearchRows } from "@/hooks/use-arr-search-rows";
 import type { SonarrSearchResult } from "@/lib/types";
 
 export default function SeriesSearchScreen() {
   const router = useRouter();
   const { q } = useLocalSearchParams<{ q?: string }>();
   const [query, setQuery] = useState(q ?? "");
-  const { data: results, isLoading } = useSonarrSearch(query);
-  const { data: existing } = useSonarrSeries();
+  // Shows already in Sonarr match locally and render on the keystroke; only the
+  // TVDB lookup underneath waits on the network (#304).
+  const { rows, isLoading, isError, error } = useSonarrSearchRows(query);
   const [advancedTarget, setAdvancedTarget] = useState<SonarrSearchResult | null>(null);
-
-  const existingByTvdbId = useMemo(() => {
-    const map = new Map<number, number>();
-    for (const s of existing ?? []) {
-      map.set(s.tvdbId, s.id);
-    }
-    return map;
-  }, [existing]);
 
   return (
     <ScreenWrapper>
@@ -38,28 +34,41 @@ export default function SeriesSearchScreen() {
         containerClassName="mb-4"
       />
 
-      {isLoading && <Text className="text-zinc-500">Searching...</Text>}
+      {isLoading && <Text className="text-zinc-500 mb-3">Searching...</Text>}
 
-      {results && results.length === 0 && query.length >= 2 && (
+      {/* The lookup can fail while library matches still render, so the failure
+          needs to be visible rather than read as "no results". */}
+      {isError && (
+        <ErrorBanner error={error} title="Couldn't search Sonarr" className="mb-4" />
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && query.trim().length >= 2 && (
         <EmptyState title="No results" message={`No shows found for "${query}"`} />
       )}
 
-      {results && results.length > 0 && (
+      {rows.length > 0 && (
         <View className="gap-3">
-          {results.map((result) => {
-            const existingId = existingByTvdbId.get(result.tvdbId);
-            return (
+          {rows.map((row) =>
+            row.kind === "library" ? (
+              <ArrLibraryRow
+                key={row.key}
+                serviceId="sonarr"
+                fallbackIcon={Tv}
+                display={row.display}
+                onOpen={() => router.push(`/series/${row.id}`)}
+              />
+            ) : (
               <SonarrSearchRow
-                key={result.tvdbId}
-                result={result}
-                existingSeriesId={existingId}
-                onAdvanced={() => setAdvancedTarget(result)}
+                key={row.key}
+                result={row.result}
+                existingSeriesId={row.existingId}
+                onAdvanced={() => setAdvancedTarget(row.result)}
                 onOpenExisting={() =>
-                  existingId !== undefined && router.push(`/series/${existingId}`)
+                  row.existingId !== undefined && router.push(`/series/${row.existingId}`)
                 }
               />
-            );
-          })}
+            ),
+          )}
         </View>
       )}
 

--- a/components/search/arr-library-row.tsx
+++ b/components/search/arr-library-row.tsx
@@ -1,0 +1,35 @@
+import type { ComponentType } from "react";
+import { MediaSearchResultCard } from "@/components/search/media-search-result-card";
+import type { LibraryRowDisplay } from "@/hooks/use-arr-search-rows";
+import type { ServiceId } from "@/lib/constants";
+
+/**
+ * A library hit promoted above the lookup results (#304). Service-agnostic: the
+ * display fields are built by the adapter in use-arr-search-rows.ts, so Radarr,
+ * Sonarr and Lidarr share this one row. Nothing to add here, so the card renders
+ * its "In library" state and the whole row opens the existing detail screen.
+ */
+export function ArrLibraryRow({
+  serviceId,
+  fallbackIcon,
+  display,
+  onOpen,
+}: {
+  serviceId: ServiceId;
+  fallbackIcon: ComponentType<{ size?: number; color?: string }>;
+  display: LibraryRowDisplay;
+  onOpen: () => void;
+}) {
+  return (
+    <MediaSearchResultCard
+      serviceId={serviceId}
+      poster={display.poster}
+      fallbackIcon={fallbackIcon}
+      title={display.title}
+      metaLine={display.metaLine}
+      overview={display.overview}
+      alreadyAdded
+      onOpenExisting={onOpen}
+    />
+  );
+}

--- a/components/search/lidarr-search-section.tsx
+++ b/components/search/lidarr-search-section.tsx
@@ -1,32 +1,31 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "expo-router";
-import { Music } from "lucide-react-native";
+import { Music, Mic2 } from "lucide-react-native";
 import { SearchSection } from "@/components/search/search-section";
+import { ArrLibraryRow } from "@/components/search/arr-library-row";
 import { LidarrSearchRow } from "@/components/search/lidarr-search-row";
 import { AddArtistSheet } from "@/components/lidarr/add-artist-sheet";
-import { useLidarrSearch, useLidarrArtists } from "@/hooks/use-lidarr";
+import { useLidarrSearchRows } from "@/hooks/use-arr-search-rows";
 import type { LidarrArtistSearchResult } from "@/lib/types";
 
 const PREVIEW_LIMIT = 5;
+// See radarr-search-section.tsx for why library rows are capped in the preview.
+const LIBRARY_PREVIEW_LIMIT = 3;
 
-/** Music section of global search — Lidarr artist lookup, dedup by foreignArtistId. */
+/**
+ * Music section of global search — library matches first, then the Lidarr artist
+ * lookup deduped against them (#304).
+ */
 export function LidarrSearchSection({ query }: { query: string }) {
   const router = useRouter();
-  const { data: results, isLoading, isError, error } = useLidarrSearch(query);
-  const { data: existing } = useLidarrArtists();
+  const { rows, total, isLoading, isError, error } = useLidarrSearchRows(
+    query,
+    LIBRARY_PREVIEW_LIMIT,
+  );
   const [advancedTarget, setAdvancedTarget] =
     useState<LidarrArtistSearchResult | null>(null);
 
-  const existingByForeignId = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const a of existing ?? []) {
-      map.set(a.foreignArtistId, a.id);
-    }
-    return map;
-  }, [existing]);
-
-  const all = results ?? [];
-  const preview = all.slice(0, PREVIEW_LIMIT);
+  const preview = rows.slice(0, PREVIEW_LIMIT);
 
   return (
     <>
@@ -34,27 +33,34 @@ export function LidarrSearchSection({ query }: { query: string }) {
         title="Music"
         icon={Music}
         serviceLabel="Lidarr"
-        total={all.length}
+        total={total}
         isLoading={isLoading}
         isError={isError}
         error={error}
-        hasMore={all.length > preview.length}
+        hasMore={total > preview.length}
         onShowAll={() => router.push({ pathname: "/artist/search", params: { q: query } })}
       >
-        {preview.map((result) => {
-          const existingId = existingByForeignId.get(result.foreignArtistId);
-          return (
+        {preview.map((row) =>
+          row.kind === "library" ? (
+            <ArrLibraryRow
+              key={row.key}
+              serviceId="lidarr"
+              fallbackIcon={Mic2}
+              display={row.display}
+              onOpen={() => router.push(`/artist/${row.id}`)}
+            />
+          ) : (
             <LidarrSearchRow
-              key={result.foreignArtistId}
-              result={result}
-              existingArtistId={existingId}
-              onAdvanced={() => setAdvancedTarget(result)}
+              key={row.key}
+              result={row.result}
+              existingArtistId={row.existingId}
+              onAdvanced={() => setAdvancedTarget(row.result)}
               onOpenExisting={() =>
-                existingId !== undefined && router.push(`/artist/${existingId}`)
+                row.existingId !== undefined && router.push(`/artist/${row.existingId}`)
               }
             />
-          );
-        })}
+          ),
+        )}
       </SearchSection>
 
       <AddArtistSheet

--- a/components/search/media-search-result-card.tsx
+++ b/components/search/media-search-result-card.tsx
@@ -1,8 +1,9 @@
 import type { ComponentType } from "react";
 import { View, Text, Pressable } from "react-native";
 import { Image } from "expo-image";
-import { Plus, Check, SlidersHorizontal } from "lucide-react-native";
+import { Plus, ChevronRight, SlidersHorizontal } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { useServiceImage } from "@/hooks/use-service-image";
 import type { ServiceId } from "@/lib/constants";
@@ -25,12 +26,18 @@ interface MediaSearchResultCardProps {
   /** Single metadata line (year, or year · network · seasons, or type · disambiguation). */
   metaLine?: string;
   overview?: string;
-  /** When true, shows the green Check + makes the card tap-to-open-existing. */
+  /**
+   * When true, swaps the add buttons for an "In library" badge + chevron and
+   * makes the whole card tap-to-open-existing. Set both for a lookup result that
+   * is already added and for a library row promoted above the lookup (#304), so
+   * the two are indistinguishable in the merged list.
+   */
   alreadyAdded: boolean;
   /** Disables the quick-add button while the add mutation is in flight. */
   addPending?: boolean;
-  onQuickAdd: () => void;
-  onAdvanced: () => void;
+  /** Unused when `alreadyAdded` — library rows have nothing to add. */
+  onQuickAdd?: () => void;
+  onAdvanced?: () => void;
   onOpenExisting: () => void;
 }
 
@@ -83,8 +90,15 @@ export function MediaSearchResultCard({
         <Text className="text-zinc-200 text-sm font-medium" numberOfLines={1}>
           {title}
         </Text>
-        {metaLine ? (
-          <Text className="text-zinc-500 text-xs">{metaLine}</Text>
+        {metaLine || alreadyAdded ? (
+          <View className="flex-row items-center gap-2">
+            {metaLine ? (
+              <Text className="text-zinc-500 text-xs shrink" numberOfLines={1}>
+                {metaLine}
+              </Text>
+            ) : null}
+            {alreadyAdded ? <Badge label="In library" variant="success" /> : null}
+          </View>
         ) : null}
         {overview ? (
           <Text className="text-zinc-500 text-xs mt-1" numberOfLines={2}>
@@ -94,7 +108,7 @@ export function MediaSearchResultCard({
       </View>
       {alreadyAdded ? (
         <View className="self-center p-2">
-          <Icon icon={Check} size={20} color="#22c55e" />
+          <Icon icon={ChevronRight} size={20} color="#71717a" />
         </View>
       ) : (
         <View className="flex-row items-center self-center">

--- a/components/search/radarr-search-section.tsx
+++ b/components/search/radarr-search-section.tsx
@@ -1,31 +1,32 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "expo-router";
 import { Film } from "lucide-react-native";
 import { SearchSection } from "@/components/search/search-section";
+import { ArrLibraryRow } from "@/components/search/arr-library-row";
 import { RadarrSearchRow } from "@/components/search/radarr-search-row";
 import { AddMovieSheet } from "@/components/radarr/add-movie-sheet";
-import { useRadarrSearch, useRadarrMovies } from "@/hooks/use-radarr";
+import { useRadarrSearchRows } from "@/hooks/use-arr-search-rows";
 import type { RadarrSearchResult } from "@/lib/types";
 
 const PREVIEW_LIMIT = 5;
+// Cap on promoted library rows so a settled lookup always has room in the
+// preview. The dedicated screen behind "Show all" uses the full limit.
+const LIBRARY_PREVIEW_LIMIT = 3;
 
-/** Movies section of global search — Radarr lookup, library dedup by tmdbId. */
+/**
+ * Movies section of global search — library matches first, then the Radarr
+ * lookup deduped against them (#304). Takes the raw query and debounces the
+ * lookup internally, so library hits track the keystrokes.
+ */
 export function RadarrSearchSection({ query }: { query: string }) {
   const router = useRouter();
-  const { data: results, isLoading, isError, error } = useRadarrSearch(query);
-  const { data: existing } = useRadarrMovies();
+  const { rows, total, isLoading, isError, error } = useRadarrSearchRows(
+    query,
+    LIBRARY_PREVIEW_LIMIT,
+  );
   const [advancedTarget, setAdvancedTarget] = useState<RadarrSearchResult | null>(null);
 
-  const existingByTmdbId = useMemo(() => {
-    const map = new Map<number, number>();
-    for (const m of existing ?? []) {
-      map.set(m.tmdbId, m.id);
-    }
-    return map;
-  }, [existing]);
-
-  const all = results ?? [];
-  const preview = all.slice(0, PREVIEW_LIMIT);
+  const preview = rows.slice(0, PREVIEW_LIMIT);
 
   return (
     <>
@@ -33,27 +34,34 @@ export function RadarrSearchSection({ query }: { query: string }) {
         title="Movies"
         icon={Film}
         serviceLabel="Radarr"
-        total={all.length}
+        total={total}
         isLoading={isLoading}
         isError={isError}
         error={error}
-        hasMore={all.length > preview.length}
+        hasMore={total > preview.length}
         onShowAll={() => router.push({ pathname: "/movie/search", params: { q: query } })}
       >
-        {preview.map((result) => {
-          const existingId = existingByTmdbId.get(result.tmdbId);
-          return (
+        {preview.map((row) =>
+          row.kind === "library" ? (
+            <ArrLibraryRow
+              key={row.key}
+              serviceId="radarr"
+              fallbackIcon={Film}
+              display={row.display}
+              onOpen={() => router.push(`/movie/${row.id}`)}
+            />
+          ) : (
             <RadarrSearchRow
-              key={result.tmdbId}
-              result={result}
-              existingMovieId={existingId}
-              onAdvanced={() => setAdvancedTarget(result)}
+              key={row.key}
+              result={row.result}
+              existingMovieId={row.existingId}
+              onAdvanced={() => setAdvancedTarget(row.result)}
               onOpenExisting={() =>
-                existingId !== undefined && router.push(`/movie/${existingId}`)
+                row.existingId !== undefined && router.push(`/movie/${row.existingId}`)
               }
             />
-          );
-        })}
+          ),
+        )}
       </SearchSection>
 
       <AddMovieSheet

--- a/components/search/search-section.tsx
+++ b/components/search/search-section.tsx
@@ -69,23 +69,30 @@ export function SearchSection({
         <Text className="text-zinc-600 text-xs">{serviceLabel}</Text>
       </Pressable>
 
-      {expanded &&
-        (isError ? (
-          <ErrorBanner error={error} title={`Couldn't search ${serviceLabel}`} />
-        ) : settledEmpty ? (
-          <Text className="text-zinc-600 text-xs px-1 pb-1">No matches</Text>
-        ) : (
-          <View className="gap-2">
-            {children}
-            {hasMore && onShowAll && (
-              <Pressable onPress={onShowAll} className="py-1.5 active:opacity-70" hitSlop={4}>
-                <Text className="text-primary text-sm font-medium">
-                  Show all {total} →
-                </Text>
-              </Pressable>
-            )}
-          </View>
-        ))}
+      {expanded && (
+        <View className="gap-2">
+          {/* The banner sits above the results rather than replacing them: the
+              *arr sections can match your library locally even when the remote
+              lookup fails, and those rows must stay reachable (#304). */}
+          {isError && (
+            <ErrorBanner error={error} title={`Couldn't search ${serviceLabel}`} />
+          )}
+          {settledEmpty ? (
+            <Text className="text-zinc-600 text-xs px-1 pb-1">No matches</Text>
+          ) : (
+            <>
+              {children}
+              {hasMore && onShowAll && (
+                <Pressable onPress={onShowAll} className="py-1.5 active:opacity-70" hitSlop={4}>
+                  <Text className="text-primary text-sm font-medium">
+                    Show all {total} →
+                  </Text>
+                </Pressable>
+              )}
+            </>
+          )}
+        </View>
+      )}
     </View>
   );
 }

--- a/components/search/sonarr-search-section.tsx
+++ b/components/search/sonarr-search-section.tsx
@@ -1,31 +1,30 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "expo-router";
 import { Tv } from "lucide-react-native";
 import { SearchSection } from "@/components/search/search-section";
+import { ArrLibraryRow } from "@/components/search/arr-library-row";
 import { SonarrSearchRow } from "@/components/search/sonarr-search-row";
 import { AddSeriesSheet } from "@/components/sonarr/add-series-sheet";
-import { useSonarrSearch, useSonarrSeries } from "@/hooks/use-sonarr";
+import { useSonarrSearchRows } from "@/hooks/use-arr-search-rows";
 import type { SonarrSearchResult } from "@/lib/types";
 
 const PREVIEW_LIMIT = 5;
+// See radarr-search-section.tsx for why library rows are capped in the preview.
+const LIBRARY_PREVIEW_LIMIT = 3;
 
-/** TV section of global search — Sonarr lookup, library dedup by tvdbId. */
+/**
+ * TV section of global search — library matches first, then the Sonarr lookup
+ * deduped against them (#304).
+ */
 export function SonarrSearchSection({ query }: { query: string }) {
   const router = useRouter();
-  const { data: results, isLoading, isError, error } = useSonarrSearch(query);
-  const { data: existing } = useSonarrSeries();
+  const { rows, total, isLoading, isError, error } = useSonarrSearchRows(
+    query,
+    LIBRARY_PREVIEW_LIMIT,
+  );
   const [advancedTarget, setAdvancedTarget] = useState<SonarrSearchResult | null>(null);
 
-  const existingByTvdbId = useMemo(() => {
-    const map = new Map<number, number>();
-    for (const s of existing ?? []) {
-      map.set(s.tvdbId, s.id);
-    }
-    return map;
-  }, [existing]);
-
-  const all = results ?? [];
-  const preview = all.slice(0, PREVIEW_LIMIT);
+  const preview = rows.slice(0, PREVIEW_LIMIT);
 
   return (
     <>
@@ -33,27 +32,34 @@ export function SonarrSearchSection({ query }: { query: string }) {
         title="TV Shows"
         icon={Tv}
         serviceLabel="Sonarr"
-        total={all.length}
+        total={total}
         isLoading={isLoading}
         isError={isError}
         error={error}
-        hasMore={all.length > preview.length}
+        hasMore={total > preview.length}
         onShowAll={() => router.push({ pathname: "/series/search", params: { q: query } })}
       >
-        {preview.map((result) => {
-          const existingId = existingByTvdbId.get(result.tvdbId);
-          return (
+        {preview.map((row) =>
+          row.kind === "library" ? (
+            <ArrLibraryRow
+              key={row.key}
+              serviceId="sonarr"
+              fallbackIcon={Tv}
+              display={row.display}
+              onOpen={() => router.push(`/series/${row.id}`)}
+            />
+          ) : (
             <SonarrSearchRow
-              key={result.tvdbId}
-              result={result}
-              existingSeriesId={existingId}
-              onAdvanced={() => setAdvancedTarget(result)}
+              key={row.key}
+              result={row.result}
+              existingSeriesId={row.existingId}
+              onAdvanced={() => setAdvancedTarget(row.result)}
               onOpenExisting={() =>
-                existingId !== undefined && router.push(`/series/${existingId}`)
+                row.existingId !== undefined && router.push(`/series/${row.existingId}`)
               }
             />
-          );
-        })}
+          ),
+        )}
       </SearchSection>
 
       <AddSeriesSheet

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -756,6 +756,14 @@
           indexer search never blocks the rest. Plex, Jellyfin and Emby library search is not included,
           and the magnifier is hidden entirely when none of those six services is attached.
         </p>
+        <p>
+          Movies, shows and artists you <strong>already have appear first</strong>. They are matched
+          against the library the app has already loaded, so they show up as you type instead of
+          waiting on the Radarr, Sonarr or Lidarr metadata lookup. Those rows carry an
+          <em>In library</em> badge and open the item's own screen instead of the add flow. The same
+          ordering applies on the dedicated search screens behind the magnifier in the Movies, TV and
+          Music tabs.
+        </p>
 
         <h3>Magnet links</h3>
         <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -278,7 +278,7 @@
         </div>
         <div class="card feature-card">
           <h3><span class="dot"></span>Global search</h3>
-          <p>One search box across Radarr, Sonarr, Lidarr, Seerr, Prowlarr and Jackett, with each section loading independently.</p>
+          <p>One search box across Radarr, Sonarr, Lidarr, Seerr, Prowlarr and Jackett, with each section loading independently. Titles already in your library match on the device and show up first, before any lookup returns.</p>
         </div>
         <div class="card feature-card">
           <h3><span class="dot"></span>Unified calendar and activity</h3>

--- a/hooks/use-arr-search-rows.test.ts
+++ b/hooks/use-arr-search-rows.test.ts
@@ -1,0 +1,226 @@
+// Mock native storage before importing — use-arr-search-rows pulls in the *arr
+// hooks → services → config-store → AsyncStorage/SecureStore at module load.
+// The functions under test are pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import {
+  LIDARR_SEARCH_ADAPTER,
+  RADARR_SEARCH_ADAPTER,
+  SONARR_SEARCH_ADAPTER,
+  buildSearchRows,
+  isLookupPending,
+} from "./use-arr-search-rows";
+import type {
+  LidarrArtist,
+  RadarrMovie,
+  RadarrSearchResult,
+  SonarrSeries,
+} from "@/lib/types";
+
+// The real entities carry dozens of fields the adapters never read.
+function movie(over: Partial<RadarrMovie>): RadarrMovie {
+  return { id: 1, tmdbId: 100, title: "Dune", images: [], ...over } as RadarrMovie;
+}
+function series(over: Partial<SonarrSeries>): SonarrSeries {
+  return {
+    id: 1,
+    tvdbId: 200,
+    title: "The Office",
+    network: "NBC",
+    images: [],
+    ...over,
+  } as SonarrSeries;
+}
+function artist(over: Partial<LidarrArtist>): LidarrArtist {
+  return {
+    id: 1,
+    foreignArtistId: "mb-1",
+    artistName: "Radiohead",
+    images: [],
+    ...over,
+  } as LidarrArtist;
+}
+
+describe("RADARR_SEARCH_ADAPTER", () => {
+  it("matches on title, sortTitle and year", () => {
+    expect(
+      RADARR_SEARCH_ADAPTER.fields(
+        movie({ title: "The Thing", sortTitle: "thing", year: 1982 }),
+      ),
+    ).toEqual({ title: "The Thing", sortTitle: "thing", year: 1982 });
+  });
+
+  it("keys the library by tmdbId and exposes the library id separately", () => {
+    const m = movie({ id: 7, tmdbId: 438 });
+    expect(RADARR_SEARCH_ADAPTER.libraryKey(m)).toBe(438);
+    expect(RADARR_SEARCH_ADAPTER.libraryId(m)).toBe(7);
+    expect(
+      RADARR_SEARCH_ADAPTER.lookupKey({ tmdbId: 438 } as RadarrSearchResult),
+    ).toBe(438);
+  });
+
+  it("builds the same meta line as the lookup row", () => {
+    expect(
+      RADARR_SEARCH_ADAPTER.display(
+        movie({ year: 2021, collection: { title: "Dune Collection", tmdbId: 9 } }),
+      ).metaLine,
+    ).toBe("2021 · Part of Dune Collection");
+    expect(RADARR_SEARCH_ADAPTER.display(movie({ year: 2021 })).metaLine).toBe("2021");
+    expect(RADARR_SEARCH_ADAPTER.display(movie({})).metaLine).toBeUndefined();
+  });
+
+  it("picks the poster image and tolerates a missing images array", () => {
+    const poster = { coverType: "poster", url: "/p.jpg", remoteUrl: "http://x/p.jpg" };
+    const fanart = { coverType: "fanart", url: "/f.jpg", remoteUrl: "http://x/f.jpg" };
+    expect(
+      RADARR_SEARCH_ADAPTER.display(
+        movie({ images: [fanart, poster] as RadarrMovie["images"] }),
+      ).poster,
+    ).toBe(poster);
+    expect(
+      RADARR_SEARCH_ADAPTER.display(
+        movie({ images: undefined as unknown as RadarrMovie["images"] }),
+      ).poster,
+    ).toBeUndefined();
+  });
+});
+
+describe("SONARR_SEARCH_ADAPTER", () => {
+  it("keys the library by tvdbId", () => {
+    const s = series({ id: 4, tvdbId: 121361 });
+    expect(SONARR_SEARCH_ADAPTER.libraryKey(s)).toBe(121361);
+    expect(SONARR_SEARCH_ADAPTER.libraryId(s)).toBe(4);
+  });
+
+  it("prefers statistics.seasonCount over the top-level field", () => {
+    const s = series({
+      year: 2005,
+      seasonCount: 2,
+      statistics: { seasonCount: 9 } as SonarrSeries["statistics"],
+    });
+    expect(SONARR_SEARCH_ADAPTER.display(s).metaLine).toBe("2005 · NBC · 9 seasons");
+  });
+
+  it("singularizes a one-season show", () => {
+    expect(
+      SONARR_SEARCH_ADAPTER.display(series({ year: 2019, seasonCount: 1 })).metaLine,
+    ).toBe("2019 · NBC · 1 season");
+  });
+
+  it("drops the parts it has no data for", () => {
+    expect(
+      SONARR_SEARCH_ADAPTER.display(
+        series({ network: "", seasonCount: 0 }),
+      ).metaLine,
+    ).toBeUndefined();
+  });
+});
+
+describe("LIDARR_SEARCH_ADAPTER", () => {
+  it("maps artistName/sortName onto the shared title fields", () => {
+    expect(
+      LIDARR_SEARCH_ADAPTER.fields(
+        artist({ artistName: "The Beatles", sortName: "Beatles, The" }),
+      ),
+    ).toEqual({ title: "The Beatles", sortTitle: "Beatles, The" });
+  });
+
+  it("keys the library by foreignArtistId (a string, not a number)", () => {
+    const a = artist({ id: 3, foreignArtistId: "a74b1b7f" });
+    expect(LIDARR_SEARCH_ADAPTER.libraryKey(a)).toBe("a74b1b7f");
+    expect(LIDARR_SEARCH_ADAPTER.libraryId(a)).toBe(3);
+  });
+
+  it("builds the type · disambiguation meta line", () => {
+    expect(
+      LIDARR_SEARCH_ADAPTER.display(
+        artist({ artistType: "Group", disambiguation: "UK rock band" }),
+      ).metaLine,
+    ).toBe("Group · UK rock band");
+    expect(LIDARR_SEARCH_ADAPTER.display(artist({})).metaLine).toBeUndefined();
+  });
+});
+
+describe("buildSearchRows", () => {
+  const existing = new Map<number, number>([[438, 7]]);
+
+  it("namespaces the keys so a library and lookup row can't collide (#304)", () => {
+    const rows = buildSearchRows(
+      [movie({ id: 7, tmdbId: 438 })],
+      [{ tmdbId: 999 } as RadarrSearchResult],
+      existing,
+      RADARR_SEARCH_ADAPTER,
+    );
+    expect(rows.map((r) => r.key)).toEqual(["lib:438", "new:999"]);
+  });
+
+  it("carries the library id onto a library row for the detail push", () => {
+    const [row] = buildSearchRows(
+      [movie({ id: 7, tmdbId: 438 })],
+      undefined,
+      existing,
+      RADARR_SEARCH_ADAPTER,
+    );
+    expect(row).toMatchObject({ kind: "library", id: 7 });
+  });
+
+  it("marks a lookup result that is already in the library", () => {
+    // 438 is in `existing` but was not promoted (no local text match), so it
+    // stays a lookup row and must still show as added.
+    const rows = buildSearchRows(
+      [],
+      [{ tmdbId: 438 } as RadarrSearchResult, { tmdbId: 999 } as RadarrSearchResult],
+      existing,
+      RADARR_SEARCH_ADAPTER,
+    );
+    expect(rows.map((r) => (r.kind === "lookup" ? r.existingId : null))).toEqual([
+      7,
+      undefined,
+    ]);
+  });
+
+  it("works with the string-keyed Lidarr adapter", () => {
+    const rows = buildSearchRows(
+      [artist({ id: 3, foreignArtistId: "a74b" })],
+      undefined,
+      new Map<string, number>(),
+      LIDARR_SEARCH_ADAPTER,
+    );
+    expect(rows[0].key).toBe("lib:a74b");
+  });
+});
+
+describe("isLookupPending", () => {
+  it("is false below the two-character minimum", () => {
+    expect(isLookupPending("d", "d", true)).toBe(false);
+    expect(isLookupPending("", "", false)).toBe(false);
+  });
+
+  it("is true while the lookup is fetching", () => {
+    expect(isLookupPending("dune", "dune", true)).toBe(true);
+  });
+
+  it("is true while the debounce has not caught up, so the empty state can't flash", () => {
+    expect(isLookupPending("dune", "dun", false)).toBe(true);
+  });
+
+  it("is false once the term settled and the fetch finished", () => {
+    expect(isLookupPending("dune", "dune", false)).toBe(false);
+  });
+});

--- a/hooks/use-arr-search-rows.ts
+++ b/hooks/use-arr-search-rows.ts
@@ -1,0 +1,283 @@
+import { useMemo } from "react";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useLidarrArtists, useLidarrSearch } from "@/hooks/use-lidarr";
+import { useRadarrMovies, useRadarrSearch } from "@/hooks/use-radarr";
+import { useSonarrSearch, useSonarrSeries } from "@/hooks/use-sonarr";
+import {
+  DEFAULT_LIBRARY_MATCH_LIMIT,
+  buildLibraryIndex,
+  matchLibraryIndex,
+  mergeLibraryFirst,
+  type LibraryMatchFields,
+} from "@/lib/library-search";
+import type {
+  LidarrArtist,
+  LidarrArtistSearchResult,
+  RadarrMovie,
+  RadarrSearchResult,
+  SonarrSearchResult,
+  SonarrSeries,
+} from "@/lib/types";
+
+// Merged search rows for the three *arr add-search surfaces (#304): whatever the
+// query matches in the library you already have, ranked first, then the remote
+// /lookup results with the promoted ones deduped out.
+//
+// The library list is already in cache on every search screen (it was fetched
+// only to build the "already added" map), so the local half costs no network and
+// renders on the keystroke. Only the lookup is debounced.
+//
+// One core hook plus three adapters, so the dedicated /movie|series|artist/search
+// screens and the global-search sections can never drift apart.
+
+const MIN_QUERY = 2;
+const DEBOUNCE_MS = 300;
+
+/** What useServiceImage needs; RadarrImage/SonarrImage/LidarrImage all satisfy it. */
+export interface SearchRowPoster {
+  url: string;
+  remoteUrl: string;
+}
+
+/** Everything ArrLibraryRow needs to render a library hit as a result card. */
+export interface LibraryRowDisplay {
+  poster?: SearchRowPoster;
+  title: string;
+  metaLine?: string;
+  overview?: string;
+}
+
+export type ArrSearchRow<TLookup> =
+  | { kind: "library"; key: string; id: number; display: LibraryRowDisplay }
+  | {
+      kind: "lookup";
+      key: string;
+      result: TLookup;
+      existingId: number | undefined;
+    };
+
+export interface ArrSearchRowsResult<TLookup> {
+  rows: ArrSearchRow<TLookup>[];
+  total: number;
+  /** True while the lookup is in flight, including a pending debounce. */
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+}
+
+/** Per-service glue: the only thing that differs between Radarr/Sonarr/Lidarr. */
+export interface ArrSearchAdapter<TLib, TLookup, K> {
+  fields: (item: TLib) => LibraryMatchFields;
+  libraryKey: (item: TLib) => K;
+  lookupKey: (item: TLookup) => K;
+  libraryId: (item: TLib) => number;
+  display: (item: TLib) => LibraryRowDisplay;
+}
+
+/**
+ * Merge + shape, split out of the hook so it can be unit tested: library matches
+ * become tappable rows, lookup results carry the library id when they're already
+ * added. Pure.
+ */
+export function buildSearchRows<TLib, TLookup, K>(
+  matches: readonly TLib[],
+  lookupResults: readonly TLookup[] | undefined,
+  existingByKey: ReadonlyMap<K, number>,
+  adapter: ArrSearchAdapter<TLib, TLookup, K>,
+): ArrSearchRow<TLookup>[] {
+  return mergeLibraryFirst({
+    libraryMatches: matches,
+    lookupResults,
+    libraryKey: adapter.libraryKey,
+    lookupKey: adapter.lookupKey,
+  }).map((row): ArrSearchRow<TLookup> =>
+    row.kind === "library"
+      ? {
+          kind: "library",
+          key: `lib:${String(adapter.libraryKey(row.item))}`,
+          id: adapter.libraryId(row.item),
+          display: adapter.display(row.item),
+        }
+      : {
+          kind: "lookup",
+          key: `new:${String(adapter.lookupKey(row.item))}`,
+          result: row.item,
+          existingId: existingByKey.get(adapter.lookupKey(row.item)),
+        },
+  );
+}
+
+/**
+ * Whether to show the searching indicator. A pending debounce counts, otherwise
+ * the empty state flashes in the gap between the keystroke and the lookup firing.
+ * Pure.
+ */
+export function isLookupPending(
+  trimmed: string,
+  debouncedQuery: string,
+  isFetching: boolean,
+): boolean {
+  if (trimmed.length < MIN_QUERY) return false;
+  return isFetching || debouncedQuery !== trimmed;
+}
+
+// The subset of a useQuery result the core hook reads.
+interface LookupState<TLookup> {
+  data: TLookup[] | undefined;
+  isFetching: boolean;
+  isError: boolean;
+  error: unknown;
+}
+
+function useArrSearchRows<TLib, TLookup, K>(
+  query: string,
+  debouncedQuery: string,
+  libraryData: TLib[] | undefined,
+  lookup: LookupState<TLookup>,
+  adapter: ArrSearchAdapter<TLib, TLookup, K>,
+  limit: number,
+): ArrSearchRowsResult<TLookup> {
+  const trimmed = query.trim();
+
+  // Normalizing a few thousand titles is cheap but not free, so it happens once
+  // per library rather than once per keystroke. TanStack Query hands back a
+  // stable array reference while the data is unchanged, so this memo holds.
+  const index = useMemo(
+    () => buildLibraryIndex(libraryData, adapter.fields),
+    [libraryData, adapter],
+  );
+
+  const existingByKey = useMemo(() => {
+    const map = new Map<K, number>();
+    for (const item of libraryData ?? []) {
+      map.set(adapter.libraryKey(item), adapter.libraryId(item));
+    }
+    return map;
+  }, [libraryData, adapter]);
+
+  const matches = useMemo(
+    () =>
+      trimmed.length >= MIN_QUERY ? matchLibraryIndex(index, trimmed, limit) : [],
+    [index, trimmed, limit],
+  );
+
+  // keepPreviousData keeps the last term's results around while the next one
+  // loads, which is what we want mid-typing. Gate on the debounced term rather
+  // than the raw one: lookup.data belongs to the debounced term, so deleting
+  // below the minimum drops the rows when the debounce catches up instead of
+  // blanking the list a beat early and flashing an empty state.
+  const lookupResults =
+    debouncedQuery.length >= MIN_QUERY ? lookup.data : undefined;
+
+  const rows = useMemo(
+    () => buildSearchRows(matches, lookupResults, existingByKey, adapter),
+    [matches, lookupResults, existingByKey, adapter],
+  );
+
+  return {
+    rows,
+    total: rows.length,
+    isLoading: isLookupPending(trimmed, debouncedQuery, lookup.isFetching),
+    isError: lookup.isError,
+    error: lookup.error,
+  };
+}
+
+// --- Radarr ---
+
+export const RADARR_SEARCH_ADAPTER: ArrSearchAdapter<RadarrMovie, RadarrSearchResult, number> = {
+  fields: (m) => ({ title: m.title, sortTitle: m.sortTitle, year: m.year }),
+  libraryKey: (m) => m.tmdbId,
+  lookupKey: (r) => r.tmdbId,
+  libraryId: (m) => m.id,
+  display: (m) => ({
+    poster: m.images?.find((i) => i.coverType === "poster"),
+    title: m.title,
+    // Mirrors RadarrSearchRow's meta line so the merged list stays uniform.
+    metaLine:
+      [
+        m.year ? String(m.year) : undefined,
+        m.collection?.title ? `Part of ${m.collection.title}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" · ") || undefined,
+    overview: m.overview,
+  }),
+};
+
+export function useRadarrSearchRows(
+  query: string,
+  limit: number = DEFAULT_LIBRARY_MATCH_LIMIT,
+): ArrSearchRowsResult<RadarrSearchResult> {
+  const debounced = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+  const lookup = useRadarrSearch(debounced);
+  const { data: library } = useRadarrMovies();
+  return useArrSearchRows(query, debounced, library, lookup, RADARR_SEARCH_ADAPTER, limit);
+}
+
+// --- Sonarr ---
+
+export const SONARR_SEARCH_ADAPTER: ArrSearchAdapter<SonarrSeries, SonarrSearchResult, number> = {
+  fields: (s) => ({ title: s.title, sortTitle: s.sortTitle, year: s.year }),
+  libraryKey: (s) => s.tvdbId,
+  lookupKey: (r) => r.tvdbId,
+  libraryId: (s) => s.id,
+  display: (s) => {
+    const seasons = s.statistics?.seasonCount ?? s.seasonCount;
+    return {
+      poster: s.images?.find((i) => i.coverType === "poster"),
+      title: s.title,
+      metaLine:
+        [
+          s.year ? String(s.year) : undefined,
+          s.network || undefined,
+          seasons ? `${seasons} season${seasons !== 1 ? "s" : ""}` : undefined,
+        ]
+          .filter(Boolean)
+          .join(" · ") || undefined,
+      overview: s.overview,
+    };
+  },
+};
+
+export function useSonarrSearchRows(
+  query: string,
+  limit: number = DEFAULT_LIBRARY_MATCH_LIMIT,
+): ArrSearchRowsResult<SonarrSearchResult> {
+  const debounced = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+  const lookup = useSonarrSearch(debounced);
+  const { data: library } = useSonarrSeries();
+  return useArrSearchRows(query, debounced, library, lookup, SONARR_SEARCH_ADAPTER, limit);
+}
+
+// --- Lidarr ---
+
+// Lidarr has no `title` and no `year`: the library entity is artistName/sortName,
+// same asymmetry components/lidarr/music-view.tsx works around for the grid.
+export const LIDARR_SEARCH_ADAPTER: ArrSearchAdapter<
+  LidarrArtist,
+  LidarrArtistSearchResult,
+  string
+> = {
+  fields: (a) => ({ title: a.artistName, sortTitle: a.sortName }),
+  libraryKey: (a) => a.foreignArtistId,
+  lookupKey: (r) => r.foreignArtistId,
+  libraryId: (a) => a.id,
+  display: (a) => ({
+    poster: a.images?.find((i) => i.coverType === "poster"),
+    title: a.artistName,
+    metaLine:
+      [a.artistType, a.disambiguation].filter(Boolean).join(" · ") || undefined,
+    overview: a.overview,
+  }),
+};
+
+export function useLidarrSearchRows(
+  query: string,
+  limit: number = DEFAULT_LIBRARY_MATCH_LIMIT,
+): ArrSearchRowsResult<LidarrArtistSearchResult> {
+  const debounced = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+  const lookup = useLidarrSearch(debounced);
+  const { data: library } = useLidarrArtists();
+  return useArrSearchRows(query, debounced, library, lookup, LIDARR_SEARCH_ADAPTER, limit);
+}

--- a/hooks/use-lidarr.ts
+++ b/hooks/use-lidarr.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import {
   getArtists,
   getArtist,
@@ -108,6 +113,8 @@ export function useLidarrSearch(term: string, instanceId?: string) {
     queryKey: ["lidarr", id, "search", term],
     queryFn: () => searchArtists(term, id ?? undefined),
     enabled: enabled && term.length >= 2 && !!id,
+    // See useRadarrSearch: hold the last results while the next term loads (#304).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import {
   getMovies,
   getMovie,
@@ -138,6 +143,9 @@ export function useRadarrSearch(term: string, instanceId?: string) {
     queryKey: ["radarr", id, "search", term],
     queryFn: () => searchMovies(term, id ?? undefined),
     enabled: enabled && term.length >= 2 && !!id,
+    // The key changes on every debounced term, so without this the list blanks
+    // between searches instead of holding the last results (#304).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import {
   getSeries,
   getSeriesById,
@@ -128,6 +133,8 @@ export function useSonarrSearch(term: string, instanceId?: string) {
     queryKey: ["sonarr", id, "search", term],
     queryFn: () => searchSeries(term, id ?? undefined),
     enabled: enabled && term.length >= 2 && !!id,
+    // See useRadarrSearch: hold the last results while the next term loads (#304).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/lib/library-search.test.ts
+++ b/lib/library-search.test.ts
@@ -1,0 +1,233 @@
+import {
+  buildLibraryIndex,
+  matchLibraryItems,
+  mergeLibraryFirst,
+  normalizeSearchText,
+  parseLibraryQuery,
+  type LibraryMatchFields,
+} from "./library-search";
+
+// The real library items carry dozens of fields the matcher never reads; these
+// fixtures stay at the three that actually decide a match.
+interface Movie {
+  tmdbId: number;
+  title: string;
+  sortTitle?: string;
+  year?: number;
+}
+
+function movie(title: string, over: Partial<Movie> = {}): Movie {
+  return { tmdbId: over.tmdbId ?? title.length, title, ...over };
+}
+
+const fields = (m: Movie): LibraryMatchFields => ({
+  title: m.title,
+  sortTitle: m.sortTitle,
+  year: m.year,
+});
+
+const titles = (items: Movie[]) => items.map((m) => m.title);
+
+describe("normalizeSearchText", () => {
+  it("lowercases and strips diacritics", () => {
+    expect(normalizeSearchText("Amélie")).toBe("amelie");
+    expect(normalizeSearchText("PIÑATA")).toBe("pinata");
+  });
+
+  it("collapses punctuation and whitespace to single spaces", () => {
+    expect(normalizeSearchText("Marvel's Daredevil")).toBe("marvel s daredevil");
+    expect(normalizeSearchText("Spider-Man:  No   Way Home")).toBe(
+      "spider man no way home",
+    );
+  });
+
+  it("keeps non-latin scripts instead of blanking them", () => {
+    expect(normalizeSearchText("君の名は。")).toBe("君の名は。");
+    expect(normalizeSearchText("Слово")).toBe("слово");
+  });
+
+  it("returns an empty string for empty or non-string input", () => {
+    expect(normalizeSearchText("")).toBe("");
+    expect(normalizeSearchText("   ")).toBe("");
+    expect(() =>
+      normalizeSearchText(undefined as unknown as string),
+    ).not.toThrow();
+    expect(normalizeSearchText(undefined as unknown as string)).toBe("");
+  });
+});
+
+describe("parseLibraryQuery", () => {
+  it("splits a trailing year off the text", () => {
+    expect(parseLibraryQuery("inception 2010")).toEqual({
+      text: "inception",
+      year: 2010,
+    });
+  });
+
+  it("keeps a bare year as text so the movie '2012' is still findable", () => {
+    expect(parseLibraryQuery("2012")).toEqual({ text: "2012" });
+  });
+
+  it("ignores an implausible year", () => {
+    expect(parseLibraryQuery("blade runner 9999")).toEqual({
+      text: "blade runner 9999",
+    });
+  });
+
+  it("normalizes the query text", () => {
+    expect(parseLibraryQuery("  Amélie  ")).toEqual({ text: "amelie" });
+  });
+});
+
+describe("matchLibraryItems", () => {
+  it("ranks exact over prefix over word-boundary over substring (#304)", () => {
+    const library = [
+      movie("Moonknight Saga"), // substring, mid-word
+      movie("The Dark Knight Rises"), // word boundary
+      movie("Knight of Cups"), // prefix
+      movie("Knight"), // exact
+    ];
+    expect(titles(matchLibraryItems(library, "knight", fields))).toEqual([
+      "Knight",
+      "Knight of Cups",
+      "The Dark Knight Rises",
+      "Moonknight Saga",
+    ]);
+  });
+
+  it("matches through sortTitle so leading articles don't have to be typed", () => {
+    const library = [movie("The Office", { sortTitle: "Office" })];
+    expect(titles(matchLibraryItems(library, "office", fields))).toEqual([
+      "The Office",
+    ]);
+  });
+
+  it("matches diacritics typed without accents", () => {
+    const library = [movie("Amélie")];
+    expect(titles(matchLibraryItems(library, "amelie", fields))).toEqual([
+      "Amélie",
+    ]);
+  });
+
+  it("falls back to out-of-order tokens for multi-word queries", () => {
+    const library = [movie("Fear and Loathing in Las Vegas")];
+    expect(titles(matchLibraryItems(library, "vegas fear", fields))).toEqual([
+      "Fear and Loathing in Las Vegas",
+    ]);
+  });
+
+  it("does not match a single token that is absent", () => {
+    expect(matchLibraryItems([movie("Inception")], "matrix", fields)).toEqual([]);
+  });
+
+  it("boosts the year that matches and demotes the one that does not", () => {
+    const library = [
+      movie("Dune", { tmdbId: 1, year: 1984 }),
+      movie("Dune", { tmdbId: 2, year: 2021 }),
+    ];
+    const out = matchLibraryItems(library, "dune 1984", fields);
+    expect(out.map((m) => m.year)).toEqual([1984, 2021]);
+  });
+
+  it("breaks score ties with the shorter title first", () => {
+    const library = [movie("Alien vs. Predator"), movie("Alien")];
+    expect(titles(matchLibraryItems(library, "alien", fields))).toEqual([
+      "Alien",
+      "Alien vs. Predator",
+    ]);
+  });
+
+  it("caps the result count at the limit", () => {
+    const library = Array.from({ length: 30 }, (_, i) =>
+      movie(`Star Trek ${i}`, { tmdbId: i }),
+    );
+    expect(matchLibraryItems(library, "star trek", fields)).toHaveLength(20);
+    expect(matchLibraryItems(library, "star trek", fields, 3)).toHaveLength(3);
+    expect(matchLibraryItems(library, "star trek", fields, 0)).toEqual([]);
+  });
+
+  it("returns nothing for an empty library or empty query", () => {
+    expect(matchLibraryItems([], "dune", fields)).toEqual([]);
+    expect(matchLibraryItems(undefined, "dune", fields)).toEqual([]);
+    expect(matchLibraryItems([movie("Dune")], "", fields)).toEqual([]);
+    expect(matchLibraryItems([movie("Dune")], "   ", fields)).toEqual([]);
+  });
+
+  it("does not throw on items with missing optional fields", () => {
+    const library = [{ tmdbId: 1, title: "Dune" }];
+    expect(() => matchLibraryItems(library, "dune", fields)).not.toThrow();
+  });
+});
+
+describe("buildLibraryIndex", () => {
+  it("pre-normalizes both haystacks", () => {
+    const [entry] = buildLibraryIndex(
+      [movie("The Office", { sortTitle: "Office, The" })],
+      fields,
+    );
+    expect(entry.title).toBe("the office");
+    expect(entry.sortTitle).toBe("office the");
+  });
+
+  it("returns an empty index for undefined data (cold cache)", () => {
+    expect(buildLibraryIndex(undefined, fields)).toEqual([]);
+  });
+});
+
+describe("mergeLibraryFirst", () => {
+  const libraryKey = (m: Movie) => m.tmdbId;
+  const lookupKey = (r: { tmdbId: number }) => r.tmdbId;
+
+  it("puts library matches first and drops their duplicate lookup rows", () => {
+    const rows = mergeLibraryFirst({
+      libraryMatches: [movie("Dune", { tmdbId: 1 })],
+      lookupResults: [{ tmdbId: 1 }, { tmdbId: 2 }],
+      libraryKey,
+      lookupKey,
+    });
+    expect(rows.map((r) => r.kind)).toEqual(["library", "lookup"]);
+    expect(rows.map((r) => (r.kind === "library" ? r.item.tmdbId : r.item.tmdbId))).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("keeps the lookup row for a library item cut by the match limit", () => {
+    const cut = movie("Dune Part Two", { tmdbId: 2 });
+    const shown = matchLibraryItems(
+      [movie("Dune", { tmdbId: 1 }), cut],
+      "dune",
+      fields,
+      1,
+    );
+    const rows = mergeLibraryFirst({
+      libraryMatches: shown,
+      lookupResults: [{ tmdbId: 1 }, { tmdbId: 2 }],
+      libraryKey,
+      lookupKey,
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].kind).toBe("library");
+    expect(rows[1]).toEqual({ kind: "lookup", item: { tmdbId: 2 } });
+  });
+
+  it("passes lookup results through untouched when nothing matched locally", () => {
+    const rows = mergeLibraryFirst({
+      libraryMatches: [],
+      lookupResults: [{ tmdbId: 7 }],
+      libraryKey,
+      lookupKey,
+    });
+    expect(rows).toEqual([{ kind: "lookup", item: { tmdbId: 7 } }]);
+  });
+
+  it("renders library matches while the lookup is still undefined", () => {
+    const rows = mergeLibraryFirst({
+      libraryMatches: [movie("Dune", { tmdbId: 1 })],
+      lookupResults: undefined,
+      libraryKey,
+      lookupKey,
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("library");
+  });
+});

--- a/lib/library-search.ts
+++ b/lib/library-search.ts
@@ -1,0 +1,198 @@
+// Client-side text matching over the *arr libraries that are already sitting in
+// the React Query cache, so a title you own appears before the /movie/lookup,
+// /series/lookup or /artist/lookup round trip returns (#304). All three services
+// ship the whole library as one unpaginated GET, so this is a linear scan over an
+// array we already have — no extra network.
+//
+// Everything here is pure and generic over the item type: Radarr movies, Sonarr
+// series and Lidarr artists all reduce to LibraryMatchFields via an adapter
+// (hooks/use-arr-search-rows.ts). Safe to call inside a useMemo.
+
+export interface LibraryMatchFields {
+  title: string;
+  // The *arr sort title, which already drops leading articles — matching it too
+  // is what makes "office" hit "The Office" without any stopword list here.
+  // Lidarr's equivalent is `sortName`, and it is optional.
+  sortTitle?: string;
+  year?: number;
+}
+
+export type MergedSearchRow<TLib, TLookup> =
+  | { kind: "library"; item: TLib }
+  | { kind: "lookup"; item: TLookup };
+
+/** Default cap on promoted library rows, so a broad query can't bury the lookup. */
+export const DEFAULT_LIBRARY_MATCH_LIMIT = 20;
+
+const SCORE_EXACT = 100;
+const SCORE_PREFIX = 80;
+const SCORE_WORD_BOUNDARY = 60;
+const SCORE_SUBSTRING = 40;
+const SCORE_TOKENS = 20;
+const YEAR_ADJUST = 10;
+
+// Punctuation is listed explicitly rather than as "everything that isn't [a-z0-9]"
+// so non-latin titles (CJK, Cyrillic, Greek) survive normalization instead of
+// being blanked out. Unicode property escapes (\p{L}) would be tidier but have no
+// precedent in this codebase and depend on the JS engine build.
+const PUNCTUATION = /[._\-–—:;,!?'"“”‘’`´()[\]{}<>/\\|&+*#@~^$%=]+/g;
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+const WHITESPACE = /\s+/g;
+
+/**
+ * Fold a title or query down to a comparable form: diacritics stripped,
+ * lowercased, punctuation collapsed to single spaces. "Amélie" and "amelie" both
+ * become "amelie"; "Marvel's Daredevil" becomes "marvel s daredevil".
+ */
+export function normalizeSearchText(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return "";
+  return input
+    .normalize("NFD")
+    .replace(COMBINING_MARKS, "")
+    .toLowerCase()
+    .replace(PUNCTUATION, " ")
+    .replace(WHITESPACE, " ")
+    .trim();
+}
+
+/**
+ * Split a trailing 4-digit year off the query ("inception 2010"), leaving the
+ * rest as the text to match. A bare year stays text — "2012" should still find
+ * the movie called 2012.
+ */
+export function parseLibraryQuery(query: string): { text: string; year?: number } {
+  const text = normalizeSearchText(query);
+  const match = /^(.*\S)\s+(\d{4})$/.exec(text);
+  if (!match) return { text };
+  const year = Number(match[2]);
+  if (year < 1870 || year > 2200) return { text };
+  return { text: match[1], year };
+}
+
+function scoreHaystack(haystack: string, text: string, tokens: string[]): number {
+  if (!haystack) return 0;
+  if (haystack === text) return SCORE_EXACT;
+  if (haystack.startsWith(text)) return SCORE_PREFIX;
+  const idx = haystack.indexOf(text);
+  if (idx > 0) {
+    // A match that begins a word ("the dark KNIGHT rises") reads as far more
+    // relevant than one buried mid-word ("mooNKNIGHT").
+    return haystack[idx - 1] === " " ? SCORE_WORD_BOUNDARY : SCORE_SUBSTRING;
+  }
+  // idx is -1 here (idx === 0 was already caught by startsWith).
+  // Last resort: every word of the query is somewhere in the title, out of order.
+  return tokens.length > 1 && tokens.every((t) => haystack.includes(t))
+    ? SCORE_TOKENS
+    : 0;
+}
+
+/** One library item with its haystacks pre-normalized. Build once per library. */
+export interface LibraryIndexEntry<T> {
+  item: T;
+  fields: LibraryMatchFields;
+  title: string;
+  sortTitle: string;
+}
+
+/**
+ * Pre-normalize a whole library so a keystroke doesn't re-fold a few thousand
+ * titles. Callers memoize this on the library array identity — TanStack Query
+ * keeps that reference stable while the data is unchanged.
+ */
+export function buildLibraryIndex<T>(
+  items: readonly T[] | undefined,
+  toFields: (item: T) => LibraryMatchFields,
+): LibraryIndexEntry<T>[] {
+  if (!Array.isArray(items)) return [];
+  return items.map((item) => {
+    const fields = toFields(item);
+    return {
+      item,
+      fields,
+      title: normalizeSearchText(fields.title),
+      sortTitle: fields.sortTitle ? normalizeSearchText(fields.sortTitle) : "",
+    };
+  });
+}
+
+/**
+ * Rank a pre-built index against a query, best match first. Returns at most
+ * `limit` items; an empty or unmatched query returns nothing.
+ */
+export function matchLibraryIndex<T>(
+  index: readonly LibraryIndexEntry<T>[],
+  query: string,
+  limit: number = DEFAULT_LIBRARY_MATCH_LIMIT,
+): T[] {
+  if (index.length === 0 || limit <= 0) return [];
+  const { text, year } = parseLibraryQuery(query);
+  if (!text) return [];
+  const tokens = text.split(" ").filter(Boolean);
+
+  const scored: { entry: LibraryIndexEntry<T>; score: number }[] = [];
+  for (const entry of index) {
+    let score = Math.max(
+      scoreHaystack(entry.title, text, tokens),
+      scoreHaystack(entry.sortTitle, text, tokens),
+    );
+    if (score === 0) continue;
+    if (year !== undefined && entry.fields.year !== undefined) {
+      score += entry.fields.year === year ? YEAR_ADJUST : -YEAR_ADJUST;
+    }
+    scored.push({ entry, score });
+  }
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    // Shorter title first: "Alien" should outrank "Alien vs. Predator".
+    const lenA = a.entry.title.length;
+    const lenB = b.entry.title.length;
+    if (lenA !== lenB) return lenA - lenB;
+    const yearA = a.entry.fields.year ?? 0;
+    const yearB = b.entry.fields.year ?? 0;
+    if (yearA !== yearB) return yearB - yearA;
+    return a.entry.fields.title.localeCompare(b.entry.fields.title);
+  });
+
+  return scored.slice(0, limit).map((s) => s.entry.item);
+}
+
+/** Convenience for callers that don't hold an index (and for tests). */
+export function matchLibraryItems<T>(
+  items: readonly T[] | undefined,
+  query: string,
+  toFields: (item: T) => LibraryMatchFields,
+  limit: number = DEFAULT_LIBRARY_MATCH_LIMIT,
+): T[] {
+  return matchLibraryIndex(buildLibraryIndex(items, toFields), query, limit);
+}
+
+/**
+ * Library matches first, then the lookup results with the promoted ones removed.
+ * Dedup is against the rows actually shown, so an item cut by the match limit
+ * still reaches the list through its lookup row.
+ */
+export function mergeLibraryFirst<TLib, TLookup, K>({
+  libraryMatches,
+  lookupResults,
+  libraryKey,
+  lookupKey,
+}: {
+  libraryMatches: readonly TLib[];
+  lookupResults: readonly TLookup[] | undefined;
+  libraryKey: (item: TLib) => K;
+  lookupKey: (item: TLookup) => K;
+}): MergedSearchRow<TLib, TLookup>[] {
+  const promoted = new Set<K>();
+  const rows: MergedSearchRow<TLib, TLookup>[] = [];
+
+  for (const item of libraryMatches) {
+    promoted.add(libraryKey(item));
+    rows.push({ kind: "library", item });
+  }
+  for (const item of lookupResults ?? []) {
+    if (promoted.has(lookupKey(item))) continue;
+    rows.push({ kind: "lookup", item });
+  }
+  return rows;
+}


### PR DESCRIPTION
Searching for something you already own waited on the *arr metadata lookup, even though the full library was already in cache on every search screen (it was fetched only to build the "already added" map). Now the cached library is matched client-side and its hits rank first, so they render on the keystroke.

Applies to `/movie/search`, `/series/search`, `/artist/search` and the matching global-search sections.

- `lib/library-search.ts`: pure normalize/rank/merge. Diacritic folding, punctuation collapsing (non-latin scripts preserved), trailing-year parsing, and exact > prefix > word-boundary > substring > scattered tokens. Matches `sortTitle` too, so "office" finds "The Office".
- `hooks/use-arr-search-rows.ts`: one core hook plus three adapters. Pre-normalized index per library, debounce on the lookup only. Replaces six copies of the hand-rolled `existingBy*Id` map.
- `keepPreviousData` on the three lookups, so the list holds the last results instead of blanking between terms.
- `alreadyAdded` now renders an "In library" badge and a chevron instead of the bare green check, so a promoted library row and a lookup result you already own look identical.
- `SearchSection` renders its error banner above the results rather than replacing them, and the dedicated screens gained an `ErrorBanner`. Both matter now that library matches can render while the lookup fails.

## Test plan

- `pnpm test`: 902 pass, 43 new across `lib/library-search.test.ts` and `hooks/use-arr-search-rows.test.ts` (ranking order, diacritics, article handling, year token, match cap, merge dedup including an item cut by the cap, per-service adapter keys and meta lines).
- `npx tsc --noEmit` clean.
- `npx expo export --platform android` bundles clean.
- Not yet exercised on a device.

Refs #304