### PR TITLE
feat(notifications): mute qBittorrent torrent-completed notifications by category (Refs #310)

### DIFF
--- a/backend/dashboarr-backend/src/db/repos/config.ts
+++ b/backend/dashboarr-backend/src/db/repos/config.ts
@@ -1,5 +1,11 @@
 import { getDb } from "../client.js";
-import type { ServiceId, NotificationSettings, NotifCategory, AppriseConfig } from "../../types.js";
+import type {
+  ServiceId,
+  NotificationSettings,
+  NotifCategory,
+  AppriseConfig,
+  QbtMutedCategories,
+} from "../../types.js";
 import { DEFAULT_NOTIFICATION_SETTINGS } from "../../types.js";
 import type { StoredServiceInstance } from "./service-instance.js";
 
@@ -12,6 +18,7 @@ import type { StoredServiceInstance } from "./service-instance.js";
 
 const PER_INSTANCE_KV_KEY = "notification.perInstance";
 const APPRISE_KV_KEY = "notification.apprise";
+const QBT_MUTED_KV_KEY = "notification.qbtMutedCategories";
 
 export function saveNotificationSettings(settings: NotificationSettings): void {
   const db = getDb();
@@ -22,7 +29,7 @@ export function saveNotificationSettings(settings: NotificationSettings): void {
     for (const [k, v] of Object.entries(settings)) {
       // Non-boolean fields are stored as JSON blobs in `kv` below, not as
       // key→boolean rows here.
-      if (k === "perInstance" || k === "apprise") continue;
+      if (k === "perInstance" || k === "apprise" || k === "qbtMutedCategories") continue;
       stmt.run(k, v ? 1 : 0);
     }
 
@@ -44,6 +51,18 @@ export function saveNotificationSettings(settings: NotificationSettings): void {
       );
     } else {
       db.prepare("DELETE FROM kv WHERE key = ?").run(APPRISE_KV_KEY);
+    }
+
+    if (
+      settings.qbtMutedCategories &&
+      Object.keys(settings.qbtMutedCategories).length > 0
+    ) {
+      db.prepare("INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)").run(
+        QBT_MUTED_KV_KEY,
+        JSON.stringify(settings.qbtMutedCategories),
+      );
+    } else {
+      db.prepare("DELETE FROM kv WHERE key = ?").run(QBT_MUTED_KV_KEY);
     }
   });
   tx();
