### PR TITLE
fix(backend): allow pairing with a private-CA backend, release v1.4.0

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -259,19 +259,30 @@ function ThemeRoot({ children }: { children: ReactNode }) {
   return <View style={[{ flex: 1 }, themeVars]}>{children}</View>;
 }
 
-// Keeps the native TLS-bypass allowlist in lockstep with config: which hosts
-// the user opted out of certificate validation for. Pushes once on hydrate and
-// again on every config change (the sync itself dedupes, so unrelated changes
+// Keeps the native TLS-bypass allowlist in lockstep with which hosts the user
+// opted out of certificate validation for. Pushes once on hydrate and again on
+// every change to either source (the sync itself dedupes, so unrelated changes
 // are cheap). Without this the native module would never learn the allowlist
 // and every connection would validate certs normally.
+//
+// Two sources: per-instance `ignoreCertErrors` in the config store, and the
+// backend's own flag in the backend store (#357). The effect stays gated on
+// `configHydrated` alone — coupling it to the backend store's hydrate would let
+// a SecureStore failure there revoke the allowlist for every service host too.
+// The backend store's `hydrate()` calls `set()`, which fires this subscription,
+// so the two parallel hydrates need no ordering between them.
 function InsecureTlsBridge() {
   const configHydrated = useConfigStore((s) => s.hydrated);
 
   useEffect(() => {
     if (!configHydrated) return;
     syncInsecureHosts();
-    const unsub = useConfigStore.subscribe(syncInsecureHosts);
-    return unsub;
+    const unsubConfig = useConfigStore.subscribe(syncInsecureHosts);
+    const unsubBackend = useBackendStore.subscribe(syncInsecureHosts);
+    return () => {
+      unsubConfig();
+      unsubBackend();
+    };
   }, [configHydrated]);
 
   return null;

--- a/app/backend.tsx
+++ b/app/backend.tsx
@@ -27,6 +27,35 @@ import { Toggle } from "@/components/ui/toggle";
 
 type Mode = "summary" | "scanning" | "manual";
 
+/**
+ * Opts the backend's hostname into the app's per-host TLS bypass (#357).
+ *
+ * Mirrors the per-instance "Allow invalid certificates" toggle in
+ * components/integrations/service-editor.tsx so the two read as one feature.
+ * Like that one it applies instantly rather than on a save, because it programs
+ * a native host allowlist — a deferred toggle would appear to do nothing.
+ *
+ * Rendered on every pairing surface (URL entry, manual token, and the paired
+ * summary), since the user may only discover they need it after a failed claim,
+ * or long after pairing if they later move the backend behind a TLS proxy.
+ */
+function CertToggle({
+  value,
+  onValueChange,
+}: {
+  value: boolean;
+  onValueChange: (v: boolean) => void;
+}) {
+  return (
+    <Toggle
+      label="Allow invalid certificates"
+      description="Skip TLS certificate checks for the backend URL. Needed when it's served with a self-signed certificate or one from your own internal CA, which phones don't trust even when the browser does. Only enable for a server you trust."
+      value={value}
+      onValueChange={onValueChange}
+    />
+  );
+}
+
 function parseQrPayload(data: string): { token: string; url?: string } | null {
   // Raw hex token (32 chars = 16 random bytes) — backend without PUBLIC_URL
   const trimmed = data.trim();
@@ -52,6 +81,10 @@ export default function BackendScreen() {
   const isHealthy = useBackendStore((s) => s.isHealthy);
   const pair = useBackendStore((s) => s.pair);
   const unpair = useBackendStore((s) => s.unpair);
+  const ignoreCertErrors = useBackendStore((s) => s.ignoreCertErrors);
+  const setIgnoreCertErrors = useBackendStore((s) => s.setIgnoreCertErrors);
+  const setDraftUrl = useBackendStore((s) => s.setDraftUrl);
+  const draftUrl = useBackendStore((s) => s.draftUrl);
 
   const [mode, setMode] = useState<Mode>("summary");
   const [busy, setBusy] = useState(false);
@@ -77,6 +110,13 @@ export default function BackendScreen() {
         return;
       }
       setBackendUrl(trimmedUrl);
+      // Publish the host BEFORE any network call so the native TLS-bypass
+      // allowlist already covers it if "Allow invalid certificates" is on —
+      // POST /pair/claim is itself the request that needs the bypass (#357).
+      // The store subscription runs synchronously, so this is in place by the
+      // time pairClaim fires. Covers the QR path too: `urlOverride` is
+      // normalized above, so a host the user never typed still lands here.
+      setDraftUrl(trimmedUrl);
       claimingRef.current = true;
       setBusy(true);
       try {
@@ -116,7 +156,7 @@ export default function BackendScreen() {
         setBusy(false);
       }
     },
-    [backendUrl, pair],
+    [backendUrl, pair, setDraftUrl],
   );
 
   const handleScan = useCallback(
@@ -257,6 +297,15 @@ export default function BackendScreen() {
     if (!url) claimingRef.current = false;
   }, [url]);
 
+  // Unpair and Rotate secret leave this screen mounted, so local state keeps
+  // whatever it had (empty, when the user arrived already paired). Seed the URL
+  // field from the draft `unpair()` preserved rather than making them retype
+  // the address they were just using. Never overwrites something typed.
+  useEffect(() => {
+    if (url || !draftUrl) return;
+    setBackendUrl((current) => current || draftUrl);
+  }, [url, draftUrl]);
+
   return (
     <ScreenWrapper>
       <BackHeader title="Backend" right={<BackendStatusPill />} />
@@ -312,6 +361,16 @@ export default function BackendScreen() {
                   className="flex-1"
                 />
               </View>
+
+              <Card className="gap-3 mb-3">
+                <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider">
+                  Connection security
+                </Text>
+                <CertToggle
+                  value={ignoreCertErrors}
+                  onValueChange={(v) => void setIgnoreCertErrors(v)}
+                />
+              </Card>
 
               <Card className="gap-3 mb-3">
                 <Toggle
@@ -377,13 +436,26 @@ export default function BackendScreen() {
                   placeholder="http://192.168.1.50:4000"
                   value={backendUrl}
                   onChangeText={setBackendUrl}
-                  onBlur={() => setBackendUrl(normalizeServiceUrl(backendUrl))}
+                  onBlur={() => {
+                    // Commit on blur, like the Apprise fields above, so flipping
+                    // the cert toggle allowlists this host even before a claim.
+                    const normalized = normalizeServiceUrl(backendUrl);
+                    setBackendUrl(normalized);
+                    setDraftUrl(normalized || null);
+                  }}
                   keyboardType="url"
                   autoCapitalize="none"
                 />
                 <Text className="text-zinc-500 text-xs mt-2">
                   Behind Cloudflare Tunnel or a reverse proxy? Enter the full https:// URL.
                 </Text>
+                <Text className="text-zinc-400 text-xs font-semibold uppercase tracking-wider mt-4">
+                  Connection security
+                </Text>
+                <CertToggle
+                  value={ignoreCertErrors}
+                  onValueChange={(v) => void setIgnoreCertErrors(v)}
+                />
               </Card>
 
               <Pressable
@@ -451,6 +523,10 @@ export default function BackendScreen() {
               value={manualToken}
               onChangeText={setManualToken}
               autoCapitalize="none"
+            />
+            <CertToggle
+              value={ignoreCertErrors}
+              onValueChange={(v) => void setIgnoreCertErrors(v)}
             />
           </Card>
 

--- a/backend/dashboarr-backend/Dockerfile
+++ b/backend/dashboarr-backend/Dockerfile
@@ -34,6 +34,15 @@ ENV NODE_ENV=production \
 VOLUME ["/data"]
 EXPOSE 4000
 
+# Liveness probe. GET /health with no Authorization header answers 200
+# {"ok":true,"name":"dashboarr-backend"} (see src/routes/health.ts). busybox
+# wget is the only HTTP client left in the runtime image — npm/npx/yarn are
+# stripped above — and it exits non-zero on any status >= 400, which is exactly
+# why hand-written probes against the old bearer-only /health marked every
+# container unhealthy forever (#357). Shell form so $PORT resolves at runtime.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -q -O /dev/null "http://127.0.0.1:$PORT/health" || exit 1
+
 # NOTE: Do NOT enable Expo "Enhanced Security for Push Notifications" on the
 # shared projectId. If enabled, every user-hosted backend breaks silently.
 LABEL dashboarr.warning="Do NOT enable Expo Enhanced Security for Push Notifications — it breaks every self-hosted backend."

--- a/backend/dashboarr-backend/README.md
+++ b/backend/dashboarr-backend/README.md
@@ -28,15 +28,15 @@ The warning is surfaced in:
 - This README
 - The Dockerfile `LABEL` metadata
 - The startup log banner
-- The `/health` JSON response (`expoAuth: "must-be-disabled"`)
-- The `/pair` HTML page
+- The authenticated `/health` JSON response (`expoAuth: "must-be-disabled"`)
 
 ---
 
 ## How it works
 
 1. You run this container alongside Radarr/Sonarr/qBittorrent/etc.
-2. It exposes an HTTP API, a pairing QR page, and webhook ingestion endpoints.
+2. It exposes an HTTP API and webhook ingestion endpoints, and prints a pairing
+   QR to its startup log.
 3. You open Dashboarr → Settings → Backend on your phone, scan the pairing
    QR, and the phone exchanges its Expo push token for a durable shared secret.
 4. The app pushes its current service config to the backend (every configured
@@ -174,10 +174,8 @@ docker run -d --name dashboarr-backend \
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| `GET`  | `/health` | none | Liveness + poller status + Expo auth canary |
-| `GET`  | `/pair` | none | HTML pairing page with QR + webhook URLs |
-| `POST` | `/pair/init` | rate-limited | Regenerate the pairing token |
-| `POST` | `/pair/claim` | one-time token in body | Exchange token + push token for shared secret |
+| `GET`  | `/health` | none (liveness) / bearer (full) | Without an `Authorization` header: `{ "ok": true, "name": "dashboarr-backend" }` — safe for a browser, a Docker `HEALTHCHECK` or an uptime monitor. With a valid bearer: adds `version`, `expoAuth`, `pollers[]` and `uptimeMs`. A **malformed or unknown** `Bearer` still returns `401`, so the app can detect a stale secret |
+| `POST` | `/pair/claim` | one-time token in body | Exchange token + push token for shared secret. The token is printed to the **startup log only** — there is deliberately no endpoint that mints or regenerates one (see `src/routes/pair.ts`), so restart the container for a fresh one |
 | `POST` | `/device/register` | bearer | Refresh push token on reinstall |
 | `POST` | `/device/unregister` | bearer | Remove this device |
 | `PUT`  | `/config` | bearer | Replace config (push-only — no GET by design, avoids exposing API keys), hot-reload pollers. Accepts the multi-instance shape `{ instances: [{ id, kind, … }], notifications }` and the legacy `{ services: [{ id, … }], notifications }` shape for back-compat. `notifications` may include an optional `apprise: { enabled, url, tags }` block (see Apprise below) |
@@ -210,6 +208,11 @@ headers.
 
 Rate limits: `/pair/*` is capped at 5 req/min, `/webhooks/*` at 60 req/min,
 everything else at 120 req/min, all per source IP.
+
+Auth is per-route: there is no global hook and no public-path allowlist, so
+every route above states its own requirement. The full `/health` body stays
+behind the bearer because `pollers[].lastError` embeds your internal service
+URLs, and the poller list itself reveals which services you have configured.
 
 ---
 
@@ -328,9 +331,9 @@ the app (Settings → Backend → Apprise) and use **Send Apprise test** to veri
 ## Verifying push delivery
 
 ```sh
-# 1. Server is up
+# 1. Server is up (no auth needed — liveness projection)
 curl http://localhost:4000/health
-# → { "ok": true, "expoAuth": "must-be-disabled", "pollers": [], ... }
+# → { "ok": true, "name": "dashboarr-backend" }
 
 # 2. Pair a fake device for smoke-testing (replace token from logs)
 curl -X POST http://localhost:4000/pair/claim \
@@ -347,6 +350,11 @@ curl -X PUT http://localhost:4000/config \
 # 4. Fire a test push (will log DeviceNotRegistered for the fake token)
 curl -X POST http://localhost:4000/notifications/test \
   -H "Authorization: Bearer <sharedSecret>"
+
+# 5. Full status: poller list, version, uptime (needs the paired bearer)
+curl http://localhost:4000/health -H "Authorization: Bearer <sharedSecret>"
+# → { "ok": true, "name": "dashboarr-backend", "version": "1.4.0",
+#     "expoAuth": "must-be-disabled", "pollers": [], "uptimeMs": 12345 }
 ```
 
 For real end-to-end testing you need a development build of Dashboarr with the
@@ -379,6 +387,72 @@ dashboarr.example.com {
   reverse_proxy dashboarr-backend:4000
 }
 ```
+
+---
+
+## Troubleshooting
+
+### `/health` returns `{"error":"missing_bearer"}`
+
+On **v1.4.0 and newer** an unauthenticated `GET /health` returns
+`200 {"ok":true,"name":"dashboarr-backend"}`. If you still get a 401:
+
+- **You are on an older image.** `docker compose pull && docker compose up -d`.
+- **You sent an `Authorization: Bearer …` the backend does not recognise.** That
+  is a real 401 (`invalid_bearer`): the shared secret was rotated, or the SQLite
+  file was replaced. Re-pair from the app.
+
+Either way it was never a reverse-proxy problem — your proxy was forwarding the
+request correctly and the backend was answering it. Adding `^/health` to an
+Authentik or Authelia Unauthenticated Paths list does not change it.
+
+### The container is permanently "unhealthy"
+
+A health check written against the old bearer-only `/health` can never pass:
+busybox `wget` exits non-zero on any status ≥ 400, so a 401 fails the probe on
+every interval forever.
+
+From v1.4.0 the image ships its own `HEALTHCHECK`, so you can delete a
+hand-written one. To use a different interval, override it:
+
+```yaml
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:4000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+```
+
+### Pairing fails with "Network request failed" behind a private CA
+
+Symptom: `https://dashboarr.example.com/health` loads fine in your phone's
+browser, but pairing fails instantly in the app and **nothing appears in the
+container log**. The TLS handshake is failing before any HTTP request is sent.
+
+Cause: the proxy is serving a certificate from a private or internal CA (Caddy's
+default internal issuer, a homelab root CA, an ACME-less Traefik). Your phone's
+browser trusts it because you installed the CA profile; app traffic does not use
+that trust store the same way, and on Android user-installed CAs are not trusted
+by apps at all unless the app opts in.
+
+Mounting the CA into the **backend** container does not help. `NODE_EXTRA_CA_CERTS`
+only affects connections the backend makes *outward* (to your services and to
+Expo). It has no bearing on the phone's connection *inward*.
+
+Fixes, best first:
+
+1. **Give that hostname a publicly-trusted certificate.** Let's Encrypt via
+   DNS-01 works for names that are not internet-reachable.
+2. **Pair over plain `http://` on your LAN.** The shared secret still protects
+   the API; see [TLS / network exposure](#tls--network-exposure).
+3. **Turn on "Allow invalid certificates"** in the app under **Settings →
+   Notifications → Backend**. It skips certificate validation for that host
+   only. Use it for a server you trust on a network you control.
+
+If pairing reaches the backend but still fails, check the token: it is
+single-use and expires in about 10 minutes. Restart the container to print a
+fresh one.
 
 ---
 

--- a/backend/dashboarr-backend/package-lock.json
+++ b/backend/dashboarr-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboarr-backend",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/rate-limit": "^10.2.1",

--- a/backend/dashboarr-backend/package.json
+++ b/backend/dashboarr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboarr-backend",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Self-hosted companion backend for Dashboarr — polls your *arr stack and sends real Expo push notifications",
   "license": "GPL-3.0",
   "private": true,
@@ -10,7 +10,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "test": "tsx --test src/types.test.ts src/services/qbittorrent.test.ts src/push/apprise.test.ts",
+    "test": "tsx --test src/types.test.ts src/services/qbittorrent.test.ts src/push/apprise.test.ts src/routes/health.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/backend/dashboarr-backend/src/auth/bearer.ts
+++ b/backend/dashboarr-backend/src/auth/bearer.ts
@@ -8,36 +8,70 @@ declare module "fastify" {
   }
 }
 
+export type BearerOutcome = "anonymous" | "authenticated";
+
 /**
- * Authenticate a request by looking up the presented Bearer against the
+ * Optional-auth resolver, for routes that answer anonymous callers with a
+ * reduced public projection instead of a flat 401. Currently only /health.
+ *
+ * Authenticates by looking up the presented Bearer against the
  * `devices.shared_secret` column. The secret is 32 bytes of `crypto.randomBytes`
  * (~256 bits of entropy) — well beyond any practical brute-force — so plain
  * SQL equality is sufficient. We do not wrap the comparison in `timingSafeEqual`
  * because the SQLite lookup already terminates the moment a match is found or
  * not found; adding a node-level constant-time compare after the fact is dead
  * code, not a defence.
+ *
+ * "anonymous" means the caller never tried to authenticate: no Authorization
+ * header, or one using a different scheme. That second case is not hypothetical
+ * — a forward-auth proxy (Authentik, Authelia) can inject its own `Basic …` on
+ * the proxied request, and treating that as a failed bearer would 401 an
+ * ordinary healthcheck and reproduce the confusion in issue #357.
+ *
+ * A `Bearer` that is empty or unknown still gets the 401: that caller MEANT to
+ * authenticate and got it wrong. The app always sends a bearer, and the 401 from
+ * `useBackendHealth` is the only way a rotated or wiped secret ever surfaces —
+ * answering it 200 would leave the app reporting "Connected" forever with its
+ * local notification fallback suppressed.
+ *
+ * Returns null once it has sent the 401; the caller must then return without
+ * touching the reply.
  */
-export async function requireBearer(
+export async function resolveBearer(
   request: FastifyRequest,
   reply: FastifyReply,
-): Promise<void> {
+): Promise<BearerOutcome | null> {
   const header = request.headers.authorization;
-  if (!header || !header.startsWith("Bearer ")) {
-    await reply.code(401).send({ error: "missing_bearer" });
-    return;
-  }
-  const presented = header.slice("Bearer ".length).trim();
+  // RFC 7235: the auth scheme is case-insensitive.
+  if (!header || !/^bearer\s/i.test(header)) return "anonymous";
+
+  const presented = header.slice(header.indexOf(" ") + 1).trim();
   if (!presented) {
     await reply.code(401).send({ error: "missing_bearer" });
-    return;
+    return null;
   }
 
   const device = findDeviceBySecret(presented);
   if (!device || device.invalid) {
     await reply.code(401).send({ error: "invalid_bearer" });
-    return;
+    return null;
   }
 
   touchDevice(device.id);
   request.device = device;
+  return "authenticated";
+}
+
+/**
+ * Bearer-or-nothing guard for every route that has no public projection.
+ */
+export async function requireBearer(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  const outcome = await resolveBearer(request, reply);
+  if (outcome === null) return; // 401 already sent
+  if (outcome === "anonymous") {
+    await reply.code(401).send({ error: "missing_bearer" });
+  }
 }

--- a/backend/dashboarr-backend/src/db/repos/pairing.ts
+++ b/backend/dashboarr-backend/src/db/repos/pairing.ts
@@ -42,8 +42,11 @@ export function getPairingToken(token: string): PairingRow | null {
 }
 
 /**
- * Current unexpired + unclaimed token, if any. Used by /pair HTML so the same
- * QR stays valid across restarts until claimed.
+ * Current unexpired + unclaimed token, if any. `ensureActiveToken` reuses it so
+ * a restart inside the 10-minute TTL reprints the same QR instead of
+ * invalidating the one the user is currently looking at. (Originally written for
+ * a /pair HTML page that no longer exists — token minting is startup-log-only
+ * now, see routes/pair.ts.)
  */
 export function getActiveToken(): string | null {
   const row = getDb()

--- a/backend/dashboarr-backend/src/index.ts
+++ b/backend/dashboarr-backend/src/index.ts
@@ -161,13 +161,21 @@ async function main(): Promise<void> {
     return reply.code(500).send({ error: "internal_error" });
   });
 
+  // 404s never reach setErrorHandler, so without this Fastify's default body
+  // echoes the caller's method and path back at them
+  // (`{"message":"Route POST:/pair/init not found",…}`), contradicting the
+  // neutral bodies the handler above exists to guarantee.
+  app.setNotFoundHandler((_request, reply) => {
+    return reply.code(404).send({ error: "not_found" });
+  });
+
   await app.register(rateLimit, {
     global: false,
   });
 
   // /pair/* — tight cap. Claiming a token is a one-shot credential exchange;
   // anything above a handful of requests per minute is abuse.
-  app.register(async (scope) => {
+  await app.register(async (scope) => {
     await scope.register(rateLimit, { max: 5, timeWindow: "1 minute" });
     await pairRoutes(scope);
   });

--- a/backend/dashboarr-backend/src/routes/health.test.ts
+++ b/backend/dashboarr-backend/src/routes/health.test.ts
@@ -1,0 +1,150 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// getEnv() caches on first call and getDb() creates the SQLite file under
+// DATA_DIR, so point both at a throwaway directory BEFORE anything that reads
+// them is imported. Hence the dynamic imports below.
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), "dashboarr-health-"));
+process.env.NODE_ENV = "test";
+process.env.LOG_LEVEL = "fatal";
+
+const { default: Fastify } = await import("fastify");
+const { healthRoutes } = await import("./health.js");
+const { createDevice } = await import("../db/repos/devices.js");
+
+function bodyOf(res: { json: () => unknown }): Record<string, unknown> {
+  return res.json() as Record<string, unknown>;
+}
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await healthRoutes(app);
+  await app.ready();
+  return app;
+}
+
+/**
+ * Anonymous liveness — the fix for #357. A browser, a Docker HEALTHCHECK and an
+ * uptime monitor all land here, and all of them used to get a 401.
+ */
+test("GET /health with no Authorization returns the liveness projection", async () => {
+  const app = await buildApp();
+  const res = await app.inject({ method: "GET", url: "/health" });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.json(), { ok: true, name: "dashboarr-backend" });
+  assert.equal(res.headers["cache-control"], "no-store");
+  assert.equal(res.headers.vary, "Authorization");
+
+  await app.close();
+});
+
+test("the liveness projection leaks no poller, version or uptime data", async () => {
+  const app = await buildApp();
+  const body = bodyOf(await app.inject({ method: "GET", url: "/health" }));
+
+  for (const key of ["pollers", "version", "uptimeMs", "expoAuth"]) {
+    assert.equal(key in body, false, `${key} must not be exposed anonymously`);
+  }
+
+  await app.close();
+});
+
+/**
+ * A forward-auth proxy (Authentik, Authelia) can inject its own Authorization
+ * header on the proxied request. That caller never tried to present a bearer,
+ * so it must not be treated as a failed one — otherwise an ordinary healthcheck
+ * behind such a proxy 401s and reproduces the original confusion.
+ */
+test("a non-Bearer Authorization scheme is treated as anonymous", async () => {
+  const app = await buildApp();
+  const res = await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { authorization: "Basic Zm9vOmJhcg==" },
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.json(), { ok: true, name: "dashboarr-backend" });
+
+  await app.close();
+});
+
+/**
+ * A wrong bearer must stay a 401: it is the app's only signal that its stored
+ * secret went stale. Answering 200 would leave it reporting "Connected" forever
+ * with its local notification fallback suppressed.
+ */
+test("an unknown Bearer still returns 401 invalid_bearer", async () => {
+  const app = await buildApp();
+  const res = await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { authorization: "Bearer nope" },
+  });
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.json(), { error: "invalid_bearer" });
+
+  await app.close();
+});
+
+test("an empty Bearer returns 401 missing_bearer", async () => {
+  const app = await buildApp();
+  const res = await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { authorization: "Bearer    " },
+  });
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.json(), { error: "missing_bearer" });
+
+  await app.close();
+});
+
+test("a valid Bearer returns the full body", async () => {
+  const device = createDevice({
+    expoPushToken: "ExponentPushToken[health-test]",
+    platform: "ios",
+  });
+  const app = await buildApp();
+  const res = await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { authorization: `Bearer ${device.sharedSecret}` },
+  });
+
+  assert.equal(res.statusCode, 200);
+  const body = bodyOf(res);
+  assert.equal(body.ok, true);
+  assert.equal(body.name, "dashboarr-backend");
+  assert.equal(body.expoAuth, "must-be-disabled");
+  assert.equal(typeof body.version, "string");
+  assert.equal(typeof body.uptimeMs, "number");
+  assert.ok(Array.isArray(body.pollers));
+
+  await app.close();
+});
+
+// RFC 7235 makes the auth scheme case-insensitive.
+test("a lowercase `bearer` scheme authenticates", async () => {
+  const device = createDevice({
+    expoPushToken: "ExponentPushToken[health-test-lower]",
+    platform: "android",
+  });
+  const app = await buildApp();
+  const res = await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { authorization: `bearer ${device.sharedSecret}` },
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(bodyOf(res).expoAuth, "must-be-disabled");
+
+  await app.close();
+});

