### PR TITLE
feat(settings): move integrations to their own routed view

### DIFF
--- a/app/(tabs)/activity.tsx
+++ b/app/(tabs)/activity.tsx
@@ -140,7 +140,7 @@ export default function ActivityScreen() {
       {sources.length === 0 ? (
         <EmptyState
           title="No monitor configured"
-          message="Enable Tautulli, Tracearr, JellyStat, Jellyfin, or Emby in Settings"
+          message="Enable Tautulli, Tracearr, JellyStat, Jellyfin, or Emby in Settings → Integrations"
         />
       ) : (
         <>

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -368,7 +368,7 @@ export default function CalendarScreen() {
           <Text className="text-zinc-500 text-sm text-center">
             {hasAnyAttached
               ? "Open the dashboard switcher and attach Sonarr or Radarr to this workspace."
-              : "Enable Sonarr or Radarr in Settings to populate the calendar."}
+              : "Enable Sonarr or Radarr in Settings → Integrations to populate the calendar."}
           </Text>
         </View>
       </ScreenWrapper>

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -300,7 +300,7 @@ export default function DashboardScreen() {
             No services configured yet.
           </Text>
           <Text className="text-zinc-500 text-sm text-center mt-1">
-            Go to Settings to add your first service.
+            Add your first service in Settings → Integrations.
           </Text>
         </View>
       ) : visibleSlots.length === 0 && !editMode && activeDashboard ? (

--- a/app/(tabs)/downloads.tsx
+++ b/app/(tabs)/downloads.tsx
@@ -151,7 +151,7 @@ export default function DownloadsScreen() {
       <ScreenWrapper>
         <EmptyState
           title="No download client configured"
-          message="Enable qBittorrent, rTorrent, Transmission, Deluge, SABnzbd, or NZBGet in Settings to manage downloads."
+          message="Enable a download client in Settings → Integrations to manage downloads."
         />
       </ScreenWrapper>
     );

--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -68,7 +68,7 @@ export default function LibraryScreen() {
       <ScreenWrapper>
         <EmptyState
           title="No library configured"
-          message="Enable Radarr or Sonarr in Settings to browse your library."
+          message="Enable Radarr or Sonarr in Settings → Integrations to browse your library."
         />
       </ScreenWrapper>
     );

--- a/app/(tabs)/services.tsx
+++ b/app/(tabs)/services.tsx
@@ -8,6 +8,7 @@ import Sortable, {
 import { useRouter } from "expo-router";
 import { Zap } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
 import { CheckingIndicator } from "@/components/ui/checking-indicator";
 import { StatusDot } from "@/components/ui/status-dot";
 import { ServiceLogo } from "@/components/ui/service-logo";
@@ -110,8 +111,15 @@ export default function ServicesScreen() {
           <Text className="text-zinc-500 text-sm text-center">
             {anyEnabledGlobally
               ? "Open the dashboard switcher and attach services to this workspace."
-              : "Go to Settings to configure your services."}
+              : "Connect a service to see it here."}
           </Text>
+          {anyEnabledGlobally ? null : (
+            <Button
+              label="Open Integrations"
+              className="mt-2"
+              onPress={() => router.push("/settings/integrations")}
+            />
+          )}
         </View>
       </ScreenWrapper>
     );

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,22 +1,23 @@
-import { useState } from "react";
+import { useMemo } from "react";
 import { View, Text } from "react-native";
 import { router } from "expo-router";
-import { Wifi, Bell, Palette, HardDrive, Info } from "lucide-react-native";
-import { ServiceLogo } from "@/components/ui/service-logo";
+import { Wifi, Bell, Palette, HardDrive, Info, Plug } from "lucide-react-native";
 import { StatusDot } from "@/components/ui/status-dot";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { useWindowControlsContentPadding } from "@/hooks/use-window-controls-inset";
 import { APP_THEMES } from "@/lib/app-themes";
 import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { lanGuardBlockReason } from "@/lib/http-client";
 import { SERVICE_IDS } from "@/lib/constants";
-import type { ServiceId } from "@/lib/constants";
+import {
+  buildIntegrationRows,
+  summarizeIntegrations,
+  type InstanceProbeContext,
+} from "@/lib/integration-status";
 import { NATIVE_VERSION } from "@/lib/app-version";
 import { SettingsGroup } from "@/components/settings/settings-group";
 import { SettingsRow } from "@/components/settings/settings-row";
-import { SERVICE_DEFAULTS_KIND_LABEL } from "@/components/settings/service-kind-shared";
-import { InstanceList } from "@/components/settings/instance-list";
-import { ServiceEditor } from "@/components/settings/service-editor";
 
 // The 7 per-category notification toggles, for the hub row's "On · X of 7
 // alerts" subtitle. Must mirror the toggles on /settings/notifications.
@@ -31,18 +32,10 @@ const NOTIF_CATEGORY_KEYS = [
 ] as const;
 
 export default function SettingsScreen() {
-  // Multi-instance settings has three views:
-  //   • main: hub with the Services list + category rows
-  //   • viewingService: list of instances for one kind (with add/edit/delete)
-  //   • editingInstance: per-instance editor (URL/auth/name/delete)
-  const [viewingService, setViewingService] = useState<ServiceId | null>(null);
-  const [editingInstance, setEditingInstance] = useState<{
-    serviceId: ServiceId;
-    instanceId: string;
-    isNew?: boolean;
-  } | null>(null);
-
   const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const getActiveUrl = useConfigStore((s) => s.getActiveUrl);
+  const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
+  const isOnWifi = useConfigStore((s) => s.isOnWifi);
   const autoSwitchNetwork = useConfigStore((s) => s.autoSwitchNetwork);
   const homeNetworksCount = useConfigStore((s) => s.homeNetworks.length);
   const treatVpnAsHome = useConfigStore((s) => s.treatVpnAsHome);
@@ -54,91 +47,43 @@ export default function SettingsScreen() {
     NOTIF_CATEGORY_KEYS.filter((k) => s.notificationSettings[k]).length,
   );
 
-  // Pull live health for every (kind, instance) pair so the kind-row dots can
-  // reflect ok/auth_failed/offline instead of just "any instance enabled".
-  // Cached + polled by the shared hook — no extra requests fired here.
-  const { data: healthData } = useServiceHealth();
+  // Pull live health for every (kind, instance) pair so the Integrations row
+  // can summarise it. Cached + polled by the shared hook — no extra requests.
+  const { data: healthData, isPending, isPlaceholderData } = useServiceHealth();
+  const determining = isPending || isPlaceholderData;
+
+  // The exact same projection the Integrations hub renders, so the row's count
+  // and the hub's summary line can never disagree.
+  const summary = useMemo(() => {
+    const context: Record<string, InstanceProbeContext> = {};
+    for (const kind of SERVICE_IDS) {
+      for (const inst of serviceInstances[kind] ?? []) {
+        const activeUrl = getActiveUrl(kind, inst.id);
+        context[inst.id] = {
+          activeUrl,
+          lanBlocked: lanGuardBlockReason(activeUrl, inst) !== null,
+        };
+      }
+    }
+    return summarizeIntegrations(
+      buildIntegrationRows(
+        serviceInstances,
+        determining ? undefined : healthData,
+        context,
+      ),
+    );
+    // networkAwayFromHome / isOnWifi feed lanGuardBlockReason indirectly.
+  }, [
+    serviceInstances,
+    healthData,
+    determining,
+    getActiveUrl,
+    networkAwayFromHome,
+    isOnWifi,
+  ]);
 
   // Keeps the title clear of the iPadOS 26 window-control cluster (#342).
   const windowControlsPadding = useWindowControlsContentPadding();
-
-  if (editingInstance) {
-    return (
-      // Key by instance id so the editor fully remounts when switching between
-      // instances. The form seeds its URL/credential fields from `inst` via
-      // useState initializers (which run once per mount); without a per-instance
-      // key those fields would keep a previous instance's values — the "remote
-      // URL shows blank until you tap it" symptom — and a Save could then
-      // persist the stale/empty value over a good stored URL (#106).
-      <ServiceEditor
-        key={editingInstance.instanceId}
-        serviceId={editingInstance.serviceId}
-        instanceId={editingInstance.instanceId}
-        isNew={editingInstance.isNew ?? false}
-        onBack={() => setEditingInstance(null)}
-        onDeleted={() => setEditingInstance(null)}
-      />
-    );
-  }
-
-  if (viewingService) {
-    return (
-      <InstanceList
-        serviceId={viewingService}
-        onBack={() => setViewingService(null)}
-        onEditInstance={(instanceId, options) =>
-          setEditingInstance({
-            serviceId: viewingService,
-            instanceId,
-            isNew: options?.isNew,
-          })
-        }
-      />
-    );
-  }
-
-  const renderKindRow = (id: ServiceId) => {
-    const list = serviceInstances[id] ?? [];
-    const enabledCount = list.filter((i) => i.enabled).length;
-    const subtitle =
-      list.length === 0
-        ? "Tap to add"
-        : list.length === 1
-          ? list[0].enabled
-            ? list[0].useRemote
-              ? list[0].remoteUrl || "No remote URL set"
-              : list[0].localUrl || list[0].remoteUrl || "No URL set"
-            : "Tap to configure"
-          : `${list.length} instances · ${enabledCount} enabled`;
-    // Only show the dot when the kind has at least one enabled instance —
-    // disabled kinds have nothing to be healthy about. Use the aggregated
-    // kind status from the health hook (best of any instance: ok >
-    // auth_failed > offline) so a healthy primary masks a broken secondary.
-    const kindHealth = enabledCount > 0
-      ? healthData?.find((h) => h.id === id)?.status
-      : undefined;
-    return (
-      <SettingsRow
-        key={id}
-        leading={<ServiceLogo id={id} size={20} />}
-        label={SERVICE_DEFAULTS_KIND_LABEL[id]}
-        subtitle={subtitle}
-        onPress={() => setViewingService(id)}
-        right={
-          kindHealth ? <StatusDot state={kindHealth} size="sm" /> : null
-        }
-      />
-    );
-  };
-
-  // Determine ordering: kinds with at least one enabled instance come first,
-  // matching the v12 "configured at top" UX.
-  const enabledKinds = SERVICE_IDS.filter((id) =>
-    (serviceInstances[id] ?? []).some((i) => i.enabled),
-  );
-  const disabledKinds = SERVICE_IDS.filter(
-    (id) => !(serviceInstances[id] ?? []).some((i) => i.enabled),
-  );
 
   const networkNeedsHomeNetwork =
     autoSwitchNetwork && homeNetworksCount === 0 && !treatVpnAsHome;
@@ -162,19 +107,20 @@ export default function SettingsScreen() {
         </Text>
       </View>
 
-      <SettingsGroup
-        title="Services"
-        footer="Instances are shared across dashboards. Attach them to a workspace in its settings."
-      >
-        {enabledKinds.map(renderKindRow)}
-        {disabledKinds.length > 0 && enabledKinds.length > 0 ? (
-          <View className="px-4 py-2 bg-surface-light/30">
-            <Text className="text-zinc-500 text-xs font-semibold uppercase tracking-wider">
-              Not configured
-            </Text>
-          </View>
-        ) : null}
-        {disabledKinds.map(renderKindRow)}
+      {/* One row, no section header: "Services" above a row called
+          "Integrations" next to a tab called Services is three names for the
+          same thing. The full list lives at /settings/integrations. */}
+      <SettingsGroup>
+        <SettingsRow
+          icon={Plug}
+          label="Integrations"
+          subtitle={summary.line}
+          subtitleTone={summary.attention > 0 ? "warn" : "default"}
+          right={
+            summary.worst ? <StatusDot state={summary.worst} size="sm" /> : null
+          }
+          onPress={() => router.push("/settings/integrations")}
+        />
       </SettingsGroup>
 
       <SettingsGroup title="App">

--- a/app/dashboard-edit/[id].tsx
+++ b/app/dashboard-edit/[id].tsx
@@ -1050,7 +1050,7 @@ const InstanceKindCard = memo(function InstanceKindCard({
           </Text>
           {!inst.enabled && (
             <Text className="text-zinc-600 text-xs mt-0.5">
-              Enable in Settings to attach
+              Enable in Settings → Integrations to attach
             </Text>
           )}
         </View>
@@ -1087,7 +1087,7 @@ const InstanceKindCard = memo(function InstanceKindCard({
             numberOfLines={1}
           >
             {kindUntouchable
-              ? "All instances disabled — enable in Settings"
+              ? "All instances disabled — enable in Settings → Integrations"
               : `${attachedCount} of ${list.length} attached`}
           </Text>
         </View>

--- a/app/jellystat-stats.tsx
+++ b/app/jellystat-stats.tsx
@@ -117,7 +117,7 @@ export default function JellystatStatsScreen() {
         <BackHeader title="JellyStat Stats" />
         <EmptyState
           title="No JellyStat configured"
-          message="Enable JellyStat in Settings to see stats"
+          message="Enable JellyStat in Settings → Integrations to see stats"
         />
       </ScreenWrapper>
     );

--- a/app/settings/integrations/[kind]/[instanceId].tsx
+++ b/app/settings/integrations/[kind]/[instanceId].tsx
@@ -1,0 +1,57 @@
+import { useCallback } from "react";
+import { useLocalSearchParams, useRouter, Redirect } from "expo-router";
+import { ServiceEditor } from "@/components/integrations/service-editor";
+import { useConfigStore } from "@/store/config-store";
+import { EMPTY_INSTANCES } from "@/components/settings/service-kind-shared";
+import { SERVICE_IDS, type ServiceId } from "@/lib/constants";
+
+/**
+ * Per-instance editor route.
+ *
+ * Thin on purpose: the form itself is components/integrations/service-editor.tsx.
+ * This file only resolves and validates the params, and owns the back target.
+ */
+export default function InstanceEditorRoute() {
+  const router = useRouter();
+  const { kind, instanceId, new: isNew } = useLocalSearchParams<{
+    kind: string;
+    instanceId: string;
+    new?: string;
+  }>();
+
+  const validKind = SERVICE_IDS.includes(kind as ServiceId)
+    ? (kind as ServiceId)
+    : null;
+
+  const exists = useConfigStore((s) =>
+    validKind
+      ? (s.serviceInstances[validKind] ?? EMPTY_INSTANCES).some(
+          (i) => i.id === instanceId,
+        )
+      : false,
+  );
+
+  // A cold-start deep link can name a kind that never existed or an instance
+  // the user has since deleted. Land on the hub rather than a dead screen.
+  const goBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace("/settings/integrations");
+  }, [router]);
+
+  if (!validKind || !exists) return <Redirect href="/settings/integrations" />;
+
+  return (
+    // Keyed by instance id so the form fully remounts when switching between
+    // instances of the same kind. The fields seed from the store via useState
+    // initializers, which run once per mount; without the key a stale value
+    // could be saved over a good stored URL (#106).
+    <ServiceEditor
+      key={instanceId}
+      serviceId={validKind}
+      instanceId={instanceId}
+      isNew={isNew === "1"}
+      onBack={goBack}
+      onDeleted={goBack}
+    />
+  );
+}

--- a/app/settings/integrations/[kind]/index.tsx
+++ b/app/settings/integrations/[kind]/index.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useState } from "react";
-import { View, Text, BackHandler, Pressable } from "react-native";
-import { useFocusEffect } from "expo-router";
-import { Plus, Trash2, ArrowUp, ArrowDown } from "lucide-react-native";
+import { useState } from "react";
+import { View, Text, Pressable, Linking } from "react-native";
+import { useLocalSearchParams, useRouter, Redirect } from "expo-router";
+import { Plus, Trash2, ArrowUp, ArrowDown, ExternalLink } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { StatusDot } from "@/components/ui/status-dot";
+import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { BackHeader } from "@/components/common/back-header";
 import { ConfirmModal } from "@/components/common/confirm-modal";
@@ -15,35 +18,51 @@ import {
 } from "@/components/settings/service-kind-shared";
 import { useConfigStore } from "@/store/config-store";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { SERVICE_CATALOG } from "@/lib/service-catalog";
 import type { HealthStatusKind } from "@/lib/types";
 import { qbClearSession } from "@/services/qbittorrent-api";
-import type { ServiceId } from "@/lib/constants";
+import { SERVICE_IDS, type ServiceId } from "@/lib/constants";
 
-export function InstanceList({
-  serviceId,
-  onBack,
-  onEditInstance,
+/**
+ * Instance list for one service kind.
+ *
+ * Absorbs the old components/settings/instance-list.tsx. The BackHandler
+ * interception that file carried is gone: this is a real route now, so the
+ * hardware back and the edge swipe pop it for free.
+ */
+export default function KindInstancesRoute() {
+  const router = useRouter();
+  const { kind } = useLocalSearchParams<{ kind: string }>();
+  const validKind = SERVICE_IDS.includes(kind as ServiceId)
+    ? (kind as ServiceId)
+    : null;
+
+  if (!validKind) return <Redirect href="/settings/integrations" />;
+  return <KindInstances kind={validKind} router={router} />;
+}
+
+function KindInstances({
+  kind,
+  router,
 }: {
-  serviceId: ServiceId;
-  onBack: () => void;
-  onEditInstance: (
-    instanceId: string,
-    options?: { isNew?: boolean },
-  ) => void;
+  kind: ServiceId;
+  router: ReturnType<typeof useRouter>;
 }) {
   const instances = useConfigStore(
-    (s) => s.serviceInstances[serviceId] ?? EMPTY_INSTANCES,
+    (s) => s.serviceInstances[kind] ?? EMPTY_INSTANCES,
   );
   const addInstance = useConfigStore((s) => s.addInstance);
   const removeInstance = useConfigStore((s) => s.removeInstance);
   const moveInstance = useConfigStore((s) => s.moveInstance);
   const dashboards = useConfigStore((s) => s.dashboards);
-  const kindLabel = SERVICE_DEFAULTS_KIND_LABEL[serviceId];
+  const kindLabel = SERVICE_DEFAULTS_KIND_LABEL[kind];
+  const catalog = SERVICE_CATALOG[kind];
+
   // Per-instance tri-state health for the row dot. The shared hook is already
   // polling, so this is a pure index by instance UUID.
   const { data: healthData } = useServiceHealth();
   const healthByInstance = new Map<string, HealthStatusKind>();
-  for (const inst of healthData?.find((h) => h.id === serviceId)?.instances ?? []) {
+  for (const inst of healthData?.find((h) => h.id === kind)?.instances ?? []) {
     healthByInstance.set(inst.instanceId, inst.status);
   }
 
@@ -54,27 +73,24 @@ export function InstanceList({
   const countAttached = (instanceId: string): number => {
     let n = 0;
     for (const d of dashboards) {
-      if (d.attachedInstances === undefined || d.attachedInstances.includes(instanceId)) {
+      if (
+        d.attachedInstances === undefined ||
+        d.attachedInstances.includes(instanceId)
+      ) {
         n++;
       }
     }
     return n;
   };
 
+  // Plain useState, not a flow step: this confirm chains into nothing.
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
-  // Intercept Android hardware back / swipe-back so it returns to the main
-  // settings list instead of popping the Settings tab (which would land on
-  // the dashboard).
-  useFocusEffect(
-    useCallback(() => {
-      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
-        onBack();
-        return true;
-      });
-      return () => sub.remove();
-    }, [onBack]),
-  );
+  const openInstance = (instanceId: string, opts?: { isNew?: boolean }) => {
+    router.push(
+      `/settings/integrations/${kind}/${instanceId}${opts?.isNew ? "?new=1" : ""}` as never,
+    );
+  };
 
   const handleAdd = () => {
     // First instance for a kind takes the kind's default name; subsequent ones
@@ -83,23 +99,47 @@ export function InstanceList({
     const existing = instances.length;
     const defaultName =
       existing === 0 ? kindLabel : `${kindLabel} ${existing + 1}`;
-    const inst = addInstance(serviceId, { name: defaultName });
-    onEditInstance(inst.id, { isNew: true });
+    const inst = addInstance(kind, { name: defaultName });
+    openInstance(inst.id, { isNew: true });
   };
 
   const performDelete = async (instanceId: string) => {
     setConfirmDelete(null);
-    if (serviceId === "qbittorrent") {
+    if (kind === "qbittorrent") {
       // Drop any cached qBit session for the deleted instance before its
       // SecureStore row goes away.
       await qbClearSession(instanceId);
     }
-    await removeInstance(serviceId, instanceId);
+    await removeInstance(kind, instanceId);
   };
 
   return (
     <ScreenWrapper>
-      <BackHeader title={kindLabel} onBack={onBack} />
+      <BackHeader title={kindLabel} />
+
+      <Card className="gap-3 mb-4">
+        <View className="flex-row items-center gap-3">
+          <View className="w-12 h-12 rounded-2xl bg-surface-light items-center justify-center">
+            <ServiceLogo id={kind} size={28} />
+          </View>
+          <View className="flex-1">
+            <Text className="text-zinc-100 text-lg font-bold">{kindLabel}</Text>
+            <Text className="text-zinc-400 text-sm mt-0.5">
+              {catalog.tagline}
+            </Text>
+          </View>
+        </View>
+        {catalog.docsUrl ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            label="Open docs"
+            className="self-start"
+            icon={<Icon icon={ExternalLink} size={14} color="#a1a1aa" />}
+            onPress={() => void Linking.openURL(catalog.docsUrl!)}
+          />
+        ) : null}
+      </Card>
 
       <SettingsGroup
         title={instances.length === 1 ? "Instance" : "Instances"}
@@ -127,7 +167,7 @@ export function InstanceList({
               className="flex-row items-center border-b border-surface-light last:border-b-0"
             >
               <Pressable
-                onPress={() => onEditInstance(inst.id)}
+                onPress={() => openInstance(inst.id)}
                 className="flex-1 flex-row items-center px-4 py-3 active:opacity-70"
               >
                 <View className="flex-1">
@@ -157,7 +197,7 @@ export function InstanceList({
               {instances.length > 1 ? (
                 <View className="flex-row items-center pr-2">
                   <Pressable
-                    onPress={() => moveInstance(serviceId, inst.id, "up")}
+                    onPress={() => moveInstance(kind, inst.id, "up")}
                     disabled={idx === 0}
                     hitSlop={6}
                     className="p-2 active:opacity-60"
@@ -166,7 +206,7 @@ export function InstanceList({
                     <Icon icon={ArrowUp} size={16} color="#a1a1aa" />
                   </Pressable>
                   <Pressable
-                    onPress={() => moveInstance(serviceId, inst.id, "down")}
+                    onPress={() => moveInstance(kind, inst.id, "down")}
                     disabled={idx === instances.length - 1}
                     hitSlop={6}
                     className="p-2 active:opacity-60"
@@ -188,7 +228,9 @@ export function InstanceList({
         })}
         <SettingsRow
           icon={Plus}
-          label={instances.length === 0 ? `Add ${kindLabel}` : `Add another instance`}
+          label={
+            instances.length === 0 ? `Add ${kindLabel}` : "Add another instance"
+          }
           subtitle={
             instances.length > 0
               ? "Configure a second server of this kind"
@@ -204,7 +246,8 @@ export function InstanceList({
         message={
           confirmDelete
             ? `This will remove "${
-                instances.find((i) => i.id === confirmDelete)?.name ?? "this instance"
+                instances.find((i) => i.id === confirmDelete)?.name ??
+                "this instance"
               }" and its credentials. This cannot be undone.`
             : ""
         }

--- a/app/settings/integrations/[kind]/index.tsx
+++ b/app/settings/integrations/[kind]/index.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
-import { View, Text, Pressable, Linking } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { useLocalSearchParams, useRouter, Redirect } from "expo-router";
-import { Plus, Trash2, ArrowUp, ArrowDown, ExternalLink } from "lucide-react-native";
+import { Plus, Trash2, ArrowUp, ArrowDown } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { Card } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { StatusDot } from "@/components/ui/status-dot";
 import { ServiceLogo } from "@/components/ui/service-logo";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
@@ -129,16 +128,6 @@ function KindInstances({
             </Text>
           </View>
         </View>
-        {catalog.docsUrl ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            label="Open docs"
-            className="self-start"
-            icon={<Icon icon={ExternalLink} size={14} color="#a1a1aa" />}
-            onPress={() => void Linking.openURL(catalog.docsUrl!)}
-          />
-        ) : null}
       </Card>
 
       <SettingsGroup

--- a/app/settings/integrations/browse.tsx
+++ b/app/settings/integrations/browse.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import { useRouter } from "expo-router";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { Check, SearchX } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { TextInput } from "@/components/ui/text-input";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ServiceLogo } from "@/components/ui/service-logo";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { BackHeader } from "@/components/common/back-header";
+import { SettingsGroup } from "@/components/settings/settings-group";
+import { SettingsRow } from "@/components/settings/settings-row";
+import { SERVICE_DEFAULTS_KIND_LABEL } from "@/components/settings/service-kind-shared";
+import { useConfigStore } from "@/store/config-store";
+import { lightHaptic } from "@/lib/haptics";
+import {
+  SERVICE_CATALOG,
+  CATEGORY_ORDER,
+  SERVICE_CATEGORY_LABELS,
+  servicesInCategory,
+  filterCatalog,
+} from "@/lib/service-catalog";
+import { isConfigured, resolveBrowseRoute } from "@/lib/integration-status";
+import type { ServiceId } from "@/lib/constants";
+
+/**
+ * The full service catalog: search plus category sections.
+ *
+ * Browsing never writes to the store. Every kind already owns a seeded
+ * placeholder instance (defaultInstances()), so tapping an unconfigured
+ * service opens that slot's editor rather than creating a second one.
+ */
+export default function BrowseIntegrations() {
+  const router = useRouter();
+  const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const [query, setQuery] = useState("");
+
+  const trimmed = query.trim();
+  // Not debounced on purpose: this filters 25 in-memory strings and never
+  // touches the network. app/search.tsx debounces at 300ms because every
+  // keystroke there fires a request per service.
+  const results = useMemo(() => filterCatalog(trimmed), [trimmed]);
+
+  const open = (kind: ServiceId) => {
+    lightHaptic();
+    router.push(resolveBrowseRoute(kind, serviceInstances[kind] ?? []) as never);
+  };
+
+  const renderRow = (kind: ServiceId) => {
+    const instances = serviceInstances[kind] ?? [];
+    const configured = isConfigured(instances);
+    // An already-configured kind lands on its instance list, so say what the
+    // tap is for rather than leaving "Already set up" reading as a dead end.
+    const count = instances.filter(
+      (i) => i.localUrl.length > 0 || i.remoteUrl.length > 0,
+    ).length;
+    return (
+      <SettingsRow
+        key={kind}
+        leading={<ServiceLogo id={kind} size={20} online={configured} />}
+        label={SERVICE_DEFAULTS_KIND_LABEL[kind]}
+        subtitle={
+          configured
+            ? `${count} set up · tap to add another`
+            : SERVICE_CATALOG[kind].tagline
+        }
+        right={
+          configured ? <Icon icon={Check} size={16} color="#22c55e" /> : null
+        }
+        onPress={() => open(kind)}
+      />
+    );
+  };
+
+  return (
+    <ScreenWrapper>
+      <BackHeader title="Add a service" />
+
+      <TextInput
+        placeholder="Search services"
+        value={query}
+        onChangeText={setQuery}
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="search"
+        containerClassName="mb-4"
+      />
+
+      {trimmed.length === 0 ? (
+        // Default view is already grouped by category, so there is no chip row
+        // on top of it — that would be a second control for a distinction the
+        // page has already made.
+        CATEGORY_ORDER.map((category, i) => (
+          <Animated.View
+            key={category}
+            entering={FadeInDown.delay(Math.min(i, 4) * 35).duration(240)}
+          >
+            <SettingsGroup title={SERVICE_CATEGORY_LABELS[category]}>
+              {servicesInCategory(category).map(renderRow)}
+            </SettingsGroup>
+          </Animated.View>
+        ))
+      ) : results.length > 0 ? (
+        <SettingsGroup title="Results">{results.map(renderRow)}</SettingsGroup>
+      ) : (
+        <EmptyState
+          icon={<Icon icon={SearchX} size={32} color="#71717a" />}
+          title="No services match"
+          message={`Nothing for "${trimmed}". Try a different name.`}
+        />
+      )}
+    </ScreenWrapper>
+  );
+}

--- a/app/settings/integrations/index.tsx
+++ b/app/settings/integrations/index.tsx
@@ -1,0 +1,218 @@
+import { useMemo } from "react";
+import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { Plus, Plug } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { StatusDot } from "@/components/ui/status-dot";
+import { ServiceLogo } from "@/components/ui/service-logo";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { BackHeader } from "@/components/common/back-header";
+import { SettingsGroup } from "@/components/settings/settings-group";
+import { SettingsRow } from "@/components/settings/settings-row";
+import { SERVICE_DEFAULTS_KIND_LABEL } from "@/components/settings/service-kind-shared";
+import { useConfigStore } from "@/store/config-store";
+import { useServiceHealth } from "@/hooks/use-service-health";
+import { lanGuardBlockReason } from "@/lib/http-client";
+import { SERVICE_CATALOG } from "@/lib/service-catalog";
+import {
+  buildIntegrationRows,
+  summarizeIntegrations,
+  integrationSubtitle,
+  resolveKindRoute,
+  type InstanceProbeContext,
+} from "@/lib/integration-status";
+import { SERVICE_IDS, type ServiceId } from "@/lib/constants";
+
+/** Sensible first integrations for someone with an empty install. */
+const STARTING_POINTS: ServiceId[] = ["qbittorrent", "radarr", "sonarr", "plex"];
+
+export default function IntegrationsHub() {
+  const router = useRouter();
+  const serviceInstances = useConfigStore((s) => s.serviceInstances);
+  const getActiveUrl = useConfigStore((s) => s.getActiveUrl);
+  // Re-resolve the probe context whenever the network verdict changes: the
+  // same LAN URL is reachable at home and blocked on cellular.
+  const networkAwayFromHome = useConfigStore((s) => s.networkAwayFromHome);
+  const isOnWifi = useConfigStore((s) => s.isOnWifi);
+
+  const { data: healthData, isPending, isPlaceholderData } = useServiceHealth();
+  // "Determining": the first probe batch, or a re-keyed refetch after a
+  // network or workspace change. Same derivation as the Services tab.
+  const determining = isPending || isPlaceholderData;
+
+  const rows = useMemo(() => {
+    const context: Record<string, InstanceProbeContext> = {};
+    for (const kind of SERVICE_IDS) {
+      for (const inst of serviceInstances[kind] ?? []) {
+        const activeUrl = getActiveUrl(kind, inst.id);
+        context[inst.id] = {
+          activeUrl,
+          lanBlocked: lanGuardBlockReason(activeUrl, inst) !== null,
+        };
+      }
+    }
+    return buildIntegrationRows(
+      serviceInstances,
+      determining ? undefined : healthData,
+      context,
+    );
+    // networkAwayFromHome / isOnWifi feed lanGuardBlockReason indirectly.
+  }, [
+    serviceInstances,
+    healthData,
+    determining,
+    getActiveUrl,
+    networkAwayFromHome,
+    isOnWifi,
+  ]);
+
+  const summary = summarizeIntegrations(rows);
+  const configured = rows.filter((r) => r.configured);
+  const attention = rows
+    .flatMap((r) => r.rows)
+    .filter((r) => r.state === "attention");
+
+  const goBrowse = () => router.push("/settings/integrations/browse");
+
+  const renderCatalogRow = (kind: ServiceId) => (
+    <SettingsRow
+      key={kind}
+      leading={<ServiceLogo id={kind} size={20} />}
+      label={SERVICE_DEFAULTS_KIND_LABEL[kind]}
+      subtitle={SERVICE_CATALOG[kind].tagline}
+      onPress={() =>
+        router.push(
+          resolveKindRoute(kind, serviceInstances[kind] ?? []) as never,
+        )
+      }
+    />
+  );
+
+  // Nothing anywhere has a URL: this is the app's first-run service setup.
+  // The attention check matters for one real case: a service enabled with no
+  // URL is "unconfigured" for this list but still needs saying, so it must not
+  // be swallowed by the welcome card.
+  if (configured.length === 0 && attention.length === 0) {
+    return (
+      <ScreenWrapper>
+        <BackHeader title="Integrations" />
+        <Card className="items-center py-6 mb-4">
+          <View className="w-14 h-14 rounded-2xl bg-primary/15 items-center justify-center mb-3">
+            <Icon icon={Plug} size={26} color="#60a5fa" />
+          </View>
+          <Text className="text-zinc-100 text-lg font-bold">
+            No services yet
+          </Text>
+          <Text className="text-zinc-400 text-sm text-center mt-1 px-4">
+            Connect your first service to fill the dashboard. Most people start
+            with a download client.
+          </Text>
+          <Button
+            label="Browse services"
+            className="mt-4"
+            icon={<Icon icon={Plus} size={16} color="#fff" />}
+            onPress={goBrowse}
+          />
+        </Card>
+
+        <SettingsGroup title="Popular starting points">
+          {STARTING_POINTS.map(renderCatalogRow)}
+        </SettingsGroup>
+      </ScreenWrapper>
+    );
+  }
+
+  return (
+    <ScreenWrapper>
+      <BackHeader title="Integrations" />
+
+      <Text className="text-zinc-500 text-xs mb-4 ml-1" numberOfLines={2}>
+        {summary.line}
+      </Text>
+
+      {attention.length > 0 ? (
+        <Animated.View entering={FadeInDown.duration(260)}>
+          <SettingsGroup title="Needs attention">
+            {attention.map((row) => (
+              <SettingsRow
+                key={row.instanceId}
+                leading={<ServiceLogo id={row.kind} size={20} />}
+                label={row.instanceName}
+                subtitle={row.reason}
+                subtitleTone="warn"
+                right={<StatusDot state={row.status ?? "offline"} size="sm" />}
+                onPress={() =>
+                  router.push(
+                    `/settings/integrations/${row.kind}/${row.instanceId}` as never,
+                  )
+                }
+              />
+            ))}
+          </SettingsGroup>
+        </Animated.View>
+      ) : null}
+
+      <Animated.View entering={FadeInDown.delay(35).duration(260)}>
+        <SettingsGroup
+          title="Your services"
+          footer="Instances are shared across dashboards. Attach them to a workspace in its settings."
+        >
+          {configured.map((row) => {
+            const subtitle = integrationSubtitle(row);
+            return (
+              <SettingsRow
+                key={row.kind}
+                leading={
+                  <ServiceLogo
+                    id={row.kind}
+                    size={20}
+                    online={row.enabledCount > 0}
+                  />
+                }
+                label={row.label}
+                subtitle={subtitle.text}
+                subtitleTone={subtitle.tone}
+                right={
+                  row.enabledCount === 0 ? (
+                    <Badge label="Off" variant="default" />
+                  ) : row.state === "away" ? (
+                    // Away is not a health verdict — the subtitle already says
+                    // "away from home". A dot here would read as broken.
+                    null
+                  ) : (
+                    <StatusDot
+                      state={
+                        row.state === "checking"
+                          ? "checking"
+                          : (row.status ?? "checking")
+                      }
+                      size="sm"
+                    />
+                  )
+                }
+                onPress={() =>
+                  router.push(resolveKindRoute(row.kind, row.instances) as never)
+                }
+              />
+            );
+          })}
+        </SettingsGroup>
+      </Animated.View>
+
+      <Animated.View entering={FadeInDown.delay(70).duration(260)}>
+        <SettingsGroup>
+          <SettingsRow
+            icon={Plus}
+            label="Add a service"
+            subtitle={`${summary.available} available`}
+            onPress={goBrowse}
+          />
+        </SettingsGroup>
+      </Animated.View>
+    </ScreenWrapper>
+  );
+}

--- a/app/tautulli-stats.tsx
+++ b/app/tautulli-stats.tsx
@@ -89,7 +89,7 @@ export default function TautulliStatsScreen() {
         <BackHeader title="Tautulli Stats" />
         <EmptyState
           title="No Tautulli configured"
-          message="Enable Tautulli in Settings to see stats"
+          message="Enable Tautulli in Settings → Integrations to see stats"
         />
       </ScreenWrapper>
     );

--- a/components/dashboard/add-widget-sheet.tsx
+++ b/components/dashboard/add-widget-sheet.tsx
@@ -307,7 +307,7 @@ function LockedRow({ widget, index }: LockedRowProps) {
             className="text-zinc-600 text-xs mt-0.5"
             numberOfLines={1}
           >
-            Enable {serviceName} in Settings
+            Enable {serviceName} in Settings → Integrations
           </Text>
         </View>
         <View className="w-7 h-7 rounded-full bg-surface-light items-center justify-center border border-border">

--- a/components/dashboard/widget-settings/calendar-settings.tsx
+++ b/components/dashboard/widget-settings/calendar-settings.tsx
@@ -74,7 +74,7 @@ export function CalendarSettings({ slotId }: WidgetSettingsComponentProps) {
             description={
               sonarrEnabled
                 ? "Show upcoming episodes from monitored series"
-                : "Enable Sonarr in Settings to use this source"
+                : "Enable Sonarr in Settings → Integrations"
             }
             value={settings.includeSonarr && sonarrEnabled}
             onValueChange={(includeSonarr) => update({ includeSonarr })}
@@ -85,7 +85,7 @@ export function CalendarSettings({ slotId }: WidgetSettingsComponentProps) {
             description={
               radarrEnabled
                 ? "Show upcoming movies on the Radarr calendar"
-                : "Enable Radarr in Settings to use this source"
+                : "Enable Radarr in Settings → Integrations"
             }
             value={settings.includeRadarr && radarrEnabled}
             onValueChange={(includeRadarr) => update({ includeRadarr })}

--- a/components/dashboard/widget-settings/recently-downloaded-settings.tsx
+++ b/components/dashboard/widget-settings/recently-downloaded-settings.tsx
@@ -56,7 +56,7 @@ export function RecentlyDownloadedSettings({ slotId }: WidgetSettingsComponentPr
             description={
               sonarrEnabled
                 ? "Show recently imported episodes"
-                : "Enable Sonarr in Settings to use this source"
+                : "Enable Sonarr in Settings → Integrations"
             }
             value={settings.includeSonarr && sonarrEnabled}
             onValueChange={(includeSonarr) => update({ includeSonarr })}
@@ -67,7 +67,7 @@ export function RecentlyDownloadedSettings({ slotId }: WidgetSettingsComponentPr
             description={
               radarrEnabled
                 ? "Show recently imported movies"
-                : "Enable Radarr in Settings to use this source"
+                : "Enable Radarr in Settings → Integrations"
             }
             value={settings.includeRadarr && radarrEnabled}
             onValueChange={(includeRadarr) => update({ includeRadarr })}

--- a/components/dashboard/widget-settings/still-pending-settings.tsx
+++ b/components/dashboard/widget-settings/still-pending-settings.tsx
@@ -84,7 +84,7 @@ export function StillPendingSettings({ slotId }: WidgetSettingsComponentProps) {
             description={
               sonarrEnabled
                 ? "Show aired episodes that haven't downloaded"
-                : "Enable Sonarr in Settings to use this source"
+                : "Enable Sonarr in Settings → Integrations"
             }
             value={settings.includeSonarr && sonarrEnabled}
             onValueChange={(includeSonarr) => update({ includeSonarr })}
@@ -95,7 +95,7 @@ export function StillPendingSettings({ slotId }: WidgetSettingsComponentProps) {
             description={
               radarrEnabled
                 ? "Show released movies that haven't downloaded"
-                : "Enable Radarr in Settings to use this source"
+                : "Enable Radarr in Settings → Integrations"
             }
             value={settings.includeRadarr && radarrEnabled}
             onValueChange={(includeRadarr) => update({ includeRadarr })}

--- a/components/integrations/auth-card.tsx
+++ b/components/integrations/auth-card.tsx
@@ -1,0 +1,98 @@
+import { View, Text } from "react-native";
+import { LogIn } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { TextInput } from "@/components/ui/text-input";
+import { secretsShapeFor, type ServiceCatalogEntry } from "@/lib/service-catalog";
+
+/**
+ * The credential form for one instance.
+ *
+ * Which fields render is decided by the catalog entry, not by a chain of
+ * `serviceId === "..."` comparisons. `oauth` is additive: Plex shows the
+ * Connect button AND the API-key field, because the PIN flow writes into the
+ * same secret the field edits and not everyone can complete a browser flow.
+ */
+export function AuthCard({
+  entry,
+  apiKey,
+  onApiKeyChange,
+  username,
+  onUsernameChange,
+  password,
+  onPasswordChange,
+  onConnectPlex,
+  connecting,
+}: {
+  entry: ServiceCatalogEntry;
+  apiKey: string;
+  onApiKeyChange: (v: string) => void;
+  username: string;
+  onUsernameChange: (v: string) => void;
+  password: string;
+  onPasswordChange: (v: string) => void;
+  onConnectPlex: () => void;
+  connecting: boolean;
+}) {
+  const usesUserPass = secretsShapeFor(entry.authShape) === "userPass";
+  const usesPasswordOnly = entry.authShape === "passwordOnly";
+
+  return (
+    <Card className="gap-4 mb-4">
+      <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+        Authentication
+      </Text>
+
+      {entry.oauth === "plex" ? (
+        <View className="gap-2">
+          <Button
+            label="Connect with Plex"
+            onPress={onConnectPlex}
+            loading={connecting}
+            icon={<Icon icon={LogIn} size={18} color="#fff" />}
+          />
+          <Text className="text-zinc-500 text-xs">
+            Sign in to auto-fill this server&apos;s URLs and token, or enter a
+            token manually below.
+          </Text>
+        </View>
+      ) : null}
+
+      {usesUserPass ? (
+        <>
+          {usesPasswordOnly ? null : (
+            <TextInput
+              label="Username"
+              placeholder="admin"
+              value={username}
+              onChangeText={onUsernameChange}
+            />
+          )}
+          <TextInput
+            label="Password"
+            placeholder="••••••••"
+            value={password}
+            onChangeText={onPasswordChange}
+            secureTextEntry
+          />
+        </>
+      ) : (
+        <View className="gap-1.5">
+          <TextInput
+            label="API Key"
+            placeholder="Enter API key"
+            value={apiKey}
+            onChangeText={onApiKeyChange}
+            secureTextEntry
+          />
+          {entry.apiKeyHint ? (
+            <Text className="text-zinc-600 text-xs">
+              Find it in {entry.apiKeyHint}
+            </Text>
+          ) : null}
+        </View>
+      )}
+    </Card>
+  );
+}

--- a/components/integrations/service-editor.tsx
+++ b/components/integrations/service-editor.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { View, Text, BackHandler, Pressable, Linking, Platform } from "react-native";
+import { View, Text, Pressable, Linking, Platform } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import * as WebBrowser from "expo-web-browser";
-import { useFocusEffect } from "expo-router";
+import { useNavigation, usePreventRemove } from "@react-navigation/native";
+import { useRouter } from "expo-router";
 import { toast, toastError } from "@/components/ui/toast";
-import { Trash2, Copy, LogIn } from "lucide-react-native";
+import { Trash2, Copy, Layers } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
 import { ScreenWrapper } from "@/components/common/screen-wrapper";
 import { Card } from "@/components/ui/card";
@@ -27,7 +28,9 @@ import {
   discoverServers,
   type PlexServer,
 } from "@/services/plex-auth";
-import type { ServiceId } from "@/lib/constants";
+import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
+import { SERVICE_CATALOG, secretsShapeFor } from "@/lib/service-catalog";
+import { kindListRoute } from "@/lib/integration-status";
 import {
   CATEGORIES_FOR_KIND,
   CATEGORY_LABELS,
@@ -45,6 +48,9 @@ import { useModalFlow } from "@/hooks/use-modal-flow";
 import { ActionSheet } from "@/components/ui/action-sheet";
 import { ArrDefaultsCard } from "@/components/settings/arr-defaults-card";
 import { QbtMutedCategories } from "@/components/settings/qbt-muted-categories";
+import { SettingsGroup } from "@/components/settings/settings-group";
+import { SettingsRow } from "@/components/settings/settings-row";
+import { AuthCard } from "@/components/integrations/auth-card";
 import {
   SERVICE_DEFAULTS_KIND_LABEL,
   EMPTY_INSTANCES,
@@ -120,6 +126,17 @@ export function ServiceEditor({
   // hooks/use-modal-flow.ts. The HTTP-warning promise resolves only once the
   // confirm is fully dismissed, so handleSave's continuation (AddToDashboards
   // sheet or onBack's unmount) never runs mid-dismiss.
+  const navigation = useNavigation();
+  const allowRemoveRef = useRef(false);
+  // The navigation action usePreventRemove intercepted, replayed verbatim once
+  // the user resolves the unsaved sheet. Consumed once by leave(), so a sheet
+  // the user cancelled can never replay its action on a later, unrelated save.
+  // A ref, not state: Save flips the bypass and navigates in the same tick, and
+  // a state flip would land after the navigation had already tripped the guard.
+  const leaveActionRef = useRef<Parameters<
+    typeof navigation.dispatch
+  >[0] | null>(null);
+
   const flow = useModalFlow<{
     unsaved: void;
     confirmDelete: void;
@@ -128,16 +145,19 @@ export function ServiceEditor({
     serverPicker: PlexServer[];
   }>();
 
-  // Deluge's Web UI has a single password and no username at all, so it takes
-  // the username/password secrets shape (below) but hides the username field.
-  const usesPasswordOnly = serviceId === "deluge";
-  const usesBasicAuth =
-    usesPasswordOnly ||
-    serviceId === "qbittorrent" ||
-    serviceId === "rtorrent" ||
-    serviceId === "transmission" ||
-    serviceId === "glances" ||
-    serviceId === "nzbget";
+  // The credential form shape comes from the catalog rather than a chain of
+  // `serviceId === "..."` comparisons, so a new service is a data entry.
+  //
+  // NOTE: this is the FORM shape, not SERVICE_DEFAULTS[id].httpAuth. qBittorrent
+  // and Deluge take a username/password pair but authenticate against a login
+  // endpoint and carry a session cookie rather than sending HTTP Basic, so the
+  // two sets differ. See the warning on ServiceAuthShape in lib/service-catalog.ts.
+  const catalogEntry = SERVICE_CATALOG[serviceId];
+  const usesUserPass = secretsShapeFor(catalogEntry.authShape) === "userPass";
+  // AuthCard owns the username/password vs API-key split; this component still
+  // needs the shape for the dirty check, the configured snapshot and the write.
+  const defaultPort = SERVICE_DEFAULTS[serviceId].defaultPort;
+  const router = useRouter();
 
   // Snapshot at mount whether this instance has never been configured before
   // (no URL, no creds). Covers two flows that should both surface the prompt:
@@ -154,7 +174,7 @@ export function ServiceEditor({
     () =>
       config.localUrl.length === 0 &&
       config.remoteUrl.length === 0 &&
-      (usesBasicAuth
+      (usesUserPass
         ? !secrets.username && !secrets.password
         : !secrets.apiKey),
   );
@@ -167,41 +187,62 @@ export function ServiceEditor({
     localUrl !== config.localUrl ||
     remoteUrl !== config.remoteUrl ||
     headersJson !== savedHeadersJson ||
-    (usesBasicAuth
+    (usesUserPass
       ? username !== (secrets.username ?? "") || password !== (secrets.password ?? "")
       : apiKey !== (secrets.apiKey ?? ""));
 
-  const handleBack = () => {
-    if (!isDirty) {
-      onBack();
-      return;
-    }
-    flow.open("unsaved");
-  };
-
-  // Intercept Android hardware back / swipe-back so it closes the editor
-  // (with the unsaved-changes guard) instead of popping the Settings tab.
-  useFocusEffect(
-    useCallback(() => {
-      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
-        handleBack();
-        return true;
-      });
-      return () => sub.remove();
-    }, [handleBack]),
+  // Unsaved-changes guard. usePreventRemove intercepts the Android hardware
+  // back, the iOS edge swipe and our own header arrow through ONE code path,
+  // and hands us the navigation action the user actually asked for so we can
+  // replay it verbatim after they choose. This is the pattern already used by
+  // app/dashboard-edit/[id].tsx and app/overseerr/customize-discover.tsx;
+  // `beforeRemove` is not fully supported on native-stack.
+  usePreventRemove(
+    isDirty,
+    useCallback(
+      ({ data }) => {
+        if (allowRemoveRef.current) {
+          allowRemoveRef.current = false;
+          navigation.dispatch(data.action);
+          return;
+        }
+        leaveActionRef.current = data.action;
+        flow.open("unsaved");
+      },
+      [navigation, flow],
+    ),
   );
+
+  // Leave the editor, replaying the gesture the user actually made when there
+  // was one. Callers that did not come from the guard (the Save button) null
+  // the ref first, so they get a plain back instead of a stale action.
+  const leave = () => {
+    const action = leaveActionRef.current;
+    leaveActionRef.current = null;
+    allowRemoveRef.current = true;
+    if (action) navigation.dispatch(action);
+    else onBack();
+  };
 
   const confirmHttpWarning = (message: string) =>
     new Promise<boolean>((resolve) => {
       flow.open("httpWarning", { message, resolve });
     });
 
-  const handleSave = async () => {
-    if (!inst) return;
+  /**
+   * "saved"    — persisted, caller should leave.
+   * "prompted" — persisted, but the first-save AddToDashboards sheet is now
+   *              queued. The caller must NOT queue a leave: a whenClear
+   *              continuation supersedes a pending open, so doing so would
+   *              silently swallow the sheet (lib/modal-flow.ts).
+   * "aborted"  — validation failed or the user backed out; stay put.
+   */
+  const handleSave = async (): Promise<"saved" | "prompted" | "aborted"> => {
+    if (!inst) return "aborted";
     const trimmedName = name.trim();
     if (!trimmedName) {
       toast("Name cannot be empty", "error");
-      return;
+      return "aborted";
     }
 
     const normLocal = normalizeServiceUrl(localUrl);
@@ -212,16 +253,16 @@ export function ServiceEditor({
     const localResult = validateServiceUrl(normLocal, "local");
     if (localResult.kind === "invalid") {
       toast(localResult.message, "error");
-      return;
+      return "aborted";
     }
     const remoteResult = validateServiceUrl(normRemote, "remote");
     if (remoteResult.kind === "invalid") {
       toast(remoteResult.message, "error");
-      return;
+      return "aborted";
     }
     if (remoteResult.kind === "warn") {
       const confirmed = await confirmHttpWarning(remoteResult.message);
-      if (!confirmed) return;
+      if (!confirmed) return "aborted";
     }
 
     // Mirror the schema validator so the user can't save an invalid header
@@ -230,11 +271,11 @@ export function ServiceEditor({
     for (const [name, val] of Object.entries(customHeaders)) {
       if (!headerNameRe.test(name)) {
         toast(`Invalid header name: "${name}"`, "error");
-        return;
+        return "aborted";
       }
       if (/[\r\n]/.test(val)) {
         toast(`Header "${name}" value contains newlines`, "error");
-        return;
+        return "aborted";
       }
     }
 
@@ -243,7 +284,7 @@ export function ServiceEditor({
       localUrl: normLocal,
       remoteUrl: normRemote,
     });
-    if (usesBasicAuth) {
+    if (usesUserPass) {
       await updateInstanceSecrets(instanceId, {
         username,
         password,
@@ -273,17 +314,17 @@ export function ServiceEditor({
     // and the hint that widgets are added separately.
     if ((isNew || wasInitiallyUnconfigured) && !promptShown) {
       const hasUrl = normLocal.length > 0 || normRemote.length > 0;
-      const hasCreds = usesBasicAuth
+      const hasCreds = usesUserPass
         ? username.length > 0 || password.length > 0
         : apiKey.length > 0;
       if (hasUrl && hasCreds) {
         setPromptShown(true);
         flow.open("addToDashboards");
-        return;
+        return "prompted";
       }
     }
 
-    onBack();
+    return "saved";
   };
 
   const handleTest = async () => {
@@ -499,15 +540,22 @@ export function ServiceEditor({
 
   const performDelete = () => {
     flow.close();
-    // The store write swaps this editor for the "not found" branch and
-    // onDeleted unmounts it — both only after the confirm is fully gone.
+    // Only after the confirm is fully gone (issue #83). Pop FIRST, then tear
+    // down: removeInstance flips `inst` to undefined, so awaiting it before
+    // leaving would flash the "Not found" branch under the pop animation.
+    // The store action is not tied to this component and completes fine after
+    // the unmount.
     flow.whenClear(() => {
+      // The guard must not challenge a deletion — the instance is going away,
+      // so there is nothing left to save.
+      leaveActionRef.current = null;
+      allowRemoveRef.current = true;
+      onDeleted();
       void (async () => {
         if (serviceId === "qbittorrent") {
           await qbClearSession(instanceId);
         }
         await removeInstance(serviceId, instanceId);
-        onDeleted();
       })();
     });
   };
@@ -528,13 +576,33 @@ export function ServiceEditor({
     <ScreenWrapper>
       <BackHeader
         title={config.name}
-        onBack={handleBack}
+        // No dirty check here on purpose: usePreventRemove intercepts this
+        // pop exactly like the hardware back and the edge swipe.
+        onBack={onBack}
         right={
           isDirty ? (
             <Text className="text-amber-400 text-xs">• unsaved</Text>
           ) : null
         }
       />
+
+      {/* Enabled sits alone above everything, because it is the one switch in
+          this screen that is neither a connection field nor a preference. */}
+      <Card className="gap-4 mb-4">
+        <Toggle
+          label="Enabled"
+          description="Show this instance in tabs and on dashboards."
+          value={config.enabled}
+          onValueChange={() => toggleInstance(serviceId, instanceId)}
+        />
+      </Card>
+
+      {/* Everything from here to the Save button is deferred; everything after
+          it writes immediately. The two labels make that rule visible instead
+          of leaving the user to discover it one toggle at a time. */}
+      <Text className="text-zinc-500 text-xs font-semibold uppercase tracking-wider mb-2 ml-1">
+        Connection
+      </Text>
 
       <Card className="gap-4 mb-4">
         <TextInput
@@ -543,30 +611,98 @@ export function ServiceEditor({
           value={name}
           onChangeText={setName}
         />
-        <Toggle
-          label="Enabled"
-          value={config.enabled}
-          onValueChange={() => toggleInstance(serviceId, instanceId)}
-        />
       </Card>
 
       <Card className="gap-4 mb-4">
         <TextInput
           label="Local URL"
-          placeholder="http://192.168.1.100:8080"
+          placeholder={`http://192.168.1.100:${defaultPort}`}
           value={localUrl}
           onChangeText={setLocalUrl}
           onBlur={() => setLocalUrl(normalizeServiceUrl(localUrl))}
           keyboardType="url"
         />
-        <TextInput
-          label="Remote URL"
-          placeholder="https://service.mydomain.com"
-          value={remoteUrl}
-          onChangeText={setRemoteUrl}
-          onBlur={() => setRemoteUrl(normalizeServiceUrl(remoteUrl))}
-          keyboardType="url"
+        <View className="gap-1.5">
+          <TextInput
+            label="Remote URL"
+            placeholder="https://service.mydomain.com"
+            value={remoteUrl}
+            onChangeText={setRemoteUrl}
+            onBlur={() => setRemoteUrl(normalizeServiceUrl(remoteUrl))}
+            keyboardType="url"
+          />
+          <Text className="text-zinc-600 text-xs">
+            {SERVICE_DEFAULTS_KIND_LABEL[serviceId]} usually listens on port{" "}
+            {defaultPort}.
+          </Text>
+        </View>
+      </Card>
+
+      <AuthCard
+        entry={catalogEntry}
+        apiKey={apiKey}
+        onApiKeyChange={setApiKey}
+        username={username}
+        onUsernameChange={setUsername}
+        password={password}
+        onPasswordChange={setPassword}
+        onConnectPlex={() => void handleConnectPlex()}
+        connecting={connecting}
+      />
+
+      <Card className="gap-4 mb-4">
+        <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+          Custom Headers
+        </Text>
+        <HeaderListEditor
+          value={customHeaders}
+          onChange={setCustomHeaders}
+          helperText="Sent on every request to this instance. Combined with the global headers (Settings → Network → Custom Headers). The service's own auth (API Key, Plex Token, etc.) always wins on collision."
         />
+      </Card>
+
+      <View className="flex-row gap-3 mb-4">
+        <Button
+          label="Test Connection"
+          onPress={handleTest}
+          variant="outline"
+          loading={testing}
+          className="flex-1"
+        />
+        <Button
+          label="Save"
+          onPress={() => {
+            // Not a guard-intercepted gesture, so drop any action a cancelled
+            // unsaved sheet left behind and just go back.
+            leaveActionRef.current = null;
+            void handleSave().then((outcome) => {
+              // "prompted" leaves via the AddToDashboards sheet's onClose.
+              if (outcome === "saved") leave();
+            });
+          }}
+          className="flex-1"
+        />
+      </View>
+
+      <Text className="text-zinc-500 text-xs font-semibold uppercase tracking-wider mb-1 ml-1">
+        Preferences
+      </Text>
+      <Text className="text-zinc-600 text-xs mb-2 ml-1">
+        Saved as you change them.
+      </Text>
+
+      {/* "Always use Remote URL" and "Allow invalid certificates" live BELOW
+          the Save row rather than up with the URL fields, so the deferred /
+          instant split is literally true. Deferring them is not an option:
+          handleTest reads config.useRemote to pick which slot to probe (the
+          #356 green-toast-next-to-red-dot contradiction), and ignoreCertErrors
+          programs a native host allowlist derived from the SAVED instances
+          (lib/insecure-tls.ts), so a deferred toggle would appear to do
+          nothing until Save. */}
+      <Card className="gap-4 mb-4">
+        <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+          Routing and security
+        </Text>
         <Toggle
           label="Always use Remote URL"
           description="Force the remote URL even when on a configured home network. Leave off to let auto-switch use the local URL at home."
@@ -582,64 +718,6 @@ export function ServiceEditor({
           onValueChange={(v) =>
             updateInstance(serviceId, instanceId, { ignoreCertErrors: v })
           }
-        />
-      </Card>
-
-      <Card className="gap-4 mb-4">
-        <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
-          Authentication
-        </Text>
-        {serviceId === "plex" ? (
-          <View className="gap-2">
-            <Button
-              label="Connect with Plex"
-              onPress={() => void handleConnectPlex()}
-              loading={connecting}
-              icon={<Icon icon={LogIn} size={18} color="#fff" />}
-            />
-            <Text className="text-zinc-500 text-xs">
-              Sign in to auto-fill this server&apos;s URLs and token, or enter a
-              token manually below.
-            </Text>
-          </View>
-        ) : null}
-        {usesBasicAuth ? (
-          <>
-            {usesPasswordOnly ? null : (
-              <TextInput
-                label="Username"
-                placeholder="admin"
-                value={username}
-                onChangeText={setUsername}
-              />
-            )}
-            <TextInput
-              label="Password"
-              placeholder="••••••••"
-              value={password}
-              onChangeText={setPassword}
-              secureTextEntry
-            />
-          </>
-        ) : (
-          <TextInput
-            label="API Key"
-            placeholder="Enter API key"
-            value={apiKey}
-            onChangeText={setApiKey}
-            secureTextEntry
-          />
-        )}
-      </Card>
-
-      <Card className="gap-4 mb-4">
-        <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
-          Custom Headers
-        </Text>
-        <HeaderListEditor
-          value={customHeaders}
-          onChange={setCustomHeaders}
-          helperText="Sent on every request to this instance. Combined with the global headers (Settings → Network → Custom Headers). The service's own auth (API Key, Plex Token, etc.) always wins on collision."
         />
       </Card>
 
@@ -665,16 +743,22 @@ export function ServiceEditor({
 
       <WebhookInstanceIdCard serviceId={serviceId} instanceId={instanceId} />
 
-      <View className="flex-row gap-3 mb-4">
-        <Button
-          label="Test Connection"
-          onPress={handleTest}
-          variant="outline"
-          loading={testing}
-          className="flex-1"
+      {/* Always shown, including at one instance. A single-instance kind is
+          routed straight here from the hub and from Browse, so this row is the
+          only way to reach the list — and therefore the only way to add a
+          second server of this kind. */}
+      <SettingsGroup>
+        <SettingsRow
+          icon={Layers}
+          label="Instances"
+          subtitle={
+            instancesForKind.length === 1
+              ? `1 ${SERVICE_DEFAULTS_KIND_LABEL[serviceId]} server · add another`
+              : `${instancesForKind.length} ${SERVICE_DEFAULTS_KIND_LABEL[serviceId]} servers`
+          }
+          onPress={() => router.push(kindListRoute(serviceId) as never)}
         />
-        <Button label="Save" onPress={handleSave} className="flex-1" />
-      </View>
+      </SettingsGroup>
 
       {/* Delete is only offered when the user has more than one instance of this
           kind — kinds always carry at least one slot, so removing the only
@@ -706,7 +790,7 @@ export function ServiceEditor({
           flow.close();
           // Unmounting the editor while the sheet is still tearing down is
           // the issue-#83 race — leave only once it reports fully gone.
-          flow.whenClear(() => onBack());
+          flow.whenClear(leave);
         }}
         onClosed={flow.onClosed}
       />
@@ -719,14 +803,21 @@ export function ServiceEditor({
           {
             label: "Save",
             // "Save" can open the HTTP-warning modal — run it only once the
-            // sheet has fully closed.
-            onPress: () => flow.whenClear(() => void handleSave()),
+            // sheet has fully closed. Only queue the leave when the save did
+            // not open the first-save sheet, or the continuation would
+            // supersede that pending open and the sheet would never show.
+            onPress: () =>
+              flow.whenClear(() => {
+                void handleSave().then((outcome) => {
+                  if (outcome === "saved") flow.whenClear(leave);
+                });
+              }),
           },
           {
             label: "Discard",
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
             variant: "danger",
-            onPress: () => flow.whenClear(() => onBack()),
+            onPress: () => flow.whenClear(leave),
           },
         ]}
       />

--- a/components/integrations/service-editor.tsx
+++ b/components/integrations/service-editor.tsx
@@ -88,6 +88,7 @@ export function ServiceEditor({
   const updateInstanceSecrets = useConfigStore((s) => s.updateInstanceSecrets);
   const toggleInstance = useConfigStore((s) => s.toggleInstance);
   const removeInstance = useConfigStore((s) => s.removeInstance);
+  const addInstance = useConfigStore((s) => s.addInstance);
 
   // First-save dashboard prompt is offered exactly once per editor session,
   // after the user saves an instance whose initial state was unconfigured
@@ -174,13 +175,21 @@ export function ServiceEditor({
     isBlankInstance(config, secrets, usesUserPass),
   );
 
+  const isBlank = isBlankInstance(config, secrets, usesUserPass);
+
   // Live equivalent of the snapshot above. `handleAdd` writes the new instance
   // to the store before navigating here, so backing out of one you never filled
   // in used to leave a blank server sitting in the list. The first instance of
   // a kind never showed the bug because it reuses the seeded placeholder, which
   // is invisible until configured.
-  const isBlankNewInstance =
-    isNew && isBlankInstance(config, secrets, usesUserPass);
+  const isBlankNewInstance = isNew && isBlank;
+
+  // Removing the only instance of a kind is how you take an integration out of
+  // your services entirely, so it has to be offered. There is nothing to remove
+  // yet when that lone instance is still blank.
+  const isLastInstance = instancesForKind.length === 1;
+  const canRemove = !isLastInstance || !isBlank;
+  const kindLabel = SERVICE_DEFAULTS_KIND_LABEL[serviceId];
 
   // Navigate first, then delete: removeInstance flips `inst` to undefined, so
   // deleting before the pop flashes the "Not found" branch. The store action
@@ -576,6 +585,14 @@ export function ServiceEditor({
           await qbClearSession(instanceId);
         }
         await removeInstance(serviceId, instanceId);
+        // Every kind must keep at least one slot. Leaving the array empty
+        // crashes the workspace editor, which reads list[0].id unguarded for
+        // any kind it considers single-instance (app/dashboard-edit/[id].tsx).
+        // A fresh blank placeholder also restores the kind to "not set up", so
+        // it leaves Your services and reappears under Add a service.
+        if (isLastInstance) {
+          addInstance(serviceId, { name: kindLabel });
+        }
       })();
     });
   };
@@ -780,13 +797,13 @@ export function ServiceEditor({
         />
       </SettingsGroup>
 
-      {/* Delete is only offered when the user has more than one instance of this
-          kind — kinds always carry at least one slot, so removing the only
-          instance would leave the kind in an unpopulated state and force the
-          user to re-create it. Better to let them disable instead. */}
-      {instancesForKind.length > 1 ? (
+      {/* Offered for the last instance too: that is the only way to take an
+          integration back out of your services once it is set up. Hidden only
+          when the lone instance is still blank, since there is nothing to
+          remove. */}
+      {canRemove ? (
         <Button
-          label="Delete instance"
+          label={isLastInstance ? `Remove ${kindLabel}` : "Delete instance"}
           onPress={() => flow.open("confirmDelete")}
           variant="outline"
         />
@@ -794,8 +811,12 @@ export function ServiceEditor({
 
       <ConfirmModal
         {...flow.bind("confirmDelete")}
-        title="Delete instance"
-        message={`This will remove "${config.name}" and its credentials. This cannot be undone.`}
+        title={isLastInstance ? `Remove ${kindLabel}` : "Delete instance"}
+        message={
+          isLastInstance
+            ? `This will remove "${config.name}" and its credentials, and take ${kindLabel} out of your services. You can set it up again from Add a service.`
+            : `This will remove "${config.name}" and its credentials. This cannot be undone.`
+        }
         icon={Trash2}
         tone="danger"
         confirmLabel="Delete"

--- a/components/integrations/service-editor.tsx
+++ b/components/integrations/service-editor.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/services/plex-auth";
 import { SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
 import { SERVICE_CATALOG, secretsShapeFor } from "@/lib/service-catalog";
-import { kindListRoute } from "@/lib/integration-status";
+import { kindListRoute, isBlankInstance } from "@/lib/integration-status";
 import {
   CATEGORIES_FOR_KIND,
   CATEGORY_LABELS,
@@ -170,14 +170,25 @@ export function ServiceEditor({
   //      add from the user's perspective.
   // Re-configuring an already-set-up instance (URL or creds present) won't
   // trigger the prompt — the snapshot stays false through the session.
-  const [wasInitiallyUnconfigured] = useState(
-    () =>
-      config.localUrl.length === 0 &&
-      config.remoteUrl.length === 0 &&
-      (usesUserPass
-        ? !secrets.username && !secrets.password
-        : !secrets.apiKey),
+  const [wasInitiallyUnconfigured] = useState(() =>
+    isBlankInstance(config, secrets, usesUserPass),
   );
+
+  // Live equivalent of the snapshot above. `handleAdd` writes the new instance
+  // to the store before navigating here, so backing out of one you never filled
+  // in used to leave a blank server sitting in the list. The first instance of
+  // a kind never showed the bug because it reuses the seeded placeholder, which
+  // is invisible until configured.
+  const isBlankNewInstance =
+    isNew && isBlankInstance(config, secrets, usesUserPass);
+
+  // Navigate first, then delete: removeInstance flips `inst` to undefined, so
+  // deleting before the pop flashes the "Not found" branch. The store action
+  // is not tied to this component and finishes after the unmount.
+  const dropBlankNewInstance = () => {
+    if (!isBlankNewInstance) return;
+    void removeInstance(serviceId, instanceId);
+  };
 
   const headersJson = JSON.stringify(customHeaders);
   const savedHeadersJson = JSON.stringify(secrets.customHeaders ?? {});
@@ -198,7 +209,7 @@ export function ServiceEditor({
   // app/dashboard-edit/[id].tsx and app/overseerr/customize-discover.tsx;
   // `beforeRemove` is not fully supported on native-stack.
   usePreventRemove(
-    isDirty,
+    isDirty || isBlankNewInstance,
     useCallback(
       ({ data }) => {
         if (allowRemoveRef.current) {
@@ -206,10 +217,19 @@ export function ServiceEditor({
           navigation.dispatch(data.action);
           return;
         }
+        // Abandoning an instance you just added and never filled in. Nothing
+        // to save, so do not ask: drop the empty row and leave.
+        if (!isDirty && isBlankNewInstance) {
+          allowRemoveRef.current = true;
+          navigation.dispatch(data.action);
+          dropBlankNewInstance();
+          return;
+        }
         leaveActionRef.current = data.action;
         flow.open("unsaved");
       },
-      [navigation, flow],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [navigation, flow, isDirty, isBlankNewInstance],
     ),
   );
 
@@ -817,7 +837,11 @@ export function ServiceEditor({
             label: "Discard",
             icon: <Icon icon={Trash2} size={18} color="#ef4444" />,
             variant: "danger",
-            onPress: () => flow.whenClear(leave),
+            onPress: () =>
+              flow.whenClear(() => {
+                leave();
+                dropBlankNewInstance();
+              }),
           },
         ]}
       />

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -241,7 +241,7 @@
         <p>On a fresh install the Dashboard tab shows:</p>
         <div class="quote">
           <strong>No services configured yet.</strong><br>
-          Go to Settings to add your first service.
+          Add your first service in Settings &rarr; Integrations.
         </div>
         <p>
           A three-step intro carousel explains the workspace concept. You can skip it and replay
@@ -251,7 +251,7 @@
         <ul>
           <li>One dashboard named <strong>Default</strong>, holding three widget cards: Service Health, Radarr Queue and Calendar.</li>
           <li>Three pinned bottom tabs: <strong>Downloads</strong>, <strong>Calendar</strong> and <strong>Services</strong>. Together with Dashboard and Settings, that is the five-icon bar you see on day one.</li>
-          <li>One placeholder instance for every supported service, all disabled with blank URLs. That is why you normally tap an existing row in Settings rather than creating anything new.</li>
+          <li>One placeholder instance for every supported service, all disabled with blank URLs. That is why you normally tap an existing row in Integrations rather than creating anything new.</li>
         </ul>
 
         <h3>Want to look around first?</h3>
@@ -272,28 +272,42 @@
       <section id="add-service">
         <h2>3. Add your first service <a class="anchor" href="#add-service" aria-label="Permalink to Add your first service">#</a></h2>
         <p>
-          Everything lives on the <strong>Settings</strong> tab, subtitled "Applies to all dashboards".
-          It has two groups:
+          Services live behind the <strong>Integrations</strong> row on the <strong>Settings</strong>
+          tab, subtitled "Applies to all dashboards". The row itself summarises the state of
+          everything you have connected, for example
+          <strong>"7 connected, 1 needs attention"</strong>.
         </p>
+        <p>Tapping it opens <strong>Integrations</strong>, which has up to three parts:</p>
         <ul>
-          <li><strong>Services</strong>, one row per service kind. Configured kinds sort first, the rest sit under a <strong>Not configured</strong> divider.</li>
-          <li><strong>App</strong>: Network, Notifications, Appearance, Backup &amp; Storage, About.</li>
+          <li><strong>Needs attention</strong>, one row per instance that is enabled but failing, with the reason ("Authentication failed", "Unreachable", "Enabled but no URL set"). Tapping a row opens that instance's editor directly. Instances that are only out of reach because you are away from your home network are listed separately as <strong>away</strong>, not as failures.</li>
+          <li><strong>Your services</strong>, one row per service kind you have set up.</li>
+          <li><strong>Add a service</strong>, which opens the searchable catalogue of everything Dashboarr supports, grouped into Download clients, Media automation, Indexers, Media servers, Requests and automation, and Monitoring. Search matches old names and abbreviations too, so "readarr" finds Bindery and "qbit" finds qBittorrent.</li>
         </ul>
-        <p>Tap a service kind to open its instance list, then tap the instance to open the editor.</p>
+        <p>
+          On a brand-new install Integrations opens on a <strong>"No services yet"</strong> card with
+          a <strong>Browse services</strong> button and a short list of popular starting points.
+        </p>
+        <p>
+          Picking a service opens its editor. A kind that has more than one instance shows its
+          instance list first.
+        </p>
 
         <h3>The instance editor, top to bottom</h3>
         <div class="table-scroll">
           <table>
             <thead><tr><th>Card</th><th>What is in it</th></tr></thead>
             <tbody>
-              <tr><td>(first card)</td><td><strong>Name</strong> and an <strong>Enabled</strong> toggle</td></tr>
-              <tr><td>(second card)</td><td><strong>Local URL</strong>, <strong>Remote URL</strong>, <strong>Always use Remote URL</strong>, <strong>Allow invalid certificates</strong></td></tr>
-              <tr><td>Authentication</td><td>Either <strong>Username</strong> and <strong>Password</strong>, or a single <strong>API Key</strong>. Plex also gets a <strong>Connect with Plex</strong> button.</td></tr>
-              <tr><td>Custom Headers</td><td>Optional per-instance headers for reverse-proxy auth</td></tr>
-              <tr><td>Add Defaults</td><td>Radarr, Sonarr and Lidarr only: Quality Profile, Root Folder, and Metadata Profile for Lidarr</td></tr>
-              <tr><td>Notifications</td><td>Per-instance overrides for each notification category</td></tr>
-              <tr><td>Webhook Attribution</td><td>Only when a backend is paired, and only for Radarr, Sonarr, Tautulli, Seerr, Bazarr and Tracearr</td></tr>
-              <tr><td>(buttons)</td><td><strong>Test Connection</strong> and <strong>Save</strong>, side by side</td></tr>
+              <tr><td>(top card)</td><td>The <strong>Enabled</strong> toggle, on its own</td></tr>
+              <tr><td>Connection: Name</td><td><strong>Name</strong> for this instance</td></tr>
+              <tr><td>Connection: URLs</td><td><strong>Local URL</strong> and <strong>Remote URL</strong>, with the service's usual port as a hint</td></tr>
+              <tr><td>Connection: Authentication</td><td>Either <strong>Username</strong> and <strong>Password</strong>, or a single <strong>API Key</strong> with a hint about where to find it. Plex also gets a <strong>Connect with Plex</strong> button.</td></tr>
+              <tr><td>Connection: Custom Headers</td><td>Optional per-instance headers for reverse-proxy auth</td></tr>
+              <tr><td>(buttons)</td><td><strong>Test Connection</strong> and <strong>Save</strong>, side by side. Everything above them is saved by the Save button.</td></tr>
+              <tr><td>Preferences: Routing and security</td><td><strong>Always use Remote URL</strong>, <strong>Allow invalid certificates</strong></td></tr>
+              <tr><td>Preferences: Torrents</td><td>qBittorrent only: tag added torrents with "Dashboarr"</td></tr>
+              <tr><td>Preferences: Add Defaults</td><td>Radarr, Sonarr and Lidarr only: Quality Profile, Root Folder, and Metadata Profile for Lidarr</td></tr>
+              <tr><td>Preferences: Notifications</td><td>Per-instance overrides for each notification category</td></tr>
+              <tr><td>Preferences: Webhook Attribution</td><td>Only when a backend is paired, and only for Radarr, Sonarr, Tautulli, Seerr, Bazarr and Tracearr</td></tr>
             </tbody>
           </table>
         </div>
@@ -309,11 +323,16 @@
 
         <h3>What saves instantly, and what does not</h3>
         <p>
-          <strong>Enabled</strong>, <strong>Always use Remote URL</strong>,
-          <strong>Allow invalid certificates</strong> and the Add Defaults pickers apply the moment
-          you flip them. <strong>Name</strong>, both URLs, credentials and Custom Headers only
-          persist when you press <strong>Save</strong>. While changes are pending the editor title
-          shows <strong>"unsaved"</strong> in amber, and backing out offers Save or Discard.
+          The editor is split by that rule, so you can read it off the screen. Everything under
+          <strong>Connection</strong>, above the Save button, only persists when you press
+          <strong>Save</strong>: Name, both URLs, credentials and Custom Headers. Everything under
+          <strong>Preferences</strong>, below it, applies the moment you change it, and the section
+          says so. The <strong>Enabled</strong> toggle sits above both and is also instant.
+        </p>
+        <p>
+          While changes are pending the editor title shows <strong>"unsaved"</strong> in amber.
+          Leaving with unsaved changes offers Save or Discard, whether you use the back arrow, the
+          Android back gesture or the iOS edge swipe.
         </p>
 
         <h3>Test Connection</h3>
@@ -343,11 +362,13 @@
 
         <h3>Status dots</h3>
         <p>
-          Once a kind has at least one enabled instance, its Settings row shows a coloured dot:
+          Once a kind has at least one enabled instance, its Integrations row shows a coloured dot:
           <strong>green</strong> for reachable, <strong>amber</strong> for reachable but credentials
-          rejected, <strong>red</strong> for unreachable. While the first health check is running
-          there is no dot at all. Health polls every 30 seconds, so Settings can lag a config change
-          by up to half a minute. Test Connection is the only immediate probe.
+          rejected, <strong>red</strong> for unreachable. While the first health check is running the
+          dot pulses grey. Unlike the dashboard's Service Health widget, this list reports the
+          <em>worst</em> instance of a kind, so a broken second server is never hidden behind a
+          healthy first one. Health polls every 30 seconds, so the list can lag a config change by up
+          to half a minute. Test Connection is the only immediate probe.
         </p>
 
         <h3>Multiple instances</h3>
@@ -609,7 +630,7 @@
         <p>
           <strong>Add widget</strong> at the bottom opens a sheet grouped into <strong>Available</strong>
           and <strong>Requires setup</strong>. "Requires setup" items are widgets whose service is
-          attached to this dashboard but currently disabled in Settings. Widgets for services that are
+          attached to this dashboard but currently disabled in Integrations. Widgets for services that are
           not attached at all are hidden entirely, so if a widget you expect is missing, attach its
           service first.
         </p>
@@ -666,8 +687,8 @@
           save without touching a checkbox.
         </div>
         <p>
-          Instances that are disabled in Settings cannot be newly attached. Their rows are dimmed and
-          read "Enable in Settings to attach".
+          Instances that are disabled cannot be newly attached. Their rows are dimmed and
+          read "Enable in Settings &rarr; Integrations to attach".
         </p>
 
         <h3>Appearance</h3>
@@ -1046,7 +1067,7 @@
           service you think it does.
         </p>
 
-        <h3>A service is green in Settings but missing from the Services tab.</h3>
+        <h3>A service is green in Integrations but missing from the Services tab.</h3>
         <p>
           The Services tab only shows services attached to the dashboard you are on. Attach it via
           Dashboard, sliders icon, Attached instances.
@@ -1055,7 +1076,7 @@
         <h3>A widget I expect is not in the Add widget sheet.</h3>
         <p>
           Its service is not attached to this dashboard. Attach it first. If it appears greyed out
-          under "Requires setup", the service is attached but disabled in Settings.
+          under "Requires setup", the service is attached but disabled in Integrations.
         </p>
 
         <h3>A widget disappeared from the dashboard.</h3>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -377,8 +377,14 @@
           household. Use <strong>"Add another instance"</strong> at the bottom of the instance list.
           New instances auto-name themselves (<code>Radarr</code>, then <code>Radarr 2</code>). With
           two or more, each row gains reorder arrows and a delete button, and that order is the order
-          shown in the per-screen instance switcher. You cannot delete the last remaining instance of
-          a kind, so disable it instead.
+          shown in the per-screen instance switcher. Reach the list from the
+          <strong>Instances</strong> row at the bottom of any instance editor.
+        </p>
+        <p>
+          To take a service back out of your setup entirely, open its last remaining instance and use
+          <strong>"Remove &lt;service&gt;"</strong>. That clears its URLs and credentials, drops it from
+          <strong>Your services</strong>, and returns it to <strong>Add a service</strong> as an empty
+          slot ready to set up again.
         </p>
         <p>
           When a kind has two or more enabled instances attached to the current dashboard, its screen

--- a/lib/integration-status.test.ts
+++ b/lib/integration-status.test.ts
@@ -233,6 +233,87 @@ describe("buildIntegrationRows", () => {
     expect(rows.find((r) => r.kind === "radarr")!.state).toBe("unconfigured");
   });
 
+  // hooks/use-service-health.ts turns a kind whose probe body threw into
+  // { status: "offline", instances: [] } via its allSettled fallback. Treating
+  // the missing per-instance row as "not probed yet" hid that failure behind a
+  // permanent "Checking..." dot.
+  it("treats a settled kind with no instance rows as a real verdict", () => {
+    const a = inst({ id: "a" });
+    const map = emptyInstances();
+    map.radarr = [a];
+
+    const rows = buildIntegrationRows(
+      map,
+      [
+        {
+          id: "radarr",
+          name: "Radarr",
+          online: false,
+          status: "offline",
+          instances: [],
+        },
+      ],
+      ctxFor([a]),
+    );
+
+    const radarr = rows.find((r) => r.kind === "radarr")!;
+    expect(radarr.state).toBe("attention");
+    expect(radarr.rows[0].state).toBe("attention");
+    expect(radarr.rows[0].reason).toBe("Unreachable · 192.168.1.5:7878");
+    expect(summarizeIntegrations(rows).attention).toBe(1);
+  });
+
+  it("still reports checking when the kind has not been probed at all", () => {
+    const a = inst({ id: "a" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    // Health for other kinds resolved, this one is absent entirely.
+    const rows = buildIntegrationRows(map, [], ctxFor([a]));
+    expect(rows.find((r) => r.kind === "radarr")!.state).toBe("checking");
+  });
+
+  it("still reports checking for an instance added after the probe was keyed", () => {
+    const a = inst({ id: "a" });
+    const b = inst({ id: "b", name: "Radarr Cabin" });
+    const map = emptyInstances();
+    map.radarr = [a, b];
+
+    // Non-empty instances list that simply predates `b`.
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [{ instanceId: "a", status: "ok" }]),
+      ctxFor([a, b]),
+    );
+
+    const radarr = rows.find((r) => r.kind === "radarr")!;
+    expect(radarr.rows.map((r) => r.state)).toEqual(["ok", "checking"]);
+  });
+
+  it("does not let the settled fallback override away or disabled", () => {
+    const a = inst({ id: "a" });
+    const b = inst({ id: "b", enabled: false });
+    const map = emptyInstances();
+    map.radarr = [a];
+    map.sonarr = [b];
+
+    const thrown = (kind: ServiceId): ServiceHealthStatus => ({
+      id: kind,
+      name: kind,
+      online: false,
+      status: "offline",
+      instances: [],
+    });
+
+    const rows = buildIntegrationRows(
+      map,
+      [thrown("radarr"), thrown("sonarr")],
+      { ...ctxFor([a], { lanBlocked: true }), ...ctxFor([b]) },
+    );
+
+    expect(rows.find((r) => r.kind === "radarr")!.state).toBe("away");
+    expect(rows.find((r) => r.kind === "sonarr")!.state).toBe("off");
+  });
+
   it("returns one row per kind in canonical order", () => {
     const rows = buildIntegrationRows(emptyInstances(), undefined, {});
     expect(rows.map((r) => r.kind)).toEqual([...SERVICE_IDS]);

--- a/lib/integration-status.test.ts
+++ b/lib/integration-status.test.ts
@@ -1,0 +1,470 @@
+import { SERVICE_IDS, type ServiceId } from "@/lib/constants";
+import type { ServiceInstance } from "@/store/config-store";
+import type { ServiceHealthStatus, HealthStatusKind } from "@/lib/types";
+import {
+  classifyInstance,
+  buildIntegrationRows,
+  summarizeIntegrations,
+  integrationSubtitle,
+  resolveKindRoute,
+  resolveBrowseRoute,
+  isConfigured,
+  type InstanceProbeContext,
+} from "@/lib/integration-status";
+
+function inst(over: Partial<ServiceInstance> = {}): ServiceInstance {
+  return {
+    id: "i1",
+    enabled: true,
+    name: "Radarr",
+    localUrl: "http://192.168.1.5:7878",
+    remoteUrl: "",
+    useRemote: false,
+    ...over,
+  };
+}
+
+/** An empty per-kind map, so tests only fill in the kinds they care about. */
+function emptyInstances(): Record<ServiceId, ServiceInstance[]> {
+  return SERVICE_IDS.reduce(
+    (acc, id) => {
+      acc[id] = [];
+      return acc;
+    },
+    {} as Record<ServiceId, ServiceInstance[]>,
+  );
+}
+
+function ctxFor(
+  instances: ServiceInstance[],
+  over: Partial<InstanceProbeContext> = {},
+): Record<string, InstanceProbeContext> {
+  return Object.fromEntries(
+    instances.map((i) => [
+      i.id,
+      { activeUrl: i.localUrl || i.remoteUrl, lanBlocked: false, ...over },
+    ]),
+  );
+}
+
+function health(
+  kind: ServiceId,
+  entries: { instanceId: string; status: HealthStatusKind; responseTime?: number }[],
+): ServiceHealthStatus[] {
+  return [
+    {
+      id: kind,
+      name: kind,
+      online: entries.some((e) => e.status === "ok"),
+      status: entries[0]?.status ?? "offline",
+      instances: entries.map((e) => ({
+        instanceId: e.instanceId,
+        instanceName: "x",
+        online: e.status === "ok",
+        status: e.status,
+        responseTime: e.responseTime,
+      })),
+    },
+  ];
+}
+
+describe("isConfigured", () => {
+  it("is false for a seeded placeholder with no URLs", () => {
+    expect(isConfigured([inst({ enabled: false, localUrl: "", remoteUrl: "" })])).toBe(
+      false,
+    );
+  });
+
+  it("is true when either URL slot is filled, even while disabled", () => {
+    expect(isConfigured([inst({ enabled: false })])).toBe(true);
+    expect(
+      isConfigured([inst({ enabled: false, localUrl: "", remoteUrl: "https://a.b" })]),
+    ).toBe(true);
+  });
+});
+
+describe("classifyInstance", () => {
+  it("reports a healthy enabled instance as ok", () => {
+    const r = classifyInstance("radarr", inst(), { status: "ok" }, false, "http://a");
+    expect(r.state).toBe("ok");
+    expect(r.status).toBe("ok");
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("reports auth failures with a specific reason", () => {
+    const r = classifyInstance(
+      "radarr",
+      inst(),
+      { status: "auth_failed" },
+      false,
+      "http://a",
+    );
+    expect(r.state).toBe("attention");
+    expect(r.reason).toBe("Authentication failed");
+  });
+
+  it("names the host in the unreachable reason", () => {
+    const r = classifyInstance(
+      "radarr",
+      inst(),
+      { status: "offline" },
+      false,
+      "http://192.168.1.5:7878/sub",
+    );
+    expect(r.state).toBe("attention");
+    expect(r.reason).toBe("Unreachable · 192.168.1.5:7878");
+  });
+
+  // The split that stops the hub screaming on cellular.
+  it("reports a LAN-blocked instance as away, never as attention", () => {
+    const r = classifyInstance(
+      "radarr",
+      inst(),
+      { status: "offline" },
+      true,
+      "http://192.168.1.5:7878",
+    );
+    expect(r.state).toBe("away");
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("prefers away over a pending probe", () => {
+    const r = classifyInstance("radarr", inst(), undefined, true, "http://a");
+    expect(r.state).toBe("away");
+  });
+
+  it("reports checking before the first probe resolves", () => {
+    const r = classifyInstance("radarr", inst(), undefined, false, "http://a");
+    expect(r.state).toBe("checking");
+    expect(r.status).toBeUndefined();
+  });
+
+  it("reports a disabled but configured instance as off", () => {
+    const r = classifyInstance(
+      "radarr",
+      inst({ enabled: false }),
+      { status: "ok" },
+      false,
+      "http://a",
+    );
+    expect(r.state).toBe("off");
+  });
+
+  it("reports an untouched placeholder as unconfigured", () => {
+    const r = classifyInstance(
+      "radarr",
+      inst({ enabled: false, localUrl: "", remoteUrl: "" }),
+      undefined,
+      false,
+      "",
+    );
+    expect(r.state).toBe("unconfigured");
+  });
+
+  it("flags an enabled instance with no URL, which health cannot verdict on", () => {
+    const r = classifyInstance(
+      "radarr",
+      inst({ localUrl: "", remoteUrl: "" }),
+      undefined,
+      false,
+      "",
+    );
+    expect(r.state).toBe("attention");
+    expect(r.reason).toBe("Enabled but no URL set");
+  });
+});
+
+describe("buildIntegrationRows", () => {
+  it("surfaces a broken secondary that the health hook's rollup would mask", () => {
+    // useServiceHealth aggregates best-of-any, so this kind reads "ok" there.
+    const a = inst({ id: "a", name: "Radarr Home" });
+    const b = inst({ id: "b", name: "Radarr Cabin" });
+    const map = emptyInstances();
+    map.radarr = [a, b];
+
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [
+        { instanceId: "a", status: "ok" },
+        { instanceId: "b", status: "auth_failed" },
+      ]),
+      ctxFor([a, b]),
+    );
+
+    const radarr = rows.find((r) => r.kind === "radarr")!;
+    expect(radarr.state).toBe("attention");
+    expect(radarr.status).toBe("auth_failed");
+    expect(radarr.rows.map((r) => r.state)).toEqual(["ok", "attention"]);
+  });
+
+  it("does not flag a kind whose only bad instance is disabled", () => {
+    const a = inst({ id: "a" });
+    const b = inst({ id: "b", enabled: false });
+    const map = emptyInstances();
+    map.radarr = [a, b];
+
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [
+        { instanceId: "a", status: "ok" },
+        { instanceId: "b", status: "offline" },
+      ]),
+      ctxFor([a, b]),
+    );
+    expect(rows.find((r) => r.kind === "radarr")!.state).toBe("ok");
+  });
+
+  it("marks a configured kind with nothing enabled as off", () => {
+    const a = inst({ id: "a", enabled: false });
+    const map = emptyInstances();
+    map.radarr = [a];
+    const rows = buildIntegrationRows(map, [], ctxFor([a]));
+    const radarr = rows.find((r) => r.kind === "radarr")!;
+    expect(radarr.state).toBe("off");
+    expect(radarr.configured).toBe(true);
+    expect(radarr.enabledCount).toBe(0);
+  });
+
+  it("treats a seeded placeholder kind as unconfigured, not broken", () => {
+    const a = inst({ id: "a", enabled: false, localUrl: "", remoteUrl: "" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    const rows = buildIntegrationRows(map, undefined, ctxFor([a]));
+    expect(rows.find((r) => r.kind === "radarr")!.state).toBe("unconfigured");
+  });
+
+  it("returns one row per kind in canonical order", () => {
+    const rows = buildIntegrationRows(emptyInstances(), undefined, {});
+    expect(rows.map((r) => r.kind)).toEqual([...SERVICE_IDS]);
+  });
+});
+
+describe("summarizeIntegrations", () => {
+  // The invariant that keeps the Settings row and the hub honest.
+  it("partitions every kind into exactly one bucket", () => {
+    const a = inst({ id: "a" });
+    const b = inst({ id: "b", enabled: false });
+    const c = inst({ id: "c", name: "Sonarr" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    map.sonarr = [c];
+    map.plex = [b];
+
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [{ instanceId: "a", status: "ok" }]).concat(
+        health("sonarr", [{ instanceId: "c", status: "offline" }]),
+      ),
+      ctxFor([a, b, c]),
+    );
+    const s = summarizeIntegrations(rows);
+
+    expect(
+      s.connected + s.attention + s.away + s.checking + s.off + s.available,
+    ).toBe(SERVICE_IDS.length);
+    expect(s.connected).toBe(1);
+    expect(s.attention).toBe(1);
+    expect(s.off).toBe(1);
+    expect(s.available).toBe(SERVICE_IDS.length - 3);
+  });
+
+  it("holds the invariant for a completely empty install", () => {
+    const rows = buildIntegrationRows(emptyInstances(), undefined, {});
+    const s = summarizeIntegrations(rows);
+    expect(
+      s.connected + s.attention + s.away + s.checking + s.off + s.available,
+    ).toBe(SERVICE_IDS.length);
+    expect(s.line).toBe("Set up your first service");
+  });
+
+  it("reports auth failures as the worst dot", () => {
+    const a = inst({ id: "a" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [{ instanceId: "a", status: "auth_failed" }]),
+      ctxFor([a]),
+    );
+    expect(summarizeIntegrations(rows).worst).toBe("auth_failed");
+  });
+
+  it("has no dot when nothing needs attention", () => {
+    const a = inst({ id: "a" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [{ instanceId: "a", status: "ok" }]),
+      ctxFor([a]),
+    );
+    const s = summarizeIntegrations(rows);
+    expect(s.worst).toBeUndefined();
+    expect(s.line).toBe("1 service connected");
+  });
+
+  it("says away rather than needs attention when off the home network", () => {
+    const a = inst({ id: "a" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    const rows = buildIntegrationRows(
+      map,
+      health("radarr", [{ instanceId: "a", status: "offline" }]),
+      ctxFor([a], { lanBlocked: true }),
+    );
+    const s = summarizeIntegrations(rows);
+    expect(s.attention).toBe(0);
+    expect(s.away).toBe(1);
+    expect(s.worst).toBeUndefined();
+    expect(s.line).toBe("0 connected · 1 away from home");
+  });
+
+  it("reports checking while the first probe batch is in flight", () => {
+    const a = inst({ id: "a" });
+    const map = emptyInstances();
+    map.radarr = [a];
+    const rows = buildIntegrationRows(map, undefined, ctxFor([a]));
+    expect(summarizeIntegrations(rows).line).toBe("Checking 1 service…");
+  });
+});
+
+describe("integrationSubtitle", () => {
+  function rowFor(
+    instances: ServiceInstance[],
+    healthData?: ServiceHealthStatus[],
+    over: Partial<InstanceProbeContext> = {},
+  ) {
+    const map = emptyInstances();
+    map.radarr = instances;
+    return buildIntegrationRows(map, healthData, ctxFor(instances, over)).find(
+      (r) => r.kind === "radarr",
+    )!;
+  }
+
+  it("invites setup for an untouched kind", () => {
+    const r = rowFor([inst({ enabled: false, localUrl: "", remoteUrl: "" })]);
+    expect(integrationSubtitle(r)).toEqual({ text: "Not set up", tone: "default" });
+  });
+
+  it("says configured but off for a disabled instance", () => {
+    const r = rowFor([inst({ enabled: false })]);
+    expect(integrationSubtitle(r).text).toBe("Configured, turned off");
+  });
+
+  it("shows the active URL and latency for one healthy instance", () => {
+    const r = rowFor(
+      [inst()],
+      health("radarr", [{ instanceId: "i1", status: "ok", responseTime: 34 }]),
+    );
+    expect(integrationSubtitle(r)).toEqual({
+      text: "http://192.168.1.5:7878 · 34 ms",
+      tone: "default",
+    });
+  });
+
+  it("warns with the reason for one broken instance", () => {
+    const r = rowFor(
+      [inst()],
+      health("radarr", [{ instanceId: "i1", status: "auth_failed" }]),
+    );
+    expect(integrationSubtitle(r)).toEqual({
+      text: "Authentication failed",
+      tone: "warn",
+    });
+  });
+
+  it("stays calm for a single away instance", () => {
+    const r = rowFor(
+      [inst()],
+      health("radarr", [{ instanceId: "i1", status: "offline" }]),
+      { lanBlocked: true },
+    );
+    expect(integrationSubtitle(r)).toEqual({
+      text: "Local only · away from home",
+      tone: "default",
+    });
+  });
+
+  it("counts connected instances when there are several", () => {
+    const a = inst({ id: "a" });
+    const b = inst({ id: "b" });
+    const r = rowFor(
+      [a, b],
+      health("radarr", [
+        { instanceId: "a", status: "ok" },
+        { instanceId: "b", status: "ok" },
+      ]),
+    );
+    expect(integrationSubtitle(r)).toEqual({
+      text: "2 instances · 2 connected",
+      tone: "default",
+    });
+  });
+
+  it("warns when one of several instances is broken", () => {
+    const a = inst({ id: "a" });
+    const b = inst({ id: "b" });
+    const r = rowFor(
+      [a, b],
+      health("radarr", [
+        { instanceId: "a", status: "ok" },
+        { instanceId: "b", status: "offline" },
+      ]),
+    );
+    expect(integrationSubtitle(r)).toEqual({
+      text: "2 instances · 1 needs attention",
+      tone: "warn",
+    });
+  });
+});
+
+describe("resolveKindRoute", () => {
+  it("skips the list level for the single-instance case", () => {
+    expect(resolveKindRoute("radarr", [inst({ id: "abc" })])).toBe(
+      "/settings/integrations/radarr/abc",
+    );
+  });
+
+  it("goes to the instance list when there are several", () => {
+    expect(
+      resolveKindRoute("radarr", [inst({ id: "a" }), inst({ id: "b" })]),
+    ).toBe("/settings/integrations/radarr");
+  });
+
+  it("goes to the instance list when a kind somehow has none", () => {
+    expect(resolveKindRoute("radarr", [])).toBe("/settings/integrations/radarr");
+  });
+});
+
+describe("resolveBrowseRoute", () => {
+  // The regression this guards: with one configured instance, sending Browse
+  // to that instance's editor left no reachable way to add a second server,
+  // because a single-instance kind shows its list nowhere else.
+  it("sends an already-configured kind to its instance list, not the editor", () => {
+    const only = inst({ id: "abc" });
+    expect(resolveBrowseRoute("radarr", [only])).toBe(
+      "/settings/integrations/radarr",
+    );
+    expect(resolveBrowseRoute("radarr", [only])).not.toBe(
+      resolveKindRoute("radarr", [only]),
+    );
+  });
+
+  it("keeps the one-tap path for a kind that is not set up yet", () => {
+    const placeholder = inst({
+      id: "abc",
+      enabled: false,
+      localUrl: "",
+      remoteUrl: "",
+    });
+    expect(resolveBrowseRoute("radarr", [placeholder])).toBe(
+      "/settings/integrations/radarr/abc",
+    );
+  });
+
+  it("sends a configured multi-instance kind to its list too", () => {
+    expect(
+      resolveBrowseRoute("radarr", [inst({ id: "a" }), inst({ id: "b" })]),
+    ).toBe("/settings/integrations/radarr");
+  });
+});

--- a/lib/integration-status.test.ts
+++ b/lib/integration-status.test.ts
@@ -9,6 +9,7 @@ import {
   resolveKindRoute,
   resolveBrowseRoute,
   isConfigured,
+  isBlankInstance,
   type InstanceProbeContext,
 } from "@/lib/integration-status";
 
@@ -80,6 +81,40 @@ describe("isConfigured", () => {
     expect(
       isConfigured([inst({ enabled: false, localUrl: "", remoteUrl: "https://a.b" })]),
     ).toBe(true);
+  });
+});
+
+describe("isBlankInstance", () => {
+  const blank = { localUrl: "", remoteUrl: "" };
+
+  it("is true for a slot with no URL and no credential", () => {
+    expect(isBlankInstance(blank, {}, false)).toBe(true);
+    expect(isBlankInstance(blank, {}, true)).toBe(true);
+  });
+
+  it("is false once either URL slot is filled", () => {
+    expect(isBlankInstance({ localUrl: "http://a", remoteUrl: "" }, {}, false)).toBe(
+      false,
+    );
+    expect(isBlankInstance({ localUrl: "", remoteUrl: "https://a" }, {}, false)).toBe(
+      false,
+    );
+  });
+
+  it("reads the credential slot the service actually uses", () => {
+    // An API-key service with a stray username is still blank, and vice versa,
+    // or backing out would keep a row the user never really configured.
+    expect(isBlankInstance(blank, { apiKey: "k" }, false)).toBe(false);
+    expect(isBlankInstance(blank, { username: "u" }, false)).toBe(true);
+
+    expect(isBlankInstance(blank, { username: "u" }, true)).toBe(false);
+    expect(isBlankInstance(blank, { password: "p" }, true)).toBe(false);
+    expect(isBlankInstance(blank, { apiKey: "k" }, true)).toBe(true);
+  });
+
+  it("treats empty strings as absent", () => {
+    expect(isBlankInstance(blank, { apiKey: "" }, false)).toBe(true);
+    expect(isBlankInstance(blank, { username: "", password: "" }, true)).toBe(true);
   });
 });
 

--- a/lib/integration-status.ts
+++ b/lib/integration-status.ts
@@ -87,6 +87,27 @@ export function isConfigured(instances: readonly ServiceInstance[]): boolean {
   );
 }
 
+/**
+ * True when an instance holds neither a URL nor a credential, i.e. it is an
+ * empty slot rather than a server anyone configured.
+ *
+ * Two callers in the editor, and they must agree: the mount snapshot that
+ * decides whether to offer the first-save dashboards sheet, and the live check
+ * that decides whether backing out of a freshly added instance should delete
+ * the empty row it left behind.
+ */
+export function isBlankInstance(
+  inst: { localUrl: string; remoteUrl: string },
+  secrets: { apiKey?: string; username?: string; password?: string },
+  usesUserPass: boolean,
+): boolean {
+  const hasUrl = inst.localUrl.length > 0 || inst.remoteUrl.length > 0;
+  const hasCreds = usesUserPass
+    ? Boolean(secrets.username) || Boolean(secrets.password)
+    : Boolean(secrets.apiKey);
+  return !hasUrl && !hasCreds;
+}
+
 /** Host and port of a URL, for the "Unreachable · host:port" reason line. */
 function hostLabel(url: string): string {
   if (!url) return "";

--- a/lib/integration-status.ts
+++ b/lib/integration-status.ts
@@ -1,0 +1,376 @@
+import { SERVICE_IDS, SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
+import type { ServiceInstance } from "@/store/config-store";
+import type { HealthStatusKind, ServiceHealthStatus } from "@/lib/types";
+
+/**
+ * Pure projection of (instances + health + network context) into the rows the
+ * Integrations surfaces render.
+ *
+ * Two hard rules:
+ *  - This module imports TYPES from store/config-store, never values. A value
+ *    import pulls AsyncStorage and expo-secure-store into its test.
+ *  - Nothing here reads the store or the network. The caller resolves each
+ *    instance's active URL and LAN-guard verdict and passes them in, which is
+ *    what makes every branch below testable.
+ */
+
+/**
+ * Per-instance state.
+ *
+ * `away` exists because checkInstanceHealth reports a private LAN URL as
+ * `unreachable` (hence `offline`) whenever the device is off the home network.
+ * Without splitting it out, every hub visit on cellular would render a full
+ * "Needs attention" list claiming a working setup is broken, which is worse
+ * than the small per-row dot it replaces.
+ */
+export type InstanceState =
+  | "ok"
+  | "attention"
+  | "away"
+  | "checking"
+  | "off"
+  | "unconfigured";
+
+/** What the caller must resolve per instance before building rows. */
+export interface InstanceProbeContext {
+  /** getActiveUrl(kind, instanceId) — the URL the app would really use now. */
+  activeUrl: string;
+  /** lanGuardBlockReason(activeUrl, inst) !== null. */
+  lanBlocked: boolean;
+}
+
+export interface IntegrationInstanceRow {
+  kind: ServiceId;
+  instanceId: string;
+  instanceName: string;
+  state: InstanceState;
+  /** Raw health verdict when one exists. Absent while checking or disabled. */
+  status?: HealthStatusKind;
+  /** Human-readable cause, set only for `attention`. */
+  reason?: string;
+  activeUrl: string;
+  responseTime?: number;
+}
+
+export interface IntegrationRow {
+  kind: ServiceId;
+  label: string;
+  instances: ServiceInstance[];
+  rows: IntegrationInstanceRow[];
+  /** At least one instance has a URL. */
+  configured: boolean;
+  enabledCount: number;
+  /** Kind-level rollup, by the precedence below. */
+  state: InstanceState;
+  /** Dot state for the kind row. Absent when nothing is enabled. */
+  status?: HealthStatusKind;
+}
+
+/**
+ * Kind rollup precedence. Deliberately worst-first, which is the OPPOSITE of
+ * hooks/use-service-health.ts's best-of-any aggregate (ok > auth_failed >
+ * offline). That aggregate is right for a dashboard widget, where a healthy
+ * primary should keep the tile green, and wrong here, where the whole point is
+ * to surface the broken secondary.
+ */
+const STATE_PRECEDENCE: InstanceState[] = [
+  "attention",
+  "checking",
+  "away",
+  "ok",
+];
+
+/** True when any instance of this kind has a URL saved. */
+export function isConfigured(instances: readonly ServiceInstance[]): boolean {
+  return instances.some(
+    (i) => i.localUrl.length > 0 || i.remoteUrl.length > 0,
+  );
+}
+
+/** Host and port of a URL, for the "Unreachable · host:port" reason line. */
+function hostLabel(url: string): string {
+  if (!url) return "";
+  // Cheap parse: RN's URL polyfill is present but this runs per row on render.
+  const stripped = url.replace(/^[a-z]+:\/\//i, "");
+  const end = stripped.search(/[/?#]/);
+  return end === -1 ? stripped : stripped.slice(0, end);
+}
+
+/**
+ * Classify one instance.
+ *
+ * `health` is that instance's entry from useServiceHealth, or undefined when
+ * the first probe batch has not resolved yet.
+ */
+export function classifyInstance(
+  kind: ServiceId,
+  inst: ServiceInstance,
+  health: { status: HealthStatusKind; message?: string } | undefined,
+  lanBlocked: boolean,
+  activeUrl: string,
+): IntegrationInstanceRow {
+  const base = { kind, instanceId: inst.id, instanceName: inst.name, activeUrl };
+
+  const hasUrl = inst.localUrl.length > 0 || inst.remoteUrl.length > 0;
+
+  if (!inst.enabled) {
+    return { ...base, state: hasUrl ? "off" : "unconfigured" };
+  }
+
+  // Enabled with nothing to talk to is a real misconfiguration, and the health
+  // hook has no verdict for it, so catch it before reading `health`.
+  if (!hasUrl) {
+    return {
+      ...base,
+      state: "attention",
+      reason: "Enabled but no URL set",
+    };
+  }
+
+  // Off the home network with a LAN-only URL. Not broken, just out of reach.
+  if (lanBlocked) {
+    return { ...base, state: "away" };
+  }
+
+  if (!health) {
+    return { ...base, state: "checking" };
+  }
+
+  if (health.status === "ok") {
+    return { ...base, state: "ok", status: "ok" };
+  }
+
+  const host = hostLabel(activeUrl);
+  return {
+    ...base,
+    state: "attention",
+    status: health.status,
+    reason:
+      health.status === "auth_failed"
+        ? "Authentication failed"
+        : host
+          ? `Unreachable · ${host}`
+          : "Unreachable",
+  };
+}
+
+function rollUp(rows: IntegrationInstanceRow[]): InstanceState | undefined {
+  for (const state of STATE_PRECEDENCE) {
+    if (rows.some((r) => r.state === state)) return state;
+  }
+  return undefined;
+}
+
+/** Build one row per service kind, in canonical SERVICE_IDS order. */
+export function buildIntegrationRows(
+  serviceInstances: Record<ServiceId, ServiceInstance[]>,
+  healthData: ServiceHealthStatus[] | undefined,
+  context: Record<string, InstanceProbeContext>,
+): IntegrationRow[] {
+  return SERVICE_IDS.map((kind) => {
+    const instances = serviceInstances[kind] ?? [];
+    const healthForKind = healthData?.find((h) => h.id === kind);
+
+    const rows = instances.map((inst) => {
+      const ctx = context[inst.id];
+      const health = healthForKind?.instances.find(
+        (i) => i.instanceId === inst.id,
+      );
+      const row = classifyInstance(
+        kind,
+        inst,
+        health ? { status: health.status, message: health.message } : undefined,
+        ctx?.lanBlocked ?? false,
+        ctx?.activeUrl ?? "",
+      );
+      return { ...row, responseTime: health?.responseTime };
+    });
+
+    const enabledCount = instances.filter((i) => i.enabled).length;
+    const configured = isConfigured(instances);
+    const enabledRows = rows.filter((r) =>
+      ["attention", "checking", "away", "ok"].includes(r.state),
+    );
+
+    const state: InstanceState = !configured
+      ? "unconfigured"
+      : enabledCount === 0
+        ? "off"
+        : (rollUp(enabledRows) ?? "off");
+
+    return {
+      kind,
+      label: SERVICE_DEFAULTS[kind].name,
+      instances,
+      rows,
+      configured,
+      enabledCount,
+      state,
+      status:
+        state === "attention" || state === "ok"
+          ? (rows.find((r) => r.state === state)?.status ??
+            (state === "ok" ? "ok" : "offline"))
+          : undefined,
+    };
+  });
+}
+
+export interface IntegrationSummary {
+  connected: number;
+  attention: number;
+  away: number;
+  checking: number;
+  off: number;
+  available: number;
+  /** Worst dot to show next to the Settings row. */
+  worst?: HealthStatusKind;
+  line: string;
+}
+
+/**
+ * Counts for the Settings row subtitle and the hub summary line.
+ *
+ * Every kind lands in exactly one bucket, so
+ *   connected + attention + away + checking + off + available === SERVICE_IDS.length
+ * for any store shape. The test asserts it.
+ */
+export function summarizeIntegrations(
+  rows: readonly IntegrationRow[],
+): IntegrationSummary {
+  let connected = 0;
+  let attention = 0;
+  let away = 0;
+  let checking = 0;
+  let off = 0;
+  let available = 0;
+
+  for (const row of rows) {
+    switch (row.state) {
+      case "ok":
+        connected++;
+        break;
+      case "attention":
+        attention++;
+        break;
+      case "away":
+        away++;
+        break;
+      case "checking":
+        checking++;
+        break;
+      case "off":
+        off++;
+        break;
+      default:
+        available++;
+    }
+  }
+
+  const anyAuthFailed = rows.some(
+    (r) => r.state === "attention" && r.status === "auth_failed",
+  );
+
+  // Configured kinds that are up right now, for the headline number.
+  const live = connected + attention + away + checking;
+
+  let line: string;
+  if (live === 0 && off === 0) {
+    line = "Set up your first service";
+  } else if (checking > 0 && connected === 0 && attention === 0) {
+    line = `Checking ${live} service${live === 1 ? "" : "s"}…`;
+  } else if (attention > 0) {
+    line = `${connected} connected · ${attention} need${attention === 1 ? "s" : ""} attention`;
+  } else if (away > 0) {
+    line = `${connected} connected · ${away} away from home`;
+  } else {
+    line = `${connected} service${connected === 1 ? "" : "s"} connected`;
+  }
+
+  return {
+    connected,
+    attention,
+    away,
+    checking,
+    off,
+    available,
+    worst:
+      attention > 0 ? (anyAuthFailed ? "auth_failed" : "offline") : undefined,
+    line,
+  };
+}
+
+/** Subtitle and tone for a kind row on the hub. */
+export function integrationSubtitle(row: IntegrationRow): {
+  text: string;
+  tone: "default" | "warn";
+} {
+  if (!row.configured) return { text: "Not set up", tone: "default" };
+  if (row.enabledCount === 0)
+    return { text: "Configured, turned off", tone: "default" };
+
+  if (row.instances.length === 1) {
+    const only = row.rows[0];
+    if (only.state === "away")
+      return { text: "Local only · away from home", tone: "default" };
+    if (only.state === "attention")
+      return { text: only.reason ?? "Needs attention", tone: "warn" };
+    if (only.state === "checking")
+      return { text: only.activeUrl || "Checking…", tone: "default" };
+    const ms = only.responseTime ? ` · ${Math.round(only.responseTime)} ms` : "";
+    return { text: `${only.activeUrl}${ms}`, tone: "default" };
+  }
+
+  const bad = row.rows.filter((r) => r.state === "attention").length;
+  const ok = row.rows.filter((r) => r.state === "ok").length;
+  const plural = `${row.instances.length} instances`;
+  if (bad > 0)
+    return {
+      text: `${plural} · ${bad} need${bad === 1 ? "s" : ""} attention`,
+      tone: "warn",
+    };
+  return { text: `${plural} · ${ok} connected`, tone: "default" };
+}
+
+/**
+ * Where tapping a kind should go.
+ *
+ * A single instance skips the list level entirely, which is the normal case
+ * because defaultInstances() seeds exactly one placeholder per kind. That
+ * keeps "open Radarr's settings" at the same tap count as the old in-place
+ * settings screen despite the extra route level.
+ */
+export function resolveKindRoute(
+  kind: ServiceId,
+  instances: readonly ServiceInstance[],
+): string {
+  if (instances.length === 1) {
+    return `/settings/integrations/${kind}/${instances[0].id}`;
+  }
+  return `/settings/integrations/${kind}`;
+}
+
+/** The instance list for a kind. */
+export function kindListRoute(kind: ServiceId): string {
+  return `/settings/integrations/${kind}`;
+}
+
+/**
+ * Where tapping a row on the Browse catalog should go.
+ *
+ * Deliberately different from resolveKindRoute. Browse is the ADD surface, so a
+ * kind you have already set up opens its instance list, which carries "Add
+ * another instance". Jumping straight into the single existing instance's
+ * editor would make "add a second Radarr" unreachable, since a kind with one
+ * instance never shows a list anywhere else.
+ *
+ * A kind you have not set up still goes straight to its seeded placeholder's
+ * editor, which is the one-tap path that makes browsing worth using.
+ */
+export function resolveBrowseRoute(
+  kind: ServiceId,
+  instances: readonly ServiceInstance[],
+): string {
+  return isConfigured(instances)
+    ? kindListRoute(kind)
+    : resolveKindRoute(kind, instances);
+}

--- a/lib/integration-status.ts
+++ b/lib/integration-status.ts
@@ -176,10 +176,27 @@ export function buildIntegrationRows(
       const health = healthForKind?.instances.find(
         (i) => i.instanceId === inst.id,
       );
+
+      // A kind whose probe body threw settles as
+      // { status: "offline", instances: [] } — see the allSettled fallback in
+      // hooks/use-service-health.ts. That is a real verdict, not a pending one,
+      // so fall back to the kind status instead of reporting "checking"
+      // forever and hiding the failure from "Needs attention".
+      //
+      // Scoped to the empty-instances shape on purpose: a NON-empty list that
+      // simply lacks this instance means the row was added after the probe was
+      // keyed, which is genuinely still pending.
+      const settledKindFallback =
+        healthForKind && healthForKind.instances.length === 0
+          ? { status: healthForKind.status }
+          : undefined;
+
       const row = classifyInstance(
         kind,
         inst,
-        health ? { status: health.status, message: health.message } : undefined,
+        health
+          ? { status: health.status, message: health.message }
+          : settledKindFallback,
         ctx?.lanBlocked ?? false,
         ctx?.activeUrl ?? "",
       );

--- a/lib/service-catalog.test.ts
+++ b/lib/service-catalog.test.ts
@@ -1,0 +1,165 @@
+import { SERVICE_IDS, SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
+import {
+  SERVICE_CATALOG,
+  CATEGORY_ORDER,
+  SERVICE_CATEGORY_LABELS,
+  servicesInCategory,
+  secretsShapeFor,
+  filterCatalog,
+} from "@/lib/service-catalog";
+
+/**
+ * A literal copy of the booleans that lived in service-editor.tsx before the
+ * catalog replaced them:
+ *
+ *   const usesPasswordOnly = serviceId === "deluge";
+ *   const usesBasicAuth =
+ *     usesPasswordOnly || serviceId === "qbittorrent" || "rtorrent" ||
+ *     "transmission" || "glances" || "nzbget";
+ *
+ * Kept as data, not re-derived from the catalog, so the parity test below is a
+ * real check against the shipped behaviour rather than a tautology.
+ */
+const LEGACY_USES_BASIC_AUTH = new Set<ServiceId>([
+  "deluge",
+  "qbittorrent",
+  "rtorrent",
+  "transmission",
+  "glances",
+  "nzbget",
+]);
+const LEGACY_USES_PASSWORD_ONLY = new Set<ServiceId>(["deluge"]);
+
+describe("SERVICE_CATALOG", () => {
+  it("has exactly one entry per service id", () => {
+    expect(Object.keys(SERVICE_CATALOG).sort()).toEqual([...SERVICE_IDS].sort());
+  });
+
+  it("gives every service a non-empty tagline and a known category", () => {
+    for (const id of SERVICE_IDS) {
+      const entry = SERVICE_CATALOG[id];
+      expect(entry.tagline.length).toBeGreaterThan(0);
+      expect(CATEGORY_ORDER).toContain(entry.category);
+    }
+  });
+
+  it("labels every category in CATEGORY_ORDER", () => {
+    for (const category of CATEGORY_ORDER) {
+      expect(SERVICE_CATEGORY_LABELS[category].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("partitions every service into exactly one category", () => {
+    const seen = CATEGORY_ORDER.flatMap((c) => servicesInCategory(c));
+    expect(seen.sort()).toEqual([...SERVICE_IDS].sort());
+    expect(new Set(seen).size).toBe(SERVICE_IDS.length);
+  });
+});
+
+describe("auth shapes", () => {
+  // The load-bearing test. Every id must resolve to the same credential form
+  // it had before the catalog existed; a mismatch means that service silently
+  // stops reading or writing its saved credential.
+  it("matches the pre-catalog usesBasicAuth boolean for all 25 kinds", () => {
+    for (const id of SERVICE_IDS) {
+      const shape = secretsShapeFor(SERVICE_CATALOG[id].authShape);
+      expect({ id, shape }).toEqual({
+        id,
+        shape: LEGACY_USES_BASIC_AUTH.has(id) ? "userPass" : "apiKey",
+      });
+    }
+  });
+
+  it("keeps Plex on apiKey so the manual token field survives", () => {
+    // The Connect-with-Plex PIN flow writes into the SAME apiKey secret the
+    // manual field edits, and isDirty/wasInitiallyUnconfigured both read it.
+    // Modelling Plex as its own exclusive shape would drop the manual path.
+    expect(SERVICE_CATALOG.plex.authShape).toBe("apiKey");
+    expect(SERVICE_CATALOG.plex.oauth).toBe("plex");
+    expect(secretsShapeFor(SERVICE_CATALOG.plex.authShape)).toBe("apiKey");
+  });
+
+  it("marks Deluge, and only Deluge, as passwordOnly", () => {
+    const passwordOnly = SERVICE_IDS.filter(
+      (id) => SERVICE_CATALOG[id].authShape === "passwordOnly",
+    );
+    expect(new Set(passwordOnly)).toEqual(LEGACY_USES_PASSWORD_ONLY);
+  });
+
+  it("only offers OAuth alongside a credential shape, never instead of one", () => {
+    for (const id of SERVICE_IDS) {
+      const entry = SERVICE_CATALOG[id];
+      if (entry.oauth) expect(entry.authShape).toBe("apiKey");
+    }
+  });
+
+  // Guard rail: authShape and SERVICE_DEFAULTS.httpAuth look interchangeable
+  // and are not. httpAuth is a transport flag (send HTTP Basic/Digest per
+  // request); authShape is the credential form. They diverge on qBittorrent
+  // and Deluge, which post to a login endpoint and carry a session cookie.
+  it("does not track SERVICE_DEFAULTS.httpAuth", () => {
+    const userPass = new Set(
+      SERVICE_IDS.filter(
+        (id) => secretsShapeFor(SERVICE_CATALOG[id].authShape) === "userPass",
+      ),
+    );
+    const httpAuth = new Set(
+      SERVICE_IDS.filter((id) => SERVICE_DEFAULTS[id].httpAuth === true),
+    );
+
+    expect(userPass).toEqual(LEGACY_USES_BASIC_AUTH);
+    expect(httpAuth).toEqual(
+      new Set<ServiceId>(["rtorrent", "transmission", "nzbget", "glances"]),
+    );
+    expect(userPass).not.toEqual(httpAuth);
+    // The exact services that make them differ.
+    expect(userPass.has("qbittorrent")).toBe(true);
+    expect(httpAuth.has("qbittorrent")).toBe(false);
+    expect(userPass.has("deluge")).toBe(true);
+    expect(httpAuth.has("deluge")).toBe(false);
+  });
+});
+
+describe("filterCatalog", () => {
+  it("returns every service for an empty or whitespace query", () => {
+    expect(filterCatalog("")).toEqual([...SERVICE_IDS]);
+    expect(filterCatalog("   ")).toEqual([...SERVICE_IDS]);
+  });
+
+  it("finds Seerr by its old and forked names", () => {
+    expect(filterCatalog("seerr")).toContain("overseerr");
+    expect(filterCatalog("overseerr")).toContain("overseerr");
+    expect(filterCatalog("jellyseerr")).toContain("overseerr");
+  });
+
+  it("finds Bindery by the archived Readarr name", () => {
+    expect(filterCatalog("readarr")).toContain("bindery");
+  });
+
+  it("finds every usenet client by protocol", () => {
+    const hits = filterCatalog("usenet");
+    expect(hits).toEqual(
+      expect.arrayContaining(["sabnzbd", "nzbget", "nzbhydra2"]),
+    );
+  });
+
+  it("matches common abbreviations", () => {
+    expect(filterCatalog("qbit")).toContain("qbittorrent");
+    expect(filterCatalog("hydra")).toContain("nzbhydra2");
+    expect(filterCatalog("sab")).toContain("sabnzbd");
+  });
+
+  it("is case insensitive and matches on display name", () => {
+    expect(filterCatalog("RaDaRr")).toEqual(["radarr"]);
+  });
+
+  it("returns nothing for a query that matches no service", () => {
+    expect(filterCatalog("zzzznope")).toEqual([]);
+  });
+
+  it("preserves canonical SERVICE_IDS order", () => {
+    const hits = filterCatalog("torrent client");
+    const canonical = SERVICE_IDS.filter((id) => hits.includes(id));
+    expect(hits).toEqual(canonical);
+  });
+});

--- a/lib/service-catalog.ts
+++ b/lib/service-catalog.ts
@@ -1,0 +1,311 @@
+import { SERVICE_IDS, SERVICE_DEFAULTS, type ServiceId } from "@/lib/constants";
+
+/**
+ * Presentation and capability metadata for every service kind.
+ *
+ * This is the single place the Integrations UI reads to answer "what is this
+ * service, where does it belong, and what does its credential form look like".
+ * It mirrors the shape of components/dashboard/widget-registry.tsx: one flat
+ * Record keyed by id, plain object literals, plus a few pure selectors.
+ *
+ * Deliberately pure data — it imports only lib/constants, so its test needs no
+ * React renderer and no AsyncStorage/SecureStore shims.
+ */
+
+export type ServiceCategory =
+  | "downloads"
+  | "automation"
+  | "indexers"
+  | "media-servers"
+  | "requests"
+  | "monitoring";
+
+/**
+ * The shape of the credential FORM and of the stored ServiceSecrets.
+ *
+ * WARNING: this is NOT the same thing as `SERVICE_DEFAULTS[id].httpAuth`, and
+ * the two must never be merged. `httpAuth` is a wire-level transport flag
+ * (send HTTP Basic/Digest on every request) covering only
+ *   { rtorrent, transmission, nzbget, glances }
+ * whereas the userPass side of `authShape` also covers qBittorrent and Deluge,
+ * which post their credentials to a login endpoint and carry a session cookie
+ * instead. Collapsing the two sets breaks auth for both of those clients.
+ * lib/service-catalog.test.ts locks the inequality.
+ */
+export type ServiceAuthShape = "apiKey" | "userPass" | "passwordOnly";
+
+export interface ServiceCatalogEntry {
+  category: ServiceCategory;
+  /** One short noun phrase shown under the name in the browse list. */
+  tagline: string;
+  /** Extra search terms: former names, forks, protocol words, abbreviations. */
+  keywords: string[];
+  authShape: ServiceAuthShape;
+  /**
+   * An OAuth-style sign-in offered IN ADDITION TO `authShape`, never instead
+   * of it. Plex is `apiKey` + `oauth: "plex"`: the PIN flow writes the token
+   * into the same apiKey secret the manual field edits, and dropping the
+   * manual field would strand anyone who cannot complete the browser flow.
+   */
+  oauth?: "plex";
+  /** Where to find the key in the service's own UI. Omitted when unverified. */
+  apiKeyHint?: string;
+  docsUrl?: string;
+}
+
+export const SERVICE_CATALOG: Record<ServiceId, ServiceCatalogEntry> = {
+  // --- Download clients ---
+  qbittorrent: {
+    category: "downloads",
+    tagline: "Torrent client",
+    keywords: ["qbit", "qb", "torrent"],
+    authShape: "userPass",
+  },
+  rtorrent: {
+    category: "downloads",
+    tagline: "Torrent client",
+    keywords: ["rutorrent", "torrent", "xmlrpc"],
+    authShape: "userPass",
+  },
+  transmission: {
+    category: "downloads",
+    tagline: "Torrent client",
+    keywords: ["torrent"],
+    authShape: "userPass",
+  },
+  deluge: {
+    category: "downloads",
+    tagline: "Torrent client",
+    keywords: ["torrent"],
+    // Deluge's Web UI has a single password and no username at all.
+    authShape: "passwordOnly",
+  },
+  sabnzbd: {
+    category: "downloads",
+    tagline: "Usenet downloader",
+    keywords: ["sab", "usenet", "nzb"],
+    authShape: "apiKey",
+    apiKeyHint: "Config > General > API Key",
+  },
+  nzbget: {
+    category: "downloads",
+    tagline: "Usenet downloader",
+    keywords: ["usenet", "nzb"],
+    authShape: "userPass",
+  },
+
+  // --- Media automation ---
+  radarr: {
+    category: "automation",
+    tagline: "Movie automation",
+    keywords: ["movies", "arr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > Security > API Key",
+  },
+  sonarr: {
+    category: "automation",
+    tagline: "TV automation",
+    keywords: ["tv", "series", "shows", "arr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > Security > API Key",
+  },
+  lidarr: {
+    category: "automation",
+    tagline: "Music automation",
+    keywords: ["music", "albums", "arr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > Security > API Key",
+  },
+  bindery: {
+    category: "automation",
+    tagline: "Book and audiobook automation",
+    // Bindery is the successor to the archived Readarr, so people search for
+    // the old name long after the migration.
+    keywords: ["books", "audiobooks", "readarr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > Security",
+  },
+  bazarr: {
+    category: "automation",
+    tagline: "Subtitle automation",
+    keywords: ["subtitles", "subs", "arr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > Security > API Key",
+  },
+
+  // --- Indexers ---
+  prowlarr: {
+    category: "indexers",
+    tagline: "Indexer manager",
+    keywords: ["indexer", "trackers", "arr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > Security > API Key",
+  },
+  jackett: {
+    category: "indexers",
+    tagline: "Torrent indexer proxy",
+    keywords: ["indexer", "trackers", "torznab"],
+    authShape: "apiKey",
+    apiKeyHint: "Shown at the top of the Jackett dashboard",
+  },
+  nzbhydra2: {
+    category: "indexers",
+    tagline: "Usenet meta-search",
+    keywords: ["hydra", "usenet", "nzb", "indexer", "newznab"],
+    authShape: "apiKey",
+    apiKeyHint: "Config > Main > Security > API key",
+  },
+
+  // --- Media servers ---
+  plex: {
+    category: "media-servers",
+    tagline: "Media server",
+    keywords: ["pms"],
+    // See ServiceCatalogEntry.oauth: additive, not a replacement.
+    authShape: "apiKey",
+    oauth: "plex",
+    apiKeyHint: "Filled in by Connect with Plex, or paste an X-Plex-Token",
+  },
+  jellyfin: {
+    category: "media-servers",
+    tagline: "Media server",
+    keywords: ["jelly"],
+    authShape: "apiKey",
+    apiKeyHint: "Dashboard > Advanced > API Keys",
+  },
+  emby: {
+    category: "media-servers",
+    tagline: "Media server",
+    keywords: [],
+    authShape: "apiKey",
+  },
+
+  // --- Requests and automation ---
+  overseerr: {
+    category: "requests",
+    tagline: "Media requests",
+    // The id stays `overseerr` for back-compat while the product is "Seerr";
+    // both spellings plus the Jellyfin fork have to match.
+    keywords: ["seerr", "overseerr", "jellyseerr", "requests"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > General > API Key",
+  },
+  autobrr: {
+    category: "requests",
+    tagline: "Release filtering",
+    keywords: ["irc", "announce", "filters", "brr"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > API keys",
+  },
+  cleanuparr: {
+    category: "requests",
+    tagline: "Queue cleanup",
+    keywords: ["cleanup", "strike", "arr"],
+    authShape: "apiKey",
+    apiKeyHint: "Account Settings",
+  },
+
+  // --- Monitoring ---
+  tautulli: {
+    category: "monitoring",
+    tagline: "Plex activity and stats",
+    keywords: ["plexpy", "stats", "history"],
+    authShape: "apiKey",
+    apiKeyHint: "Settings > Web Interface > API > API Key",
+  },
+  tracearr: {
+    category: "monitoring",
+    tagline: "Streaming activity and history",
+    keywords: ["stats", "history", "streams"],
+    authShape: "apiKey",
+    apiKeyHint: "Tracearr, as a trr_pub_ token",
+  },
+  jellystat: {
+    category: "monitoring",
+    tagline: "Jellyfin activity and stats",
+    keywords: ["jellyfin", "stats", "history"],
+    authShape: "apiKey",
+  },
+  glances: {
+    category: "monitoring",
+    tagline: "System monitoring",
+    keywords: ["cpu", "ram", "system", "server"],
+    authShape: "userPass",
+  },
+  unraid: {
+    category: "monitoring",
+    tagline: "Server and array monitoring",
+    keywords: ["nas", "array", "docker", "server"],
+    // The GraphQL API has to be switched on there first, and the key needs
+    // array-read permission.
+    apiKeyHint: "Settings > Management Access",
+    authShape: "apiKey",
+  },
+};
+
+/** Display order of the category sections on the browse screen. */
+export const CATEGORY_ORDER: ServiceCategory[] = [
+  "downloads",
+  "automation",
+  "indexers",
+  "media-servers",
+  "requests",
+  "monitoring",
+];
+
+/**
+ * Named SERVICE_CATEGORY_LABELS, not CATEGORY_LABELS: lib/notification-categories.ts
+ * already exports a CATEGORY_LABELS keyed by NotifCategory, and two same-named
+ * exports of different key types in neighbouring files is a guaranteed wrong
+ * autoimport.
+ */
+export const SERVICE_CATEGORY_LABELS: Record<ServiceCategory, string> = {
+  downloads: "Download clients",
+  automation: "Media automation",
+  indexers: "Indexers",
+  "media-servers": "Media servers",
+  requests: "Requests and automation",
+  monitoring: "Monitoring",
+};
+
+/** Service kinds in a category, in canonical SERVICE_IDS order. */
+export function servicesInCategory(category: ServiceCategory): ServiceId[] {
+  return SERVICE_IDS.filter((id) => SERVICE_CATALOG[id].category === category);
+}
+
+/**
+ * Which ServiceSecrets fields the editor reads and writes for an auth shape.
+ * `passwordOnly` still stores the username/password pair (with the username
+ * field hidden), so it collapses to "userPass" here.
+ *
+ * This is the ONLY place that mapping lives. The editor uses it for the form
+ * branch, the initial-configured snapshot, the dirty check and the secrets
+ * write — a second inline copy is how a credential silently stops saving.
+ */
+export function secretsShapeFor(
+  shape: ServiceAuthShape,
+): "userPass" | "apiKey" {
+  return shape === "apiKey" ? "apiKey" : "userPass";
+}
+
+/**
+ * Substring match over the display name, the id, the tagline and the keywords.
+ * Returns canonical order; an empty query returns every kind.
+ *
+ * Not debounced at the call site on purpose: this filters 25 in-memory strings
+ * and never touches the network, unlike app/search.tsx (300ms) which fires a
+ * request per keystroke.
+ */
+export function filterCatalog(query: string): ServiceId[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return [...SERVICE_IDS];
+  return SERVICE_IDS.filter((id) => {
+    const entry = SERVICE_CATALOG[id];
+    return (
+      SERVICE_DEFAULTS[id].name.toLowerCase().includes(q) ||
+      id.includes(q) ||
+      entry.tagline.toLowerCase().includes(q) ||
+      entry.keywords.some((k) => k.includes(q))
+    );
+  });
+}

--- a/lib/service-catalog.ts
+++ b/lib/service-catalog.ts
@@ -50,7 +50,6 @@ export interface ServiceCatalogEntry {
   oauth?: "plex";
   /** Where to find the key in the service's own UI. Omitted when unverified. */
   apiKeyHint?: string;
-  docsUrl?: string;
 }
 
 export const SERVICE_CATALOG: Record<ServiceId, ServiceCatalogEntry> = {


### PR DESCRIPTION
## Summary

Service configuration moves out of the Settings tab into its own routed view at `/settings/integrations`, reworked for the 25 services we now ship.

Settings keeps a single Integrations row with a live summary instead of listing all 25 kinds. The new view has a hub (needs attention, your services, add a service), a searchable catalog grouped into 6 categories, and real routes for the per-kind instance list and the per-instance editor.

The drill-down used to be faked with `useState` inside the Settings tab, so there were no deep links, no iOS edge swipe, and two hand-rolled Android `BackHandler` interceptors. Those are gone. The editor now guards unsaved changes with `usePreventRemove`, the same pattern `dashboard-edit` and `customize-discover` already use.

Also in here:

- `lib/service-catalog.ts` carries category, tagline, search keywords, auth shape and API key hints, replacing the `serviceId === "..."` chain in the editor. Adding a service is now a data entry plus an adapter.
- `lib/integration-status.ts` projects instances, health and network state into rows. It reports the worst instance per kind, unlike the dashboard widget's best-of-any rollup, so a broken second server is no longer hidden behind a healthy first one.
- Instances that are unreachable only because you are away from home are classified separately from failures, so the hub does not report a working stack as broken on cellular.
- The editor is split into a deferred Connection zone above Save and an instant Preferences zone below it, so the mixed save behaviour is visible rather than learned one toggle at a time. `Always use Remote URL` and `Allow invalid certificates` moved below the divider rather than becoming deferred: `handleTest` reads `useRemote` to pick which slot to probe, and `ignoreCertErrors` programs a native allowlist from saved state.
- Browse routes an already-configured kind to its instance list. Sending it to the single instance's editor left no reachable way to add a second server of that kind.

No config migration. `CURRENT_CONFIG_VERSION` stays at 47 and `defaultInstances()` is unchanged; this is presentation only.

Docs and the in-app "Enable X in Settings" strings are updated. All 25 `defaultPort` values were checked against the table in `docs/guide.html` before being surfaced as URL placeholders.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest`: 65 suites, 1332 tests, 52 of them new
- [x] `npx expo export --platform android` builds, all four routes present in the route manifest
- [ ] On device: predictive back with a clean editor and a dirty one, discard, save then leave, first-save dashboards sheet, delete from the editor and from the instance list, cold-start deep link to `/settings/integrations/radarr/<uuid>`, deep link to a deleted uuid and to a bogus kind
- [ ] On iOS: the same list plus the edge swipe while dirty and while a modal is presented
- [ ] Hub on cellular with LAN-only services: they should read as away, not as needing attention

Not yet verified on hardware.

Two tests are worth knowing about. `lib/service-catalog.test.ts` asserts every service's auth shape matches the pre-refactor `usesBasicAuth` boolean, and locks the inequality against `SERVICE_DEFAULTS.httpAuth`, which is a different set (qBittorrent and Deluge post to a login endpoint rather than sending HTTP Basic). `lib/integration-status.test.ts` asserts the summary buckets always partition every kind exactly once.
