### PR TITLE
feat(arr): force import for blocked Radarr/Sonarr queue items (Refs #325)

### DIFF
--- a/components/services/queue-issues-banner.tsx
+++ b/components/services/queue-issues-banner.tsx
@@ -1,13 +1,21 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ComponentType } from "react";
 import { View, Text, Pressable } from "react-native";
-import { AlertTriangle, ChevronRight, Ban, Search, Trash2 } from "lucide-react-native";
+import {
+  AlertTriangle,
+  ChevronRight,
+  Ban,
+  FolderInput,
+  Search,
+  Trash2,
+} from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
-import { ConfirmModal } from "@/components/common/confirm-modal";
+import { ConfirmModal, type ConfirmTone } from "@/components/common/confirm-modal";
 import { QueueIssuesSheet } from "@/components/services/queue-issues-sheet";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import {
   useArrQueueIssues,
+  useForceImportArrQueue,
   useRemoveFromArrQueue,
   type ArrQueueRemoveMode,
 } from "@/hooks/use-arr-queue-issues";
@@ -22,33 +30,57 @@ interface QueueIssuesBannerProps {
   className?: string;
 }
 
-interface PendingRemoval {
+// Everything a stuck grab can have done to it: the three removal modes (#285)
+// plus importing it anyway (#325).
+type QueueActionMode = ArrQueueRemoveMode | "forceImport";
+
+interface PendingAction {
   item: ArrQueueItem;
-  mode: ArrQueueRemoveMode;
+  mode: QueueActionMode;
 }
 
-// Copy per removal mode. "Blocklist" here means *arr marks the grab as failed so
-// the release is never picked up again; the search variant additionally kicks
-// off a hunt for a replacement (issue #285).
-const REMOVAL_COPY: Record<
-  ArrQueueRemoveMode,
-  { title: string; confirmLabel: string; describe: (service: string) => string }
+// Confirm-dialog copy per action. "Blocklist" here means *arr marks the grab as
+// failed so the release is never picked up again; the search variant
+// additionally kicks off a hunt for a replacement (issue #285).
+const ACTION_COPY: Record<
+  QueueActionMode,
+  {
+    title: string;
+    confirmLabel: string;
+    tone: ConfirmTone;
+    icon: ComponentType<any>;
+    describe: (service: string) => string;
+  }
 > = {
+  forceImport: {
+    title: "Force import?",
+    confirmLabel: "Force Import",
+    tone: "default",
+    icon: FolderInput,
+    describe: (service) =>
+      `${service} imports the downloaded files even though it blocked them, replacing the current file if one exists.`,
+  },
   remove: {
     title: "Remove from queue?",
     confirmLabel: "Remove",
+    tone: "danger",
+    icon: Trash2,
     describe: (service) =>
       `${service} drops this grab and deletes it from the download client. The release stays eligible, so it can be grabbed again.`,
   },
   blocklistAndSearch: {
     title: "Blocklist and search?",
     confirmLabel: "Blocklist & Search",
+    tone: "danger",
+    icon: Ban,
     describe: (service) =>
       `${service} removes this grab, blocks the release so it is never grabbed again, and starts searching for a replacement.`,
   },
   blocklist: {
     title: "Blocklist release?",
     confirmLabel: "Blocklist",
+    tone: "danger",
+    icon: Ban,
     describe: (service) =>
       `${service} removes this grab and blocks the release so it is never grabbed again. No replacement search runs.`,
   },
@@ -58,7 +90,8 @@ const REMOVAL_COPY: Record<
  * Top-of-screen banner for an *arr view: when the active instance has grabs
  * stuck with a warning or error (a blocked import, a stalled or failed
  * download), it shows a tappable summary that opens the issue list, where each
- * item can be removed or blocklisted (#285). Renders null when the queue is
+ * item can be removed or blocklisted (#285), and a blocked import can be
+ * forced through (#325). Renders null when the queue is
  * healthy. See lib/arr-queue-issues.ts for why the copy says "queue issues"
  * rather than "import issues" — the detection is deliberately broader.
  *
@@ -72,6 +105,7 @@ export function QueueIssuesBanner({
 }: QueueIssuesBannerProps) {
   const { issues: fetched } = useArrQueueIssues(adapter, instanceId);
   const removeMutation = useRemoveFromArrQueue(adapter, instanceId);
+  const forceImportMutation = useForceImportArrQueue(adapter, instanceId);
 
   // Queue ids already removed on the service but still in the cached response
   // until the invalidated refetch lands. Without this the list reopens with the
@@ -97,26 +131,42 @@ export function QueueIssuesBanner({
   const flow = useModalFlow<{
     issues: void;
     itemActions: ArrQueueItem;
-    confirmRemove: PendingRemoval;
+    confirmAction: PendingAction;
   }>();
 
   const sheetItem = flow.payload("itemActions");
-  const pending = flow.payload("confirmRemove");
+  const pending = flow.payload("confirmAction");
 
   const actions: ActionSheetAction[] = sheetItem
     ? [
+        // The constructive fix comes first: import the blocked download anyway
+        // (#325). Only offered where it can work — an import-blocked grab on a
+        // service whose adapter implements forceImport.
+        ...(sheetItem.canForceImport && adapter.forceImport
+          ? [
+              {
+                label: "Force import",
+                icon: <Icon icon={FolderInput} size={18} color="#34d399" />,
+                onPress: () =>
+                  flow.open("confirmAction", {
+                    item: sheetItem,
+                    mode: "forceImport" as const,
+                  }),
+              },
+            ]
+          : []),
         {
           label: "Remove from queue",
           icon: <Icon icon={Trash2} size={18} color="#a1a1aa" />,
           onPress: () =>
-            flow.open("confirmRemove", { item: sheetItem, mode: "remove" }),
+            flow.open("confirmAction", { item: sheetItem, mode: "remove" }),
         },
         {
           label: "Blocklist & Search",
           icon: <Icon icon={Search} size={18} color="#ef4444" />,
           variant: "danger",
           onPress: () =>
-            flow.open("confirmRemove", {
+            flow.open("confirmAction", {
               item: sheetItem,
               mode: "blocklistAndSearch",
             }),
@@ -126,24 +176,45 @@ export function QueueIssuesBanner({
           icon: <Icon icon={Ban} size={18} color="#ef4444" />,
           variant: "danger",
           onPress: () =>
-            flow.open("confirmRemove", { item: sheetItem, mode: "blocklist" }),
+            flow.open("confirmAction", { item: sheetItem, mode: "blocklist" }),
         },
       ]
     : [];
 
-  const confirmRemove = () => {
+  const confirmAction = () => {
     if (!pending) return;
-    const { id } = pending.item;
+    const { item, mode } = pending;
     flow.close();
+
+    if (mode === "forceImport") {
+      if (!item.downloadId) return;
+      forceImportMutation.mutate(
+        { downloadId: item.downloadId },
+        {
+          // Unlike a removal the row is NOT hidden: the import runs async on
+          // the server, and hiding it via removedIds would also hide an import
+          // that fails and stays blocked — permanently, since the prune effect
+          // only forgets ids that leave the queue. The invalidated refetch
+          // clears the row as soon as *arr moves it out of the blocked state.
+          onSuccess: () => {
+            if (issues.some((i) => i.id !== item.id)) flow.open("issues");
+          },
+        },
+      );
+      return;
+    }
+
     removeMutation.mutate(
-      { queueId: id, mode: pending.mode },
+      { queueId: item.id, mode },
       {
         // Back to the list so several stuck grabs can be cleared in a row. The
         // just-handled item is hidden immediately; when it was the last one the
         // list is empty and there is nothing to return to.
         onSuccess: () => {
-          setRemovedIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
-          if (issues.some((i) => i.id !== id)) flow.open("issues");
+          setRemovedIds((prev) =>
+            prev.includes(item.id) ? prev : [...prev, item.id],
+          );
+          if (issues.some((i) => i.id !== item.id)) flow.open("issues");
         },
       },
     );
@@ -218,17 +289,17 @@ export function QueueIssuesBanner({
       />
 
       <ConfirmModal
-        {...flow.bind("confirmRemove")}
-        title={pending ? REMOVAL_COPY[pending.mode].title : ""}
+        {...flow.bind("confirmAction")}
+        title={pending ? ACTION_COPY[pending.mode].title : ""}
         message={
           pending
-            ? `${REMOVAL_COPY[pending.mode].describe(adapter.displayName)}\n\n${pending.item.releaseTitle}`
+            ? `${ACTION_COPY[pending.mode].describe(adapter.displayName)}\n\n${pending.item.releaseTitle}`
             : ""
         }
-        icon={pending?.mode === "remove" ? Trash2 : Ban}
-        tone="danger"
-        confirmLabel={pending ? REMOVAL_COPY[pending.mode].confirmLabel : undefined}
-        onConfirm={confirmRemove}
+        icon={pending ? ACTION_COPY[pending.mode].icon : Trash2}
+        tone={pending ? ACTION_COPY[pending.mode].tone : "danger"}
+        confirmLabel={pending ? ACTION_COPY[pending.mode].confirmLabel : undefined}
+        onConfirm={confirmAction}
       />
     </>
   );

--- a/hooks/use-arr-queue-issues.ts
+++ b/hooks/use-arr-queue-issues.ts
@@ -84,3 +84,28 @@ export function useRemoveFromArrQueue(
     onError: (err) => toastError("Failed to update queue", err),
   });
 }
+
+/**
+ * Imports a blocked grab anyway via the adapter's forceImport (#325). Success
+ * only means *arr accepted the ManualImport command — the import itself runs
+ * async on the server, so the toast says "started" and the invalidated refetch
+ * (plus the regular queue poll) is what clears the row.
+ */
+export function useForceImportArrQueue(
+  adapter: ArrQueueAdapter,
+  instanceId?: string,
+) {
+  const { instanceId: id } = useInstanceTarget(adapter.serviceId, instanceId);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ downloadId }: { downloadId: string }) =>
+      adapter.forceImport!(id!, downloadId),
+    onSuccess: () => {
+      toast(`Import started, ${adapter.displayName} is processing it`);
+      if (!id) return;
+      queryClient.invalidateQueries({ queryKey: adapter.queueQueryKey(id) });
+    },
+    onError: (err) => toastError("Force import failed", err),
+  });
+}

--- a/lib/arr-queue-adapter.ts
+++ b/lib/arr-queue-adapter.ts
@@ -30,6 +30,16 @@ export interface ArrQueueItem {
   statusLabel: string;
   // Every reason *arr gave, deduped. Empty when it gave none.
   messages: string[];
+
+  // --- Blocked-import override (#325) ---
+  // Download-client id (torrent hash / nzo id) — the `/manualimport` lookup
+  // key. *arr omits it on some records, so force import is only offered when
+  // it is present.
+  downloadId?: string;
+  // True when this grab is stuck on the import decision with a downloadId to
+  // act on — the one stuck state `forceImport` can resolve. Left unset by
+  // adapters without a forceImport (Lidarr).
+  canForceImport?: boolean;
 }
 
 // Shared adapter: every *arr service that exposes a download queue implements
@@ -76,4 +86,9 @@ export interface ArrQueueAdapter {
     queueId: number,
     opts: ArrQueueRemoveOptions,
   ) => Promise<void>;
+
+  // Imports a blocked download anyway, replacing the existing file — desktop
+  // Manual Import from the phone (#325). Optional: Lidarr's manualimport
+  // payload is track-level and unverified, so it doesn't implement this.
+  forceImport?: (instanceId: string, downloadId: string) => Promise<void>;
 }

--- a/lib/arr-queue-adapters/radarr.ts
+++ b/lib/arr-queue-adapters/radarr.ts
@@ -3,10 +3,12 @@ import {
   getWantedMissing,
   getRadarrPoster,
   removeFromQueue,
+  forceImportQueueItem,
 } from "@/services/radarr-api";
 import type { RadarrQueue, RadarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
 import {
+  queueImportBlocked,
   queueIssueMessages,
   queueIssueSeverity,
   queueStatusLabel,
@@ -46,6 +48,8 @@ export const radarrArrQueueAdapter: ArrQueueAdapter = {
         severity: queueIssueSeverity(item),
         statusLabel: queueStatusLabel(item),
         messages: queueIssueMessages(item),
+        downloadId: item.downloadId,
+        canForceImport: queueImportBlocked(item) && !!item.downloadId,
       };
     }),
 
@@ -54,4 +58,7 @@ export const radarrArrQueueAdapter: ArrQueueAdapter = {
 
   removeFromQueue: (instanceId, queueId, opts) =>
     removeFromQueue(queueId, opts, instanceId),
+
+  forceImport: (instanceId, downloadId) =>
+    forceImportQueueItem(downloadId, instanceId),
 };

--- a/lib/arr-queue-adapters/sonarr.ts
+++ b/lib/arr-queue-adapters/sonarr.ts
@@ -3,10 +3,12 @@ import {
   getWantedMissing,
   getSonarrPoster,
   removeFromQueue,
+  forceImportQueueItem,
 } from "@/services/sonarr-api";
 import type { SonarrQueue, SonarrQueueItem, SonarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
 import {
+  queueImportBlocked,
   queueIssueMessages,
   queueIssueSeverity,
   queueStatusLabel,
@@ -58,6 +60,8 @@ export const sonarrArrQueueAdapter: ArrQueueAdapter = {
         severity: queueIssueSeverity(item),
         statusLabel: queueStatusLabel(item),
         messages: queueIssueMessages(item),
+        downloadId: item.downloadId,
+        canForceImport: queueImportBlocked(item) && !!item.downloadId,
       };
     }),
 
@@ -66,4 +70,7 @@ export const sonarrArrQueueAdapter: ArrQueueAdapter = {
 
   removeFromQueue: (instanceId, queueId, opts) =>
     removeFromQueue(queueId, opts, instanceId),
+
+  forceImport: (instanceId, downloadId) =>
+    forceImportQueueItem(downloadId, instanceId),
 };

--- a/lib/arr-queue-issues.test.ts
+++ b/lib/arr-queue-issues.test.ts
@@ -1,4 +1,5 @@
 import {
+  queueImportBlocked,
   queueIssueSeverity,
   queueIssueMessages,
   queueStatusLabel,
@@ -136,6 +137,65 @@ describe("queueStatusLabel", () => {
       "Download failed",
     );
     expect(queueStatusLabel({})).toBe("Downloading");
+  });
+});
+
+describe("queueImportBlocked", () => {
+  it("matches importBlocked regardless of severity", () => {
+    expect(
+      queueImportBlocked(record({ trackedDownloadState: "importBlocked" })),
+    ).toBe(true);
+    expect(
+      queueImportBlocked(
+        record({
+          trackedDownloadState: "importBlocked",
+          trackedDownloadStatus: "warning",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches importPending only when it carries an issue", () => {
+    expect(
+      queueImportBlocked(record({ trackedDownloadState: "importPending" })),
+    ).toBe(false);
+    expect(
+      queueImportBlocked(
+        record({
+          trackedDownloadState: "importPending",
+          trackedDownloadStatus: "warning",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      queueImportBlocked(record({ trackedDownloadState: "ImportBlocked" })),
+    ).toBe(true);
+  });
+
+  // A failed or in-flight download has nothing on disk to import, however
+  // loudly the record is flagged.
+  it("rejects the non-import stuck states", () => {
+    expect(
+      queueImportBlocked(
+        record({
+          trackedDownloadState: "failed",
+          trackedDownloadStatus: "error",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      queueImportBlocked(
+        record({
+          trackedDownloadState: "downloading",
+          trackedDownloadStatus: "warning",
+        }),
+      ),
+    ).toBe(false);
+    expect(queueImportBlocked(record())).toBe(false);
+    expect(queueImportBlocked({})).toBe(false);
   });
 });
 

--- a/lib/arr-queue-issues.ts
+++ b/lib/arr-queue-issues.ts
@@ -97,6 +97,20 @@ export function queueStatusLabel(item: ArrQueueIssueRecord): string {
 }
 
 /**
+ * A completed grab stuck on *arr's import decision — the only stuck state a
+ * force import can resolve (#325). Matches exactly the records
+ * `queueStatusLabel` calls "Import blocked": `importBlocked`, plus
+ * `importPending` when it carries a warning/error (the pre-v4 spelling of the
+ * same situation). A failed or stalled *download* is not importable, so it
+ * stays out.
+ */
+export function queueImportBlocked(item: ArrQueueIssueRecord): boolean {
+  const state = (item.trackedDownloadState ?? "").toLowerCase();
+  if (state === "importblocked") return true;
+  return state === "importpending" && queueIssueSeverity(item) !== null;
+}
+
+/**
  * Every reason *arr gives, flattened and deduped, most important first.
  *
  * A `statusMessages` entry normally names the release in `title` and lists the

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -466,7 +466,9 @@ const DEMO_RADARR_QUEUE = {
       movie: makeMovie(8, "Kingdom of the Planet of the Apes", 2024, 653346, false),
     },
     // Finished downloading but Radarr refuses to import it — drives the import
-    // issues banner (#285).
+    // issues banner (#285) and its Force import action (#325). The "not an
+    // upgrade" message is the exact scenario force import resolves, and the
+    // downloadId links it to DEMO_RADARR_MANUAL_IMPORT below.
     {
       id: 103,
       movieId: 11,
@@ -478,7 +480,7 @@ const DEMO_RADARR_QUEUE = {
         {
           title: "Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP",
           messages: [
-            "No files found are eligible for import in /downloads/complete/Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP",
+            "Not an upgrade for existing movie file(s). Existing quality: Bluray-1080p",
           ],
         },
       ],
@@ -487,11 +489,31 @@ const DEMO_RADARR_QUEUE = {
       timeleft: null,
       protocol: "torrent",
       downloadClient: "qBittorrent",
+      downloadId: "DEMO-FURIOSA-2160P",
       quality: { quality: { name: "Bluray-2160p" } },
       movie: makeMovie(11, "Furiosa: A Mad Max Saga", 2024, 786892, false),
     },
   ],
 };
+
+// GET /manualimport candidates for the blocked grab above — lets demo mode
+// exercise the whole force-import flow (#325).
+const DEMO_RADARR_MANUAL_IMPORT = [
+  {
+    id: 1,
+    path: "/downloads/complete/Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP/furiosa.a.mad.max.saga.2024.2160p.mkv",
+    relativePath: "furiosa.a.mad.max.saga.2024.2160p.mkv",
+    folderName: "Furiosa.A.Mad.Max.Saga.2024.2160p.UHD.BluRay.x265-GROUP",
+    size: 62277025792,
+    movie: makeMovie(11, "Furiosa: A Mad Max Saga", 2024, 786892, false),
+    quality: { quality: { id: 19, name: "Bluray-2160p" } },
+    languages: [{ id: 1, name: "English" }],
+    releaseGroup: "GROUP",
+    downloadId: "DEMO-FURIOSA-2160P",
+    indexerFlags: 0,
+    rejections: [{ reason: "Not an upgrade for existing movie file(s)" }],
+  },
+];
 
 const DEMO_RADARR_WANTED = {
   page: 1,
@@ -619,7 +641,8 @@ const DEMO_SONARR_QUEUE = {
       series: makeSeries(3, "Fallout", 2024, 456789),
     },
     // Finished downloading but Sonarr refuses to import it — drives the import
-    // issues banner (#285).
+    // issues banner (#285) and its Force import action (#325); the downloadId
+    // links it to DEMO_SONARR_MANUAL_IMPORT below.
     {
       id: 302,
       seriesId: 3,
@@ -640,11 +663,40 @@ const DEMO_SONARR_QUEUE = {
       sizeleft: 0,
       timeleft: null,
       protocol: "torrent",
+      downloadId: "DEMO-FALLOUT-S01E07",
       quality: { quality: { name: "WEBDL-1080p" } },
       series: makeSeries(3, "Fallout", 2024, 456789),
     },
   ],
 };
+
+// GET /manualimport candidates for the blocked grab above — lets demo mode
+// exercise the whole force-import flow (#325).
+const DEMO_SONARR_MANUAL_IMPORT = [
+  {
+    id: 1,
+    path: "/downloads/complete/Fallout.S01E07.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb/fallout.s01e07.1080p.mkv",
+    relativePath: "fallout.s01e07.1080p.mkv",
+    folderName: "Fallout.S01E07.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb",
+    size: 2952790016,
+    series: makeSeries(3, "Fallout", 2024, 456789),
+    seasonNumber: 1,
+    episodes: [{ id: 204 }],
+    episodeFileId: 0,
+    releaseType: "singleEpisode",
+    quality: { quality: { id: 3, name: "WEBDL-1080p" } },
+    languages: [{ id: 1, name: "English" }],
+    releaseGroup: "NTb",
+    downloadId: "DEMO-FALLOUT-S01E07",
+    indexerFlags: 0,
+    rejections: [
+      {
+        reason:
+          "One or more episodes expected in this release were not imported or missing",
+      },
+    ],
+  },
+];
 
 // --- Lidarr ---
 
@@ -1771,6 +1823,7 @@ export function getDemoResponse(
       if (normalized === "/movie") return DEMO_RADARR_MOVIES;
       if (normalized === "/movie/:id") return DEMO_RADARR_MOVIES[0];
       if (normalized.startsWith("/queue")) return DEMO_RADARR_QUEUE;
+      if (normalized.startsWith("/manualimport")) return DEMO_RADARR_MANUAL_IMPORT;
       if (normalized.startsWith("/wanted/missing")) return DEMO_RADARR_WANTED;
       if (normalized.startsWith("/calendar")) return DEMO_RADARR_CALENDAR;
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "HD-1080p" }, { id: 2, name: "Ultra-HD" }];
@@ -1788,6 +1841,7 @@ export function getDemoResponse(
       if (normalized === "/series/:id") return DEMO_SONARR_SERIES[0];
       if (normalized.startsWith("/calendar")) return DEMO_SONARR_CALENDAR;
       if (normalized.startsWith("/queue")) return DEMO_SONARR_QUEUE;
+      if (normalized.startsWith("/manualimport")) return DEMO_SONARR_MANUAL_IMPORT;
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "Any" }, { id: 2, name: "HD-1080p" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/tv", freeSpace: 2199023255552 }];
       if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -418,6 +418,26 @@ export interface ArrQualityModel {
   revision?: { version?: number; real?: number; isRepack?: boolean };
 }
 
+// A candidate file from `GET /manualimport?downloadId=` — the list Radarr's own
+// Manual Import screen shows for a completed download (#325). `quality` and
+// `languages` round-trip verbatim into the ManualImport command, so only the
+// fields the force-import flow reads are typed.
+export interface RadarrManualImportItem {
+  id: number;
+  path?: string;
+  relativePath?: string;
+  folderName?: string;
+  name?: string;
+  size?: number;
+  movie?: { id: number; title?: string };
+  quality?: ArrQualityModel;
+  languages?: { id: number; name: string }[];
+  releaseGroup?: string;
+  downloadId?: string;
+  indexerFlags?: number;
+  rejections?: { reason: string }[];
+}
+
 // The `data` bag on a history record. The *arr API types it as
 // Dictionary<string,string>, so every value is a string (or absent). These are
 // the keys populated for grab/import/failed events; the index signature keeps
@@ -724,6 +744,29 @@ export interface SonarrQueue {
   pageSize: number;
   totalRecords: number;
   records: SonarrQueueItem[];
+}
+
+// Sonarr's counterpart of RadarrManualImportItem: file→episode mapping instead
+// of a movie, plus `releaseType`/`episodeFileId` which its ManualImport command
+// accepts and Radarr's does not.
+export interface SonarrManualImportItem {
+  id: number;
+  path?: string;
+  relativePath?: string;
+  folderName?: string;
+  name?: string;
+  size?: number;
+  series?: { id: number; title?: string };
+  seasonNumber?: number;
+  episodes?: { id: number }[];
+  episodeFileId?: number;
+  releaseType?: string;
+  quality?: ArrQualityModel;
+  languages?: { id: number; name: string }[];
+  releaseGroup?: string;
+  downloadId?: string;
+  indexerFlags?: number;
+  rejections?: { reason: string }[];
 }
 
 // Paged /wanted/missing response — aired, monitored episodes without a file.

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -3,6 +3,7 @@ import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
 import type {
   RadarrMovie,
   RadarrQueue,
+  RadarrManualImportItem,
   RadarrHistory,
   RadarrHistoryRecord,
   RadarrWantedMissing,
@@ -100,6 +101,62 @@ export function removeFromQueue(
       blocklist: opts.blocklist ?? false,
       skipRedownload: opts.skipRedownload ?? false,
     },
+    instanceId,
+  });
+}
+
+// --- Force import (#325) ---
+
+// The import candidates Radarr matched for a completed download — the same
+// list its own Manual Import screen shows. `filterExistingFiles: false` so
+// nothing the scan found is hidden from the eligibility check below.
+function getManualImportItems(
+  downloadId: string,
+  instanceId?: string,
+): Promise<RadarrManualImportItem[]> {
+  return serviceRequest<RadarrManualImportItem[]>("radarr", "/manualimport", {
+    params: { downloadId, filterExistingFiles: false },
+    instanceId,
+  });
+}
+
+/**
+ * Imports a completed download Radarr refused to import ("Import blocked",
+ * typically a grab-anyway release that isn't a quality upgrade), replacing the
+ * existing movie file. The app-side equivalent of desktop Manual Import: fetch
+ * Radarr's own candidates for the download, then issue a ManualImport command
+ * for every file it identified — the command imports regardless of rejections,
+ * which is the "force". File payload mirrors Radarr's web UI
+ * (InteractiveImportModalContent). Only files Radarr matched to a movie with a
+ * parsed quality qualify; anything unidentified needs the desktop screen's
+ * manual mapping, so with no qualifying file this rejects instead of silently
+ * importing nothing.
+ */
+export async function forceImportQueueItem(
+  downloadId: string,
+  instanceId?: string,
+): Promise<void> {
+  const candidates = await getManualImportItems(downloadId, instanceId);
+  const files = candidates
+    .filter((c) => c.path && c.movie && c.quality)
+    .map((c) => ({
+      path: c.path,
+      folderName: c.folderName,
+      movieId: c.movie!.id,
+      quality: c.quality,
+      languages: c.languages ?? [],
+      releaseGroup: c.releaseGroup,
+      indexerFlags: c.indexerFlags ?? 0,
+      downloadId,
+    }));
+  if (files.length === 0) {
+    throw new Error(
+      "Radarr couldn't match this download to a movie. Use Manual Import in Radarr to map it.",
+    );
+  }
+  return serviceRequest<void>("radarr", "/command", {
+    method: "POST",
+    body: JSON.stringify({ name: "ManualImport", files, importMode: "auto" }),
     instanceId,
   });
 }

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -6,6 +6,7 @@ import type {
   SonarrEpisodeFile,
   SonarrCalendarEntry,
   SonarrQueue,
+  SonarrManualImportItem,
   SonarrHistory,
   SonarrHistoryRecord,
   SonarrSearchResult,
@@ -200,6 +201,65 @@ export function removeFromQueue(
       blocklist: opts.blocklist ?? false,
       skipRedownload: opts.skipRedownload ?? false,
     },
+    instanceId,
+  });
+}
+
+// --- Force import (#325) ---
+
+// The import candidates Sonarr matched for a completed download — the same
+// list its own Manual Import screen shows. `filterExistingFiles: false` so
+// nothing the scan found is hidden from the eligibility check below.
+function getManualImportItems(
+  downloadId: string,
+  instanceId?: string,
+): Promise<SonarrManualImportItem[]> {
+  return serviceRequest<SonarrManualImportItem[]>("sonarr", "/manualimport", {
+    params: { downloadId, filterExistingFiles: false },
+    instanceId,
+  });
+}
+
+/**
+ * Imports a completed download Sonarr refused to import ("Import blocked",
+ * typically a grab-anyway release that isn't a quality upgrade), replacing the
+ * existing episode files. The app-side equivalent of desktop Manual Import:
+ * fetch Sonarr's own candidates for the download, then issue a ManualImport
+ * command for every file it identified — the command imports regardless of
+ * rejections, which is the "force". File payload mirrors Sonarr's web UI
+ * (InteractiveImportModalContent). Only files Sonarr mapped to episodes with a
+ * parsed quality qualify; anything unidentified needs the desktop screen's
+ * manual mapping, so with no qualifying file this rejects instead of silently
+ * importing nothing.
+ */
+export async function forceImportQueueItem(
+  downloadId: string,
+  instanceId?: string,
+): Promise<void> {
+  const candidates = await getManualImportItems(downloadId, instanceId);
+  const files = candidates
+    .filter((c) => c.path && c.series && c.episodes?.length && c.quality)
+    .map((c) => ({
+      path: c.path,
+      folderName: c.folderName,
+      seriesId: c.series!.id,
+      episodeIds: c.episodes!.map((e) => e.id),
+      quality: c.quality,
+      languages: c.languages ?? [],
+      releaseGroup: c.releaseGroup,
+      indexerFlags: c.indexerFlags ?? 0,
+      releaseType: c.releaseType,
+      episodeFileId: c.episodeFileId,
+      downloadId,
+    }));
+  if (files.length === 0) {
+    throw new Error(
+      "Sonarr couldn't match this download to any episode. Use Manual Import in Sonarr to map it.",
+    );
+  }
+  return serviceRequest<void>("sonarr", "/command", {
+    method: "POST",
+    body: JSON.stringify({ name: "ManualImport", files, importMode: "auto" }),
     instanceId,
   });
 }


### PR DESCRIPTION
Adds a Force import action to the queue issues banner for import-blocked Radarr/Sonarr items (e.g. a grab-anyway release stuck on "not an upgrade"). It fetches the instance's own /manualimport candidates for the download and issues a ManualImport command with importMode auto, replacing the existing file exactly like desktop Manual Import. Payloads verified against the upstream OpenAPI specs, C# command models, and both web frontends. Lidarr is untouched (action hidden there). Demo mode fixtures exercise the full flow.

Refs #325

## Test plan
- tsc --noEmit clean
- jest: 935 passed, incl. new queueImportBlocked tests
- Real-instance check: Grab anyway a lower-quality release in Radarr, then Force import it from the queue issues banner