--- a/backend/dashboarr-backend/src/routes/health.ts
+++ b/backend/dashboarr-backend/src/routes/health.ts
@@ -1,17 +1,41 @@
 import type { FastifyInstance } from "fastify";
-import { requireBearer } from "../auth/bearer.js";
+import { resolveBearer } from "../auth/bearer.js";
 import { getScheduler } from "../workers/scheduler.js";
 import { VERSION } from "../version.js";
 
 /**
- * /health is intentionally behind `requireBearer`. Unauthenticated callers
- * would otherwise learn which services are configured and could read
- * `pollers[].lastError`, which includes internal service URLs embedded in
- * `ServiceHttpError.message` (see services/http.ts). The frontend already
- * holds a bearer, so requiring it here costs nothing.
+ * Two projections, selected by the Authorization header.
+ *
+ * Anonymous callers get liveness only: `{ ok, name }`. That is what a Docker
+ * HEALTHCHECK, an uptime monitor, or a reverse-proxy probe needs. Answering
+ * them 401 produced two duplicate "my reverse proxy must be broken" reports
+ * (#357) and left containers permanently unhealthy, because busybox wget exits
+ * non-zero on any status >= 400.
+ *
+ * The full body stays behind the bearer: `pollers[].lastError` embeds internal
+ * service URLs (see ServiceHttpError in services/http.ts) and the poller list
+ * itself reveals which services are configured. `version` and `expoAuth` are
+ * authenticated too — version fingerprinting is free reconnaissance, and the
+ * operator who wants it has the startup banner or a bearer.
+ *
+ * A malformed or unknown Bearer is still a 401 — see resolveBearer for why that
+ * matters to the app.
  */
 export async function healthRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/health", { preHandler: requireBearer }, async () => {