@@ -86,6 +105,20 @@ export function loadNotificationSettings(): NotificationSettings {
       const parsed = JSON.parse(appriseRow.value);
       if (parsed && typeof parsed === "object") {
         result.apprise = parsed as AppriseConfig;
+      }
+    } catch {
+      // Malformed JSON — drop silently, same rationale as perInstance above.
+    }
+  }
+
+  const qbtMutedRow = getDb()
+    .prepare<[string], { value: string }>("SELECT value FROM kv WHERE key = ?")
+    .get(QBT_MUTED_KV_KEY);
+  if (qbtMutedRow?.value) {
+    try {
+      const parsed = JSON.parse(qbtMutedRow.value);
+      if (parsed && typeof parsed === "object") {
+        result.qbtMutedCategories = parsed as QbtMutedCategories;
       }
     } catch {
       // Malformed JSON — drop silently, same rationale as perInstance above.

--- a/backend/dashboarr-backend/src/types.test.ts
+++ b/backend/dashboarr-backend/src/types.test.ts
@@ -5,6 +5,7 @@ import {
   notificationSettingsSchema,
   DEFAULT_NOTIFICATION_SETTINGS,
 } from "./types.js";
+import { isQbtCategoryMuted } from "./workers/transitions.js";
 
 /**
  * Regression guard for the bug where the app sends a config entry for a service
@@ -92,4 +93,36 @@ test("apprise sub-fields default when partially provided", () => {
   if (!result.success) return;
   assert.equal(result.data.apprise?.enabled, false);
   assert.equal(result.data.apprise?.tags, "");
+});
+
+// qbtMutedCategories (issue #310) — optional per-instance category mute list.
+
+test("notifications without qbtMutedCategories still parse (back-compat)", () => {
+  const result = notificationSettingsSchema.safeParse(DEFAULT_NOTIFICATION_SETTINGS);
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.equal(result.data.qbtMutedCategories, undefined);
+});
+
+test("qbtMutedCategories round-trips, including the uncategorized \"\" entry", () => {
+  const map = { "uuid-1": ["cross-seed-link", ""] };
+  const result = notificationSettingsSchema.safeParse({
+    ...DEFAULT_NOTIFICATION_SETTINGS,
+    qbtMutedCategories: map,
+  });
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.deepEqual(result.data.qbtMutedCategories, map);
+});
+
+test("isQbtCategoryMuted matches exactly and treats missing category as uncategorized", () => {
+  const map = { "uuid-1": ["cross-seed-link", ""] };
+  assert.equal(isQbtCategoryMuted(map, "uuid-1", "cross-seed-link"), true);
+  assert.equal(isQbtCategoryMuted(map, "uuid-1", "Cross-Seed-Link"), false);
+  assert.equal(isQbtCategoryMuted(map, "uuid-1", ""), true);
+  assert.equal(isQbtCategoryMuted(map, "uuid-1", undefined), true);
+  assert.equal(isQbtCategoryMuted(map, "uuid-1", "movies"), false);
+  assert.equal(isQbtCategoryMuted(map, "uuid-2", "cross-seed-link"), false);
+  assert.equal(isQbtCategoryMuted(undefined, "uuid-1", "cross-seed-link"), false);
+  assert.equal(isQbtCategoryMuted({ "uuid-1": [] }, "uuid-1", "cross-seed-link"), false);
 });

--- a/backend/dashboarr-backend/src/types.ts
+++ b/backend/dashboarr-backend/src/types.ts
@@ -146,6 +146,17 @@ export const appriseConfigSchema = z
 
 export type AppriseConfig = NonNullable<z.infer<typeof appriseConfigSchema>>;
 
+// Issue #310: per-qBittorrent-instance category mute list for torrentCompleted.
+// Keyed by instance UUID; values are exact qBittorrent category names ("" means
+// uncategorized, hence no .min(1) on the element). Absent/empty = notify for
+// everything. Persisted as a JSON blob in `kv` (key
+// "notification.qbtMutedCategories"), like perInstance and apprise.
+export const qbtMutedCategoriesSchema = z
+  .record(z.string().min(1).max(128), z.array(z.string().max(256)).max(200))
+  .optional();
+
+export type QbtMutedCategories = NonNullable<z.infer<typeof qbtMutedCategoriesSchema>>;
+
 export const notificationSettingsSchema = z.object({
   enabled: z.boolean().default(true),
   torrentCompleted: z.boolean().default(true),
@@ -165,6 +176,7 @@ export const notificationSettingsSchema = z.object({
   tracearrStreamStopped: z.boolean().default(false),
   perInstance: perInstanceOverridesSchema,
   apprise: appriseConfigSchema,
+  qbtMutedCategories: qbtMutedCategoriesSchema,
 });
 
 export type NotificationSettings = z.infer<typeof notificationSettingsSchema>;

--- a/backend/dashboarr-backend/src/workers/transitions.ts
+++ b/backend/dashboarr-backend/src/workers/transitions.ts
@@ -1,11 +1,12 @@
 import { getState, setState } from "../db/repos/seen-state.js";
+import { loadNotificationSettings } from "../db/repos/config.js";
 import { getEnv } from "../env.js";
 import { dispatchPush } from "../push/dispatcher.js";
 import type { TorrentState, QBTorrent } from "../services/qbittorrent.js";
 import type { TransmissionTorrent } from "../services/transmission.js";
 import type { SabHistorySlot } from "../services/sabnzbd.js";
 import type { NzbgetHistoryItem } from "../services/nzbget.js";
-import type { NotificationCategory } from "../types.js";
+import type { NotificationCategory, QbtMutedCategories } from "../types.js";
 import type { RadarrHistoryRecord } from "../services/radarr.js";
 import type { SonarrHistoryRecord } from "../services/sonarr.js";
 import type { OverseerrRequest } from "../services/overseerr.js";
@@ -74,6 +75,22 @@ function isManagedByArr(category: string): boolean {
   return MANAGED_CATEGORIES.has(category.toLowerCase());
 }
 
+/**
+ * Issue #310: user-configured mute list, per qBittorrent instance. Matching is
+ * exact and case-sensitive (names are picked from the server's own category
+ * list; qBittorrent treats "Movies" and "movies" as distinct). "" mutes
+ * uncategorized torrents.
+ */
+export function isQbtCategoryMuted(
+  map: QbtMutedCategories | undefined,
+  instanceId: string,
+  category: string | undefined,
+): boolean {
+  const muted = map?.[instanceId];
+  if (!muted || muted.length === 0) return false;
+  return muted.includes(category ?? "");
+}
+
 interface QbtSnapshot {
   [hash: string]: { name: string; state: TorrentState };
 }
@@ -98,12 +115,23 @@ export async function diffQbTorrents(
 
   const prefix = instancePrefix(instanceName, multipleOfKind);
 
+  // Lazily loaded on the first completion so the common no-transition poll
+  // never touches notification settings.
+  let mutedMap: QbtMutedCategories | undefined | null = null;
+
   for (const t of torrents) {
     const before = prev[t.hash];
     if (before && isDownloading(before.state) && isCompleted(t.state)) {
       // Skip notification for torrents managed by Radarr/Sonarr — those
       // services send their own, more informative notifications.
       if (isManagedByArr(t.category)) continue;
+
+      // User-muted categories skip before dispatchPush so the dedupe key is
+      // never claimed for a suppressed event.
+      if (mutedMap === null) {
+        mutedMap = loadNotificationSettings().qbtMutedCategories;
+      }
+      if (isQbtCategoryMuted(mutedMap, instanceId, t.category)) continue;
 
       await dispatchPush({
         category: "torrentCompleted",

--- a/components/settings/qbt-muted-categories.tsx
+++ b/components/settings/qbt-muted-categories.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { Modal, View, Text, Pressable, ScrollView } from "react-native";
+import { ChevronRight } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
+import { useConfigStore } from "@/store/config-store";
+import { useTorrentCategories } from "@/hooks/use-qbittorrent";
+import { SelectRow } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import { lightHaptic } from "@/lib/haptics";
+
+/**
+ * Per-instance mute list for the "Torrent completed" notification (#310).
+ * Muted categories (exact, case-sensitive names; "" = uncategorized) are
+ * silenced in both the backend push pipeline and the local watcher — the
+ * cross-seed injection category being the motivating case.
+ *
+ * Rendered as a compact summary row so the Notifications card stays short on
+ * servers with dozens of categories; the full checklist lives in a pageSheet.
+ * Toggles apply immediately, so an iOS swipe-dismiss can't discard changes.
+ * The sheet never chains into another modal or navigation, so plain useState
+ * visibility is safe (see the modal sequencing rules in CLAUDE.md).
+ */
+export function QbtMutedCategories({
+  instanceId,
+  disabled,
+}: {
+  instanceId: string;
+  disabled?: boolean;
+}) {
+  const mutedList = useConfigStore(
+    (s) => s.notificationSettings.qbtMutedCategories?.[instanceId],
+  );
+  const [sheetVisible, setSheetVisible] = useState(false);
+
+  const summary =
+    mutedList && mutedList.length > 0
+      ? mutedList.map((c) => (c === "" ? "Uncategorized" : c)).join(", ")
+      : "None — every category notifies";
+
+  return (
+    <View>
+      <Text className="text-zinc-500 text-xs uppercase tracking-wider mb-1">
+        Muted categories
+      </Text>
+      <Text className="text-zinc-500 text-xs leading-5 mb-2">
+        No "Download complete" notification for torrents in a muted category
+        (e.g. cross-seed's injection category). Applies to this instance only.
+      </Text>
+      <Pressable
+        onPress={() => {
+          if (disabled) return;
+          setSheetVisible(true);
+        }}
+        className="flex-row items-center gap-3 bg-surface-light rounded-2xl border border-border px-3 py-2.5 active:opacity-70"
+      >
+        <Text
+          className={`flex-1 text-sm font-medium ${
+            mutedList && mutedList.length > 0 ? "text-zinc-200" : "text-zinc-500"
+          }`}
+          numberOfLines={1}
+        >
+          {summary}
+        </Text>
+        <Icon icon={ChevronRight} size={16} color="#71717a" />
+      </Pressable>
+
+      <MutedCategoriesSheet
+        visible={sheetVisible}
+        onClose={() => setSheetVisible(false)}
+        instanceId={instanceId}
+      />
+    </View>
+  );
+}
+
+function MutedCategoriesSheet({
+  visible,
+  onClose,
+  instanceId,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  instanceId: string;
+}) {
+  const mutedList = useConfigStore(
+    (s) => s.notificationSettings.qbtMutedCategories?.[instanceId],
+  );
+  const setMuted = useConfigStore((s) => s.setQbtMutedCategories);
+  const { data: fetched, isLoading, isSuccess } = useTorrentCategories(instanceId);
+  const footerPadding = useSheetBottomPadding();
+
+  const categories = fetched ?? [];
+  const muted = new Set(mutedList ?? []);
+  // Muted names no longer on the server stay listed so they can be unmuted.
+  const stale = (mutedList ?? []).filter(
+    (c) => c !== "" && !categories.includes(c),
+  );
+
+  const toggle = (name: string) => {
+    lightHaptic();
+    const next = muted.has(name)
+      ? (mutedList ?? []).filter((c) => c !== name)
+      : [...(mutedList ?? []), name];
+    setMuted(instanceId, next);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Muted Categories" onClose={onClose} />
+
+        <Text className="text-zinc-500 text-sm px-4 pt-3">
+          Checked categories won't send "Download complete" notifications.
+        </Text>
+
+        <ScrollView
+          contentContainerClassName="px-4 py-4"
+          showsVerticalScrollIndicator={false}
+        >
+          <View className="bg-surface-light rounded-2xl border border-border divide-y divide-border/60 overflow-hidden">
+            <SelectRow
+              label="Uncategorized"
+              caption="Torrents without a category"
+              selected={muted.has("")}
+              onPress={() => toggle("")}
+            />
+            {categories.map((name) => (
+              <SelectRow
+                key={name}
+                label={name}
+                selected={muted.has(name)}
+                onPress={() => toggle(name)}
+              />
+            ))}
+            {stale.map((name) => (
+              <SelectRow
+                key={name}
+                label={name}
+                caption="Not on server"
+                selected
+                onPress={() => toggle(name)}
+              />
+            ))}
+          </View>
+          {!isLoading && !isSuccess ? (
+            <Text className="text-zinc-600 text-xs mt-2">
+              Couldn't load categories from qBittorrent.
+            </Text>
+          ) : null}
+        </ScrollView>
+
+        <View className="px-4 pb-8 pt-2 border-t border-border" style={footerPadding}>
+          <Button label="Done" onPress={onClose} />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/components/settings/service-editor.tsx
+++ b/components/settings/service-editor.tsx
@@ -38,6 +38,7 @@ import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import { ActionSheet } from "@/components/ui/action-sheet";
 import { ArrDefaultsCard } from "@/components/settings/arr-defaults-card";
+import { QbtMutedCategories } from "@/components/settings/qbt-muted-categories";
 import {
   SERVICE_DEFAULTS_KIND_LABEL,
   EMPTY_INSTANCES,
@@ -767,6 +768,9 @@ function InstanceNotificationsCard({
           />
         );
       })}
+      {serviceId === "qbittorrent" ? (
+        <QbtMutedCategories instanceId={instanceId} disabled={masterOff} />
+      ) : null}
     </Card>
   );
 }

--- a/hooks/use-notification-watchers.tsx
+++ b/hooks/use-notification-watchers.tsx
@@ -175,6 +175,11 @@ function QbDownloadWatcher({
 }) {
   const { data: downloading } = useDownloadingTorrentsForWatcher(active, instanceId);
   const prevDownloading = useRef<Map<string, QBTorrent>>(new Map());
+  // v42 (#310): user-muted categories for this instance. Exact, case-sensitive
+  // names; "" mutes uncategorized torrents.
+  const mutedList = useConfigStore(
+    (s) => s.notificationSettings.qbtMutedCategories?.[instanceId],
+  );
 
   // Reset the baseline whenever the watcher goes inactive so the next active
   // poll doesn't compare against a stale snapshot from before the gap.
@@ -205,10 +210,14 @@ function QbDownloadWatcher({
           { hashes: departed.map((t) => t.hash) },
           instanceId,
         );
-        const stateByHash = new Map(list.map((t) => [t.hash, t.state]));
+        const freshByHash = new Map(list.map((t) => [t.hash, t]));
+        const muted = new Set(mutedList ?? []);
         for (const t of departed) {
-          const newState = stateByHash.get(t.hash);
-          if (newState && isCompletedState(newState)) {
+          const fresh = freshByHash.get(t.hash);
+          if (fresh && isCompletedState(fresh.state)) {
+            // Prefer the fresh fetch's category (it may have changed since the
+            // torrent entered the downloading snapshot).
+            if (muted.has(fresh.category ?? t.category ?? "")) continue;
             sendLocalNotification({
               title: "Download complete",
               body: t.name,
@@ -221,7 +230,7 @@ function QbDownloadWatcher({
         // than risk a false positive.
       }
     })();
-  }, [downloading, active, instanceId]);
+  }, [downloading, active, instanceId, mutedList]);
 
   return null;
 }

--- a/services/backend-api.ts
+++ b/services/backend-api.ts
@@ -222,6 +222,7 @@ export function pushConfigSnapshot(): Promise<void> {
     overseerrNewRequest,
     perInstance,
     apprise,
+    qbtMutedCategories,
   } = configState.notificationSettings;
 
   return request<void>("/config", {
@@ -243,6 +244,9 @@ export function pushConfigSnapshot(): Promise<void> {
         // v34: Apprise sink config. Sent as `undefined` when unset so older
         // backends ignore it.
         apprise,
+        // v42: per-qbt-instance muted categories (#310). Sent as `undefined`
+        // when unset; older backends strip the unknown key (zod v3).
+        qbtMutedCategories,
       },
     }),
   });

--- a/store/config-migrations.test.ts
+++ b/store/config-migrations.test.ts
@@ -1733,3 +1733,36 @@ describe("v39 → v40 (weekStart stamp)", () => {
     expect(result.weekStart).toBeUndefined();
   });
 });
+
+describe("v41 → v42 (qbtMutedCategories stamp)", () => {
+  it("just stamps the version and preserves an already-set muted map", () => {
+    const result: any = migrateConfig({
+      version: 41,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+      notificationSettings: {
+        enabled: true,
+        qbtMutedCategories: { "inst-1": ["cross-seed-link", ""] },
+      },
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.notificationSettings.qbtMutedCategories).toEqual({
+      "inst-1": ["cross-seed-link", ""],
+    });
+  });
+
+  it("leaves the muted map absent when the source payload omitted it", () => {
+    const result: any = migrateConfig({
+      version: 41,
+      services: {},
+      secrets: {},
+      dashboards: [{ id: "d1", name: "Default", widgets: [] }],
+      activeDashboardId: "d1",
+      notificationSettings: { enabled: true },
+    });
+    expect(result.version).toBe(CURRENT_CONFIG_VERSION);
+    expect(result.notificationSettings.qbtMutedCategories).toBeUndefined();
+  });
+});

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -159,8 +159,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *   v41 — optional per-instance `tagAddedTorrents` on ServiceConfig
  *         (qBittorrent add-flow "Dashboarr" tag, #289). Pure version stamp —
  *         absence means off.
+ *   v42 — optional `qbtMutedCategories` on notificationSettings (#310). Pure
+ *         version stamp — absence means no muting; coerceNotificationSettings
+ *         validates the map on import.
  */
-export const CURRENT_CONFIG_VERSION = 41;
+export const CURRENT_CONFIG_VERSION = 42;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -679,6 +682,9 @@ const migrations: Record<number, (payload: any) => any> = {
   // v40 → v41: optional per-instance `tagAddedTorrents` (qBittorrent add-flow
   // "Dashboarr" tag, #289). Pure version stamp — absence means off.
   40: (payload) => ({ ...payload, version: 41 }),
+  // v41 → v42: optional `qbtMutedCategories` on notificationSettings (#310).
+  // Pure version stamp — absence means no muting.
+  41: (payload) => ({ ...payload, version: 42 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -968,6 +968,43 @@ describe("validateExportPayload — notification settings", () => {
       }),
     ).toThrow(/notificationSettings/);
   });
+
+  it("round-trips qbtMutedCategories including the uncategorized \"\" entry (v42)", () => {
+    const qbtMutedCategories = { "inst-qbt-1": ["cross-seed-link", ""] };
+    const result = validateExportPayload({
+      ...baseValid(),
+      notificationSettings: { ...fullSettings, qbtMutedCategories },
+    });
+    expect(result.notificationSettings?.qbtMutedCategories).toEqual(qbtMutedCategories);
+  });
+
+  it("silently drops malformed qbtMutedCategories values instead of failing the import", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      notificationSettings: {
+        ...fullSettings,
+        qbtMutedCategories: {
+          "inst-1": ["movies", 42, null],
+          "inst-2": "not-an-array",
+          "": ["orphan"],
+        },
+      } as any,
+    });
+    expect(result.notificationSettings?.qbtMutedCategories).toEqual({
+      "inst-1": ["movies"],
+    });
+  });
+
+  it("omits qbtMutedCategories entirely when nothing valid survives", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      notificationSettings: {
+        ...fullSettings,
+        qbtMutedCategories: { "inst-1": [42] },
+      } as any,
+    });
+    expect(result.notificationSettings?.qbtMutedCategories).toBeUndefined();
+  });
 });
 
 describe("validateExportPayload — backend", () => {

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -372,6 +372,25 @@ function coerceNotificationSettings(v: unknown): NotificationSettings | null {
       out.apprise = apprise;
     }
   }
+  // v42 (issue #310): per-qBittorrent-instance muted categories. Same
+  // silent-drop philosophy as apprise — never strand a whole restore on one
+  // optional field. "" is a valid entry (uncategorized torrents).
+  if (isPlainObject(v.qbtMutedCategories)) {
+    const qbtMutedCategories: Record<string, string[]> = {};
+    for (const [instanceId, list] of Object.entries(v.qbtMutedCategories)) {
+      if (instanceId.length === 0 || instanceId.length > 128) continue;
+      if (!Array.isArray(list)) continue;
+      const cleaned = [
+        ...new Set(list.filter((c): c is string => typeof c === "string" && c.length <= 256)),
+      ];
+      if (cleaned.length > 0) {
+        qbtMutedCategories[instanceId] = cleaned;
+      }
+    }
+    if (Object.keys(qbtMutedCategories).length > 0) {
+      out.qbtMutedCategories = qbtMutedCategories;
+    }
+  }
   return out as NotificationSettings;
 }
 

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -283,6 +283,11 @@ export interface NotificationSettings {
   perInstance?: Record<string, Partial<Record<NotifCategory, boolean>>>;
   // v34: Apprise notification sink (additive to Expo push). undefined = unset.
   apprise?: AppriseConfig;
+  // v42 (issue #310): per-qBittorrent-instance muted category names for the
+  // torrentCompleted notification (e.g. cross-seed's injection category).
+  // Keyed by instance UUID; "" mutes uncategorized torrents. Matching is exact
+  // and case-sensitive. Absent/empty = notify for everything.
+  qbtMutedCategories?: Record<string, string[]>;
 }
 
 export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
