### PR TITLE
fix(settings): keep Test Connection and the health dots in agreement

### DIFF
--- a/components/dashboard/service-health-card.tsx
+++ b/components/dashboard/service-health-card.tsx
@@ -15,7 +15,11 @@ import { useManualRefresh } from "@/store/manual-refresh-store";
 import { ICON, type ServiceId } from "@/lib/constants";
 import { applyServicesOrder } from "@/lib/services-order";
 import { SERVICE_ROUTES } from "@/lib/service-routes";
-import { resolveActiveUrlKind, isRemoteOnlyOffline } from "@/lib/url-validation";
+import {
+  resolveActiveUrlKind,
+  isRemoteOnlyOffline,
+  workspaceForcesRemote,
+} from "@/lib/url-validation";
 import { useConfigStore } from "@/store/config-store";
 import { useAttachedInstances, useActiveDashboard } from "@/hooks/use-active-dashboard";
 import {
@@ -108,11 +112,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
   // A workspace that explicitly selected no live home networks (homeNetworkIds:
   // [] or only stale ids) is "always remote" — mirror getActiveUrl step 2 so the
   // L/R badge reads "remote" even when global auto-switch is off (#148).
-  const workspaceForcesRemote = (() => {
-    const ids = activeDashboard?.homeNetworkIds;
-    if (!Array.isArray(ids)) return false;
-    return !ids.some((id) => homeNetworks.some((n) => n.id === id));
-  })();
+  const forcesRemote = workspaceForcesRemote(activeDashboard, homeNetworks);
 
   const hiddenSet = new Set(settings.hiddenKinds);
   // Index health by (kind, instanceId) so we can pair each bound instance with
@@ -161,7 +161,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
         inst,
         autoSwitchNetwork,
         networkAwayFromHome,
-        workspaceForcesRemote,
+        forcesRemote,
       );
       entries.push({
         kindId,
@@ -175,7 +175,7 @@ export function ServiceHealthCard({ slotId }: WidgetComponentProps) {
           inst,
           autoSwitchNetwork,
           networkAwayFromHome,
-          workspaceForcesRemote,
+          forcesRemote,
         ),
         awayBlocked,
         // Away-blocked instances are deterministically offline-by-config (no

--- a/components/settings/service-editor.tsx
+++ b/components/settings/service-editor.tsx
@@ -16,7 +16,7 @@ import { HeaderListEditor } from "@/components/ui/header-list-editor";
 import { useConfigStore, type ServiceConfig } from "@/store/config-store";
 import { useBackendStore } from "@/store/backend-store";
 import { BackHeader } from "@/components/common/back-header";
-import { testServiceConnection } from "@/lib/http-client";
+import { testServiceConnection, lanGuardBlockReason } from "@/lib/http-client";
 import { qbClearSession } from "@/services/qbittorrent-api";
 import { getPlexClientId } from "@/lib/plex-client-id";
 import {
@@ -32,7 +32,12 @@ import {
   CATEGORY_LABELS,
   type NotifCategory,
 } from "@/lib/notification-categories";
-import { validateServiceUrl, normalizeServiceUrl } from "@/lib/url-validation";
+import {
+  validateServiceUrl,
+  normalizeServiceUrl,
+  resolveActiveUrlKind,
+  workspaceForcesRemote,
+} from "@/lib/url-validation";
 import { brrrHaptic } from "@/lib/haptics";
 import { ConfirmModal } from "@/components/common/confirm-modal";
 import { useModalFlow } from "@/hooks/use-modal-flow";
@@ -274,15 +279,36 @@ export function ServiceEditor({
 
   const handleTest = async () => {
     setTesting(true);
-    // Resolve which URL the app will actually use right now, mirroring
-    // getActiveUrl: the per-instance "always remote" override OR auto-switch
-    // deciding we're away from home (in which case the app uses remote only and
-    // never the local URL). We test the in-progress form values, not the saved
-    // ones, so Test validates what the user typed before they Save.
-    const { autoSwitchNetwork, networkAwayFromHome } = useConfigStore.getState();
-    const useRemote =
-      config.useRemote || (autoSwitchNetwork && networkAwayFromHome);
-    const which = useRemote ? "remote" : "local";
+    // Resolve which URL the app will actually use right now through the SAME
+    // helper the health grid's L/R badge uses, so Test can never probe a
+    // different slot than the dots (it used to re-derive the decision by hand
+    // and missed both the workspace "always remote" pin and getActiveUrl's
+    // remote→local fallback). We feed it the in-progress form values, not the
+    // saved ones, so Test validates what the user typed before they Save.
+    const {
+      autoSwitchNetwork,
+      networkAwayFromHome,
+      dashboards,
+      activeDashboardId,
+      homeNetworks,
+    } = useConfigStore.getState();
+    const forcesRemote = workspaceForcesRemote(
+      dashboards.find((d) => d.id === activeDashboardId) ?? dashboards[0],
+      homeNetworks,
+    );
+    const which =
+      resolveActiveUrlKind(
+        { localUrl, remoteUrl, useRemote: config.useRemote },
+        autoSwitchNetwork,
+        networkAwayFromHome,
+        forcesRemote,
+      ) ??
+      // Neither URL is set: nothing to resolve, so pick the slot whose
+      // "you haven't configured this" message fits the current mode.
+      (config.useRemote || forcesRemote || (autoSwitchNetwork && networkAwayFromHome)
+        ? "remote"
+        : "local");
+    const useRemote = which === "remote";
     const rawTestUrl = useRemote ? remoteUrl : localUrl;
     const testUrl = normalizeServiceUrl(rawTestUrl);
     if (testUrl !== rawTestUrl) {
@@ -295,7 +321,17 @@ export function ServiceEditor({
     // no remote URL is set for this service.
     if (!testUrl) {
       setTesting(false);
-      if (useRemote && !config.useRemote && autoSwitchNetwork && networkAwayFromHome) {
+      if (useRemote && !config.useRemote && forcesRemote) {
+        toast(
+          "This dashboard uses remote URLs only (its Home networks selection is empty), but none is set here. Add a remote URL, or pick its home networks in the dashboard's settings.",
+          "error",
+        );
+      } else if (
+        useRemote &&
+        !config.useRemote &&
+        autoSwitchNetwork &&
+        networkAwayFromHome
+      ) {
         toast(
           "Away from home: Dashboarr is using remote URLs only, but none is set here. Add a remote URL, or turn off Auto-switch network if this device stays on your home WiFi.",
           "error",
@@ -315,7 +351,17 @@ export function ServiceEditor({
     setTesting(false);
 
     if (result.kind === "ok") {
-      toast(`Connected via ${which} URL in ${result.responseTime}ms`, "success");
+      // The URL answered, but the health probes may still be short-circuiting
+      // it: Test always fires at what you typed, while the dots run the off-WiFi
+      // LAN guard (#356). Say so, otherwise a green toast next to a red dot
+      // reads as a contradiction with no explanation anywhere.
+      const blocked = lanGuardBlockReason(testUrl, { remoteUrl });
+      toast(
+        blocked
+          ? `Connected via ${which} URL in ${result.responseTime}ms. Dashboarr still shows it offline on this network: private LAN address off Wi-Fi (${blocked}).`
+          : `Connected via ${which} URL in ${result.responseTime}ms`,
+        blocked ? "info" : "success",
+      );
     } else if (result.kind === "auth_failed") {
       toast(`Auth failed (${which} URL): ${result.message}`, "error");
     } else {

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -2,6 +2,7 @@ import { resetDigestSessions } from "@/lib/http-auth";
 import {
   serviceRequest,
   pingService,
+  lanGuardBlockReason,
   testServiceConnection,
   AuthProxyResponseError,
   HttpError,
@@ -392,6 +393,30 @@ describe("off-WiFi LAN guard — VPN awareness (#185)", () => {
     await expect(serviceRequest("radarr", "/system/status")).rejects.toThrow(
       "(no VPN detected)",
     );
+  });
+
+  it("reports the guard verdict to the UI via lanGuardBlockReason (#356)", async () => {
+    // Test Connection skips the guard, so the settings screen asks for the
+    // verdict separately to explain a green toast sitting next to a red dot.
+    mockStateRef.current.isOnWifi = false;
+    mockStateRef.current.isVpnActive = false;
+    expect(lanGuardBlockReason("http://192.168.1.50:7878")).toBe(
+      "no VPN detected",
+    );
+
+    mockStateRef.current.isVpnActive = true;
+    expect(lanGuardBlockReason("http://192.168.1.50:7878")).toBe(
+      "VPN detected, but Treat VPN as home is off",
+    );
+
+    // Judged against the IN-PROGRESS remote URL from the form, not the saved
+    // one, and a public host is never blocked.
+    expect(
+      lanGuardBlockReason("http://192.168.1.50:7878", {
+        remoteUrl: "192.168.1.50:7878",
+      }),
+    ).toBeNull();
+    expect(lanGuardBlockReason("https://media.example.com")).toBeNull();
   });
 
   it("never short-circuits while WiFi state is still unknown (cold start)", async () => {

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -88,6 +88,23 @@ function lanGuardReason(): string {
     : "no VPN detected";
 }
 
+/**
+ * The guard's verdict for UI that has to explain a disagreement (#356): the
+ * settings "Test" button fires at the URL you typed and deliberately skips the
+ * guard, so a URL can answer there while the health probes short-circuit it.
+ * Returns null when nothing is being blocked, otherwise the reason to show.
+ *
+ * `inst` carries the IN-PROGRESS Remote URL from the form, not the saved one,
+ * so the remote-slot stand-down is judged against what the user is about to
+ * save.
+ */
+export function lanGuardBlockReason(
+  url: string,
+  inst?: { remoteUrl: string },
+): string | null {
+  return lanUnreachableOffWifi(url, inst) ? lanGuardReason() : null;
+}
+
 interface RequestOptions extends Omit<RequestInit, "signal"> {
   timeout?: number;
   params?: Record<string, string | number | boolean>;

--- a/lib/url-validation.test.ts
+++ b/lib/url-validation.test.ts
@@ -5,6 +5,7 @@ import {
   isRemoteOnlyOffline,
   isPrivateHost,
   isPrivateUrl,
+  workspaceForcesRemote,
 } from "./url-validation";
 
 describe("validateServiceUrl", () => {
@@ -190,6 +191,29 @@ describe("resolveActiveUrlKind", () => {
 
   it("falls back to remote at home when no local is configured", () => {
     expect(resolveActiveUrlKind(inst({ localUrl: "" }), true, false)).toBe("remote");
+  });
+});
+
+describe("workspaceForcesRemote (#148)", () => {
+  const nets = [{ id: "n1" }, { id: "n2" }];
+
+  it("is false for auto-attach (undefined = every home network)", () => {
+    expect(workspaceForcesRemote({}, nets)).toBe(false);
+    expect(workspaceForcesRemote(undefined, nets)).toBe(false);
+  });
+
+  it("is true for an explicit empty selection", () => {
+    expect(workspaceForcesRemote({ homeNetworkIds: [] }, nets)).toBe(true);
+  });
+
+  it("is true when every selected id is stale", () => {
+    expect(workspaceForcesRemote({ homeNetworkIds: ["gone"] }, nets)).toBe(true);
+  });
+
+  it("is false when at least one selected id is still live", () => {
+    expect(workspaceForcesRemote({ homeNetworkIds: ["gone", "n2"] }, nets)).toBe(
+      false,
+    );
   });
 });
 

--- a/lib/url-validation.ts
+++ b/lib/url-validation.ts
@@ -102,6 +102,26 @@ export function isPrivateUrl(url: string): boolean {
 }
 
 /**
+ * True when the active workspace explicitly selected NO live home network
+ * (`homeNetworkIds: []`, or only ids that no longer match a saved network) and
+ * is therefore pinned to "always remote" — `getActiveUrl` step 2 (#148), which
+ * holds even when global auto-switch is off. `undefined` (auto-attach every
+ * network, the default) is NOT remote-only.
+ *
+ * Feeds the `workspaceForcesRemote` argument of `resolveActiveUrlKind` /
+ * `isRemoteOnlyOffline`. Shared so the health grid's L/R badge and the settings
+ * "Test" button can't drift from each other, or from `getActiveUrl`.
+ */
+export function workspaceForcesRemote(
+  dashboard: { homeNetworkIds?: string[] } | undefined,
+  homeNetworks: { id: string }[],
+): boolean {
+  const ids = dashboard?.homeNetworkIds;
+  if (!Array.isArray(ids)) return false;
+  return !ids.some((id) => homeNetworks.some((n) => n.id === id));
+}
+
+/**
  * Which URL bucket a service instance is actively using right now: "local",
  * "remote", or null when neither URL is configured. This MIRRORS the decision
  * tree in `getActiveUrl` (store/config-store.ts) — keep the two in sync — but

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -67,7 +67,10 @@ import { useBackendStore } from "@/store/backend-store";
 import { queryClient } from "@/lib/query-client";
 import type { ServiceId, WidgetId } from "@/lib/constants";
 import { normalizeBssid } from "@/lib/wifi";
-import { normalizeServiceUrl } from "@/lib/url-validation";
+import {
+  normalizeServiceUrl,
+  workspaceForcesRemote,
+} from "@/lib/url-validation";
 import { generateInstanceId } from "@/lib/uuid";
 
 export interface WakeOnLanDevice {
@@ -2617,10 +2620,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     const activeDash = state.dashboards.find(
       (d) => d.id === state.activeDashboardId,
     );
-    if (
-      Array.isArray(activeDash?.homeNetworkIds) &&
-      effectiveHomeNetworkIdSet(activeDash, state.homeNetworks).size === 0
-    ) {
+    if (workspaceForcesRemote(activeDash, state.homeNetworks)) {
       return remote;
     }
     // 3. Auto-switch off → user opted out of switching; use local (or remote if


### PR DESCRIPTION
Refs #356. Follow-up to #365.

**a. One resolver, three callers.** `handleTest` re-derived the local/remote decision by hand, so it missed the workspace "always remote" pin (`homeNetworkIds: []`, #148) and `getActiveUrl`'s remote→local fallback: Test could probe a different slot than the dots. It now calls `resolveActiveUrlKind`, the same helper the L/R badge uses. The `workspaceForcesRemote` predicate was duplicated inline in the health card and in `getActiveUrl`; it is now one exported function all three share.

**b. Test says when the dots will still disagree.** Test deliberately skips the off-WiFi LAN guard (you must be able to validate a URL you just typed); the health probes apply it. When a URL answers but the guard is still short-circuiting it, the toast now says so and names the reason, instead of a green toast sitting next to a red dot with no explanation. Reachable case: auto-switch off, VPN up, LAN URL routed by the tunnel, "Treat VPN as home" off.

Also adds a distinct message for "this dashboard is pinned to remote URLs but none is set here", which previously showed the away-from-home text.

## Test plan
- New: `workspaceForcesRemote` (4 cases), `lanGuardBlockReason` (4 assertions).
- Full suite: 1042 passing. `tsc --noEmit` clean.