### PR TITLE
fix: clarify rTorrent authentication failures

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -506,7 +506,7 @@
             </thead>
             <tbody>
               <tr><td><strong>qBittorrent</strong></td><td>8080</td><td>User + password</td><td>WebUI must be enabled. qBittorrent 5.2.0 changed the login response, so you need app v1.6.3+ (and backend v1.2.5+) or valid credentials are rejected.</td></tr>
-              <tr><td><strong>rTorrent / ruTorrent</strong></td><td>8080</td><td>User + password</td><td>Enter the bare origin of the web server in front of rtorrent, not rtorrent's SCGI port. Dashboarr appends the conventional <code>/RPC2</code> XML-RPC mount itself, so only add a prefix if your mount is nested. Deleting a torrent with its files needs ruTorrent's erasedata plugin.</td></tr>
+              <tr><td><strong>rTorrent / ruTorrent</strong></td><td>8080</td><td>HTTP Basic user + password</td><td>Enter the bare origin of the web server in front of rtorrent, not rtorrent's SCGI port. Dashboarr appends the conventional <code>/RPC2</code> XML-RPC mount itself, so only add a prefix if your mount is nested. Digest authentication is not supported; use an HTTPS endpoint before changing the web-server authentication scheme to Basic. Deleting a torrent with its files needs ruTorrent's erasedata plugin.</td></tr>
               <tr><td><strong>Transmission</strong></td><td>9091</td><td>User + password (both optional)</td><td>The RPC server must be enabled and its host whitelist must allow your phone. A blocked host answers 403, which looks like a credentials error.</td></tr>
               <tr><td><strong>SABnzbd</strong></td><td>8080</td><td>API key</td><td>The key travels in the URL query string, so a reverse proxy that strips or logs query params will break or leak it.</td></tr>
               <tr><td><strong>NZBGet</strong></td><td>6789</td><td>User + password</td><td>These are <code>ControlUsername</code> and <code>ControlPassword</code> from <code>nzbget.conf</code>, not a separate web login.</td></tr>
@@ -1061,6 +1061,17 @@
         <p>
           qBittorrent 5.2.0 changed its login API. Update to app v1.6.3 or newer, and backend v1.2.5
           or newer. Also check the URL is the bare origin with no <code>/api/v2</code> suffix.
+        </p>
+
+        <h3>rTorrent requires Digest authentication or forbids RPC access.</h3>
+        <p>
+          Dashboarr can authenticate to the rTorrent <code>/RPC2</code> mount with HTTP Basic only.
+          If the server advertises Digest, first configure an HTTPS endpoint, then change the
+          authentication scheme in the web server or reverse proxy in front of rTorrent. Do not use
+          Basic authentication over plain HTTP, because it exposes reusable credentials to network
+          observers. Changing the Dashboarr username or password will not help. For a 403 response,
+          check that the same server or proxy allows the Dashboarr client to access the
+          <code>/RPC2</code> location.
         </p>
 
         <h3>Radarr or Sonarr behind Authentik or Authelia will not connect.</h3>

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -497,6 +497,148 @@ describe("testServiceConnection — auth-proxy detection (#239)", () => {
   });
 });
 