@@ -556,6 +561,9 @@ interface ConfigActions {
     category: NotifCategory,
     value: boolean | "inherit",
   ) => void;
+  // v42: replace the muted-category list for one qBittorrent instance. An
+  // empty list deletes the entry; an empty map is stored as undefined.
+  setQbtMutedCategories: (instanceId: string, categories: string[]) => void;
 
   // Lookup helpers. instanceId is optional — when omitted, the active instance
   // for that kind is used (legacy single-instance behavior).
@@ -1653,6 +1661,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
 
       // v21: drop any per-instance notification overrides keyed to the
       // deleted instance so orphan keys don't accumulate in storage.
+      // v42: same for the muted-category map.
       let notificationSettings = state.notificationSettings;
       if (notificationSettings.perInstance?.[instanceId] !== undefined) {
         const { [instanceId]: _drop, ...rest } = notificationSettings.perInstance;
@@ -1660,6 +1669,15 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
           ...notificationSettings,
           perInstance: Object.keys(rest).length === 0 ? undefined : rest,
         };
+      }
+      if (notificationSettings.qbtMutedCategories?.[instanceId] !== undefined) {
+        const { [instanceId]: _drop, ...rest } = notificationSettings.qbtMutedCategories;
+        notificationSettings = {
+          ...notificationSettings,
+          qbtMutedCategories: Object.keys(rest).length === 0 ? undefined : rest,
+        };
+      }
+      if (notificationSettings !== state.notificationSettings) {
         setJSON(STORAGE_KEYS.notificationSettings, notificationSettings);
       }
 
