### PR TITLE
feat(qbittorrent): custom category and optional Dashboarr tag on add (Refs #289)

### DIFF
--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -63,6 +63,7 @@ import {
   type UnifiedTorrent,
 } from "@/lib/torrent-adapter";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { isValidQbCategoryName } from "@/lib/qbittorrent-category";
 
 const FILTER_OPTIONS: { key: TorrentFilterType; label: string }[] = [
   { key: "all", label: "All" },
@@ -76,6 +77,11 @@ const FILTER_OPTIONS: { key: TorrentFilterType; label: string }[] = [
 // omitted `category` param as all and an empty string as uncategorized, so we
 // can't reuse "" for "all" — this maps to "omit the param" before the request.
 const ALL_CATEGORIES = "__all__";
+
+// Sentinel for the add form's "Custom…" category choice (#289). A backslash is
+// invalid in qBittorrent category names, so this can never collide with a real
+// category the server reports.
+const CUSTOM_CATEGORY = "\\custom";
 
 const SORT_OPTIONS: { key: DownloadsSortKey; label: string }[] = [
   { key: "progress-desc", label: "Progress: High → Low" },
@@ -121,8 +127,10 @@ export function TorrentDownloadsView({
   const [categoryBulkOpen, setCategoryBulkOpen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [magnetUri, setMagnetUri] = useState("");
-  // "" = no category (qBittorrent-only; other clients never show the picker).
+  // "" = no category, CUSTOM_CATEGORY = free-text entry below the picker
+  // (qBittorrent-only; other clients never show the picker).
   const [addCategory, setAddCategory] = useState("");
+  const [customCategory, setCustomCategory] = useState("");
 
   // Runs on mount too (segment switches remount this view per client), so a
   // pending magnet re-prefills whichever client the user lands on.
@@ -214,14 +222,25 @@ export function TorrentDownloadsView({
   // user sees what they're adding (covers pasted and incoming magnets alike).
   const magnetName = magnetDisplayName(magnetUri.trim());
 
+  // Custom entry resolves to its trimmed text; an empty custom field falls
+  // back to "no category". Invalid names must be blocked client-side because
+  // /torrents/add doesn't reject them — it silently adds uncategorized.
+  const resolvedAddCategory =
+    addCategory === CUSTOM_CATEGORY ? customCategory.trim() : addCategory;
+  const customCategoryInvalid =
+    addCategory === CUSTOM_CATEGORY &&
+    customCategory.trim().length > 0 &&
+    !isValidQbCategoryName(customCategory.trim());
+
   const handleAdd = () => {
-    if (!magnetUri.trim()) return;
+    if (!magnetUri.trim() || customCategoryInvalid) return;
     addTorrent.mutate(
-      { uri: magnetUri.trim(), label: addCategory || undefined },
+      { uri: magnetUri.trim(), label: resolvedAddCategory || undefined },
       {
         onSuccess: () => {
           setMagnetUri("");
           setAddCategory("");
+          setCustomCategory("");
           setShowAddModal(false);
           onMagnetConsumed?.();
           toast("Torrent added");
@@ -388,16 +407,40 @@ export function TorrentDownloadsView({
             // just cover the Add button.
             autoFocus={!incomingMagnet}
           />
-          {adapter.capabilities.categories && categories.length > 0 ? (
-            <Select
-              label="Category"
-              value={addCategory}
-              options={[
-                { value: "", label: "None" },
-                ...categories.map((c) => ({ value: c, label: c })),
-              ]}
-              onChange={setAddCategory}
-            />
+          {adapter.capabilities.categories ? (
+            <>
+              <Select
+                label="Category"
+                value={addCategory}
+                options={[
+                  { value: "", label: "None" },
+                  ...categories.map((c) => ({ value: c, label: c })),
+                  {
+                    value: CUSTOM_CATEGORY,
+                    label: "Custom…",
+                    description: "Type a new category name",
+                  },
+                ]}
+                onChange={setAddCategory}
+              />
+              {addCategory === CUSTOM_CATEGORY ? (
+                <View>
+                  <TextInput
+                    placeholder="New category name"
+                    value={customCategory}
+                    onChangeText={setCustomCategory}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                  />
+                  {customCategoryInvalid ? (
+                    <Text className="text-red-400 text-xs mt-1">
+                      Names can&apos;t contain &quot;\&quot; or start/end with
+                      &quot;/&quot; (use &quot;a/b&quot; for a subcategory).
+                    </Text>
+                  ) : null}
+                </View>
+              ) : null}
+            </>
           ) : null}
           <View className="flex-row gap-2">
             <Button
@@ -408,6 +451,7 @@ export function TorrentDownloadsView({
                 setShowAddModal(false);
                 setMagnetUri("");
                 setAddCategory("");
+                setCustomCategory("");
                 onMagnetConsumed?.();
               }}
               className="flex-1"
@@ -417,6 +461,7 @@ export function TorrentDownloadsView({
               size="sm"
               onPress={handleAdd}
               loading={addTorrent.isPending}
+              disabled={customCategoryInvalid}
               className="flex-1"
             />
           </View>

--- a/components/settings/service-editor.tsx
+++ b/components/settings/service-editor.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Toggle } from "@/components/ui/toggle";
 import { Select } from "@/components/ui/select";
 import { HeaderListEditor } from "@/components/ui/header-list-editor";
-import { useConfigStore } from "@/store/config-store";
+import { useConfigStore, type ServiceConfig } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
 import { BackHeader } from "@/components/common/back-header";
 import { testServiceConnection } from "@/lib/http-client";
@@ -83,7 +83,7 @@ export function ServiceEditor({
   // (or skipped) the sheet.
   const [promptShown, setPromptShown] = useState(false);
 
-  const config = inst ?? {
+  const config: ServiceConfig = inst ?? {
     enabled: false,
     name: SERVICE_DEFAULTS_KIND_LABEL[serviceId],
     localUrl: "",
@@ -584,6 +584,22 @@ export function ServiceEditor({
           helperText="Sent on every request to this instance. Combined with the global headers (Settings → Network → Custom Headers). The service's own auth (API Key, Plex Token, etc.) always wins on collision."
         />
       </Card>
+
+      {serviceId === "qbittorrent" ? (
+        <Card className="gap-4 mb-4">
+          <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+            Torrents
+          </Text>
+          <Toggle
+            label='Tag added torrents with "Dashboarr"'
+            description="Adds a Dashboarr tag to torrents you add from the app, so server-side scripts and filters can tell where they came from. The tag is created in qBittorrent on first use."
+            value={config.tagAddedTorrents ?? false}
+            onValueChange={(v) =>
+              updateInstance(serviceId, instanceId, { tagAddedTorrents: v })
+            }
+          />
+        </Card>
+      ) : null}
 
       <ArrDefaultsCard serviceId={serviceId} instanceId={instanceId} />
 

--- a/lib/qbittorrent-category.test.ts
+++ b/lib/qbittorrent-category.test.ts
@@ -1,0 +1,14 @@
+import { isValidQbCategoryName } from "@/lib/qbittorrent-category";
+
+describe("isValidQbCategoryName", () => {
+  it.each(["Dashboarr", "Dashboarr-Movie", "tv-sonarr", "a", "movies/4k", "a/b/c", "with space"])(
+    "accepts %j",
+    (name) => {
+      expect(isValidQbCategoryName(name)).toBe(true);
+    },
+  );
+
+  it.each(["", "\\", "a\\b", "/a", "a/", "/", "a//b", "//"])("rejects %j", (name) => {
+    expect(isValidQbCategoryName(name)).toBe(false);
+  });
+});

--- a/lib/qbittorrent-category.ts
+++ b/lib/qbittorrent-category.ts
@@ -1,0 +1,13 @@
+// qBittorrent category-name validity, mirroring Session::isValidCategoryName
+// (src/base/bittorrent/sessionimpl.cpp). This matters on the add form because
+// POST /torrents/add does NOT reject an invalid category — it silently adds
+// the torrent uncategorized — so we validate before sending. The rules: no
+// backslashes, and "/" only as a separator between non-empty segments
+// ("a/b" nests a subcategory; "/a", "a/", "a//b" are invalid).
+export function isValidQbCategoryName(name: string): boolean {
+  if (name.length === 0) return false;
+  if (name.includes("\\")) return false;
+  if (name.startsWith("/") || name.endsWith("/")) return false;
+  if (name.includes("//")) return false;
+  return true;
+}

--- a/lib/torrent-adapters/qbittorrent.ts
+++ b/lib/torrent-adapters/qbittorrent.ts
@@ -17,9 +17,11 @@ import {
   getTransferInfo,
   getTorrents,
   addTorrentMagnet,
+  DASHBOARR_TAG,
   type QBTorrentFilter,
 } from "@/services/qbittorrent-api";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { useConfigStore } from "@/store/config-store";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import { isTorrentPaused } from "@/lib/types";
 import type { QBTorrent, QBServerState, TorrentState } from "@/lib/types";
@@ -214,12 +216,24 @@ export const qbittorrentTorrentAdapter: TorrentAdapter = {
     const queryClient = useQueryClient();
     const { instanceId: id } = useInstanceTarget("qbittorrent", instanceId);
     // The unified surface's `label` maps to qBittorrent's category on add;
-    // savePath is ignored (qBittorrent derives it from the category).
+    // savePath is ignored (qBittorrent derives it from the category). The
+    // per-instance `tagAddedTorrents` setting is read at mutate time so a
+    // settings change applies without remounting the view (#289).
     return useMutation({
-      mutationFn: ({ uri, label }: { uri: string; label?: string; savePath?: string }) =>
-        addTorrentMagnet(uri, id ?? undefined, label),
-      onSuccess: () =>
-        queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] }),
+      mutationFn: ({ uri, label }: { uri: string; label?: string; savePath?: string }) => {
+        const inst = id
+          ? useConfigStore.getState().getInstance("qbittorrent", id)
+          : undefined;
+        const tags = inst?.tagAddedTorrents ? [DASHBOARR_TAG] : undefined;
+        return addTorrentMagnet(uri, id ?? undefined, label, tags);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "torrents"] });
+        // A custom category is created server-side by the add itself, so the
+        // cached list is stale — refetch it or the new name is missing from
+        // the picker and the category filter until the screen remounts (#289).
+        queryClient.invalidateQueries({ queryKey: ["qbittorrent", id, "categories"] });
+      },
     });
   },
 

--- a/services/qbittorrent-api.ts
+++ b/services/qbittorrent-api.ts
@@ -496,13 +496,21 @@ export function deleteTorrents(
   );
 }
 
+// Tag applied on add when the instance's `tagAddedTorrents` setting is on, so
+// server-side scripts/filters can tell app-added torrents apart (#289).
+export const DASHBOARR_TAG = "Dashboarr";
+
 export async function addTorrentMagnet(
   magnetUri: string,
   instanceId?: string,
   category?: string,
+  tags?: string[],
 ): Promise<void> {
   const params = new URLSearchParams({ urls: magnetUri });
+  // Both category and tags are auto-created server-side when they don't exist
+  // yet (unlike /torrents/setCategory, which 409s on unknown names).
   if (category) params.set("category", category);
+  if (tags?.length) params.set("tags", tags.join(","));
   let result: unknown;
   try {
     result = await qbRequest<unknown>(

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -156,8 +156,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *   v40 — optional `weekStart` calendar first-day-of-week preference (#320).
  *         Pure version stamp — absence means "auto" (follow the device), and
  *         importConfig whitelists the value.
+ *   v41 — optional per-instance `tagAddedTorrents` on ServiceConfig
+ *         (qBittorrent add-flow "Dashboarr" tag, #289). Pure version stamp —
+ *         absence means off.
  */
-export const CURRENT_CONFIG_VERSION = 40;
+export const CURRENT_CONFIG_VERSION = 41;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -673,6 +676,9 @@ const migrations: Record<number, (payload: any) => any> = {
   // v39 → v40: optional `weekStart` first-day-of-week preference (#320).
   // Pure version stamp — absence means "auto" (follow the device).
   39: (payload) => ({ ...payload, version: 40 }),
+  // v40 → v41: optional per-instance `tagAddedTorrents` (qBittorrent add-flow
+  // "Dashboarr" tag, #289). Pure version stamp — absence means off.
+  40: (payload) => ({ ...payload, version: 41 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -303,6 +303,28 @@ describe("validateExportPayload — service instance coercion", () => {
     expect(result.services.radarr[0].defaultRootFolderPath).toBeUndefined();
     expect(result.services.radarr[0].defaultMetadataProfileId).toBeUndefined();
   });
+
+  it("round-trips tagAddedTorrents=true (v41)", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      services: { qbittorrent: [validInstance({ tagAddedTorrents: true })] },
+    });
+    expect(result.services.qbittorrent[0].tagAddedTorrents).toBe(true);
+  });
+
+  it("drops tagAddedTorrents when absent or non-true", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      services: {
+        qbittorrent: [
+          validInstance(),
+          validInstance({ id: "uuid-2", tagAddedTorrents: "yes" }),
+        ],
+      },
+    });
+    expect(result.services.qbittorrent[0].tagAddedTorrents).toBeUndefined();
+    expect(result.services.qbittorrent[1].tagAddedTorrents).toBeUndefined();
+  });
 });
 
 describe("validateExportPayload — service IDs (forward-compat silent drop)", () => {

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -100,6 +100,11 @@ function coerceServiceInstance(v: unknown): ServiceInstance | null {
   ) {
     out.defaultRootFolderPath = v.defaultRootFolderPath;
   }
+  // v41 (#289): optional qBittorrent-only add-flow tagging. Only persisted
+  // when explicitly enabled — absence (or garbage) means off.
+  if (v.tagAddedTorrents === true) {
+    out.tagAddedTorrents = true;
+  }
   return out;
 }
 

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -109,6 +109,11 @@ export interface ServiceConfig {
   defaultQualityProfileId?: number;
   defaultRootFolderPath?: string;
   defaultMetadataProfileId?: number;
+  // v41 (#289): qBittorrent-only — tag torrents added manually from the app
+  // with "Dashboarr" so server-side scripts/filters can identify their origin.
+  // Off by default (absent/undefined behaves like false) because enabling it
+  // writes a tag into the user's qBittorrent config on first use.
+  tagAddedTorrents?: boolean;
 }
 
 // A configured service instance: a ServiceConfig plus a stable UUID `id` that


### PR DESCRIPTION
Refs #289

- Add-torrent picker gets a **Custom** option to type any category name. qBittorrent auto-creates it on add, so it shows up in the picker and filter from then on. Names are validated client-side because `/torrents/add` silently drops an invalid one instead of erroring.
- New opt-in per-instance setting (off by default) that tags torrents added from the app with `Dashboarr`, for server-side scripts and filters. Tag rather than category so it does not compete with the real category or change the save path under ATM.
- Config schema v41 with migration, export/import coercion.

## Test plan
- `npx tsc --noEmit` clean
- `npx jest lib/qbittorrent-category.test.ts store/config-schema.test.ts` passing
- Manual: add a torrent with a new custom category, confirm it lands categorized and appears in the picker; toggle the tag setting and confirm the tag on the next add