+describe("testServiceConnection — rTorrent authentication diagnostics (#352)", () => {
+  let originalFetch: typeof global.fetch;
+  let fetchSpy: jest.Mock;
+
+  function respond(overrides: Record<string, any>) {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "content-type": "text/xml" }),
+      text: async () => "",
+      clone() {
+        return this;
+      },
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchSpy = jest.fn();
+    global.fetch = fetchSpy as any;
+    mockStateRef.current = makeState();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("accepts a successful XML-RPC response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        text: async () =>
+          '<?xml version="1.0"?><methodResponse><params></params></methodResponse>',
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", {
+        url: "http://seedbox.local",
+        username: "u",
+        password: "p",
+      }),
+    ).resolves.toMatchObject({ kind: "ok" });
+  });
+
+  it("explains that a Digest challenge is unsupported", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers({
+          "www-authenticate":
+            'Digest realm="rTorrent, private", charset = "UTF-8", qop="auth"',
+        }),
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", {
+        url: "http://seedbox.local",
+        username: "u",
+        password: "p",
+      }),
+    ).resolves.toEqual({
+      kind: "auth_failed",
+      message:
+        "Server requires Digest authentication, but Dashboarr only supports HTTP Basic authentication",
+    });
+  });
+
+  it("reports rejected credentials for a Basic challenge", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers({ "www-authenticate": 'Basic realm="rTorrent"' }),
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", {
+        url: "http://seedbox.local",
+        username: "u",
+        password: "wrong",
+      }),
+    ).resolves.toEqual({
+      kind: "auth_failed",
+      message: "Wrong username or password",
+    });
+  });
+
+  it("treats multiple challenges containing Basic as supported", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers({
+          "www-authenticate":
+            'Digest realm="rTorrent", qop="auth", Basic realm="rTorrent"',
+        }),
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", {
+        url: "http://seedbox.local",
+        username: "u",
+        password: "wrong",
+      }),
+    ).resolves.toEqual({
+      kind: "auth_failed",
+      message: "Wrong username or password",
+    });
+  });
+
+  it("reports forbidden RPC access without blaming credentials", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", {
+        url: "http://seedbox.local",
+        username: "u",
+        password: "p",
+      }),
+    ).resolves.toEqual({
+      kind: "auth_failed",
+      message:
+        "RPC access forbidden — check /RPC2 server or reverse-proxy access rules",
+    });
+  });
+});
+
 // External signal (TanStack Query's queryFn signal) composed with the internal
 // timeout controller — either firing must abort the fetch (#290).
 describe("serviceRequest — signal composition (#290)", () => {

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -591,6 +591,47 @@ describe("testServiceConnection — rTorrent authentication diagnostics (#352)",
     });
   });
 