@@ -2511,6 +2529,23 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     const next: NotificationSettings = {
       ...current,
       perInstance: Object.keys(map).length === 0 ? undefined : map,
+    };
+    setJSON(STORAGE_KEYS.notificationSettings, next);
+    set({ notificationSettings: next });
+  },
+
+  setQbtMutedCategories: (instanceId, categories) => {
+    const current = get().notificationSettings;
+    const map = { ...(current.qbtMutedCategories ?? {}) };
+    const deduped = [...new Set(categories)];
+    if (deduped.length === 0) {
+      delete map[instanceId];
+    } else {
+      map[instanceId] = deduped;
+    }
+    const next: NotificationSettings = {
+      ...current,
+      qbtMutedCategories: Object.keys(map).length === 0 ? undefined : map,
     };
     setJSON(STORAGE_KEYS.notificationSettings, next);
     set({ notificationSettings: next });


### PR DESCRIPTION
## Summary
Per-instance "Muted categories" for the qBittorrent torrent-completed notification (Refs #310). Muted categories (exact names, "" = uncategorized) are silenced in both the backend push pipeline and the local foreground watcher; absent/empty means everything notifies, so new categories keep notifying by default.

- New optional `qbtMutedCategories` map on notification settings (app + backend zod schema, kv-blob persistence, config v42 stamp migration)
- Skip in `diffQbTorrents` before `dispatchPush` so dedupe keys are never burned; same filter in the local qbt watcher
- Instance editor UI: summary row + pageSheet checklist (live categories, Uncategorized, stale muted names kept unmutable)

## Test plan
- Backend: `npm run typecheck` + `npm test` (29 pass, new schema/helper cases)
- App: `tsc --noEmit` clean, `jest` 940+ pass (new coercion/migration cases)
- E2E smoke against a temp-DATA_DIR backend: muted completions suppressed without claiming dedupe keys, unmuted category dispatches