### PR TITLE
fix(jackett): fan out all-indexers search per indexer (Refs #314)

### DIFF
--- a/lib/indexer-adapter.ts
+++ b/lib/indexer-adapter.ts
@@ -1,5 +1,4 @@
 import type { ComponentType } from "react";
-import type { UseQueryResult } from "@tanstack/react-query";
 import type { ServiceId } from "@/lib/constants";
 
 // Shared release-search surface for indexer proxies (Prowlarr, Jackett). The
@@ -45,6 +44,16 @@ export interface IndexerSearchOptions {
   indexerId?: string;
 }
 
+// Minimal query-state surface the shared search views consume. A plain
+// UseQueryResult satisfies it structurally (Prowlarr); Jackett synthesizes it
+// from one query per indexer (lib/indexer-adapters/jackett-fanout.ts).
+export interface IndexerSearchState {
+  data: UnifiedRelease[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+}
+
 export interface IndexerSearchAdapter {
   serviceId: ServiceId;
   displayName: string;
@@ -52,6 +61,6 @@ export interface IndexerSearchAdapter {
   useSearch: (
     query: string,
     opts?: IndexerSearchOptions,
-  ) => UseQueryResult<UnifiedRelease[]>;
+  ) => IndexerSearchState;
   GrabFlow: ComponentType<GrabFlowProps>;
 }

--- a/lib/indexer-adapters/jackett-fanout.test.ts
+++ b/lib/indexer-adapters/jackett-fanout.test.ts
@@ -1,0 +1,100 @@
+import {
+  combineIndexerSearches,
+  type IndexerSearchSlice,
+} from "@/lib/indexer-adapters/jackett-fanout";
+import type { UnifiedRelease } from "@/lib/indexer-adapter";
+
+function release(id: string, seeders?: number): UnifiedRelease {
+  return {
+    id,
+    title: id,
+    indexer: "T",
+    sizeBytes: 1,
+    seeders,
+    protocol: "torrent",
+  };
+}
+
+function done(name: string, releases: UnifiedRelease[]): IndexerSearchSlice {
+  return { name, pending: false, releases };
+}
+
+function failed(name: string, error: string): IndexerSearchSlice {
+  return { name, pending: false, error };
+}
+
+const PENDING: IndexerSearchSlice = { name: "Slow", pending: true };
+
+describe("combineIndexerSearches", () => {
+  it("merges settled slices and sorts by seeders, missing counts last", () => {
+    const out = combineIndexerSearches([
+      done("A", [release("a1", 5), release("a2")]),
+      done("B", [release("b1", 80)]),
+    ]);
+    expect(out).toMatchObject({ isLoading: false, isError: false, error: null });
+    expect(out.data?.map((r) => r.id)).toEqual(["b1", "a1", "a2"]);
+  });
+
+  // A hung tracker must not hold the fast ones' releases hostage — that was
+  // the whole point of fanning out (#314).
+  it("exposes partial results while other indexers are still pending", () => {
+    const out = combineIndexerSearches([done("A", [release("a1", 5)]), PENDING]);
+    expect(out.isLoading).toBe(true);
+    expect(out.isError).toBe(false);
+    expect(out.data?.map((r) => r.id)).toEqual(["a1"]);
+  });
+
+  // data must stay undefined here: [] would render "No results" while the
+  // search is still running.
+  it("keeps data undefined while pending with nothing to show yet", () => {
+    const out = combineIndexerSearches([PENDING, failed("B", "boom")]);
+    expect(out).toEqual({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+  });
+
+  it("aggregates failures into one error only when nothing came back", () => {
+    const out = combineIndexerSearches([
+      failed("A", "Timed out"),
+      failed("B", "403 Forbidden"),
+      done("C", []),
+    ]);
+    expect(out.isError).toBe(true);
+    expect(out.error?.message).toBe("2 of 3 indexers failed. A: Timed out");
+  });
+
+  // The scoped single-indexer search shows the tracker's message verbatim —
+  // the banner title already names the indexer.
+  it("passes a sole slice's error through bare", () => {
+    const out = combineIndexerSearches([failed("FileList", "cookie expired")]);
+    expect(out.error?.message).toBe("cookie expired");
+  });
+
+  // A partial failure with something to show stays silent, same rule as the
+  // old aggregate handling (#314).
+  it("stays silent on failures when other indexers returned releases", () => {
+    const out = combineIndexerSearches([
+      done("A", [release("a1", 1)]),
+      failed("B", "boom"),
+    ]);
+    expect(out).toMatchObject({ isLoading: false, isError: false });
+    expect(out.data).toHaveLength(1);
+  });
+
+  it("settles to an empty result on a genuine all-indexer no-match", () => {
+    const out = combineIndexerSearches([done("A", []), done("B", [])]);
+    expect(out).toEqual({ data: [], isLoading: false, isError: false, error: null });
+  });
+
+  it("settles to an empty result with no indexers configured", () => {
+    expect(combineIndexerSearches([])).toEqual({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+  });
+});

--- a/lib/indexer-adapters/jackett-fanout.ts
+++ b/lib/indexer-adapters/jackett-fanout.ts
@@ -1,0 +1,57 @@
+import type { IndexerSearchState, UnifiedRelease } from "@/lib/indexer-adapter";
+
+// Pure merge step of the Jackett per-indexer search fan-out (see
+// lib/indexer-adapters/jackett.ts for why the fan-out exists — #314). Kept
+// free of react-query so the pending/partial/error rules are unit-testable.
+
+// One indexer's slice of an in-flight all-indexers search.
+export interface IndexerSearchSlice {
+  // Display name, used in the aggregated error message.
+  name: string;
+  // Still in flight — neither releases nor error yet.
+  pending: boolean;
+  releases?: UnifiedRelease[];
+  error?: string;
+}
+
+export function combineIndexerSearches(
+  slices: IndexerSearchSlice[],
+): IndexerSearchState {
+  // Jackett returns results in per-tracker arrival order and the UI slices the
+  // top of the list, so sorting by seeders is load-bearing.
+  const merged = slices
+    .flatMap((s) => s.releases ?? [])
+    .sort((a, b) => (b.seeders ?? -1) - (a.seeders ?? -1));
+
+  // While slow trackers are still answering, show what the fast ones already
+  // returned; with nothing yet, data stays undefined so the view renders
+  // "Searching..." instead of a premature "No results".
+  if (slices.some((s) => s.pending)) {
+    return {
+      data: merged.length > 0 ? merged : undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    };
+  }
+
+  // A partial failure with something to show stays silent — an error banner
+  // must not hide the working trackers' releases (#314).
+  const failed = slices.filter((s) => s.error !== undefined);
+  if (merged.length === 0 && failed.length > 0) {
+    const first = failed[0];
+    const message =
+      slices.length === 1
+        ? (first.error ?? "Search failed")
+        : `${failed.length} of ${slices.length} indexers failed. ` +
+          `${first.name}: ${first.error}`;
+    return {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error(message),
+    };
+  }
+
+  return { data: merged, isLoading: false, isError: false, error: null };
+}

--- a/lib/indexer-adapters/jackett.ts
+++ b/lib/indexer-adapters/jackett.ts
@@ -1,11 +1,17 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 
-import { searchAll } from "@/services/jackett-api";
+import { getIndexers, searchIndexer } from "@/services/jackett-api";
+import { isAbortError } from "@/lib/http-client";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 import { JackettGrabFlow } from "@/components/indexers/jackett-grab-flow";
+import {
+  combineIndexerSearches,
+  type IndexerSearchSlice,
+} from "@/lib/indexer-adapters/jackett-fanout";
 import type {
   IndexerSearchAdapter,
   IndexerSearchOptions,
+  IndexerSearchState,
   UnifiedRelease,
 } from "@/lib/indexer-adapter";
 import type { JackettRelease, JackettResultsResponse } from "@/lib/types";
@@ -27,6 +33,13 @@ function jackettToUnified(r: JackettRelease): UnifiedRelease {
   };
 }
 
+const IDLE: IndexerSearchState = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  error: null,
+};
+
 export const jackettIndexerAdapter: IndexerSearchAdapter = {
   serviceId: "jackett",
   displayName: "Jackett",
@@ -34,27 +47,74 @@ export const jackettIndexerAdapter: IndexerSearchAdapter = {
   // Interactive indexer searches are slow and expensive: don't auto-retry a
   // transient failure (it multiplies a 90s timeout by three before the user
   // sees anything), consume the queryFn signal so backing out aborts the
-  // in-flight fetch, and cache a completed search long enough that returning
+  // in-flight fetches, and cache a completed search long enough that returning
   // to the tab doesn't re-run it. Same contract as useRadarrReleases (#290).
-  useSearch: (query: string, opts?: IndexerSearchOptions) => {
+  //
+  // The all-indexers search fans out ONE request per configured indexer
+  // instead of hitting Jackett's `all` meta-indexer: `all` responds only after
+  // the slowest tracker finishes (Task.WhenAll in ResultsController, no
+  // server-side timeout), so one hung tracker used to drag the aggregate past
+  // 90s and abort the whole search (#314). Fanned out, each tracker gets its
+  // own timeout, results merge as they arrive, and a stalled tracker only
+  // loses its own rows.
+  useSearch: (query: string, opts?: IndexerSearchOptions): IndexerSearchState => {
     const { instanceId: id, enabled } = useInstanceTarget("jackett", opts?.instanceId);
-    const indexerId = opts?.indexerId;
-    return useQuery({
-      // `indexerId` is part of the key so a tracker-scoped search can never be
-      // served the cached all-indexers result (or vice versa).
-      queryKey: ["jackett", id, "search", query, indexerId],
-      queryFn: ({ signal }) => searchAll(query, id ?? undefined, signal, indexerId),
-      enabled: enabled && query.length >= 2 && !!id,
-      staleTime: 60_000,
-      gcTime: 5 * 60_000,
-      retry: false,
-      // Jackett returns results in per-tracker arrival order and the UI slices
-      // the top of the list, so sorting by seeders is load-bearing.
-      select: (resp: JackettResultsResponse) =>
-        resp.Results.map(jackettToUnified).sort(
-          (a, b) => (b.seeders ?? -1) - (a.seeders ?? -1),
+    const scopedId = opts?.indexerId;
+    const searchOn = enabled && query.length >= 2 && !!id;
+
+    // Same key/staleness as useJackettIndexers, so the Indexers tab's cached
+    // list feeds the fan-out instead of a refetch per search.
+    const indexers = useQuery({
+      queryKey: ["jackett", id, "indexers"],
+      queryFn: () => getIndexers(id ?? undefined),
+      enabled: searchOn && !scopedId,
+      staleTime: 300000,
+    });
+
+    const targets: Array<{ id: string; name: string }> = scopedId
+      ? [{ id: scopedId, name: scopedId }]
+      : (indexers.data ?? []).map((i) => ({ id: i.id, name: i.name }));
+
+    const combined = useQueries({
+      queries: targets.map((t) => ({
+        // Same key shape for a scoped search and a fan-out slice, so the
+        // per-indexer Search button (#315) and the all-search share cache.
+        queryKey: ["jackett", id, "search", query, t.id],
+        queryFn: ({ signal }: { signal: AbortSignal }) =>
+          searchIndexer(query, t.id, id ?? undefined, signal),
+        enabled: searchOn,
+        staleTime: 60_000,
+        gcTime: 5 * 60_000,
+        retry: false,
+        select: (resp: JackettResultsResponse) =>
+          resp.Results.map(jackettToUnified),
+      })),
+      combine: (results) =>
+        combineIndexerSearches(
+          results.map((r, i): IndexerSearchSlice => ({
+            name: targets[i]?.name ?? "",
+            pending: r.isPending,
+            releases: r.data,
+            error: r.isError
+              ? // A per-indexer 90s abort surfaces as Hermes' bare "Aborted".
+                isAbortError(r.error)
+                ? "Timed out"
+                : r.error instanceof Error
+                  ? r.error.message
+                  : String(r.error)
+              : undefined,
+          })),
         ),
     });
+
+    if (!searchOn) return IDLE;
+    if (!scopedId && indexers.isLoading) {
+      return { data: undefined, isLoading: true, isError: false, error: null };
+    }
+    if (!scopedId && indexers.isError) {
+      return { data: undefined, isLoading: false, isError: true, error: indexers.error };
+    }
+    return combined;
   },
 
   GrabFlow: JackettGrabFlow,

--- a/services/jackett-api.test.ts
+++ b/services/jackett-api.test.ts
@@ -8,10 +8,9 @@ jest.mock("@/lib/http-client", () => ({
 import { serviceRequest } from "@/lib/http-client";
 import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
 import {
-  assertIndexersUsable,
   getIndexers,
   parseIndexersXml,
-  searchAll,
+  searchIndexer,
   testIndexer,
 } from "@/services/jackett-api";
 import type { JackettIndexerResult, JackettResultsResponse } from "@/lib/types";
@@ -110,12 +109,13 @@ describe("getIndexers", () => {
   });
 });
 
-describe("searchAll", () => {
-  it("GETs the JSON results endpoint with the query", async () => {
+describe("searchIndexer", () => {
+  // The tracker is a path segment, not a query param.
+  it("GETs the tracker-scoped JSON results endpoint with the query", async () => {
     const payload = { Results: [], Indexers: [] };
     mockRequest.mockResolvedValue(payload);
-    await expect(searchAll("ubuntu", "inst-2")).resolves.toBe(payload);
-    expect(mockRequest).toHaveBeenCalledWith("jackett", "/indexers/all/results", {
+    await expect(searchIndexer("ubuntu", "1337x", "inst-2")).resolves.toBe(payload);
+    expect(mockRequest).toHaveBeenCalledWith("jackett", "/indexers/1337x/results", {
       params: { Query: "ubuntu" },
       timeout: INTERACTIVE_SEARCH_TIMEOUT,
       instanceId: "inst-2",
@@ -123,30 +123,42 @@ describe("searchAll", () => {
     });
   });
 
-  // The 15s default aborts a fan-out that was going to succeed (#314), and
+  // The 15s default aborts a search that was going to succeed (#314), and
   // without the signal a hung fetch outlives the search that started it.
   it("uses the interactive-search timeout and forwards the abort signal", async () => {
     mockRequest.mockResolvedValue({ Results: [], Indexers: [] });
     const controller = new AbortController();
-    await searchAll("ubuntu", "inst-2", controller.signal);
+    await searchIndexer("ubuntu", "1337x", "inst-2", controller.signal);
     const opts = mockRequest.mock.calls[0][2];
     expect(opts.timeout).toBe(INTERACTIVE_SEARCH_TIMEOUT);
     expect(opts.signal).toBe(controller.signal);
   });
 
-  it("rejects when the 200 body says every indexer failed", async () => {
+  // A failing tracker answers 200 with Results: [] and its message on the row,
+  // indistinguishable from a genuine no-match without the promotion (#314).
+  it("rejects with the tracker's own error when it failed with no results", async () => {
     mockRequest.mockResolvedValue(response(0, [{ Name: "1337x", Error: "boom" }]));
-    await expect(searchAll("ubuntu")).rejects.toThrow(
-      "1 of 1 indexer failed. 1337x: boom",
-    );
+    await expect(searchIndexer("ubuntu", "id0")).rejects.toThrow("boom");
   });
 
-  // The tracker is a path segment, not a query param — "all" is just Jackett's
-  // meta-indexer id for the same route.
-  it("scopes to one tracker when given an indexerId", async () => {
-    mockRequest.mockResolvedValue({ Results: [], Indexers: [] });
-    await searchAll("ubuntu", "inst-2", undefined, "1337x");
-    expect(mockRequest.mock.calls[0][1]).toBe("/indexers/1337x/results");
+  // Older builds echo the row under a differently-cased id; the sole row is
+  // still the one that was queried.
+  it("matches the row by id with a sole-row fallback", async () => {
+    mockRequest.mockResolvedValue(response(0, [{ Name: "1337x", Error: "cookie expired" }]));
+    await expect(searchIndexer("ubuntu", "1337X")).rejects.toThrow("cookie expired");
+  });
+
+  it("stays silent on a genuine no-match", async () => {
+    mockRequest.mockResolvedValue(response(0, [{ Name: "1337x", Error: null }]));
+    await expect(searchIndexer("ubuntu", "id0")).resolves.toMatchObject({
+      Results: [],
+    });
+  });
+
+  it("returns results even when the row also reports an error", async () => {
+    const payload = response(2, [{ Name: "1337x", Error: "flaky mirror" }]);
+    mockRequest.mockResolvedValue(payload);
+    await expect(searchIndexer("ubuntu", "id0")).resolves.toBe(payload);
   });
 });
 
@@ -247,40 +259,5 @@ function response(
   };
 }
 
-describe("assertIndexersUsable", () => {
-  // A search where every tracker errored decodes as `Results: []`, which the UI
-  // otherwise renders as a plain "No results" (#314).
-  it("throws when there are no results and every indexer errored", () => {
-    const resp = response(0, [
-      { Name: "1337x", Error: "Connection timed out" },
-      { Name: "Nyaa", Error: "403 Forbidden" },
-    ]);
-    expect(() => assertIndexersUsable(resp)).toThrow(
-      "2 of 2 indexers failed. 1337x: Connection timed out",
-    );
-  });
-
-  // A partial failure still has something to show, so it must not become an
-  // error banner that hides the working trackers' releases.
-  it("stays silent when some indexers errored but results came back", () => {
-    const resp = response(3, [
-      { Name: "1337x", Error: null },
-      { Name: "Nyaa", Error: "403 Forbidden" },
-    ]);
-    expect(() => assertIndexersUsable(resp)).not.toThrow();
-  });
-
-  it("stays silent on a genuine no-match", () => {
-    const resp = response(0, [
-      { Name: "1337x", Error: null },
-      { Name: "Nyaa", Error: null },
-    ]);
-    expect(() => assertIndexersUsable(resp)).not.toThrow();
-  });
-
-  it("tolerates a response with no Indexers array", () => {
-    expect(() =>
-      assertIndexersUsable({ Results: [] } as unknown as JackettResultsResponse),
-    ).not.toThrow();
-  });
-});
+// The all-indexers pending/partial/error merge rules live in
+// lib/indexer-adapters/jackett-fanout.test.ts.

--- a/services/jackett-api.ts
+++ b/services/jackett-api.ts
@@ -17,31 +17,36 @@ import type {
 //     indexer list comes from the Torznab meta endpoint instead.
 //   - No Category[] filtering: RequestOptions.params cannot emit repeated query
 //     keys. Single-tracker filtering does not need one — the tracker is a PATH
-//     segment (`/indexers/{id}/results`), and "all" is just Jackett's own
-//     meta-indexer id for that same route.
+//     segment (`/indexers/{id}/results`).
 // Per-instance routing: every function takes an optional `instanceId`. When
 // omitted, the user's active Jackett is used.
 
 // --- Search ---
 
-// JSON manual-search endpoint (the one Jackett's own web UI uses). Returns
-// releases across every configured indexer plus per-indexer status rows.
-// Jackett queries every tracker synchronously before responding, which blows
-// past the 15s default on any real setup — hence the interactive-search
-// timeout. `signal` is the caller's cancel channel: without it a hung fetch
-// outlives the search that started it and later searches dedupe onto the
-// zombie, the "stuck on Searching... forever" report in #314.
-// `indexerId` scopes the search to a single tracker (the per-indexer Search
-// button in the Jackett indexer list, #315); omitted, it fans out to every
-// configured one.
-export async function searchAll(
+// JSON manual-search endpoint (the one Jackett's own web UI uses), always
+// scoped to ONE tracker. Deliberately no all-indexers call: Jackett's `all`
+// meta-indexer answers only after EVERY configured tracker finishes
+// (Task.WhenAll in ResultsController, no server-side timeout), so a single
+// hung tracker stalls the aggregate past any client timeout — the "Aborted"
+// report in #314. The all-indexers search fans out one request per configured
+// indexer instead (lib/indexer-adapters/jackett.ts), so a stalled tracker
+// only loses its own rows. `signal` is the caller's cancel channel: without
+// it a hung fetch outlives the search that started it and later searches
+// dedupe onto the zombie.
+export async function searchIndexer(
   query: string,
+  indexerId: string,
   instanceId?: string,
   signal?: AbortSignal,
-  indexerId?: string,
 ): Promise<JackettResultsResponse> {
-  const resp = await runSearch(query, indexerId ?? "all", instanceId, signal);
-  assertIndexersUsable(resp);
+  const resp = await runSearch(query, indexerId, instanceId, signal);
+  // Jackett answers 200 with `Results: []` whether nothing matched or the
+  // tracker blew up, which renders as a bare "No results" (#314). Promote the
+  // row's own Error string to a thrown error so the UI can tell them apart.
+  if (resp.Results.length === 0) {
+    const row = findIndexerRow(resp, indexerId);
+    if (row?.Error) throw new Error(row.Error);
+  }
   return resp;
 }
 
@@ -63,22 +68,10 @@ function runSearch(
   );
 }
 
-// Jackett answers 200 with `Results: []` whether nothing matched or every
-// tracker blew up, so a broken setup is indistinguishable from a bad query and
-// renders as a bare "No results" (#314). Promote its own per-indexer Error
-// strings to a thrown error the UI can show. Only when there is nothing at all
-// to display: a partial failure still renders what the working trackers
-// returned. Exported for tests.
-export function assertIndexersUsable(resp: JackettResultsResponse): void {
-  if (resp.Results.length > 0) return;
-  const indexers = resp.Indexers ?? [];
-  const failed = indexers.filter((i) => !!i.Error);
-  if (failed.length === 0) return;
-  throw new Error(
-    `${failed.length} of ${indexers.length} indexer` +
-      `${indexers.length === 1 ? "" : "s"} failed. ` +
-      `${failed[0].Name}: ${failed[0].Error}`,
-  );
+// Jackett echoes one status row per queried indexer; match by id and fall back
+// to the sole row, since a tracker whose id differs in case still reports here.
+function findIndexerRow(resp: JackettResultsResponse, indexerId: string) {
+  return resp.Indexers?.find((i) => i.ID === indexerId) ?? resp.Indexers?.[0];
 }
 
 // --- Test ---
@@ -100,10 +93,7 @@ export async function testIndexer(
   signal?: AbortSignal,
 ): Promise<JackettIndexerTestResult> {
   const resp = await runSearch("", indexerId, instanceId, signal);
-  // Jackett echoes one row per queried indexer; match by id and fall back to the
-  // sole row, since a tracker whose id differs in case still reports here.
-  const row =
-    resp.Indexers?.find((i) => i.ID === indexerId) ?? resp.Indexers?.[0];
+  const row = findIndexerRow(resp, indexerId);
   const results = row?.Results ?? resp.Results.length;
   const elapsedMs = row?.ElapsedTime;
   if (row?.Error) return { ok: false, results, elapsedMs, error: row.Error };


### PR DESCRIPTION
Jackett's `all` meta-indexer responds only after the slowest tracker finishes (Task.WhenAll in ResultsController, no server-side timeout), so one hung indexer dragged the aggregate past the 90s timeout and aborted the whole search ("Couldn't search Jackett: Aborted"). Search each configured indexer with its own request and timeout instead, merging results as they arrive, so a stalled tracker only loses its own rows.

- per-indexer queries share cache with the scoped "Only X" search
- partial results render while slow trackers are still answering; error banner only when nothing came back
- a timed-out tracker reads "Timed out" instead of Hermes' bare "Aborted"

Refs #314

## Test plan

- jest: 48 suites / 931 tests pass (new combiner tests in `lib/indexer-adapters/jackett-fanout.test.ts`, reworked `searchIndexer` tests)
- `tsc --noEmit` clean for app code