+  it("asks for credentials instead of blaming them when none were entered", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers({ "www-authenticate": 'Basic realm="rTorrent"' }),
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", { url: "http://seedbox.local" }),
+    ).resolves.toEqual({
+      kind: "auth_failed",
+      message: "Server requires credentials",
+    });
+  });
+
+  it("falls back to a credential failure when no challenge header is sent", async () => {
+    // Reverse proxies routinely strip WWW-Authenticate from the response.
+    fetchSpy.mockResolvedValueOnce(
+      respond({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+      }),
+    );
+
+    await expect(
+      testServiceConnection("rtorrent", {
+        url: "http://seedbox.local",
+        username: "u",
+        password: "p",
+      }),
+    ).resolves.toEqual({
+      kind: "auth_failed",
+      message: "Wrong username or password",
+    });
+  });
+
   it("treats multiple challenges containing Basic as supported", async () => {
     fetchSpy.mockResolvedValueOnce(
       respond({

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -654,6 +654,45 @@ type ProbeOutcome =
   | { kind: "auth_failed"; message: string }
   | { kind: "unreachable"; message: string };
 
+function parseAuthenticationSchemes(header: string): string[] {
+  const segments: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+
+  for (let i = 0; i < header.length; i += 1) {
+    const char = header[i];
+    if (escaped) {
+      escaped = false;
+    } else if (quoted && char === "\\") {
+      escaped = true;
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else if (char === "," && !quoted) {
+      segments.push(header.slice(start, i));
+      start = i + 1;
+    }
+  }
+  segments.push(header.slice(start));
+
+  const schemes: string[] = [];
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    // Auth parameters permit whitespace around `=`; challenges start with a
+    // scheme token followed by whitespace (or nothing, such as Negotiate).
+    if (/^[A-Za-z][A-Za-z0-9!#$%&'*+.^_`|~-]*\s*=/.test(trimmed)) continue;
+    const match = trimmed
+      .match(/^([A-Za-z][A-Za-z0-9!#$%&'*+.^_`|~-]*)(?:\s|$)/);
+    if (
+      match &&
+      !schemes.some((scheme) => scheme.toLowerCase() === match[1].toLowerCase())
+    ) {
+      schemes.push(match[1]);
+    }
+  }
+  return schemes;
+}
+
 async function runConnectionProbe(
   serviceId: ServiceId,
   baseUrl: string,
@@ -900,10 +939,11 @@ async function runConnectionProbe(
 
     case "rtorrent": {
       // rtorrent has no GET endpoint — POST a tiny XML-RPC system.listMethods
-      // to the /RPC2 mount. Basic auth guards it: 401/403 → bad creds. A
-      // well-formed <methodResponse> (even a <fault>) means we reached an
-      // XML-RPC endpoint and authenticated; an HTML body (e.g. the ruTorrent
-      // UI) means the URL points somewhere other than the RPC mount.
+      // to the /RPC2 mount. Dashboarr supports Basic auth only, so inspect a
+      // 401 challenge before deciding whether credentials or the server's auth
+      // scheme need attention. A well-formed <methodResponse> (even a <fault>)
+      // means we reached an XML-RPC endpoint and authenticated; an HTML body
+      // (e.g. the ruTorrent UI) means the URL points somewhere else.
       const url = buildUrl(baseUrl, defaults.apiBasePath, defaults.pingPath);
       const extra: Record<string, string> = { "Content-Type": "text/xml" };
       // Match the nzbget/glances probes: send Basic auth if EITHER field is set
@@ -917,8 +957,28 @@ async function runConnectionProbe(
         body: '<?xml version="1.0"?><methodCall><methodName>system.listMethods</methodName><params></params></methodCall>',
         signal,
       });
-      if (res.status === 401 || res.status === 403)
+      if (res.status === 401) {
+        const schemes = parseAuthenticationSchemes(
+          res.headers.get("www-authenticate") ?? "",
+        );
+        if (
+          schemes.length > 0 &&
+          !schemes.some((scheme) => scheme.toLowerCase() === "basic")
+        ) {
+          return {
+            kind: "auth_failed",
+            message: `Server requires ${schemes.join(" or ")} authentication, but Dashboarr only supports HTTP Basic authentication`,
+          };
+        }
         return { kind: "auth_failed", message: "Wrong username or password" };
+      }
+      if (res.status === 403) {
+        return {
+          kind: "auth_failed",
+          message:
+            "RPC access forbidden — check /RPC2 server or reverse-proxy access rules",
+        };
+      }
       if (res.status >= 500)
         return { kind: "unreachable", message: `Server error ${res.status}` };
       if (!res.ok)

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -970,7 +970,15 @@ async function runConnectionProbe(
             message: `Server requires ${schemes.join(" or ")} authentication, but Dashboarr only supports HTTP Basic authentication`,
           };
         }
-        return { kind: "auth_failed", message: "Wrong username or password" };
+        // Same as the glances probe: with both fields empty there is no
+        // password to be wrong, the server is simply asking for one.
+        return {
+          kind: "auth_failed",
+          message:
+            username || password
+              ? "Wrong username or password"
+              : "Server requires credentials",
+        };
       }
       if (res.status === 403) {
         return {


### PR DESCRIPTION
Dashboarr currently maps every 401 or 403 from the rTorrent XML-RPC connection probe to “Wrong username or password.” The reporter's `/RPC2` endpoint instead returns a 401 with a `WWW-Authenticate: Digest` challenge and succeeds when curl uses Digest, confirming that the credentials are not the immediate problem. Dashboarr's rTorrent transport supports HTTP Basic authentication only, so the existing toast sends users toward ineffective credential changes. The same shared probe result also feeds stored-instance health status, making an accurate message useful beyond the editor's Test Connection action.

## Test plan

- A 200 rTorrent probe containing an XML-RPC `<methodResponse>` still returns `ok` and is not affected by the new diagnostics.
- A 401 whose `WWW-Authenticate` header advertises Digest returns `auth_failed` with an unsupported-Digest/Basic-required message, not “Wrong username or password.”
- A 401 that advertises Basic authentication continues to report a credential failure; if multiple challenges include Basic, it is treated as a supported-scheme credential rejection rather than unsupported auth.
- A 403 from `/RPC2` returns `auth_failed` with guidance about server or reverse-proxy access rules and does not blame the credentials.
- The guide identifies HTTP Basic as the supported rTorrent authentication scheme and explains that Digest authentication must be changed server-side before Dashboarr can connect.

## Summary

Refine the rTorrent branch of `runConnectionProbe` to inspect the authentication challenge before classifying a failed response: a 401 that advertises only Digest or another non-Basic scheme should explain that the server requires an unsupported scheme and that Dashboarr requires Basic authentication, while a Basic challenge can retain the bad-credentials guidance. Classify 403 separately with an actionable message about `/RPC2` access restrictions instead of claiming the username or password is wrong, preserving the existing `auth_failed` result shape so `service-editor` and health consumers receive the improved text without parallel UI logic. Add focused probe tests for the reported Digest response, the supported Basic-auth rejection, forbidden RPC access, and the existing successful XML-RPC response.

Refs #352

