### PR TITLE
feat(qbittorrent): add category picker when adding a torrent

### DIFF
--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -37,6 +37,7 @@ import { ErrorBanner } from "@/components/common/error-banner";
 import { FilterSortButton } from "@/components/common/filter-sort-button";
 import { FilterSortSheet } from "@/components/common/filter-sort-sheet";
 import { ActionSheet } from "@/components/ui/action-sheet";
+import { Select } from "@/components/ui/select";
 import { CategorySheet } from "@/components/qbittorrent/category-sheet";
 import { errorHaptic, mediumHaptic } from "@/lib/haptics";
 import { HAS_GLASS_TAB_BAR } from "@/lib/glass";
@@ -120,6 +121,8 @@ export function TorrentDownloadsView({
   const [categoryBulkOpen, setCategoryBulkOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
+  // "" = no category (qBittorrent-only; other clients never show the picker).
+  const [addCategory, setAddCategory] = useState("");
 
   // Runs on mount too (segment switches remount this view per client), so a
   // pending magnet re-prefills whichever client the user lands on.
@@ -214,10 +217,11 @@ export function TorrentDownloadsView({
   const handleAdd = () => {
     if (!magnetUri.trim()) return;
     addTorrent.mutate(
-      { uri: magnetUri.trim() },
+      { uri: magnetUri.trim(), label: addCategory || undefined },
       {
         onSuccess: () => {
           setMagnetUri("");
+          setAddCategory("");
           setShowAddModal(false);
           onMagnetConsumed?.();
           toast("Torrent added");
@@ -384,6 +388,17 @@ export function TorrentDownloadsView({
             // just cover the Add button.
             autoFocus={!incomingMagnet}
           />
+          {adapter.capabilities.categories && categories.length > 0 ? (
+            <Select
+              label="Category"
+              value={addCategory}
+              options={[
+                { value: "", label: "None" },
+                ...categories.map((c) => ({ value: c, label: c })),
+              ]}
+              onChange={setAddCategory}
+            />
+          ) : null}
           <View className="flex-row gap-2">
             <Button
               label="Cancel"
@@ -392,6 +407,7 @@ export function TorrentDownloadsView({
               onPress={() => {
                 setShowAddModal(false);
                 setMagnetUri("");
+                setAddCategory("");
                 onMagnetConsumed?.();
               }}
               className="flex-1"

--- a/lib/torrent-adapters/qbittorrent.ts
+++ b/lib/torrent-adapters/qbittorrent.ts
@@ -213,11 +213,11 @@ export const qbittorrentTorrentAdapter: TorrentAdapter = {
   useAddTorrent: (instanceId?: string) => {
     const queryClient = useQueryClient();
     const { instanceId: id } = useInstanceTarget("qbittorrent", instanceId);
-    // qBittorrent's add takes a bare magnet/URL; the unified surface adds
-    // optional label/savePath which qBittorrent ignores for v1.
+    // The unified surface's `label` maps to qBittorrent's category on add;
+    // savePath is ignored (qBittorrent derives it from the category).
     return useMutation({
-      mutationFn: ({ uri }: { uri: string; label?: string; savePath?: string }) =>
-        addTorrentMagnet(uri, id ?? undefined),
+      mutationFn: ({ uri, label }: { uri: string; label?: string; savePath?: string }) =>
+        addTorrentMagnet(uri, id ?? undefined, label),
       onSuccess: () =>
         queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] }),
     });

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -487,13 +487,16 @@ export function deleteTorrents(
 export function addTorrentMagnet(
   magnetUri: string,
   instanceId?: string,
+  category?: string,
 ): Promise<void> {
+  const params = new URLSearchParams({ urls: magnetUri });
+  if (category) params.set("category", category);
   return qbRequest(
     "/torrents/add",
     {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: `urls=${encodeURIComponent(magnetUri)}`,
+      body: params.toString(),
     },
     instanceId,
   );


### PR DESCRIPTION
Adds a Category dropdown to the add-torrent card so manually added torrents (pasted or via magnet deep link) carry a qBittorrent category. Refs #289

- `addTorrentMagnet` accepts an optional category and sends it on `/torrents/add`
- qBittorrent adapter maps the unified `label` field to `category` (rTorrent/Transmission already honored it)
- Shared add card shows a Select with None + the instance's categories, gated on the categories capability

## Test plan
- `tsc --noEmit` clean, all 902 jest tests pass
- Picker hidden for rTorrent/Transmission and for qBittorrent instances with no categories