### PR TITLE
feat(dashboard): movie release date selection for Still Pending

### DIFF
--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -32,7 +32,7 @@ import {
   getAllWantedMissing as getRadarrWantedMissing,
   getQueue as getRadarrQueue,
 } from "@/services/radarr-api";
-import { radarrReleaseTime } from "@/lib/radarr-release-date";
+import { radarrPendingTime } from "@/lib/radarr-release-date";
 import { useSearchForMovie } from "@/hooks/use-radarr";
 import { useSearchForEpisodes } from "@/hooks/use-sonarr";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
@@ -178,8 +178,10 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
       if (!instanceId) return;
       for (const movie of q.data?.records ?? []) {
         // wanted/missing records are monitored + missing by contract; the
-        // effective release date replicates Radarr's own computation (#135).
-        const t = radarrReleaseTime(movie);
+        // effective release date replicates Radarr's own computation (#135),
+        // narrowed to the release types the user picked (#355). A movie with
+        // none of those dates yields null and drops off the card.
+        const t = radarrPendingTime(movie, settings.radarrReleaseTypes);
         if (t === null) continue;
         const date = localDateKey(new Date(t));
         if (date < cutoffIso || date > todayIso) continue;

--- a/components/dashboard/widget-settings/still-pending-settings.tsx
+++ b/components/dashboard/widget-settings/still-pending-settings.tsx
@@ -12,9 +12,14 @@ import {
   ChipGroup,
   HideWhenEmptyToggle,
   MaxItemsSelector,
+  MultiChipGroup,
   SettingsSection,
   ToggleCard,
 } from "@/components/dashboard/widget-settings/widget-settings-blocks";
+import {
+  RADARR_RELEASE_KINDS,
+  type RadarrReleaseKind,
+} from "@/lib/radarr-release-date";
 
 export interface StillPendingSettingsValue extends Record<string, unknown> {
   // Independent per-service bindings, same shape as the calendar widget.
@@ -24,6 +29,10 @@ export interface StillPendingSettingsValue extends Record<string, unknown> {
   includeRadarr: boolean;
   lookbackDays: number;
   maxItems: number;
+  // Which Radarr dates make a movie overdue (issue #355). All three selected —
+  // the default — means "Any": defer to Radarr's own release date, which
+  // follows the movie's Minimum Availability. See lib/radarr-release-date.ts.
+  radarrReleaseTypes: RadarrReleaseKind[];
   // When on, items dated today that have already aired/released are included
   // too (they also appear under "Today" in the Releasing Soon widget). Off by
   // default so the two cards never list the same item.
@@ -40,9 +49,16 @@ export const STILL_PENDING_DEFAULT_SETTINGS: StillPendingSettingsValue = {
   // Movies Wanted tab; this widget is about catching what just slipped by.
   lookbackDays: 14,
   maxItems: 5,
+  radarrReleaseTypes: [...RADARR_RELEASE_KINDS],
   includeToday: false,
   hideWhenEmpty: false,
 };
+
+const RELEASE_TYPE_OPTIONS: { value: RadarrReleaseKind; label: string }[] = [
+  { value: "cinemas", label: "Cinemas" },
+  { value: "digital", label: "Digital" },
+  { value: "physical", label: "Physical" },
+];
 
 const LOOKBACK_OPTIONS: { value: number; label: string }[] = [
   { value: 7, label: "7 days" },
@@ -103,6 +119,19 @@ export function StillPendingSettings({ slotId }: WidgetSettingsComponentProps) {
           label="Radarr instance"
           value={settings.radarrInstanceIds}
           onChange={(radarrInstanceIds) => update({ radarrInstanceIds })}
+        />
+      )}
+
+      {settings.includeRadarr && radarrEnabled && (
+        <MultiChipGroup
+          label="Movie release date"
+          options={RELEASE_TYPE_OPTIONS}
+          value={settings.radarrReleaseTypes}
+          onChange={(radarrReleaseTypes) => update({ radarrReleaseTypes })}
+          caption={
+            "All three selected means any release: Radarr's own date, from each movie's Minimum Availability. " +
+            "Pick fewer and a movie counts as due on the first of those dates it has; movies with none of them drop off the card."
+          }
         />
       )}
 

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -69,6 +69,59 @@ export function ChipGroup<T extends string | number>({
   );
 }
 
+/**
+ * Multi-select chip row. Pressing a chip toggles it; the last selected chip is
+ * a no-op, since an empty selection would leave the widget filtering everything
+ * out with nothing on screen explaining why. Pass `caption` for a line of help
+ * text under the chips.
+ */
+export function MultiChipGroup<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  caption,
+}: {
+  label: string;
+  options: readonly { value: T; label: string }[];
+  value: readonly T[];
+  onChange: (value: T[]) => void;
+  caption?: string;
+}) {
+  return (
+    <SettingsSection label={label}>
+      <View className="flex-row flex-wrap gap-2">
+        {options.map((option) => {
+          const selected = value.includes(option.value);
+          return (
+            <FilterChip
+              key={option.value}
+              label={option.label}
+              selected={selected}
+              onPress={() => {
+                if (!selected) {
+                  // Keep the caller's option order so the stored value doesn't
+                  // depend on the order the user tapped the chips.
+                  onChange(
+                    options
+                      .map((o) => o.value)
+                      .filter((v) => v === option.value || value.includes(v)),
+                  );
+                } else if (value.length > 1) {
+                  onChange(value.filter((v) => v !== option.value));
+                }
+              }}
+            />
+          );
+        })}
+      </View>
+      {caption ? (
+        <Text className="text-zinc-500 text-xs mt-2">{caption}</Text>
+      ) : null}
+    </SettingsSection>
+  );
+}
+
 const DEFAULT_MAX_OPTIONS: readonly { value: number; label: string }[] = [
   { value: 3, label: "3" },
   { value: 5, label: "5" },

--- a/lib/calendar-agenda.ts
+++ b/lib/calendar-agenda.ts
@@ -11,6 +11,11 @@ import {
   radarrBarKind,
   sonarrEpisodeBarKind,
 } from "@/lib/arr-poster-status";
+import {
+  pickRadarrReleaseDate,
+  RADARR_RELEASE_KINDS,
+  type RadarrReleaseKind,
+} from "@/lib/radarr-release-date";
 import type {
   RadarrImage,
   RadarrMovie,
@@ -28,31 +33,23 @@ import type {
 // This module must stay pure (no React, no react-query, no native imports) so
 // the widget's headless task can import it cheaply.
 
-export type RadarrReleaseType = "cinemas" | "digital" | "physical" | "any";
+export type RadarrReleaseType = RadarrReleaseKind | "any";
 
 /**
  * Which Radarr release date a movie lands on, honoring the user's preference.
  * "any" mirrors the Calendar tab's waterfall (digital → physical → cinemas) so
- * the same movie buckets onto the same day in every surface.
+ * the same movie buckets onto the same day in every surface. Shares the
+ * waterfall with the Still Pending widget's multi-select (issue #355) so a
+ * movie is dated the same way on both cards.
  */
 export function pickRadarrDate(
   movie: RadarrMovie,
   type: RadarrReleaseType,
 ): string | null {
-  const cinemas = movie.inCinemas;
-  const digital = movie.digitalRelease;
-  const physical = movie.physicalRelease;
-  switch (type) {
-    case "cinemas":
-      return cinemas ?? null;
-    case "digital":
-      return digital ?? null;
-    case "physical":
-      return physical ?? null;
-    case "any":
-    default:
-      return digital ?? physical ?? cinemas ?? null;
-  }
+  return pickRadarrReleaseDate(
+    movie,
+    type === "any" ? RADARR_RELEASE_KINDS : [type],
+  );
 }
 
 /**

--- a/lib/radarr-release-date.test.ts
+++ b/lib/radarr-release-date.test.ts
@@ -1,0 +1,101 @@
+import {
+  isEveryReleaseKind,
+  pickRadarrReleaseDate,
+  radarrPendingTime,
+  radarrReleaseTime,
+  RADARR_RELEASE_KINDS,
+} from "@/lib/radarr-release-date";
+import type { RadarrMovie } from "@/lib/types";
+
+function movie(over: Partial<RadarrMovie>): RadarrMovie {
+  return {
+    id: 5,
+    title: "Film",
+    year: 2024,
+    hasFile: false,
+    monitored: true,
+    status: "released",
+    isAvailable: true,
+    images: [],
+    ...over,
+  } as RadarrMovie;
+}
+
+const ALL = [...RADARR_RELEASE_KINDS];
+const iso = (d: string) => new Date(d).getTime();
+
+describe("pickRadarrReleaseDate", () => {
+  const full = movie({
+    inCinemas: "2024-01-01",
+    digitalRelease: "2024-03-01",
+    physicalRelease: "2024-04-01",
+  });
+
+  it("waterfalls digital → physical → cinemas within the selection", () => {
+    expect(pickRadarrReleaseDate(full, ALL)).toBe("2024-03-01");
+    expect(pickRadarrReleaseDate(full, ["physical", "cinemas"])).toBe("2024-04-01");
+    expect(pickRadarrReleaseDate(full, ["cinemas"])).toBe("2024-01-01");
+  });
+
+  it("skips a selected kind the movie doesn't have", () => {
+    const m = movie({ inCinemas: "2024-01-01", physicalRelease: "2024-04-01" });
+    expect(pickRadarrReleaseDate(m, ["digital", "physical"])).toBe("2024-04-01");
+    expect(pickRadarrReleaseDate(m, ["digital", "cinemas"])).toBe("2024-01-01");
+  });
+
+  it("returns null when the movie has none of the selected dates", () => {
+    const m = movie({ inCinemas: "2024-01-01" });
+    expect(pickRadarrReleaseDate(m, ["digital"])).toBeNull();
+    expect(pickRadarrReleaseDate(m, ["digital", "physical"])).toBeNull();
+  });
+});
+
+describe("isEveryReleaseKind", () => {
+  it("is true only when all three kinds are present", () => {
+    expect(isEveryReleaseKind(ALL)).toBe(true);
+    expect(isEveryReleaseKind(["physical", "digital", "cinemas"])).toBe(true);
+    expect(isEveryReleaseKind(["digital", "physical"])).toBe(false);
+    expect(isEveryReleaseKind([])).toBe(false);
+  });
+});
+
+describe("radarrPendingTime", () => {
+  // A cinema-only-available movie: Radarr dates it from its theatrical run,
+  // which is the "overdue weeks early" complaint behind issue #355.
+  const inCinemasNow = movie({
+    minimumAvailability: "inCinemas",
+    releaseDate: "2024-01-01",
+    inCinemas: "2024-01-01",
+    digitalRelease: "2024-03-01",
+  });
+
+  it("defers to Radarr's own release date when every kind is selected", () => {
+    expect(radarrPendingTime(inCinemasNow, ALL)).toBe(iso("2024-01-01"));
+    expect(radarrPendingTime(inCinemasNow, ALL)).toBe(
+      radarrReleaseTime(inCinemasNow),
+    );
+  });
+
+  it("treats an empty selection as 'any' rather than hiding everything", () => {
+    expect(radarrPendingTime(inCinemasNow, [])).toBe(
+      radarrReleaseTime(inCinemasNow),
+    );
+  });
+
+  it("uses the picked kind's date when the selection is narrowed", () => {
+    expect(radarrPendingTime(inCinemasNow, ["digital"])).toBe(iso("2024-03-01"));
+    expect(radarrPendingTime(inCinemasNow, ["cinemas"])).toBe(iso("2024-01-01"));
+  });
+
+  it("drops a movie missing every picked kind", () => {
+    expect(radarrPendingTime(inCinemasNow, ["physical"])).toBeNull();
+    expect(
+      radarrPendingTime(movie({ releaseDate: "2024-01-01" }), ["digital"]),
+    ).toBeNull();
+  });
+
+  it("ignores unparsable dates", () => {
+    const m = movie({ digitalRelease: "not-a-date" });
+    expect(radarrPendingTime(m, ["digital"])).toBeNull();
+  });
+});

--- a/lib/radarr-release-date.ts
+++ b/lib/radarr-release-date.ts
@@ -1,5 +1,14 @@
 import type { RadarrMovie } from "@/lib/types";
 
+/** The three dates Radarr tracks for a movie, as user-selectable options. */
+export type RadarrReleaseKind = "cinemas" | "digital" | "physical";
+
+export const RADARR_RELEASE_KINDS: readonly RadarrReleaseKind[] = [
+  "cinemas",
+  "digital",
+  "physical",
+];
+
 export function parseReleaseTime(d?: string): number | null {
   if (!d) return null;
   const t = new Date(d).getTime();
@@ -30,4 +39,50 @@ export function radarrReleaseTime(m: RadarrMovie): number | null {
   ].filter((t): t is number => t !== null);
   if (home.length) return Math.min(...home);
   return cinema !== null ? cinema + 90 * 24 * 60 * 60 * 1000 : null;
+}
+
+/**
+ * The first date a movie has among `kinds`, in Radarr's own
+ * digital → physical → cinemas preference order. Returns null when the movie
+ * carries none of the requested dates — callers drop the movie rather than
+ * falling back, so a narrowed selection never silently reintroduces a date the
+ * user excluded.
+ */
+export function pickRadarrReleaseDate(
+  m: RadarrMovie,
+  kinds: readonly RadarrReleaseKind[],
+): string | null {
+  const has = (k: RadarrReleaseKind) => kinds.includes(k);
+  if (has("digital") && m.digitalRelease) return m.digitalRelease;
+  if (has("physical") && m.physicalRelease) return m.physicalRelease;
+  if (has("cinemas") && m.inCinemas) return m.inCinemas;
+  return null;
+}
+
+/** Whether a selection covers every release kind, i.e. the "Any" setting. */
+export function isEveryReleaseKind(
+  kinds: readonly RadarrReleaseKind[],
+): boolean {
+  return RADARR_RELEASE_KINDS.every((k) => kinds.includes(k));
+}
+
+/**
+ * The timestamp the Still Pending widget dates a movie by, honoring the user's
+ * "Movie release date" selection (issue #355).
+ *
+ * Selecting every kind — "Any", the default — defers to `radarrReleaseTime`,
+ * which follows the movie's own Minimum Availability. That is the pre-#355
+ * behavior, so existing dashboards don't shift under anyone.
+ *
+ * A narrower selection dates the movie by `pickRadarrReleaseDate` instead, so
+ * e.g. picking Digital only stops a movie from reading as overdue from its
+ * theatrical date weeks before it's realistically grabbable. A movie with none
+ * of the selected dates drops off the widget.
+ */
+export function radarrPendingTime(
+  m: RadarrMovie,
+  kinds: readonly RadarrReleaseKind[],
+): number | null {
+  if (kinds.length === 0 || isEveryReleaseKind(kinds)) return radarrReleaseTime(m);
+  return parseReleaseTime(pickRadarrReleaseDate(m, kinds) ?? undefined);
 }


### PR DESCRIPTION
Adds a Movie Release Date option to the Still Pending widget settings: Any, Cinemas, Digital, Physical. Pending movies are filtered by the selected Radarr release date.

Refs #355

## Test plan
- `npx vitest run lib/radarr-release-date.test.ts`
- Widget settings show the new option; switching it re-filters the Still Pending list.