### PR TITLE
fix(ui): keep headers clear of the iPadOS 26 window controls (Refs #342)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Upstream API docs and per-service gotchas live in the `service-apis` skill (`.cl
 - Unified dashboard is the home screen
 - Pull-to-refresh on all screens
 - Haptic feedback on key interactions
+- **Top-of-screen header rows must clear the iPadOS 26 window-control cluster** (the macOS-style close/minimize pill overlaying the window's top-left corner in windowed mode — it covered the back arrow, #342). Any row rendered at the top of a screen inside ScreenWrapper's px-4 spreads `useWindowControlsContentPadding()` (from `hooks/use-window-controls-inset.ts`) into its `style`; edge-to-edge overlays (hero back button) use `Math.max(ownLeftOffset, useWindowControlsInset().left)` instead. `BackHeader`, `ServiceHeader`, the media hero/skeleton back buttons, and the dashboard/settings/services title rows already do this — copy the pattern for new custom headers. Values come from the `modules/window-controls` native module (iOS 26 corner-adapted layout margins) and are 0 on iPhone/Android/fullscreen, so applying them unconditionally is safe.
 
 ## Confirmations & Dialogs — MUST follow
 

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -38,6 +38,7 @@ import { WidgetSettingsSheet } from "@/components/dashboard/widget-settings-shee
 import { DashboardPickerSheet } from "@/components/dashboard/dashboard-picker-sheet";
 import { useAttachedKinds } from "@/hooks/use-active-dashboard";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { useWindowControlsContentPadding } from "@/hooks/use-window-controls-inset";
 import { hasSearchableKind } from "@/lib/global-search";
 import { resolveDashboardColor } from "@/lib/dashboard-colors";
 import { resolveDashboardIcon } from "@/lib/dashboard-icons";
@@ -196,9 +197,16 @@ export default function DashboardScreen() {
 
   const dashboardName = activeDashboard?.name ?? "Dashboarr";
 
+  // Keeps the dashboard-picker title clear of the iPadOS 26 window-control
+  // cluster (#342).
+  const windowControlsPadding = useWindowControlsContentPadding();
+
   return (
     <ScreenWrapper refreshing={refreshing} onRefresh={onRefresh}>
-      <View className="flex-row items-center justify-between mt-2 mb-4">
+      <View
+        className="flex-row items-center justify-between mt-2 mb-4"
+        style={windowControlsPadding}
+      >
         <TouchableOpacity
           onPress={openDashboardPicker}
           className="flex-row items-center gap-1.5"

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -16,6 +16,7 @@ import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { useAttachedKinds, useActiveDashboard } from "@/hooks/use-active-dashboard";
 import { useUiScale } from "@/hooks/use-ui-scale";
+import { useWindowControlsContentPadding } from "@/hooks/use-window-controls-inset";
 import { lightHaptic, mediumHaptic } from "@/lib/haptics";
 import type { ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
@@ -45,6 +46,8 @@ export default function ServicesScreen() {
   const uiScale = useUiScale();
   // Grid gap scales with the UI scale setting so spacing tracks the tiles.
   const tileGap = 12 * uiScale;
+  // Keeps the title clear of the iPadOS 26 window-control cluster (#342).
+  const windowControlsPadding = useWindowControlsContentPadding();
   // Animated ref to our own scroll view so Sortable.Grid can auto-scroll the
   // grid when a tile is dragged to the top/bottom edge.
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
@@ -165,7 +168,10 @@ export default function ServicesScreen() {
 
   return (
     <ScreenWrapper scrollable={false}>
-      <View className="flex-row items-center justify-between mb-4 pt-2">
+      <View
+        className="flex-row items-center justify-between mb-4 pt-2"
+        style={windowControlsPadding}
+      >
         <View className="flex-1 pr-3">
           <View className="flex-row items-center gap-2">
             <Text className="text-zinc-100 text-2xl font-bold">Services</Text>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -5,6 +5,7 @@ import { Wifi, Bell, Palette, HardDrive, Info } from "lucide-react-native";
 import { ServiceLogo } from "@/components/ui/service-logo";
 import { StatusDot } from "@/components/ui/status-dot";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { useWindowControlsContentPadding } from "@/hooks/use-window-controls-inset";
 import { APP_THEMES } from "@/lib/app-themes";
 import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
@@ -57,6 +58,9 @@ export default function SettingsScreen() {
   // reflect ok/auth_failed/offline instead of just "any instance enabled".
   // Cached + polled by the shared hook — no extra requests fired here.
   const { data: healthData } = useServiceHealth();
+
+  // Keeps the title clear of the iPadOS 26 window-control cluster (#342).
+  const windowControlsPadding = useWindowControlsContentPadding();
 
   if (editingInstance) {
     return (
@@ -151,7 +155,7 @@ export default function SettingsScreen() {
 
   return (
     <ScreenWrapper>
-      <View className="mt-2 mb-4">
+      <View className="mt-2 mb-4" style={windowControlsPadding}>
         <Text className="text-zinc-100 text-2xl font-bold">Settings</Text>
         <Text className="text-zinc-500 text-xs mt-0.5">
           Applies to all dashboards

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,7 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { rem, vars } from "nativewind";
 import { hexToRgbChannels } from "@/lib/app-themes";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { BASE_REM } from "@/hooks/use-ui-scale";
 import { useConfigStore } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
 import { useSortStore } from "@/store/sort-store";
@@ -202,7 +203,7 @@ const CONFIG_SYNC_DEBOUNCE_MS = 2000;
 function UiScaleBridge() {
   const uiScale = useConfigStore((s) => s.uiScale);
   useEffect(() => {
-    rem.set(14 * uiScale);
+    rem.set(BASE_REM * uiScale);
   }, [uiScale]);
   return null;
 }

--- a/components/common/back-header.tsx
+++ b/components/common/back-header.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 import { ArrowLeft } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { useWindowControlsContentPadding } from "@/hooks/use-window-controls-inset";
 
 interface BackHeaderProps {
   title?: string;
@@ -13,9 +14,14 @@ interface BackHeaderProps {
 export function BackHeader({ title, right, onBack }: BackHeaderProps) {
   const router = useRouter();
   const handlePress = onBack ?? (() => router.back());
+  // Keeps the arrow clear of the iPadOS 26 window-control cluster (#342).
+  const windowControlsPadding = useWindowControlsContentPadding();
 
   return (
-    <View className="flex-row items-center mb-4 mt-2">
+    <View
+      className="flex-row items-center mb-4 mt-2"
+      style={windowControlsPadding}
+    >
       <Pressable
         onPress={handlePress}
         className="mr-3 active:opacity-70 p-1"

--- a/components/common/media-detail-hero.tsx
+++ b/components/common/media-detail-hero.tsx
@@ -19,6 +19,8 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import type { RatingsBundle } from "@/lib/types";
+import { useWindowControlsInset } from "@/hooks/use-window-controls-inset";
+import { BASE_REM, useUiScale } from "@/hooks/use-ui-scale";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 // Backdrop is shallower than the side-by-side variant: the focal point shifts
@@ -54,6 +56,11 @@ export function MediaDetailHero({
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const handleBack = onBack ?? (() => router.back());
+  // The hero is edge-to-edge, so the button's default offset (left-3, 0.75rem)
+  // is measured from the window edge — same origin as the iPadOS 26
+  // window-control inset. Whichever is larger keeps the button clear (#342).
+  const windowControls = useWindowControlsInset();
+  const backLeft = Math.max(0.75 * BASE_REM * useUiScale(), windowControls.left);
 
   const backdropOpacity = useSharedValue(0);
   const posterOpacity = useSharedValue(0);
@@ -133,8 +140,8 @@ export function MediaDetailHero({
         <Pressable
           onPress={handleBack}
           hitSlop={12}
-          className="absolute left-3 bg-black/50 rounded-full p-2 active:opacity-70"
-          style={{ top: insets.top + 8 }}
+          className="absolute bg-black/50 rounded-full p-2 active:opacity-70"
+          style={{ top: insets.top + 8, left: backLeft }}
         >
           <Icon icon={ArrowLeft} size={22} color="#fff" />
         </Pressable>

--- a/components/common/media-detail-skeleton.tsx
+++ b/components/common/media-detail-skeleton.tsx
@@ -6,13 +6,13 @@ import { LinearGradient } from "expo-linear-gradient";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Icon } from "@/components/ui/icon";
-import { useUiScale } from "@/hooks/use-ui-scale";
+import { BASE_REM, useUiScale } from "@/hooks/use-ui-scale";
+import { useWindowControlsInset } from "@/hooks/use-window-controls-inset";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 // Match `media-detail-hero.tsx` so the skeleton settles into the same shape
 // the real hero will occupy — minimizes visual jump on data resolution.
 const BACKDROP_HEIGHT = Math.round(SCREEN_WIDTH * 0.55);
-const REM_BASE = 14;
 
 interface MediaDetailSkeletonProps {
   // Shorter accordion list shown for series; movie body has none.
@@ -25,7 +25,10 @@ export function MediaDetailSkeleton({
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const scale = useUiScale();
-  const rem = REM_BASE * scale;
+  const rem = BASE_REM * scale;
+  // Same clearance as the real hero's back button (#342).
+  const windowControls = useWindowControlsInset();
+  const backLeft = Math.max(0.75 * rem, windowControls.left);
 
   const posterW = 9 * rem;
   const posterH = 13.5 * rem;
@@ -54,8 +57,8 @@ export function MediaDetailSkeleton({
           <Pressable
             onPress={() => router.back()}
             hitSlop={12}
-            className="absolute left-3 bg-black/50 rounded-full p-2 active:opacity-70"
-            style={{ top: insets.top + 8 }}
+            className="absolute bg-black/50 rounded-full p-2 active:opacity-70"
+            style={{ top: insets.top + 8, left: backLeft }}
           >
             <Icon icon={ArrowLeft} size={22} color="#fff" />
           </Pressable>

--- a/components/common/service-header.tsx
+++ b/components/common/service-header.tsx
@@ -6,6 +6,7 @@ import { StatusDot } from "@/components/ui/status-dot";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { useActiveInstance } from "@/hooks/use-active-instance";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { useWindowControlsContentPadding } from "@/hooks/use-window-controls-inset";
 import { lightHaptic } from "@/lib/haptics";
 import { SERVICE_DEFAULTS } from "@/lib/constants";
 import type { ServiceId } from "@/lib/constants";
@@ -30,8 +31,14 @@ export function ServiceHeader({
   className = "",
   serviceId,
 }: ServiceHeaderProps) {
+  // Keeps the title clear of the iPadOS 26 window-control cluster (#342).
+  const windowControlsPadding = useWindowControlsContentPadding();
+
   return (
-    <View className={`flex-row items-center gap-2 mb-4 mt-2 ${className}`}>
+    <View
+      className={`flex-row items-center gap-2 mb-4 mt-2 ${className}`}
+      style={windowControlsPadding}
+    >
       <Text className="text-zinc-100 text-2xl font-bold">{name}</Text>
       {serviceId ? <InstancePickerInline serviceId={serviceId} /> : null}
       {serviceId ? (

--- a/hooks/use-ui-scale.ts
+++ b/hooks/use-ui-scale.ts
@@ -1,5 +1,9 @@
 import { useConfigStore } from "@/store/config-store";
 
+// Root rem value at uiScale 1.0 — app/_layout.tsx feeds rem.set(BASE_REM * uiScale),
+// so `BASE_REM * useUiScale()` is the current pt size of 1rem.
+export const BASE_REM = 14;
+
 export function useUiScale() {
   return useConfigStore((s) => s.uiScale);
 }

--- a/hooks/use-window-controls-inset.ts
+++ b/hooks/use-window-controls-inset.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { Dimensions, Platform } from "react-native";
+import { requireOptionalNativeModule } from "expo";
+import { BASE_REM, useUiScale } from "@/hooks/use-ui-scale";
+
+// iPadOS 26 draws a window-control cluster (close/minimize/expand) over the
+// top-leading corner of every window, covering anything the app renders there
+// (issue #342: the back arrow). The WindowControls native module reads the
+// system's corner-adapted layout margins — the same signal UINavigationBar
+// uses to shift its leading items — and reports how far (pt, from each window
+// edge) top-of-screen content must stay clear. Everywhere the cluster can't
+// overlap content (iPhone, fullscreen iPad, iOS < 26, Android) it reports 0,
+// so consumers can apply the inset unconditionally.
+const WindowControls =
+  Platform.OS === "ios"
+    ? requireOptionalNativeModule<{
+        getTopCornerInsets(): Promise<{ left: number; right: number }>;
+      }>("WindowControls")
+    : null;
+
+export interface WindowControlsInset {
+  left: number;
+  right: number;
+}
+
+const ZERO: WindowControlsInset = { left: 0, right: 0 };
+
+// One measurement shared by every mounted header. The cluster is fixed to the
+// window's corner, so the inset only changes when the window itself changes
+// (fullscreen <-> windowed, resize) — all of which fire a Dimensions change.
+let current: WindowControlsInset = ZERO;
+let measureStarted = false;
+let dimensionsSubscribed = false;
+let pendingFrame: number | null = null;
+const listeners = new Set<(insets: WindowControlsInset) => void>();
+
+async function measure() {
+  if (!WindowControls) return;
+  try {
+    const next = await WindowControls.getTopCornerInsets();
+    if (next.left === current.left && next.right === current.right) return;
+    current = next;
+    listeners.forEach((listener) => listener(current));
+  } catch {
+    // Older binary without the module recompiled — keep zeros.
+  }
+}
+
+function ensureDimensionsListener() {
+  if (dimensionsSubscribed) return;
+  dimensionsSubscribed = true;
+  Dimensions.addEventListener("change", () => {
+    if (pendingFrame !== null) cancelAnimationFrame(pendingFrame);
+    // Measuring in the same frame as an un-maximize reads stale margins
+    // (react-navigation hit the same race in their CornerInset view) — defer
+    // one frame so the window has settled.
+    pendingFrame = requestAnimationFrame(() => {
+      pendingFrame = null;
+      void measure();
+    });
+  });
+}
+
+export function useWindowControlsInset(): WindowControlsInset {
+  const [insets, setInsets] = useState(current);
+
+  useEffect(() => {
+    if (!WindowControls) return;
+    listeners.add(setInsets);
+    ensureDimensionsListener();
+    if (!measureStarted) {
+      measureStarted = true;
+      void measure();
+    } else {
+      setInsets(current);
+    }
+    return () => {
+      listeners.delete(setInsets);
+    };
+  }, []);
+
+  return insets;
+}
+
+/**
+ * Horizontal padding for a header row that sits inside a screen's standard
+ * 1rem content padding (ScreenWrapper px-4). The screen padding already
+ * offsets the row from the window edge, so only the remainder of the
+ * window-control inset is applied. Spread into the row's style.
+ */
+export function useWindowControlsContentPadding(): {
+  paddingLeft: number;
+  paddingRight: number;
+} {
+  const insets = useWindowControlsInset();
+  const contentPad = BASE_REM * useUiScale();
+  return {
+    paddingLeft: Math.max(0, insets.left - contentPad),
+    paddingRight: Math.max(0, insets.right - contentPad),
+  };
+}

--- a/modules/window-controls/expo-module.config.json
+++ b/modules/window-controls/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["WindowControlsModule"]
+  }
+}

--- a/modules/window-controls/ios/WindowControls.podspec
+++ b/modules/window-controls/ios/WindowControls.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'WindowControls'
+  s.version        = '1.0.0'
+  s.summary        = 'Reports the iPadOS 26 window-control corner insets'
+  s.description    = 'Reports the iPadOS 26 window-control corner insets'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/window-controls/ios/WindowControlsModule.swift
+++ b/modules/window-controls/ios/WindowControlsModule.swift
@@ -1,0 +1,60 @@
+import ExpoModulesCore
+import UIKit
+
+public class WindowControlsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("WindowControls")
+
+    // Horizontal space (pt, measured from each window edge) that content near
+    // the top of the window must leave clear of the iPadOS 26 window-control
+    // cluster (close/minimize/expand, issue #342). Zero whenever the cluster
+    // doesn't overlap content: iPhone, fullscreen iPad, iOS < 26.
+    AsyncFunction("getTopCornerInsets") { () -> [String: Double] in
+      Self.measureTopCornerInsets()
+    }.runOnQueue(.main)
+  }
+
+  private static func measureTopCornerInsets() -> [String: Double] {
+    // The corner-adaptation layout API ships with the iOS 26 SDK (Xcode 26 /
+    // Swift 6.2); older toolchains build the zero-inset stub.
+    #if compiler(>=6.2)
+    guard #available(iOS 26.0, *), let window = keyWindow() else {
+      return ["left": 0, "right": 0]
+    }
+
+    // Corner-adapted margins are position-dependent: only views whose frame
+    // reaches into the window's top corners get adapted, so a probe is laid
+    // over the top strip of the window where the app renders its headers.
+    let probe = UIView(frame: CGRect(x: 0, y: 0, width: window.bounds.width, height: 120))
+    probe.alpha = 0
+    probe.isUserInteractionEnabled = false
+    probe.isAccessibilityElement = false
+    window.addSubview(probe)
+    defer { probe.removeFromSuperview() }
+
+    window.setNeedsUpdateProperties()
+    probe.setNeedsUpdateProperties()
+    window.updatePropertiesIfNeeded()
+    probe.updatePropertiesIfNeeded()
+
+    let adapted = probe.edgeInsets(for: .margins(cornerAdaptation: .horizontal))
+    let baseline = probe.edgeInsets(for: .margins(cornerAdaptation: .none))
+
+    // An edge whose adapted margin equals the baseline margin needs no
+    // clearance; only a corner-adapted edge reports its full margin.
+    return [
+      "left": adapted.left == baseline.left ? 0 : Double(adapted.left),
+      "right": adapted.right == baseline.right ? 0 : Double(adapted.right),
+    ]
+    #else
+    return ["left": 0, "right": 0]
+    #endif
+  }
+
+  private static func keyWindow() -> UIWindow? {
+    UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow }
+  }
+}


### PR DESCRIPTION
## Summary
- iPadOS 26 windowed mode overlays a window-control cluster on the top-left corner, covering the app's custom back arrow (Refs #342)
- New local Expo module `modules/window-controls` reads the system's iOS 26 corner-adapted layout margins (the same signal UINavigationBar uses) and reports the horizontal clearance; returns 0 on iPhone, fullscreen, iOS < 26, and Android
- New `useWindowControlsInset` / `useWindowControlsContentPadding` hooks apply it to BackHeader, ServiceHeader, the media hero/skeleton back buttons, and the dashboard/settings/services title rows

## Test plan
- `tsc --noEmit` clean, all 931 jest tests pass
- Swift typechecked against the iOS 26 SDK
- Needs an iPad (or Xcode 26 iPad simulator) smoke check in windowed mode; requires a new dev build