### PR TITLE
fix(downloads): purple downloading cue on the Downloads tab (Refs #249)

### DIFF
--- a/app/nzb/[nzbId].tsx
+++ b/app/nzb/[nzbId].tsx
@@ -21,6 +21,7 @@ import {
 } from "@/hooks/use-nzbget";
 import { combineHiLo, formatBytes, formatEta, formatSpeed } from "@/lib/utils";
 import { usenetBadgeVariant } from "@/lib/usenet-adapter";
+import { downloadBadgeColor } from "@/lib/download-status";
 import type { UsenetStatus } from "@/lib/usenet-adapter";
 import type { NzbgetGroupStatus } from "@/lib/types";
 
@@ -129,6 +130,7 @@ export default function NzbgetSlotDetailScreen() {
       ? 1
       : 0;
   const isPaused = normalizedStatus === "paused";
+  const badgeVariant = usenetBadgeVariant(normalizedStatus);
   const overallSpeed = status?.DownloadRate ?? 0;
   const eta =
     inQueue && overallSpeed > 0 && remainingBytes > 0
@@ -148,15 +150,16 @@ export default function NzbgetSlotDetailScreen() {
   return (
     <ScreenWrapper>
       <Text className="text-zinc-100 text-lg font-bold mt-2 mb-1">{name}</Text>
-      <Badge
-        label={rawStatus}
-        variant={usenetBadgeVariant(normalizedStatus)}
-        className="self-start mb-4"
-      />
+      <Badge label={rawStatus} variant={badgeVariant} className="self-start mb-4" />
 
       {/* Progress / Speed */}
       <Card className="mb-4">
-        <ProgressBar progress={progress} showLabel className="mb-3" />
+        <ProgressBar
+          progress={progress}
+          fillColor={downloadBadgeColor(badgeVariant)}
+          showLabel
+          className="mb-3"
+        />
         <View className="flex-row justify-between">
           {inQueue && overallSpeed > 0 && (
             <View className="flex-row items-center gap-1">

--- a/app/sab/[nzo_id].tsx
+++ b/app/sab/[nzo_id].tsx
@@ -19,10 +19,12 @@ import {
   useDeleteSabHistorySlot,
 } from "@/hooks/use-sabnzbd";
 import type { SabSlotStatus } from "@/lib/types";
+import {
+  downloadBadgeColor,
+  type DownloadBadgeVariant,
+} from "@/lib/download-status";
 
-function getBadgeVariant(
-  status: SabSlotStatus,
-): "downloading" | "seeding" | "paused" | "error" | "default" {
+function getBadgeVariant(status: SabSlotStatus): DownloadBadgeVariant {
   if (status === "Paused") return "paused";
   if (status === "Failed") return "error";
   if (status === "Completed") return "seeding";
@@ -94,6 +96,7 @@ export default function SabSlotDetailScreen() {
     ? 1
     : 0;
   const isPaused = status === "Paused";
+  const badgeVariant = getBadgeVariant(status);
 
   const runDelete = (deleteFiles: boolean) => {
     if (inQueue) {
@@ -108,11 +111,16 @@ export default function SabSlotDetailScreen() {
   return (
     <ScreenWrapper>
       <Text className="text-zinc-100 text-lg font-bold mt-2 mb-1">{name}</Text>
-      <Badge label={status} variant={getBadgeVariant(status)} className="self-start mb-4" />
+      <Badge label={status} variant={badgeVariant} className="self-start mb-4" />
 
       {/* Progress / Speed */}
       <Card className="mb-4">
-        <ProgressBar progress={progress} showLabel className="mb-3" />
+        <ProgressBar
+          progress={progress}
+          fillColor={downloadBadgeColor(badgeVariant)}
+          showLabel
+          className="mb-3"
+        />
         <View className="flex-row justify-between">
           {inQueue && queue?.speed?.trim() && (
             <View className="flex-row items-center gap-1">

--- a/app/torrent/[hash].tsx
+++ b/app/torrent/[hash].tsx
@@ -37,6 +37,8 @@ import {
 } from "@/hooks/use-qbittorrent";
 import { formatBytes, formatSpeed, formatEta } from "@/lib/utils";
 import { isTorrentPaused } from "@/lib/types";
+import { qbBadgeVariant } from "@/lib/torrent-adapters/qbittorrent";
+import { downloadBadgeColor } from "@/lib/download-status";
 
 export default function TorrentDetailScreen() {
   const { hash } = useLocalSearchParams<{ hash: string }>();
@@ -77,6 +79,9 @@ export default function TorrentDetailScreen() {
   }
 
   const isPaused = isTorrentPaused(torrent.state);
+  // Same per-state mapping the Downloads tab row uses, so the badge and the
+  // progress bar here read exactly like the row the user tapped.
+  const badgeVariant = qbBadgeVariant(torrent.state);
 
   const handleReannounce = () => {
     reannounceMutation.mutate([hash], {
@@ -114,13 +119,18 @@ export default function TorrentDetailScreen() {
         </Text>
         <Badge
           label={torrent.state}
-          variant={isPaused ? "paused" : "downloading"}
+          variant={badgeVariant}
           className="self-start mb-4"
         />
 
         {/* Progress */}
         <Card className="mb-4">
-          <ProgressBar progress={torrent.progress} showLabel className="mb-3" />
+          <ProgressBar
+            progress={torrent.progress}
+            fillColor={downloadBadgeColor(badgeVariant)}
+            showLabel
+            className="mb-3"
+          />
           <View className="flex-row justify-between">
             <View className="flex-row items-center gap-1">
               <Icon icon={ArrowDown} size={14} color="#3b82f6" />

--- a/app/transmission/[hash].tsx
+++ b/app/transmission/[hash].tsx
@@ -28,6 +28,7 @@ import {
 } from "@/hooks/use-transmission";
 import { transmissionTorrentAdapter } from "@/lib/torrent-adapters/transmission";
 import { torrentBadgeVariant } from "@/lib/torrent-adapter";
+import { downloadBadgeColor } from "@/lib/download-status";
 import { formatBytes, formatSpeed, formatEta } from "@/lib/utils";
 
 const ETA_UNKNOWN = 8640000;
@@ -61,6 +62,7 @@ export default function TransmissionDetailScreen() {
 
   const { torrent, files, trackers } = detail;
   const isPaused = torrent.status === "paused";
+  const badgeVariant = torrentBadgeVariant(torrent.status);
 
   const handleReannounce = () => {
     reannounceMutation.mutate([hash], {
@@ -83,13 +85,18 @@ export default function TransmissionDetailScreen() {
         <Text className="text-zinc-100 text-lg font-bold mb-1">{torrent.name}</Text>
         <Badge
           label={torrent.statusLabel}
-          variant={torrentBadgeVariant(torrent.status)}
+          variant={badgeVariant}
           className="self-start mb-4"
         />
 
         {/* Progress */}
         <Card className="mb-4">
-          <ProgressBar progress={torrent.progress} showLabel className="mb-3" />
+          <ProgressBar
+            progress={torrent.progress}
+            fillColor={downloadBadgeColor(badgeVariant)}
+            showLabel
+            className="mb-3"
+          />
           <View className="flex-row justify-between">
             <View className="flex-row items-center gap-1">
               <Icon icon={ArrowDown} size={14} color="#3b82f6" />

--- a/components/dashboard/download-card.tsx
+++ b/components/dashboard/download-card.tsx
@@ -214,7 +214,9 @@ const STATE_BADGE: Record<
   StateGroup,
   { color: string; icon: typeof Download } | null
 > = {
-  downloading: { color: "rgba(59, 130, 246, 0.9)", icon: Download },
+  // Purple matches the tile's own progress strip (downloadStatusColor) and the
+  // Downloads tab — the corner icon was the last blue "downloading" cue left.
+  downloading: { color: "rgba(168, 85, 247, 0.9)", icon: Download },
   seeding: { color: "rgba(34, 197, 94, 0.9)", icon: Upload },
   paused: { color: "rgba(245, 158, 11, 0.9)", icon: Pause },
   errored: { color: "rgba(239, 68, 68, 0.9)", icon: CircleAlert },

--- a/components/downloads/torrent-downloads-view.tsx
+++ b/components/downloads/torrent-downloads-view.tsx
@@ -30,6 +30,7 @@ import { useRefreshSpinner } from "@/components/common/pull-to-refresh";
 import { Card } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Badge } from "@/components/ui/badge";
+import { downloadBadgeColor } from "@/lib/download-status";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -769,7 +770,12 @@ function TorrentListItem({
         </View>
       ) : null}
 
-      <ProgressBar progress={torrent.progress} showLabel className="my-2" />
+      <ProgressBar
+        progress={torrent.progress}
+        fillColor={downloadBadgeColor(badgeVariant)}
+        showLabel
+        className="my-2"
+      />
 
       <View className="flex-row items-center justify-between">
         <View className="flex-row gap-3">

--- a/components/downloads/usenet-downloads-view.tsx
+++ b/components/downloads/usenet-downloads-view.tsx
@@ -17,6 +17,7 @@ import { ServiceHeader } from "@/components/common/service-header";
 import { Card } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
 import { Badge } from "@/components/ui/badge";
+import { downloadBadgeColor } from "@/lib/download-status";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "@/components/ui/text-input";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -530,7 +531,12 @@ function SlotListItem({
       </View>
 
       {showProgress && (
-        <ProgressBar progress={item.progress} showLabel className="my-2" />
+        <ProgressBar
+          progress={item.progress}
+          fillColor={downloadBadgeColor(badgeVariant)}
+          showLabel
+          className="my-2"
+        />
       )}
 
       <View className="flex-row items-center justify-between">

--- a/components/indexers/prowlarr-indexer-list.tsx
+++ b/components/indexers/prowlarr-indexer-list.tsx
@@ -71,7 +71,7 @@ export function ProwlarrIndexerList() {
                 )}
                 <Badge
                   label={indexer.protocol}
-                  variant={indexer.protocol === "torrent" ? "downloading" : "default"}
+                  variant={indexer.protocol === "torrent" ? "info" : "default"}
                 />
                 <Pressable
                   onPress={() =>

--- a/components/indexers/release-card.tsx
+++ b/components/indexers/release-card.tsx
@@ -36,7 +36,7 @@ export function ReleaseCard({
           )}
           <Badge
             label={release.protocol}
-            variant={release.protocol === "torrent" ? "downloading" : "default"}
+            variant={release.protocol === "torrent" ? "info" : "default"}
           />
         </View>
       </Pressable>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,10 +4,13 @@ type BadgeVariant = "default" | "downloading" | "grabbing" | "seeding" | "paused
 
 const VARIANT_CLASSES: Record<BadgeVariant, string> = {
   default: "bg-zinc-700",
-  downloading: "bg-blue-600",
-  // `grabbing` = an *arr item currently in the download queue. Purple mirrors
-  // Sonarr/Radarr (and the poster grid's purple bar); distinct from the
-  // blue `downloading` used for qBittorrent/indexer protocol chips.
+  // Purple = "this is being downloaded right now", everywhere in the app
+  // (issue #249). `downloading` is the download client's own state (qBittorrent,
+  // SABnzbd, ...) and `grabbing` is an *arr item sitting in the download queue —
+  // two vocabularies for the same idea, so they deliberately share one color,
+  // the purple Sonarr/Radarr use for their queue (and the poster grid's bar).
+  // A blue chip that just means "torrent protocol" wants `info`, not this.
+  downloading: "bg-purple-600",
   grabbing: "bg-purple-600",
   seeding: "bg-green-600",
   paused: "bg-yellow-600",

--- a/lib/download-status.test.ts
+++ b/lib/download-status.test.ts
@@ -1,5 +1,7 @@
-import { downloadStatusColor } from "@/lib/download-status";
+import { downloadBadgeColor, downloadStatusColor } from "@/lib/download-status";
 import { DOWNLOAD_INDICATOR_COLOR } from "@/lib/arr-poster-status";
+import { torrentBadgeVariant } from "@/lib/torrent-adapter";
+import { usenetBadgeVariant } from "@/lib/usenet-adapter";
 
 describe("downloadStatusColor", () => {
   it("downloading reads the app's purple cue (issue #208)", () => {
@@ -26,5 +28,55 @@ describe("downloadStatusColor", () => {
     expect(downloadStatusColor("queued")).toBe("#3b82f6");
     expect(downloadStatusColor("other")).toBe("#3b82f6");
     expect(downloadStatusColor("whatever")).toBe("#3b82f6");
+  });
+});
+
+describe("downloadBadgeColor", () => {
+  it("downloading is purple, not the app's blue accent (issue #249)", () => {
+    expect(downloadBadgeColor("downloading")).toBe(
+      DOWNLOAD_INDICATOR_COLOR.downloading,
+    );
+  });
+
+  it("maps the remaining badge variants to their status colors", () => {
+    expect(downloadBadgeColor("seeding")).toBe("#22c55e");
+    expect(downloadBadgeColor("paused")).toBe("#f59e0b");
+    // "error" is the badge spelling of the "errored" status.
+    expect(downloadBadgeColor("error")).toBe("#ef4444");
+    expect(downloadBadgeColor("default")).toBe("#3b82f6");
+  });
+
+  it("covers every variant the torrent/usenet adapters can produce", () => {
+    const torrentStatuses = [
+      "downloading",
+      "seeding",
+      "paused",
+      "stalled",
+      "checking",
+      "queued",
+      "errored",
+      "other",
+    ] as const;
+    const usenetStatuses = [
+      "downloading",
+      "paused",
+      "queued",
+      "completed",
+      "failed",
+      "other",
+    ] as const;
+
+    for (const status of torrentStatuses) {
+      expect(downloadBadgeColor(torrentBadgeVariant(status))).toMatch(/^#[0-9a-f]{6}$/);
+    }
+    for (const status of usenetStatuses) {
+      expect(downloadBadgeColor(usenetBadgeVariant(status))).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it("a downloading row's bar and badge agree", () => {
+    expect(downloadBadgeColor(torrentBadgeVariant("downloading"))).toBe(
+      downloadBadgeColor(usenetBadgeVariant("downloading")),
+    );
   });
 });

--- a/lib/download-status.ts
+++ b/lib/download-status.ts
@@ -27,3 +27,34 @@ export function downloadStatusColor(status: string): string {
       return "#3b82f6"; // blue (neutral)
   }
 }
+
+/**
+ * The Badge variants a download-client row can carry. Declared once here (next
+ * to the color table) instead of being re-typed inline by every adapter.
+ */
+export type DownloadBadgeVariant =
+  | "downloading"
+  | "seeding"
+  | "paused"
+  | "error"
+  | "default";
+
+/** Badge variant → the status key downloadStatusColor already understands. */
+const BADGE_VARIANT_STATUS: Record<DownloadBadgeVariant, string> = {
+  downloading: "downloading",
+  seeding: "seeding",
+  paused: "paused",
+  error: "errored",
+  default: "other",
+};
+
+/**
+ * Progress-bar fill for a download row, derived from the SAME badge variant the
+ * row already shows (issue #249). Going through the badge rather than the
+ * normalized status is deliberate: qBittorrent overrides the variant to keep its
+ * exact per-state hues (stalledDL reads as downloading, stalledUP as seeding),
+ * so a row's bar and its status pill can never disagree.
+ */
+export function downloadBadgeColor(variant: DownloadBadgeVariant): string {
+  return downloadStatusColor(BADGE_VARIANT_STATUS[variant]);
+}

--- a/lib/torrent-adapter.ts
+++ b/lib/torrent-adapter.ts
@@ -5,6 +5,7 @@ import type {
 } from "@tanstack/react-query";
 import type { ComponentType } from "react";
 import type { ServiceId } from "@/lib/constants";
+import type { DownloadBadgeVariant } from "@/lib/download-status";
 import type { DownloadsSortKey } from "@/store/sort-store";
 
 // Normalized status surface shared by every torrent component (the downloads
@@ -43,7 +44,7 @@ export interface UnifiedTorrent {
   // otherwise it falls back to torrentBadgeVariant(status). qBittorrent sets
   // this to preserve its exact per-state colors (e.g. stalledUP stays green);
   // rtorrent omits it and uses the normalized default.
-  badgeVariant?: "downloading" | "seeding" | "paused" | "error" | "default";
+  badgeVariant?: DownloadBadgeVariant;
   // Category (qBittorrent) / custom1 label (rtorrent). Single string.
   label: string;
   tags: string; // qBittorrent comma tags; rtorrent ""
@@ -187,9 +188,7 @@ export interface TorrentAdapter {
 
 // Maps a normalized status to the shared Badge component's variant vocabulary —
 // mirrors usenetBadgeVariant.
-export function torrentBadgeVariant(
-  status: TorrentStatus,
-): "downloading" | "seeding" | "paused" | "error" | "default" {
+export function torrentBadgeVariant(status: TorrentStatus): DownloadBadgeVariant {
   switch (status) {
     case "downloading":
       return "downloading";

--- a/lib/torrent-adapters/qbittorrent.ts
+++ b/lib/torrent-adapters/qbittorrent.ts
@@ -35,6 +35,7 @@ import type {
   TorrentStatus,
   UnifiedTorrent,
 } from "@/lib/torrent-adapter";
+import type { DownloadBadgeVariant } from "@/lib/download-status";
 import type { DownloadsSortKey } from "@/store/sort-store";
 
 // "all" omits the qBittorrent `filter` param rather than sending `filter=all`
@@ -82,9 +83,9 @@ function qbStatusToUnified(state: TorrentState): TorrentStatus {
 // Preserves qBittorrent's exact per-state badge colors (the legacy
 // getTorrentBadgeVariant): paused/error checked first, then the DL/UP suffix
 // tests so stalled/checking/queued keep their downloading/seeding hues.
-function qbBadgeVariant(
-  state: TorrentState,
-): "downloading" | "seeding" | "paused" | "error" | "default" {
+// Exported for the detail screen, which reads the raw QBTorrent instead of a
+// UnifiedTorrent and so can't pick up the precomputed `badgeVariant`.
+export function qbBadgeVariant(state: TorrentState): DownloadBadgeVariant {
   if (state === "error" || state === "missingFiles") return "error";
   if (isTorrentPaused(state)) return "paused";
   if (state.includes("DL") || state === "downloading" || state === "metaDL")

--- a/lib/usenet-adapter.ts
+++ b/lib/usenet-adapter.ts
@@ -5,6 +5,7 @@ import type {
   UseQueryResult,
 } from "@tanstack/react-query";
 import type { ServiceId } from "@/lib/constants";
+import type { DownloadBadgeVariant } from "@/lib/download-status";
 
 // Normalized status surface used by every shared Usenet component (downloads
 // view, dashboard widget, settings sheet). Adapters map their service-specific
@@ -110,9 +111,7 @@ export interface UsenetAdapter {
   SpeedLimitsControl?: ComponentType;
 }
 
-export function usenetBadgeVariant(
-  status: UsenetStatus,
-): "downloading" | "seeding" | "paused" | "error" | "default" {
+export function usenetBadgeVariant(status: UsenetStatus): DownloadBadgeVariant {
   switch (status) {
     case "paused":
       return "paused";


### PR DESCRIPTION
Purple already means "downloading" everywhere else in the app (the *arr poster bars, the dashboard widgets). The Downloads tab still used the blue primary accent, so it read as a different state. Refs #249

- `downloading` Badge variant goes purple, same as the existing `grabbing` variant
- Progress bars derive their fill from the row's own badge variant, so bar and pill can never disagree (seeding reads green, paused amber, errored red instead of blue for everything)
- Applied to the torrent list, the usenet list, and the four detail screens reachable from the tab
- Torrent protocol chips in Prowlarr/releases were borrowing `downloading` for its blue; moved to `info`, which renders identically
- Speed boxes keep blue down / green up, per the issue thread

Two fixes fell out: `app/torrent/[hash].tsx` hardcoded a "downloading" badge for every non-paused state (a seeding torrent would have gone purple), and the dashboard Downloads widget's corner icon was still blue while its own strip was purple.

## Test plan
- `tsc --noEmit` clean
- `jest` 944 pass, incl. 4 new `downloadBadgeColor` cases
- Not verified on device (none attached)