+  app.get("/health", async (request, reply) => {
+    // A caching proxy in front must never hand one projection to the other
+    // audience — least of all the poller list to an anonymous caller.
+    reply.header("Cache-Control", "no-store").header("Vary", "Authorization");
+
+    const outcome = await resolveBearer(request, reply);
+    if (outcome === null) return reply; // 401 already sent
+    if (outcome === "anonymous") {
+      // `ok` is liveness (the process answered), not readiness: a backend with
+      // one failing poller is still up, and flipping this would make every
+      // healthcheck restart the container over an unrelated service outage.
+      return { ok: true, name: "dashboarr-backend" };
+    }
+
     const scheduler = getScheduler();
     return {
       ok: true,

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -572,6 +572,16 @@
           keyed to hostname and covers both that instance's local and remote hostnames, which means
           any other service on the same hostname is relaxed too.
         </p>
+        <p>
+          The <strong>backend</strong> has its own copy of the same toggle, under
+          <strong>Settings, Notifications, Backend</strong>. Turn it on when the backend sits behind a
+          reverse proxy using an internal CA, such as Caddy's default internal issuer or a homelab
+          root certificate. Your phone's browser may trust that CA while the app does not, so
+          <code>/health</code> opens fine in the browser and pairing still fails with "Network request
+          failed", with nothing reaching the container. Mounting the CA into the backend container,
+          for example with <code>NODE_EXTRA_CA_CERTS</code>, does not help: that only affects calls
+          the backend makes outward, never the phone's call inward.
+        </p>
 
         <h3>Behind a forward-auth SSO proxy</h3>
         <p>
@@ -923,6 +933,24 @@
           http to https redirect silently turns the pairing POST into a GET and 404s.
         </p>
 
+        <h3>Health checks</h3>
+        <p>
+          <code>GET /health</code> with no <code>Authorization</code> header answers
+          <code>200</code> with <code>{"ok":true,"name":"dashboarr-backend"}</code>, so a browser, an
+          uptime monitor or a Docker health check can confirm the container is alive without a token.
+          The full body, which lists every poller and its last error, needs the paired bearer, because
+          those errors contain your internal service URLs.
+        </p>
+        <div class="note">
+          <strong>A 401 <code>missing_bearer</code> is not a reverse-proxy problem.</strong> Backends
+          before v1.4.0 required the bearer on <code>/health</code> too, so opening it in a browser
+          returned <code>{"error":"missing_bearer"}</code>, and any hand-written
+          <code>wget .../health</code> health check marked the container unhealthy forever. Update the
+          image. On v1.4.0 and newer a 401 means the token you sent is wrong, not that your proxy is
+          misconfigured, and adding <code>^/health</code> to an Authentik Unauthenticated Paths list
+          was never the fix.
+        </div>
+
         <h3>Webhooks</h3>
         <p>
           Webhooks make Radarr, Sonarr, Seerr and Tracearr events near-instant instead of waiting for
@@ -1151,6 +1179,18 @@
           notifies about events that complete <em>after</em> it starts, so anything already finished is
           treated as seen; for Radarr, Sonarr and Seerr the webhook test event should produce a
           confirmation push; and Bazarr and Tautulli webhooks are logged but do not push yet.
+        </p>
+
+        <h3>Backend pairing says "Network request failed" but the URL opens in my browser.</h3>
+        <p>
+          Almost always an internal CA. If the backend is behind Caddy, Traefik or Nginx serving a
+          private root certificate, your phone's browser may trust it while the app does not, and the
+          pairing request fails before it ever reaches the container, which is why nothing appears in
+          the container log. Three fixes, best first: give that hostname a publicly trusted
+          certificate; or point the app at the backend over plain <code>http://</code> on your LAN; or
+          turn on <strong>Allow invalid certificates</strong> under
+          <strong>Settings, Notifications, Backend</strong>. Check the token as well: it is single-use
+          and expires in about ten minutes, so restart the container for a fresh one.
         </p>
 
         <h3>Wake-on-LAN does nothing.</h3>

--- a/lib/backend-error.test.ts
+++ b/lib/backend-error.test.ts
@@ -1,0 +1,108 @@
+// backend-error.ts reuses isAbortError from http-client, which transitively
+// imports the config store and so touches AsyncStorage/SecureStore at module
+// load — native modules absent in the jest-expo node env. Shim them; these
+// tests only exercise the pure describeBackendTransportError.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { describeBackendTransportError } from "./backend-error";
+
+const URL_UNDER_TEST = "https://dashboarr.ember.ops/pair/claim";
+
+/** RN's fetch rejects with a plain Error named "AbortError" (see isAbortError). */
+function abortError(): Error {
+  const err = new Error("Aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+describe("describeBackendTransportError", () => {
+  it("rewrites RN's bare TypeError to name the host and the cert toggle", () => {
+    const original = new TypeError("Network request failed");
+    const result = describeBackendTransportError(original, URL_UNDER_TEST) as Error;
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toContain("dashboarr.ember.ops");
+    expect(result.message).toContain("Allow invalid certificates");
+    expect(result.cause).toBe(original);
+  });
+
+  // pairClaim only advances to its next scheme candidate when `.status` is
+  // absent, so a wrapped connection error must not acquire one.
+  it("leaves the wrapped connection error without a .status", () => {
+    const result = describeBackendTransportError(
+      new TypeError("Network request failed"),
+      URL_UNDER_TEST,
+    );
+    expect((result as { status?: number }).status).toBeUndefined();
+  });
+
+  it("rewrites an abort into a timeout message, still without a .status", () => {
+    const original = abortError();
+    const result = describeBackendTransportError(original, URL_UNDER_TEST) as Error;
+
+    expect(result.message).toContain("didn't respond");
+    expect(result.cause).toBe(original);
+    expect((result as { status?: number }).status).toBeUndefined();
+  });
+
+  // The load-bearing invariant: an HTTP answer is a real result, never a
+  // wrong-scheme guess, so it must survive untouched by reference.
+  it("returns an error carrying a numeric .status identically", () => {
+    const err = Object.assign(new Error("Backend /pair/claim HTTP 401"), { status: 401 });
+    expect(describeBackendTransportError(err, URL_UNDER_TEST)).toBe(err);
+  });
+
+  it("returns a status-carrying TypeError untouched too", () => {
+    const err = Object.assign(new TypeError("weird"), { status: 500 });
+    expect(describeBackendTransportError(err, URL_UNDER_TEST)).toBe(err);
+  });
+
+  it("falls back to a generic target when the URL is unparseable", () => {
+    const result = describeBackendTransportError(
+      new TypeError("Network request failed"),
+      "not a url",
+    ) as Error;
+    expect(result.message).toContain("the backend");
+    expect(result.message).toContain("Allow invalid certificates");
+  });
+
+  // Error toasts clamp to 4 lines (LINE_CLAMP in components/ui/toast.tsx). If a
+  // rewrite grows past that, the half telling the user what to do is the half
+  // that gets cut off — which is the whole point of the message.
+  it("keeps rewritten messages short enough to survive the toast clamp", () => {
+    const messages = [
+      describeBackendTransportError(new TypeError("Network request failed"), URL_UNDER_TEST),
+      describeBackendTransportError(abortError(), URL_UNDER_TEST),
+    ] as Error[];
+
+    for (const err of messages) {
+      expect(err.message.length).toBeLessThanOrEqual(160);
+    }
+  });
+
+  it("passes non-Error throw values through unchanged", () => {
+    expect(describeBackendTransportError("boom", URL_UNDER_TEST)).toBe("boom");
+    expect(describeBackendTransportError(undefined, URL_UNDER_TEST)).toBeUndefined();
+  });
+
+  it("passes an unrecognized Error through unchanged", () => {
+    const err = new Error("Backend not paired");
+    expect(describeBackendTransportError(err, URL_UNDER_TEST)).toBe(err);
+  });
+});

--- a/lib/backend-error.ts
+++ b/lib/backend-error.ts
@@ -1,0 +1,63 @@
+import { isAbortError } from "@/lib/http-client";
+
+/**
+ * Turns the backend transport's connection-level failures into something a user
+ * can act on (issue #357).
+ *
+ * React Native's fetch rejects with a bare `TypeError: Network request failed`
+ * for every pre-HTTP failure: DNS, connection refused, cleartext block, and —
+ * the case that produced #357 — an untrusted TLS certificate. `toastError`
+ * prefers `err.message` over the caller's fallback, so that raw string is what
+ * the user saw, with nothing pointing at the actual cause.
+ *
+ * The service path already does this at `testServiceConnection`
+ * (lib/http-client.ts); this is the backend path's equivalent, applied inside
+ * `request()` so pairing, health, test push and Apprise all get it.
+ */
+
+/**
+ * Errors carrying a numeric `.status` came from a real HTTP response and are
+ * returned untouched, by reference. `pairClaim` depends on this: it only falls
+ * through to its next scheme candidate when `.status` is absent, so wrapping an
+ * HTTP error here would turn a definitive 401 into a pointless retry.
+ */
+function hasHttpStatus(err: unknown): boolean {
+  return typeof (err as { status?: unknown } | null)?.status === "number";
+}
+
+/** Host of a request URL, for naming what we couldn't reach. */
+function hostOf(url: string): string | null {
+  try {
+    const host = new URL(url).host;
+    return host.length > 0 ? host : null;
+  } catch {
+    return null;
+  }
+}
+
+export function describeBackendTransportError(err: unknown, url: string): unknown {
+  if (hasHttpStatus(err)) return err;
+
+  if (isAbortError(err)) {
+    return new Error(
+      "The backend didn't respond in time. Check the URL and that the server is reachable.",
+      { cause: err },
+    );
+  }
+
+  if (err instanceof TypeError) {
+    const host = hostOf(url);
+    const target = host ? `"${host}"` : "the backend";
+    // Kept short on purpose: error toasts clamp to 4 lines
+    // (LINE_CLAMP in components/ui/toast.tsx), and the actionable half must
+    // survive that clamp. The self-signed/private-CA nuance is spelled out in
+    // the toggle's own description, which is on screen right next to this.
+    return new Error(
+      `Can't reach ${target}. Check the URL, or turn on "Allow invalid ` +
+        'certificates" here if its certificate is self-signed or from a private CA.',
+      { cause: err },
+    );
+  }
+
+  return err;
+}

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -253,6 +253,11 @@ export function formatErrorForCopy(err: unknown): string {
   if (err instanceof Error) {
     const parts = [`${err.name}: ${err.message}`];
     if (err.stack) parts.push(err.stack);
+    // Errors we rewrite for the user (see lib/backend-error.ts) keep the
+    // original on `cause` — that's the string worth pasting into a bug report.
+    if (err.cause instanceof Error) {
+      parts.push(`Caused by: ${err.cause.name}: ${err.cause.message}`);
+    }
     return parts.join("\n");
   }
   try {

--- a/lib/insecure-tls.test.ts
+++ b/lib/insecure-tls.test.ts
@@ -88,3 +88,51 @@ describe("computeInsecureHosts", () => {
     ).toEqual(["nas.local"]);
   });
 });
+
+// The backend lives in its own store, so its host reaches the allowlist through
+// `extraUrls` rather than through a ServiceInstance (#357).
+describe("computeInsecureHosts — extraUrls (backend host)", () => {
+  it("merges the extra host with service hosts, sorted", () => {
+    expect(
+      computeInsecureHosts(
+        services({ radarr: [inst({ ignoreCertErrors: true, localUrl: "https://nas.local:7878" })] }),
+        ["https://dashboarr.ember.ops"],
+      ),
+    ).toEqual(["dashboarr.ember.ops", "nas.local"]);
+  });
+
+  it("normalizes and lowercases an extra URL (#357 shape)", () => {
+    expect(
+      computeInsecureHosts(services({}), ["https://Dashboarr.Ember.OPS:8443"]),
+    ).toEqual(["dashboarr.ember.ops"]);
+  });
+
+  it("parses a scheme-less extra URL", () => {
+    expect(computeInsecureHosts(services({}), ["dashboarr.ember.ops:4000"])).toEqual([
+      "dashboarr.ember.ops",
+    ]);
+  });
+
+  it("ignores null, undefined, empty and whitespace extras", () => {
+    expect(
+      computeInsecureHosts(services({}), [null, undefined, "", "   "]),
+    ).toEqual([]);
+  });
+
+  it("dedupes an extra that repeats a service host", () => {
+    expect(
+      computeInsecureHosts(
+        services({ radarr: [inst({ ignoreCertErrors: true, localUrl: "https://nas.local:7878" })] }),
+        ["https://nas.local:4000"],
+      ),
+    ).toEqual(["nas.local"]);
+  });
+
+  it("defaults to no extras, leaving existing callers unchanged", () => {
+    expect(
+      computeInsecureHosts(
+        services({ radarr: [inst({ ignoreCertErrors: true, localUrl: "https://nas.local" })] }),
+      ),
+    ).toEqual(["nas.local"]);
+  });
+});

--- a/lib/insecure-tls.ts
+++ b/lib/insecure-tls.ts
@@ -3,6 +3,7 @@ import { normalizeServiceUrl } from "@/lib/url-validation";
 import type { ServiceId } from "@/lib/constants";
 import type { ServiceInstance } from "@/store/config-store";
 import { useConfigStore } from "@/store/config-store";
+import { useBackendStore } from "@/store/backend-store";
 
 // Pull the bare hostname out of a (possibly scheme-less) service URL.
 // Returns null for blanks and unparseable values rather than throwing — a
@@ -23,8 +24,14 @@ function hostOf(url: string): string | null {
 // either may be the active one depending on the network, and the native layer
 // keys purely on hostname, so listing both keeps the bypass working after an
 // auto-switch without re-syncing.
+//
+// `extraUrls` carries hosts that don't come from a service instance — today
+// just the paired (and about-to-be-paired) backend, which lives in its own
+// store. Optional so existing callers and tests are unaffected. Blanks and
+// unparseable entries are dropped like any other URL.
 export function computeInsecureHosts(
   serviceInstances: Record<ServiceId, ServiceInstance[]>,
+  extraUrls: readonly (string | null | undefined)[] = [],
 ): string[] {
   const hosts = new Set<string>();
   for (const list of Object.values(serviceInstances)) {
@@ -36,6 +43,10 @@ export function computeInsecureHosts(
       if (remote) hosts.add(remote);
     }
   }
+  for (const url of extraUrls) {
+    const host = url ? hostOf(url) : null;
+    if (host) hosts.add(host);
+  }
   return Array.from(hosts).sort();
 }
 
@@ -46,8 +57,15 @@ let lastSynced = "";
 // Recompute the allowlist from current config and push it to the native module
 // if it changed. Safe to call on every config mutation. No-ops when the native
 // module is absent (Expo Go / web / pre-rebuild binary).
+//
+// Both the paired `url` and the in-flight `draftUrl` are offered: they're not
+// mutually exclusive during a re-pair, and `pairClaim`'s https-first retry
+// (services/backend-api.ts) only rewrites the scheme, so one hostname entry
+// covers every candidate it tries.
 export function syncInsecureHosts(): void {
-  const hosts = computeInsecureHosts(useConfigStore.getState().serviceInstances);
+  const backend = useBackendStore.getState();
+  const extras = backend.ignoreCertErrors ? [backend.url, backend.draftUrl] : [];
+  const hosts = computeInsecureHosts(useConfigStore.getState().serviceInstances, extras);
   const serialized = hosts.join(",");
   if (serialized === lastSynced) return;
   lastSynced = serialized;

--- a/services/backend-api.ts
+++ b/services/backend-api.ts
@@ -2,6 +2,7 @@ import { useBackendStore } from "@/store/backend-store";
 import { useConfigStore } from "@/store/config-store";
 import { SERVICE_IDS } from "@/lib/constants";
 import { isPrivateHost } from "@/lib/url-validation";
+import { describeBackendTransportError } from "@/lib/backend-error";
 
 const DEFAULT_TIMEOUT = 10000;
 
@@ -27,12 +28,23 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), options.timeout ?? DEFAULT_TIMEOUT);
 
+  const url = `${baseUrl.replace(/\/$/, "")}${path}`;
+
   try {
-    const res = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, {
-      ...options,
-      headers,
-      signal: controller.signal,
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        ...options,
+        headers,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // Connection-level failure (TLS / DNS / refused / timeout) — no HTTP
+      // response exists. Translate it into something actionable; anything
+      // carrying a `.status` is passed straight through, which is what keeps
+      // `pairClaim`'s scheme fall-through correct.
+      throw describeBackendTransportError(err, url);
+    }
     if (!res.ok) {
       // Tag the status so callers can tell a real HTTP response (the endpoint
       // answered) apart from a connection-level failure (fetch rejects with no
@@ -55,17 +67,24 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   }
 }
 
+/**
+ * Backend `/health` has two projections (backend v1.4.0+): anonymous callers
+ * get liveness only (`ok`, `name`), a valid bearer gets everything. Every field
+ * beyond `ok`/`name` is therefore optional — the app always sends a bearer, so
+ * it sees the full body, but typing them as required would be a lie the moment
+ * anything calls this unauthenticated.
+ */
 export interface BackendHealth {
   ok: boolean;
   name: string;
-  version: string;
-  expoAuth: string;
+  version?: string;
+  expoAuth?: string;
   // Multi-instance backends: `id` is the per-instance UUID, `kind` is the
   // service kind, `name` is the user-facing label. Older backends omit
   // `kind`/`name` and put the kind in `id`. `useBackendHealth` only reads
   // `ok` today, but the richer fields are available for any future UI that
   // wants to surface backend-side per-instance polling status.
-  pollers: {
+  pollers?: {
     id: string;
     kind?: string;
     name?: string;
@@ -73,7 +92,7 @@ export interface BackendHealth {
     lastRunAt: number | null;
     lastError: string | null;
   }[];
-  uptimeMs: number;
+  uptimeMs?: number;
 }
 
 export function getBackendHealth(): Promise<BackendHealth> {

--- a/store/backend-store.ts
+++ b/store/backend-store.ts
@@ -11,6 +11,7 @@ const SECRET_KEYS = {
   url: "backend.url",
   sharedSecret: "backend.sharedSecret",
   deviceId: "backend.deviceId",
+  ignoreCertErrors: "backend.ignoreCertErrors",
 } as const;
 
 interface BackendState {
@@ -18,6 +19,26 @@ interface BackendState {
   url: string | null;
   sharedSecret: string | null;
   deviceId: string | null;
+  /**
+   * Opt the backend's hostname into the native TLS-bypass allowlist
+   * (lib/insecure-tls.ts). Needed when the backend sits behind a reverse proxy
+   * serving a self-signed cert or one from a private/internal CA: the phone's
+   * browser may trust that CA while app traffic does not, so the handshake
+   * fails before any HTTP request is sent (issue #357).
+   *
+   * Stored in SecureStore next to the other backend keys rather than in the
+   * config store, which is hydrated by a separate, unordered `hydrate()` call.
+   */
+  ignoreCertErrors: boolean;
+  /**
+   * Backend URL the user is about to pair with, before `pair()` persists it.
+   * In-memory only. `syncInsecureHosts` reads it so the TLS bypass is already
+   * in place for the `POST /pair/claim` that establishes the pairing — without
+   * it the very request that needs the bypass is the one request that can't
+   * have it. Also seeded by `unpair()` so the allowlist survives a
+   * rotate-secret → rescan round trip.
+   */
+  draftUrl: string | null;
   isHealthy: boolean;
   lastHealthAt: number | null;
   consecutiveFailures: number;
@@ -28,6 +49,8 @@ interface BackendActions {
   pair: (input: { url: string; sharedSecret: string; deviceId: string }) => Promise<void>;
   unpair: () => Promise<void>;
   setHealth: (ok: boolean) => void;
+  setIgnoreCertErrors: (value: boolean) => Promise<void>;
+  setDraftUrl: (url: string | null) => void;
 }
 
 export const useBackendStore = create<BackendState & BackendActions>((set, get) => ({
@@ -35,15 +58,18 @@ export const useBackendStore = create<BackendState & BackendActions>((set, get) 
   url: null,
   sharedSecret: null,
   deviceId: null,
+  ignoreCertErrors: false,
+  draftUrl: null,
   isHealthy: false,
   lastHealthAt: null,
   consecutiveFailures: 0,
 
   hydrate: async () => {
-    const [url, sharedSecret, deviceId] = await Promise.all([
+    const [url, sharedSecret, deviceId, ignoreCertErrors] = await Promise.all([
       getSecret(SECRET_KEYS.url),
       getSecret(SECRET_KEYS.sharedSecret),
       getSecret(SECRET_KEYS.deviceId),
+      getSecret(SECRET_KEYS.ignoreCertErrors),
     ]);
     // Optimistically assume a previously-paired backend is still reachable.
     // `setHealth` will flip to unhealthy after 2 consecutive /health failures.
@@ -55,6 +81,7 @@ export const useBackendStore = create<BackendState & BackendActions>((set, get) 
       url: url ?? null,
       sharedSecret: sharedSecret ?? null,
       deviceId: deviceId ?? null,
+      ignoreCertErrors: ignoreCertErrors === "true",
       hydrated: true,
       isHealthy: hasPairing,
     });
@@ -66,10 +93,24 @@ export const useBackendStore = create<BackendState & BackendActions>((set, get) 
       setSecret(SECRET_KEYS.sharedSecret, sharedSecret),
       setSecret(SECRET_KEYS.deviceId, deviceId),
     ]);
-    set({ url, sharedSecret, deviceId, isHealthy: true, lastHealthAt: Date.now(), consecutiveFailures: 0 });
+    // `url` now carries the host, so the draft has done its job.
+    set({
+      url,
+      sharedSecret,
+      deviceId,
+      draftUrl: null,
+      isHealthy: true,
+      lastHealthAt: Date.now(),
+      consecutiveFailures: 0,
+    });
   },
 
   unpair: async () => {
+    // `ignoreCertErrors` is deliberately NOT deleted: a private CA is a
+    // property of the user's network, not of the pairing, so unpair → rescan
+    // (and Rotate secret, which goes through here) must not silently drop the
+    // TLS bypass and reintroduce #357 on the re-pair.
+    const previousUrl = get().url;
     await Promise.all([
       deleteSecret(SECRET_KEYS.url),
       deleteSecret(SECRET_KEYS.sharedSecret),
@@ -79,6 +120,8 @@ export const useBackendStore = create<BackendState & BackendActions>((set, get) 
       url: null,
       sharedSecret: null,
       deviceId: null,
+      // Keeps the old host allowlisted for the re-pair the user is about to do.
+      draftUrl: previousUrl,
       isHealthy: false,
       lastHealthAt: null,
       consecutiveFailures: 0,
@@ -99,6 +142,14 @@ export const useBackendStore = create<BackendState & BackendActions>((set, get) 
       lastHealthAt: Date.now(),
     });
   },
+
+  setIgnoreCertErrors: async (value) => {
+    await setSecret(SECRET_KEYS.ignoreCertErrors, String(value));
+    // The store subscription in app/_layout.tsx re-pushes the native allowlist.
+    set({ ignoreCertErrors: value });
+  },
+
+  setDraftUrl: (url) => set({ draftUrl: url }),
 }));
 
 /**

--- a/store/config-migrations.ts
+++ b/store/config-migrations.ts
@@ -186,8 +186,11 @@ import { defaultPinnedTabsForInstall } from "@/lib/tab-routes";
  *         defaultInstances() iterates SERVICE_IDS and backfills a disabled
  *         navidrome instance at import time, so older exports just need the
  *         version field bumped.
+ *   v49 — added optional `backend.ignoreCertErrors` (#357), opting the backend
+ *         host into the TLS-bypass allowlist. Pure version stamp — the field is
+ *         optional, so older exports without it validate and default to false.
  */
-export const CURRENT_CONFIG_VERSION = 48;
+export const CURRENT_CONFIG_VERSION = 49;
 
 // Per-slot field renames introduced in v15. Same pairs are applied by the
 // hydrate-time migration in config-store.ts so the import path and the local
@@ -727,6 +730,10 @@ const migrations: Record<number, (payload: any) => any> = {
   // v47 → v48: added the navidrome service entry (#336). Pure version stamp —
   // defaultInstances() backfills a disabled navidrome instance at import.
   47: (payload) => ({ ...payload, version: 48 }),
+  // v48 → v49: optional `backend.ignoreCertErrors` (#357). Pure version stamp —
+  // coerceBackend treats it as an optional key, so pre-v49 exports validate and
+  // the flag defaults to false.
+  48: (payload) => ({ ...payload, version: 49 }),
 };
 
 /**

--- a/store/config-schema.test.ts
+++ b/store/config-schema.test.ts
@@ -1013,7 +1013,30 @@ describe("validateExportPayload — backend", () => {
       ...baseValid(),
       backend: { url: null, sharedSecret: null, deviceId: null },
     });
-    expect(result.backend).toEqual({ url: null, sharedSecret: null, deviceId: null });
+    expect(result.backend).toEqual({
+      url: null,
+      sharedSecret: null,
+      deviceId: null,
+      ignoreCertErrors: false,
+    });
+  });
+
+  // v49 (#357): opts the backend host into the TLS-bypass allowlist.
+  it("round-trips ignoreCertErrors=true", () => {
+    const result = validateExportPayload({
+      ...baseValid(),
+      backend: { url: null, sharedSecret: null, deviceId: null, ignoreCertErrors: true },
+    });
+    expect(result.backend?.ignoreCertErrors).toBe(true);
+  });
+
+  it("rejects a non-boolean ignoreCertErrors", () => {
+    expect(() =>
+      validateExportPayload({
+        ...baseValid(),
+        backend: { url: null, sharedSecret: null, deviceId: null, ignoreCertErrors: "yes" },
+      }),
+    ).toThrow(/backend/);
   });
 
   it("rejects a non-http(s) backend url", () => {

--- a/store/config-schema.ts
+++ b/store/config-schema.ts
@@ -399,11 +399,15 @@ function coerceBackend(v: unknown): ExportPayload["backend"] | null {
   const urlOk = v.url === null || isHttpUrlOrEmpty(v.url);
   const secretOk = v.sharedSecret === null || (typeof v.sharedSecret === "string" && v.sharedSecret.length <= 512);
   const idOk = v.deviceId === null || (typeof v.deviceId === "string" && v.deviceId.length <= 256);
-  if (!urlOk || !secretOk || !idOk) return null;
+  // v49: optional, so pre-v49 exports (which omit it) validate and default off.
+  const certOk =
+    v.ignoreCertErrors === undefined || typeof v.ignoreCertErrors === "boolean";
+  if (!urlOk || !secretOk || !idOk || !certOk) return null;
   return {
     url: typeof v.url === "string" ? v.url : null,
     sharedSecret: typeof v.sharedSecret === "string" ? v.sharedSecret : null,
     deviceId: typeof v.deviceId === "string" ? v.deviceId : null,
+    ignoreCertErrors: v.ignoreCertErrors === true,
   };
 }
 

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -414,8 +414,13 @@ export interface ExportPayload {
   // `dashboardWidgets: WidgetId[]` + `widgetSettings: Record<WidgetId, …>`.
   dashboards: Dashboard[];
   activeDashboardId: string;
-  // v2
-  backend?: { url: string | null; sharedSecret: string | null; deviceId: string | null };
+  // v2 (v49: + ignoreCertErrors)
+  backend?: {
+    url: string | null;
+    sharedSecret: string | null;
+    deviceId: string | null;
+    ignoreCertErrors?: boolean;
+  };
   notificationSettings?: NotificationSettings;
   // v4
   wolDevices?: WakeOnLanDevice[];
@@ -2738,7 +2743,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       weekStart,
       notificationSettings: notifSettings,
     } = get();
-    const { url, sharedSecret, deviceId } = useBackendStore.getState();
+    const { url, sharedSecret, deviceId, ignoreCertErrors } = useBackendStore.getState();
 
     const payload: ExportPayload = {
       version: CURRENT_CONFIG_VERSION,
@@ -2753,7 +2758,7 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
       servicesOrder,
       dashboards,
       activeDashboardId,
-      backend: { url, sharedSecret, deviceId },
+      backend: { url, sharedSecret, deviceId, ignoreCertErrors },
       notificationSettings: notifSettings,
       wolDevices,
       hapticsEnabled,
@@ -2944,6 +2949,15 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     setJSON(STORAGE_KEYS.servicesOrder, importedServicesOrder);
 
     // Restore backend pairing (v2+)
+    if (payload.backend) {
+      // Restored outside the pairing guard below: an export taken before the
+      // device was paired still carries the TLS-bypass preference, and on a
+      // fresh device that flag is what makes the first pairing succeed at all
+      // when the backend sits behind a private CA (#357).
+      await useBackendStore
+        .getState()
+        .setIgnoreCertErrors(payload.backend.ignoreCertErrors ?? false);
+    }
     if (payload.backend?.url && payload.backend?.sharedSecret) {
       await useBackendStore.getState().pair({
         url: payload.backend.url,


### PR DESCRIPTION
Refs #357

Two separate problems in that issue.

**Pairing fails behind a private CA.** The app's per-host TLS bypass is built only from service instances, so the backend URL could never opt in. The handshake fails before any HTTP request, which is why nothing reaches the container while the phone's browser works. Adds an "Allow invalid certificates" toggle for the backend, wired through a `draftUrl` so the bypass is live for the `POST /pair/claim` that establishes the pairing. Also translates the bare `Network request failed` into a message naming the host and the toggle.

**`/health` 401 is not a misconfiguration.** It's deliberately bearer-protected, but the README said `none`, so two users concluded their proxy was broken and any hand-written healthcheck marked the container unhealthy forever. Anonymous callers now get `{ok, name}`; `pollers`/`version`/`uptimeMs`/`expoAuth` stay behind the bearer. A *bad* bearer still 401s: that's the app's only signal a secret went stale. A proxy-injected non-`Bearer` scheme counts as anonymous.

Also: image `HEALTHCHECK`, neutral 404 bodies, and the stale `GET /pair` / `POST /pair/init` README rows removed (neither route exists).

App side is JS-only, so it ships over EAS Update with no rebuild. Config export gains `backend.ignoreCertErrors` (v49 stamp).

## Test plan

- `tsc --noEmit` clean; 1439 app tests pass (new `lib/backend-error.test.ts`, extended `lib/insecure-tls.test.ts`, updated `config-schema.test.ts`)
- Backend typecheck + 36 tests (7 new `src/routes/health.test.ts`) + build
- Ran the server: anonymous `/health` -> `200 {"ok":true,"name":"dashboarr-backend"}` with `Vary: Authorization`; `Basic` header -> anonymous body not 401; `Bearer nope` -> `401 invalid_bearer`; valid bearer -> body identical to v1.3.0; leak grep on anonymous body empty; `POST /pair/init` -> `{"error":"not_found"}`
- Built the image and ran it: container health status reports `healthy`