### PR TITLE
fix(bazarr): use movie endpoint for subtitle search

### DIFF
--- a/services/bazarr-api.test.ts
+++ b/services/bazarr-api.test.ts
@@ -1,0 +1,34 @@
+jest.mock("@/lib/http-client", () => ({
+  serviceRequest: jest.fn(),
+}));
+
+import { serviceRequest } from "@/lib/http-client";
+import { getWantedMovies, searchWantedMovie } from "@/services/bazarr-api";
+
+const mockRequest = serviceRequest as jest.Mock;
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  mockRequest.mockResolvedValue(undefined);
+});
+
+describe("Bazarr movie routes", () => {
+  it("gets the wanted list from the wanted endpoint", async () => {
+    await getWantedMovies(10, 25, "inst-1");
+
+    expect(mockRequest).toHaveBeenCalledWith("bazarr", "/movies/wanted", {
+      params: { start: 10, length: 25 },
+      instanceId: "inst-1",
+    });
+  });
+
+  it("PATCHes the movie resource when searching for missing subtitles", async () => {
+    await searchWantedMovie(42, "inst-1");
+
+    expect(mockRequest).toHaveBeenCalledWith("bazarr", "/movies", {
+      method: "PATCH",
+      body: JSON.stringify({ radarrid: 42, action: "search-missing" }),
+      instanceId: "inst-1",
+    });
+  });
+});

--- a/services/bazarr-api.ts
+++ b/services/bazarr-api.ts
@@ -15,10 +15,14 @@ export function getWantedMovies(
   length = 50,
   instanceId?: string,
 ): Promise<BazarrWantedMoviesResponse> {
-  return serviceRequest<BazarrWantedMoviesResponse>("bazarr", "/movies/wanted", {
-    params: { start, length },
-    instanceId,
-  });
+  return serviceRequest<BazarrWantedMoviesResponse>(
+    "bazarr",
+    "/movies/wanted",
+    {
+      params: { start, length },
+      instanceId,
+    },
+  );
 }
 
 export function getWantedEpisodes(
@@ -26,10 +30,14 @@ export function getWantedEpisodes(
   length = 50,
   instanceId?: string,
 ): Promise<BazarrWantedEpisodesResponse> {
-  return serviceRequest<BazarrWantedEpisodesResponse>("bazarr", "/episodes/wanted", {
-    params: { start, length },
-    instanceId,
-  });
+  return serviceRequest<BazarrWantedEpisodesResponse>(
+    "bazarr",
+    "/episodes/wanted",
+    {
+      params: { start, length },
+      instanceId,
+    },
+  );
 }
 
 // --- History ---
@@ -59,14 +67,19 @@ export function getEpisodeHistory(
 // --- Providers ---
 
 export function getProviders(instanceId?: string): Promise<BazarrProvider[]> {
-  return serviceRequest<BazarrProvider[]>("bazarr", "/providers", { instanceId });
+  return serviceRequest<BazarrProvider[]>("bazarr", "/providers", {
+    instanceId,
+  });
 }
 
 // --- Manual search triggers ---
-// Bazarr uses PATCH on the wanted endpoints with an action body to trigger a search.
 
-export function searchWantedMovie(radarrid: number, instanceId?: string): Promise<void> {
-  return serviceRequest<void>("bazarr", "/movies/wanted", {
+// The wanted route is GET-only; movie actions are PATCHed on the movie resource.
+export function searchWantedMovie(
+  radarrid: number,
+  instanceId?: string,
+): Promise<void> {
+  return serviceRequest<void>("bazarr", "/movies", {
     method: "PATCH",
     body: JSON.stringify({ radarrid, action: "search-missing" }),
     instanceId,


### PR DESCRIPTION
Fixes #381.\n\nUpdates Bazarr movie subtitle searches to PATCH /api/movies, while keeping wanted-list reads on GET /api/movies/wanted. Adds regression coverage for both routes.\n\nValidation:\n- ./node_modules/.bin/jest --runInBand services/bazarr-api.test.ts\n- ./node_modules/.bin/tsc --noEmit\n- ./node_modules/.bin/prettier --check services/bazarr-api.ts services/bazarr-api.test.ts\n- git diff --check