### PR TITLE
fix(downloads): clarify duplicate-torrent error on grab (Refs #329)

### DIFF
--- a/components/indexers/prowlarr-grab-flow.tsx
+++ b/components/indexers/prowlarr-grab-flow.tsx
@@ -1,6 +1,7 @@
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { toast, toastError } from "@/components/ui/toast";
 import { useGrabRelease } from "@/hooks/use-prowlarr";
+import { describeGrabFailure } from "@/lib/download-client-error";
 import type { GrabFlowProps } from "@/lib/indexer-adapter";
 
 // Prowlarr grab: server-side — POST /search {guid, indexerId} and Prowlarr
@@ -12,7 +13,10 @@ export function ProwlarrGrabFlow({ release, onClose, instanceId }: GrabFlowProps
     if (!release?.grab) return;
     grabRelease.mutate(release.grab, {
       onSuccess: () => toast("Sent to download client"),
-      onError: (err) => toastError("Failed to grab release", err),
+      onError: (err) =>
+        toastError("Failed to grab release", err, (msg) =>
+          describeGrabFailure(msg, "Prowlarr"),
+        ),
     });
     onClose();
   };

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -56,13 +56,22 @@ export function toast(
 // whenever the caller has the original error in scope.
 //   - Display: server's `{ message }` body → err.message → fallback string
 //   - Copy:    HTTP status + URL + body, or Error.name/message/stack
-export function toastError(fallback: string, err?: unknown) {
+//
+// `refine` gets the message we were about to show and may replace it, for the
+// cases where a server's own wording is actively wrong (see
+// lib/download-client-error.ts). Returning undefined keeps the original. The
+// Copy button always carries the untouched error either way.
+export function toastError(
+  fallback: string,
+  err?: unknown,
+  refine?: (message: string) => string | undefined,
+) {
   const serverMsg = err ? getHttpErrorMessage(err) : undefined;
   const errorMsg =
     err instanceof Error && err.message ? err.message : undefined;
   const message = serverMsg ?? errorMsg ?? fallback;
   const copyText = err !== undefined ? formatErrorForCopy(err) : undefined;
-  toast(message, "error", copyText);
+  toast(refine?.(message) ?? message, "error", copyText);
 }
 
 const ICON_MAP: Record<ToastType, React.ComponentType<any>> = {

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -32,6 +32,7 @@ import type { RadarrMovie } from "@/lib/types";
 import { getMovieDetails, deleteMedia } from "@/services/overseerr-api";
 import { useConfigStore } from "@/store/config-store";
 import { POLLING_INTERVALS } from "@/lib/constants";
+import { describeGrabFailure } from "@/lib/download-client-error";
 import { getDateOffset } from "@/lib/utils";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
@@ -477,7 +478,9 @@ export function useGrabRadarrRelease(instanceId?: string) {
       queryClient.invalidateQueries({ queryKey: ["radarr", id, "queue"] });
     },
     onError: (err) => {
-      toastError("Failed to grab release", err);
+      toastError("Failed to grab release", err, (msg) =>
+        describeGrabFailure(msg, "Radarr"),
+      );
     },
   });
 }

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -36,6 +36,7 @@ import {
 import { toast, toastError } from "@/components/ui/toast";
 import type { SonarrSeries } from "@/lib/types";
 import { POLLING_INTERVALS } from "@/lib/constants";
+import { describeGrabFailure } from "@/lib/download-client-error";
 import { getDateOffset } from "@/lib/utils";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
@@ -613,7 +614,9 @@ export function useGrabSonarrRelease(instanceId?: string) {
       queryClient.invalidateQueries({ queryKey: ["sonarr", id, "queue"] });
     },
     onError: (err) => {
-      toastError("Failed to grab release", err);
+      toastError("Failed to grab release", err, (msg) =>
+        describeGrabFailure(msg, "Sonarr"),
+      );
     },
   });
 }

