### PR TITLE
feat(health): test-all action for *arr health alerts (Refs #268)

### DIFF
--- a/components/dashboard/arr-health-card.tsx
+++ b/components/dashboard/arr-health-card.tsx
@@ -19,6 +19,7 @@ import {
   type ArrHealthSettingsValue,
 } from "@/components/dashboard/widget-settings/arr-health-settings";
 import { useManualRefresh } from "@/store/manual-refresh-store";
+import type { ArrHealthServiceId } from "@/services/arr-health";
 import { SERVICE_DEFAULTS } from "@/lib/constants";
 import { lightHaptic } from "@/lib/haptics";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
@@ -39,6 +40,7 @@ export function ArrHealthCard({ slotId }: WidgetComponentProps) {
   const manualRefreshing = useManualRefresh((s) => s.count > 0);
   const determining = isLoading || (manualRefreshing && isFetching);
   const [sheet, setSheet] = useState<{
+    serviceId: ArrHealthServiceId;
     serviceName: string;
     instances: ArrInstanceHealth[];
   } | null>(null);
@@ -97,7 +99,11 @@ export function ArrHealthCard({ slotId }: WidgetComponentProps) {
                 key={section.serviceId}
                 onPress={() => {
                   lightHaptic();
-                  setSheet({ serviceName, instances: section.instances });
+                  setSheet({
+                    serviceId: section.serviceId,
+                    serviceName,
+                    instances: section.instances,
+                  });
                 }}
                 className="flex-row items-center gap-3 rounded-xl bg-surface-light px-3 py-2.5 active:opacity-70"
               >
@@ -132,6 +138,7 @@ export function ArrHealthCard({ slotId }: WidgetComponentProps) {
 
       <HealthIssuesSheet
         visible={!!sheet}
+        serviceId={sheet?.serviceId ?? null}
         serviceName={sheet?.serviceName ?? ""}
         instances={sheet?.instances ?? null}
         onClose={() => setSheet(null)}

--- a/components/services/health-issues-banner.tsx
+++ b/components/services/health-issues-banner.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, ChevronRight } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { HealthIssuesSheet } from "@/components/services/health-issues-sheet";
 import { useArrInstanceHealth } from "@/hooks/use-arr-health";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
 import { worstSeverity, type ArrHealthServiceId } from "@/services/arr-health";
 import { SERVICE_DEFAULTS } from "@/lib/constants";
 import { lightHaptic } from "@/lib/haptics";
@@ -25,6 +26,10 @@ export function HealthIssuesBanner({
   className = "",
 }: HealthIssuesBannerProps) {
   const { data } = useArrInstanceHealth(serviceId, instanceId);
+  // The real store-resolved instance id — the same one the query hook folded
+  // into its cache key — so the sheet's "Test all" action posts to the right
+  // instance and its invalidation hits this banner's query (#268).
+  const { instanceId: resolvedId } = useInstanceTarget(serviceId, instanceId);
   const [open, setOpen] = useState(false);
 
   const issues = (data ?? []).filter((i) => i.type !== "ok");
@@ -84,8 +89,13 @@ export function HealthIssuesBanner({
 
       <HealthIssuesSheet
         visible={open}
+        serviceId={serviceId}
         serviceName={serviceName}
-        instances={[{ instanceId: serviceId, instanceName: serviceName, issues }]}
+        instances={
+          resolvedId
+            ? [{ instanceId: resolvedId, instanceName: serviceName, issues }]
+            : null
+        }
         onClose={() => setOpen(false)}
       />
     </>

--- a/components/services/health-issues-sheet.tsx
+++ b/components/services/health-issues-sheet.tsx
@@ -1,15 +1,42 @@
-import { Modal, View, Text, Pressable, ScrollView, Linking } from "react-native";
-import { AlertTriangle, Info, ExternalLink, CheckCircle2 } from "lucide-react-native";
+import {
+  ActivityIndicator,
+  Modal,
+  View,
+  Text,
+  Platform,
+  Pressable,
+  ScrollView,
+  Linking,
+} from "react-native";
+import {
+  AlertTriangle,
+  Info,
+  ExternalLink,
+  CheckCircle2,
+  TestTube,
+} from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SheetHeader } from "@/components/ui/sheet-header";
 import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
+import { useUiScale } from "@/hooks/use-ui-scale";
 import { lightHaptic } from "@/lib/haptics";
-import { HEALTH_TYPE_COLOR, type ArrHealthType } from "@/services/arr-health";
-import type { ArrInstanceHealth } from "@/hooks/use-arr-health";
+import {
+  testAllPathForHealthSource,
+  HEALTH_TYPE_COLOR,
+  type ArrHealthServiceId,
+  type ArrHealthType,
+} from "@/services/arr-health";
+import {
+  useTestAllForHealth,
+  type ArrInstanceHealth,
+} from "@/hooks/use-arr-health";
 
 interface HealthIssuesSheetProps {
   visible: boolean;
+  // Service kind of the listed instances; routes the "Test all" action (#268).
+  // null when closed.
+  serviceId: ArrHealthServiceId | null;
   // Display name of the tapped service kind (e.g. "Sonarr").
   serviceName: string;
   // Instances that currently have actionable health issues. null when closed.
@@ -22,6 +49,7 @@ interface HealthIssuesSheetProps {
 // components/qbittorrent/category-sheet.tsx.
 export function HealthIssuesSheet({
   visible,
+  serviceId,
   serviceName,
   instances,
   onClose,
@@ -30,6 +58,10 @@ export function HealthIssuesSheet({
   // disambiguate; a single-instance setup needs no header noise.
   const showInstanceNames = (instances?.length ?? 0) > 1;
   const scrollPadding = useSheetBottomPadding(16);
+  const uiScale = useUiScale();
+  // One mutation instance serves every row; each row matches `variables`
+  // against its own (instanceId, source) for the pending spinner.
+  const testAll = useTestAllForHealth();
 
   const openWiki = (url?: string) => {
     if (!url) return;
@@ -71,38 +103,87 @@ export function HealthIssuesSheet({
                 </Text>
               ) : null}
 
-              {inst.issues.map((issue, idx) => (
-                <View
-                  key={`${issue.source}:${idx}`}
-                  className="flex-row gap-3 bg-surface border border-border rounded-2xl p-3"
-                >
-                  <View className="pt-0.5">
-                    <Icon
-                      icon={issueIcon(issue.type)}
-                      size={18}
-                      color={HEALTH_TYPE_COLOR[issue.type]}
-                    />
+              {inst.issues.map((issue, idx) => {
+                // Upstream parity (#268): the *arr Health pages offer a
+                // test-tube "Test All" retry only for provider status checks.
+                const canTest =
+                  serviceId != null &&
+                  testAllPathForHealthSource(serviceId, issue.source) != null;
+                const testing =
+                  testAll.isPending &&
+                  testAll.variables?.instanceId === inst.instanceId &&
+                  testAll.variables?.source === issue.source;
+                return (
+                  <View
+                    key={`${issue.source}:${idx}`}
+                    className="flex-row gap-3 bg-surface border border-border rounded-2xl p-3"
+                  >
+                    <View className="pt-0.5">
+                      <Icon
+                        icon={issueIcon(issue.type)}
+                        size={18}
+                        color={HEALTH_TYPE_COLOR[issue.type]}
+                      />
+                    </View>
+                    <View className="flex-1 gap-1">
+                      <Text className="text-zinc-200 text-sm font-semibold">
+                        {issue.source}
+                      </Text>
+                      <Text className="text-zinc-400 text-sm">{issue.message}</Text>
+                      {canTest || issue.wikiUrl ? (
+                        <View className="flex-row items-center gap-4 mt-1">
+                          {canTest && serviceId ? (
+                            <Pressable
+                              onPress={() => {
+                                lightHaptic();
+                                testAll.mutate({
+                                  serviceId,
+                                  instanceId: inst.instanceId,
+                                  source: issue.source,
+                                });
+                              }}
+                              disabled={testing}
+                              hitSlop={6}
+                              className="flex-row items-center gap-1.5 active:opacity-70"
+                            >
+                              {testing ? (
+                                <ActivityIndicator
+                                  // Native spinner so it always animates (#196).
+                                  // iOS clamps numeric sizes, so "small" there;
+                                  // Android tracks the UI-scale setting.
+                                  size={
+                                    Platform.OS === "android"
+                                      ? Math.round(13 * uiScale)
+                                      : "small"
+                                  }
+                                  color="#3b82f6"
+                                />
+                              ) : (
+                                <Icon icon={TestTube} size={13} color="#3b82f6" />
+                              )}
+                              <Text className="text-primary text-sm font-medium">
+                                {testing ? "Testing…" : "Test all"}
+                              </Text>
+                            </Pressable>
+                          ) : null}
+                          {issue.wikiUrl ? (
+                            <Pressable
+                              onPress={() => openWiki(issue.wikiUrl)}
+                              hitSlop={6}
+                              className="flex-row items-center gap-1.5 active:opacity-70"
+                            >
+                              <Icon icon={ExternalLink} size={13} color="#3b82f6" />
+                              <Text className="text-primary text-sm font-medium">
+                                Open wiki
+                              </Text>
+                            </Pressable>
+                          ) : null}
+                        </View>
+                      ) : null}
+                    </View>
                   </View>
-                  <View className="flex-1 gap-1">
-                    <Text className="text-zinc-200 text-sm font-semibold">
-                      {issue.source}
-                    </Text>
-                    <Text className="text-zinc-400 text-sm">{issue.message}</Text>
-                    {issue.wikiUrl ? (
-                      <Pressable
-                        onPress={() => openWiki(issue.wikiUrl)}
-                        hitSlop={6}
-                        className="flex-row items-center gap-1.5 mt-1 active:opacity-70"
-                      >
-                        <Icon icon={ExternalLink} size={13} color="#3b82f6" />
-                        <Text className="text-primary text-sm font-medium">
-                          Open wiki
-                        </Text>
-                      </Pressable>
-                    ) : null}
-                  </View>
-                </View>
-              ))}
+                );
+              })}
             </View>
           ))}
         </ScrollView>

--- a/hooks/use-arr-health.ts
+++ b/hooks/use-arr-health.ts
@@ -1,10 +1,17 @@
-import { useQueries, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
+import { toast, toastError } from "@/components/ui/toast";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   getArrHealth,
+  testAllForHealthSource,
   worstSeverity,
   ARR_HEALTH_SERVICE_IDS,
   type ArrHealthIssue,
@@ -111,6 +118,33 @@ export function useArrHealthSections(): {
   });
 
   return { sections, isLoading: isInitialLoading, isFetching };
+}
+
+export interface TestAllHealthVars {
+  serviceId: ArrHealthServiceId;
+  instanceId: string;
+  source: string;
+}
+
+// "Test all" retry for a health item (issue #268), mirroring the test-tube
+// button on the *arr Health pages. One mutation instance serves every row in
+// the issues sheet; callers match `isPending && variables` against their own
+// (instanceId, source) for the per-row spinner, same trick as the Jackett
+// indexer list. Success only means the tests ran — the health item clears on
+// the next /health read, so refetch and let the copy stay honest about it.
+export function useTestAllForHealth() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ serviceId, instanceId, source }: TestAllHealthVars) =>
+      testAllForHealthSource(serviceId, source, instanceId),
+    onSuccess: (_data, { serviceId, instanceId }) => {
+      toast("Tests finished, refreshing health status");
+      queryClient.invalidateQueries({
+        queryKey: [serviceId, instanceId, "health"],
+      });
+    },
+    onError: (err) => toastError("Couldn't run tests", err),
+  });
 }
 
 // Single-instance variant for a service screen's health banner: follows the

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1820,6 +1820,9 @@ export function getDemoResponse(
 
   switch (serviceId) {
     case "radarr": {
+      // Health "Test all" (#268): the real endpoint answers with a per-provider
+      // result list; empty = tests ran, nothing to report.
+      if (normalized === "/indexer/testall" || normalized === "/downloadclient/testall") return [];
       if (normalized === "/movie") return DEMO_RADARR_MOVIES;
       if (normalized === "/movie/:id") return DEMO_RADARR_MOVIES[0];
       if (normalized.startsWith("/queue")) return DEMO_RADARR_QUEUE;
@@ -1837,6 +1840,8 @@ export function getDemoResponse(
       return undefined;
     }
     case "sonarr": {
+      // Health "Test all" (#268), as in the radarr case above.
+      if (normalized === "/indexer/testall" || normalized === "/downloadclient/testall") return [];
       if (normalized === "/series") return DEMO_SONARR_SERIES;
       if (normalized === "/series/:id") return DEMO_SONARR_SERIES[0];
       if (normalized.startsWith("/calendar")) return DEMO_SONARR_CALENDAR;
@@ -1854,6 +1859,8 @@ export function getDemoResponse(
       return undefined;
     }
     case "lidarr": {
+      // Health "Test all" (#268), as in the radarr case above.
+      if (normalized === "/indexer/testall" || normalized === "/downloadclient/testall") return [];
       if (normalized === "/artist") return DEMO_LIDARR_ARTISTS;
       if (normalized === "/artist/lookup") return [];
       if (normalized === "/artist/:id") {
@@ -1899,6 +1906,14 @@ export function getDemoResponse(
       return undefined;
     }
     case "prowlarr": {
+      // Health "Test all" (#268), as in the radarr case above; Prowlarr also
+      // tests its synced applications.
+      if (
+        normalized === "/indexer/testall" ||
+        normalized === "/downloadclient/testall" ||
+        normalized === "/applications/testall"
+      )
+        return [];
       if (normalized === "/indexer") return DEMO_PROWLARR_INDEXERS;
       if (normalized.startsWith("/indexerstatus")) return DEMO_PROWLARR_INDEXER_STATUSES;
       if (normalized.startsWith("/indexerstats")) return DEMO_PROWLARR_STATS;

--- a/services/arr-health.test.ts
+++ b/services/arr-health.test.ts
@@ -1,0 +1,67 @@
+// Mock native storage before importing — arr-health pulls in http-client →
+// config-store → AsyncStorage/SecureStore at module load. The function under
+// test is pure. Same shims as the other unit tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { testAllPathForHealthSource } from "@/services/arr-health";
+
+// The source → "Test all" mapping mirrors the upstream *arr Health pages
+// (issue #268): a wrong path 404s against a real instance, and a button on an
+// unmapped source would break upstream parity.
+describe("testAllPathForHealthSource", () => {
+  it("maps indexer status checks on every *arr kind", () => {
+    for (const kind of ["radarr", "sonarr", "prowlarr", "lidarr"] as const) {
+      expect(testAllPathForHealthSource(kind, "IndexerStatusCheck")).toBe(
+        "/indexer/testall",
+      );
+      expect(
+        testAllPathForHealthSource(kind, "IndexerLongTermStatusCheck"),
+      ).toBe("/indexer/testall");
+      expect(
+        testAllPathForHealthSource(kind, "DownloadClientStatusCheck"),
+      ).toBe("/downloadclient/testall");
+    }
+  });
+
+  it("maps application status checks on Prowlarr only", () => {
+    expect(
+      testAllPathForHealthSource("prowlarr", "ApplicationStatusCheck"),
+    ).toBe("/applications/testall");
+    expect(
+      testAllPathForHealthSource("prowlarr", "ApplicationLongTermStatusCheck"),
+    ).toBe("/applications/testall");
+    expect(testAllPathForHealthSource("sonarr", "ApplicationStatusCheck")).toBe(
+      null,
+    );
+    expect(testAllPathForHealthSource("radarr", "ApplicationStatusCheck")).toBe(
+      null,
+    );
+  });
+
+  it("returns null for sources without a test action", () => {
+    expect(testAllPathForHealthSource("radarr", "UpdateCheck")).toBe(null);
+    expect(testAllPathForHealthSource("radarr", "ImportListStatusCheck")).toBe(
+      null,
+    );
+    expect(testAllPathForHealthSource("sonarr", "NotificationStatusCheck")).toBe(
+      null,
+    );
+    expect(testAllPathForHealthSource("prowlarr", "IndexerRssCheck")).toBe(null);
+  });
+});

--- a/services/arr-health.ts
+++ b/services/arr-health.ts
@@ -32,6 +32,58 @@ export function getArrHealth(
   return serviceRequest<ArrHealthIssue[]>(serviceId, "/health", { instanceId });
 }
 
+// Upstream parity (issue #268): the *arr Health pages render a test-tube
+// "Test All" button only for these health sources. Radarr/Sonarr (/api/v3) and
+// Prowlarr/Lidarr (/api/v1) all expose indexer/testall and
+// downloadclient/testall; applications/testall (note the plural) is
+// Prowlarr-only.
+const TEST_ALL_BY_SOURCE: Record<string, { path: string; prowlarrOnly?: true }> = {
+  IndexerStatusCheck: { path: "/indexer/testall" },
+  IndexerLongTermStatusCheck: { path: "/indexer/testall" },
+  DownloadClientStatusCheck: { path: "/downloadclient/testall" },
+  ApplicationStatusCheck: { path: "/applications/testall", prowlarrOnly: true },
+  ApplicationLongTermStatusCheck: { path: "/applications/testall", prowlarrOnly: true },
+};
+
+// null → this source has no test action; render nothing, matching upstream.
+export function testAllPathForHealthSource(
+  serviceId: ArrHealthServiceId,
+  source: string,
+): string | null {
+  const entry = TEST_ALL_BY_SOURCE[source];
+  if (!entry) return null;
+  if (entry.prowlarrOnly && serviceId !== "prowlarr") return null;
+  return entry.path;
+}
+
+// testall runs synchronously server-side — the response doesn't arrive until
+// every provider has been probed, and an instance with dozens of indexers can
+// take well over a minute. The 15s serviceRequest default would abort mid-run
+// and misreport failure while the server keeps testing.
+const TEST_ALL_TIMEOUT_MS = 120_000;
+
+// Newer *arr builds answer with a per-provider result list, older ones with an
+// empty body; callers ignore both — a 2xx means the tests ran.
+export function testAllForHealthSource(
+  serviceId: ArrHealthServiceId,
+  source: string,
+  instanceId?: string,
+): Promise<unknown> {
+  const path = testAllPathForHealthSource(serviceId, source);
+  if (!path) {
+    return Promise.reject(
+      new Error(`No test action for health source ${source}`),
+    );
+  }
+  return serviceRequest<unknown>(serviceId, path, {
+    method: "POST",
+    // Empty body: serviceRequest only infers Content-Type when a body exists.
+    headers: { "Content-Type": "application/json" },
+    instanceId,
+    timeout: TEST_ALL_TIMEOUT_MS,
+  });
+}
+
 // Worst severity across a set of issues, used to colour the alert badge.
 // "notice" is folded into "warning" (amber); only "error" escalates to red.
 // Returns null when there's nothing to flag.


### PR DESCRIPTION
Adds the *arr Health page "Test All" action to the Health Alerts widget (Refs #268). Health items like IndexerStatusCheck get a "Test all" link in the issues sheet that posts to the matching testall endpoint (indexer/download client on Radarr/Sonarr/Prowlarr/Lidarr, applications on Prowlarr) with a 120s timeout, then refreshes health. Also fixes the per-service health banner passing the service kind instead of the real instance id, which would have misrouted the action.

Test plan:
- tsc --noEmit clean, jest 947/947 passing (new unit test covers the source-to-endpoint mapping)
- Demo mode: Sonarr/Prowlarr health sheets show "Test all" on IndexerStatusCheck; UpdateCheck/ImportListStatusCheck show only "Open wiki"