### PR TITLE
feat(backend): Deluge completion poller, release v1.3.0

### DIFF
--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboarr-backend",
-      "version": "1.2.8",
+      "version": "1.3.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/rate-limit": "^10.2.1",

--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "Self-hosted companion backend for Dashboarr — polls your *arr stack and sends real Expo push notifications",
   "license": "GPL-3.0",
   "private": true,


### PR DESCRIPTION
Cuts the backend release that carries the Deluge support merged in #370.

## Why now
`main` already sends a `deluge` service kind. An older backend does not reject it (the `dropUnknownKinds` guard added after #230 keeps the rest of the payload working), it silently discards the entry — so Deluge completion pushes never fire and nothing surfaces an error. This release is what makes them work.

## Summary
- Version bump only: 1.2.8 -> 1.3.0. Minor, because the backend gained a feature (the Deluge kind, its JSON-RPC client, poller and completion transition, all merged in #370).
- No code changes here. `package.json` + `package-lock.json` only; `pnpm-lock.yaml` does not embed the package's own version.

## Test plan
- [x] `npm test` 29 passing, `npm run typecheck` clean
- [x] `ci-backend` runs on this PR (backend paths touched) and covers typecheck, tests, and the amd64/arm64 Docker builds
- [ ] Image publish happens on the `backend-v1.3.0` tag after merge, not here

Refs #319