--- a/lib/download-client-error.test.ts
+++ b/lib/download-client-error.test.ts
@@ -1,0 +1,73 @@
+import { describeGrabFailure } from "./download-client-error";
+
+// The literals below are copied verbatim from the *arr sources so a future
+// upstream reword shows up as a failing expectation rather than a silently
+// dead rewrite:
+//   src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+//   src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+
+describe("describeGrabFailure", () => {
+  it("rewrites the qBittorrent 'check your settings' message (#329)", () => {
+    const out = describeGrabFailure(
+      "Failed to connect to qBittorrent, check your settings.",
+      "Radarr",
+    );
+    expect(out).toBe(
+      "qBittorrent did not accept the release. It is most likely already added; if it isn't, check that Radarr can reach qBittorrent.",
+    );
+  });
+
+  it("handles the 'please check your settings' variant", () => {
+    expect(
+      describeGrabFailure(
+        "Failed to connect to qBittorrent, please check your settings.",
+        "Sonarr",
+      ),
+    ).toContain("qBittorrent did not accept the release.");
+  });
+
+  it("keeps whichever download client the *arr named", () => {
+    expect(
+      describeGrabFailure(
+        "Failed to connect to Deluge, check your settings.",
+        "Prowlarr",
+      ),
+    ).toBe(
+      "Deluge did not accept the release. It is most likely already added; if it isn't, check that Prowlarr can reach Deluge.",
+    );
+  });
+
+  it("rewrites the older 'Fails.' body mapping", () => {
+    expect(
+      describeGrabFailure("Download client failed to add torrent by url", "Radarr"),
+    ).toBe(
+      "Radarr's download client did not accept the release. It is most likely already added.",
+    );
+    expect(
+      describeGrabFailure("Download client failed to add torrent", "Sonarr"),
+    ).toBe(
+      "Sonarr's download client did not accept the release. It is most likely already added.",
+    );
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(
+      describeGrabFailure(
+        "  Failed to connect to qBittorrent, check your settings.  ",
+        "Radarr",
+      ),
+    ).toBeDefined();
+  });
+
+  it("leaves every other server message alone", () => {
+    for (const msg of [
+      "Failed to authenticate with qBittorrent.",
+      "Unable to connect to qBittorrent, certificate validation failed.",
+      "Couldn't find requested release in cache, try searching again",
+      "Indexer is not configured",
+      "",
+    ]) {
+      expect(describeGrabFailure(msg, "Radarr")).toBeUndefined();
+    }
+  });
+});

--- a/lib/download-client-error.ts
+++ b/lib/download-client-error.ts
@@ -1,0 +1,83 @@
+/**
+ * Rewrites the misleading download-client errors the *arr apps hand back on a
+ * grab (issue #329).
+ *
+ * When a release is already in qBittorrent, the toast used to read
+ * "Failed to connect to qBittorrent, check your settings." even though the
+ * connection was fine. That string is not ours: Dashboarr shows the *arr's
+ * `{ message }` body verbatim (lib/http-client.ts `getHttpErrorMessage`). The
+ * chain, verified in upstream source:
+ *
+ *   1. qBittorrent 5.1+ answers `POST /api/v2/torrents/add` with 409 Conflict
+ *      and an empty body when it added nothing:
+ *        src/webui/api/torrentscontroller.cpp `addAction()` ends with
+ *        `else throw APIError(APIErrorType::Conflict);`
+ *      A duplicate infohash is exactly that case:
+ *        src/base/addtorrentmanager.cpp `processTorrent()` returns false when
+ *        `btSession()->findTorrent(infoHash)` already has it.
+ *      qBittorrent 5.0 and older instead answer 200 with the body "Fails.".
+ *   2. Radarr/Sonarr/Prowlarr share one qBittorrent proxy. Any non-401/403
+ *      HttpException becomes a fixed string:
+ *        src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+ *        `ProcessRequest` -> `DownloadClientException("Failed to connect to
+ *        qBittorrent, check your settings.")`
+ *      and the "Fails." body becomes `"Download client failed to add torrent
+ *      by url"` (same file, `AddTorrentFromUrl`).
+ *   3. Dashboarr relays that message.
+ *
+ * The *arr reply carries nothing that separates "already added" from "client
+ * unreachable", so we cannot state one as fact. What we can do is stop leading
+ * with the wrong one: put the common cause first and keep the connectivity
+ * possibility in the same sentence.
+ *
+ * The rewrite is deliberately scoped to grab call sites rather than applied
+ * inside `getHttpErrorMessage`, because the same *arr string is genuinely about
+ * connectivity when it shows up outside an add-torrent request.
+ */
+
+// "Failed to connect to qBittorrent, check your settings." — also emitted with
+// "please check your settings." and for Deluge/Transmission/uTorrent/Flood/
+// Hadouken/NZBGet/NzbVortex, which is why the client name is captured.
+const CLIENT_UNREACHABLE =
+  /^failed to connect to (.+?),\s*(?:please\s+)?check your settings\.?$/i;
+
+// "Download client failed to add torrent by url" / "...add torrent". The client
+// answered, it just refused the release, so no name is included upstream.
+const ADD_REFUSED = /^download client failed to add torrent(?: by url)?\.?$/i;
+
+/**
+ * Given the message an *arr returned for a failed grab, produce a clearer one.
+ * Returns `undefined` when the message is not one of the known-misleading
+ * strings, so callers fall through to showing the server message as-is.
+ *
+ * @param message   the *arr's `{ message }` body
+ * @param arrLabel  the app that was asked to grab, e.g. "Radarr"
+ */
+export function describeGrabFailure(
+  message: string,
+  arrLabel: string,
+): string | undefined {
+  const trimmed = message.trim();
+
+  const unreachable = CLIENT_UNREACHABLE.exec(trimmed);
+  if (unreachable) {
+    const client = unreachable[1];
+    return `${client} did not accept the release. It is most likely already added; if it isn't, check that ${arrLabel} can reach ${client}.`;
+  }
+
+  if (ADD_REFUSED.test(trimmed)) {
+    return `${arrLabel}'s download client did not accept the release. It is most likely already added.`;
+  }
+
+  return undefined;
+}
+
+/**
+ * What Dashboarr throws when it adds a torrent to qBittorrent itself (Downloads
+ * tab, Jackett grab) and qBittorrent reports that nothing was added. Same
+ * qBittorrent behaviour as above, minus the *arr in the middle: a 409 (5.1+) or
+ * a "Fails." body (5.0 and older). `addTorrent` also returns false for an
+ * unparseable magnet, so the link is named as the second possibility.
+ */
+export const QB_ADD_REFUSED_MESSAGE =
+  "qBittorrent did not add this torrent. It is most likely already in the client; otherwise the magnet or torrent link is invalid.";

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -4,6 +4,7 @@ import { useConfigStore } from "@/store/config-store";
 import { getSecret, setSecret, deleteSecret } from "@/store/storage";
 import { SERVICE_DEFAULTS, SECRET_PREFIX } from "@/lib/constants";
 import { getDemoResponse } from "@/lib/demo-data";
+import { QB_ADD_REFUSED_MESSAGE } from "@/lib/download-client-error";
 import type {
   QBTransferInfo,
   QBServerState,
@@ -161,6 +162,17 @@ async function ensureAuth(instanceId: string): Promise<void> {
   }
 }
 
+// Carries the HTTP status alongside the message so callers can branch on it
+// (e.g. 409 from /torrents/add) without parsing the string. The message text is
+// unchanged from what qbRequest threw before, because qbHealthCheck below and
+// callers in the wild match on ": 403".
+export class QbHttpError extends Error {
+  constructor(public status: number) {
+    super(`qBittorrent request failed: ${status}`);
+    this.name = "QbHttpError";
+  }
+}
+
 async function parseQbResponse<T>(response: Response): Promise<T> {
   const contentType = response.headers.get("content-type");
   if (contentType?.includes("application/json")) {
@@ -226,11 +238,11 @@ async function qbRequest<T>(
       ...options,
       headers,
     });
-    if (!retry.ok) throw new Error(`qBittorrent request failed: ${retry.status}`);
+    if (!retry.ok) throw new QbHttpError(retry.status);
     return parseQbResponse<T>(retry);
   }
 
-  if (!response.ok) throw new Error(`qBittorrent request failed: ${response.status}`);
+  if (!response.ok) throw new QbHttpError(response.status);
   return parseQbResponse<T>(response);
 }
 
@@ -484,22 +496,38 @@ export function deleteTorrents(
   );
 }
 
-export function addTorrentMagnet(
+export async function addTorrentMagnet(
   magnetUri: string,
   instanceId?: string,
   category?: string,
 ): Promise<void> {
   const params = new URLSearchParams({ urls: magnetUri });
   if (category) params.set("category", category);
-  return qbRequest(
-    "/torrents/add",
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: params.toString(),
-    },
-    instanceId,
-  );
+  let result: unknown;
+  try {
+    result = await qbRequest<unknown>(
+      "/torrents/add",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: params.toString(),
+      },
+      instanceId,
+    );
+  } catch (err) {
+    // qBittorrent 5.1+ reports "added nothing" as 409 Conflict with an empty
+    // body, which surfaced as a bare "qBittorrent request failed: 409" (#329).
+    if (err instanceof QbHttpError && err.status === 409) {
+      throw new Error(QB_ADD_REFUSED_MESSAGE);
+    }
+    throw err;
+  }
+  // qBittorrent 5.0 and older report the same thing as 200 with the body
+  // "Fails.", which used to resolve as a success and show "Torrent added"
+  // while nothing had been queued.
+  if (typeof result === "string" && result.trim() === "Fails.") {
+    throw new Error(QB_ADD_REFUSED_MESSAGE);
+  }
 }
 
 // --- Speed Limits ---


### PR DESCRIPTION
Adding a release that is already in qBittorrent showed "Failed to connect to qBittorrent, check your settings." even though the connection was fine.

That string is the *arr's, relayed verbatim. qBittorrent 5.1+ answers `POST /torrents/add` with 409 Conflict when it adds nothing (a duplicate infohash is exactly that case), and `QBittorrentProxyV2.ProcessRequest` maps every non-401/403 HTTP failure to that one message. The reply carries nothing that separates "already added" from "unreachable", so the rewrite leads with the common cause and keeps the other in the same sentence.

- `lib/download-client-error.ts` rewrites the two known-misleading *arr strings; wired at the Radarr/Sonarr/Prowlarr grab sites only, since the same string is genuinely about connectivity elsewhere
- `toastError` takes an optional `refine`; Copy still carries the untouched error
- direct qBittorrent adds (Downloads tab, Jackett grab) now surface the 409, and the `"Fails."` body from 5.0 and older, instead of a bare HTTP status or a false "Torrent added"

## Test plan
- `npx jest` 908/908 passing, 6 new cases in `lib/download-client-error.test.ts`
- `npx tsc --noEmit` clean