### PR TITLE
fix(lidarr): artist progress counts only monitored tracks

### DIFF
--- a/app/artist/[id].tsx
+++ b/app/artist/[id].tsx
@@ -50,7 +50,7 @@ import { useServiceImage } from "@/hooks/use-service-image";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import { getLidarrAlbumCover } from "@/services/lidarr-api";
 import { formatBytes } from "@/lib/utils";
-import { BAR_KIND_COLOR } from "@/lib/arr-poster-status";
+import { BAR_KIND_COLOR, lidarrArtistTrackCounts } from "@/lib/arr-poster-status";
 import type { LidarrArtist, LidarrAlbum } from "@/lib/types";
 
 type DeleteMode = "keep" | "withFiles";
@@ -385,8 +385,7 @@ function buildArtistMeta(artist: LidarrArtist): string {
 
 function buildArtistStats(artist: LidarrArtist) {
   const stats = artist.statistics;
-  const have = stats?.trackFileCount ?? 0;
-  const total = stats?.totalTrackCount ?? stats?.trackCount ?? 0;
+  const { have, total } = lidarrArtistTrackCounts(artist);
   return [
     { label: "Status", value: capitalize(artist.status) },
     { label: "Albums", value: stats?.albumCount != null ? String(stats.albumCount) : "—" },
@@ -426,8 +425,8 @@ function TrackProgressBlock({
   artist: LidarrArtist;
   downloading: boolean;
 }) {
-  const have = artist.statistics?.trackFileCount ?? 0;
-  const total = artist.statistics?.totalTrackCount ?? artist.statistics?.trackCount ?? 0;
+  // Wanted tracks only: an unmonitored album must not read as missing (#383).
+  const { have, total } = lidarrArtistTrackCounts(artist);
   if (!total) return null;
   const ratio = total > 0 ? have / total : 0;
   const missing = total - have;

--- a/lib/arr-poster-status.test.ts
+++ b/lib/arr-poster-status.test.ts
@@ -11,7 +11,18 @@ import {
   BAR_KIND_COLOR,
 } from "@/lib/arr-poster-status";
 import { binderyBookBarKind, binderyBookIsMissing } from "@/lib/arr-poster-status";
-import type { RadarrMovie, SonarrSeries, BinderyBook } from "@/lib/types";
+import {
+  lidarrArtistBarProgress,
+  lidarrArtistIsMissing,
+  lidarrArtistTrackCounts,
+} from "@/lib/arr-poster-status";
+import type {
+  RadarrMovie,
+  SonarrSeries,
+  BinderyBook,
+  LidarrArtist,
+  LidarrArtistStatistics,
+} from "@/lib/types";
 
 function series(over: Partial<SonarrSeries>): SonarrSeries {
   return {
@@ -363,5 +374,50 @@ describe("binderyBookIsMissing", () => {
   it("never flags a book whose file is present", () => {
     expect(binderyBookIsMissing(book({ status: "downloaded" }))).toBe(false);
     expect(binderyBookIsMissing(book({ status: "imported" }))).toBe(false);
+  });
+});
+
+function artist(stats: Partial<LidarrArtistStatistics>): LidarrArtist {
+  return {
+    status: "continuing",
+    monitored: true,
+    statistics: {
+      trackFileCount: 0,
+      trackCount: 0,
+      totalTrackCount: 0,
+      sizeOnDisk: 0,
+      ...stats,
+    },
+  } as LidarrArtist;
+}
+
+describe("lidarrArtistTrackCounts", () => {
+  it("counts wanted tracks (trackCount), not every track of every album (issue #383)", () => {
+    // New artist, one of ten albums left monitored, nothing downloaded yet.
+    const a = artist({ trackFileCount: 0, trackCount: 12, totalTrackCount: 120 });
+    expect(lidarrArtistTrackCounts(a)).toEqual({ have: 0, total: 12 });
+  });
+
+  it("that album fully downloaded reads complete, not 12/120", () => {
+    const a = artist({ trackFileCount: 12, trackCount: 12, totalTrackCount: 120 });
+    expect(lidarrArtistTrackCounts(a)).toEqual({ have: 12, total: 12 });
+    expect(lidarrArtistIsMissing(a)).toBe(false);
+  });
+
+  it("missing statistics read as 0/0", () => {
+    const a = { status: "continuing", monitored: true } as LidarrArtist;
+    expect(lidarrArtistTrackCounts(a)).toEqual({ have: 0, total: 0 });
+  });
+});
+
+describe("lidarrArtistBarProgress", () => {
+  it("derives from the same wanted-track counts as the detail screen", () => {
+    const a = artist({ trackFileCount: 6, trackCount: 12, totalTrackCount: 120 });
+    expect(lidarrArtistBarProgress(a)).toBe(50);
+  });
+
+  it("nothing wanted and nothing on disk reads as complete", () => {
+    const a = artist({ trackFileCount: 0, trackCount: 0, totalTrackCount: 120 });
+    expect(lidarrArtistBarProgress(a)).toBe(100);
   });
 });

--- a/lib/arr-poster-status.ts
+++ b/lib/arr-poster-status.ts
@@ -152,19 +152,37 @@ export function radarrBarKind(movie: RadarrMovie, isDownloading: boolean): Poste
 }
 
 /**
+ * Tracks on disk vs. tracks wanted for an artist. `total` is Lidarr's
+ * `trackCount`, never `totalTrackCount`: ArtistStatisticsRepository counts a
+ * track toward `trackCount` only when its album is monitored and released, or
+ * the track already has a file, whereas `totalTrackCount` is every track of
+ * every album. Dividing by the latter makes each unmonitored album read as
+ * "missing" (issue #383). Every artist progress surface (poster bar, detail
+ * Progress block, stats strip) derives from this so they cannot drift.
+ */
+export function lidarrArtistTrackCounts(artist: LidarrArtist): {
+  have: number;
+  total: number;
+} {
+  return {
+    have: artist.statistics?.trackFileCount ?? 0,
+    total: artist.statistics?.trackCount ?? 0,
+  };
+}
+
+/** Artist poster bar fill percentage (0–100) — trackFileCount / trackCount, the
+ * Sonarr-style proportional fill Lidarr's ArtistIndexProgressBar uses. */
+export function lidarrArtistBarProgress(artist: LidarrArtist): number {
+  const { have, total } = lidarrArtistTrackCounts(artist);
+  return total ? (have / total) * 100 : 100;
+}
+
+/**
  * Lidarr artist progress bar — same shape as Sonarr's series logic, but the
  * progress denominator is tracks (trackFileCount / trackCount). An `ended`
  * artist that's fully downloaded reads green; an in-progress monitored artist
  * reads red (missing), unmonitored reads amber.
  */
-/** Artist poster bar fill percentage (0–100) — trackFileCount / trackCount, the
- * Sonarr-style proportional fill Lidarr's ArtistIndexProgressBar uses. */
-export function lidarrArtistBarProgress(artist: LidarrArtist): number {
-  const trackCount = artist.statistics?.trackCount ?? 0;
-  const fileCount = artist.statistics?.trackFileCount ?? 0;
-  return trackCount ? (fileCount / trackCount) * 100 : 100;
-}
-
 export function lidarrArtistBarKind(
   artist: LidarrArtist,
   isDownloading: boolean,


### PR DESCRIPTION
Refs #383

The Lidarr artist screen's Progress block and Tracks stat divided by `totalTrackCount` (every track of every album), so unmonitoring albums never reduced the "tracks missing" count. Lidarr's own denominator is `trackCount`, which only includes tracks from monitored, released albums plus tracks already on disk. The poster bar in the Music list already used it, so the two surfaces disagreed.

- Add `lidarrArtistTrackCounts` in `lib/arr-poster-status.ts`; the poster bar and the artist screen now derive from it
- Artist Progress block and stats strip use wanted tracks as the total
- Tests for the reporter's scenario (one monitored album of ten reads 0/12, not 0/120)

## Test plan
- [ ] Lidarr artist with most albums unmonitored: Progress shows only the monitored albums' tracks as missing
- [ ] Download that album: Progress reads complete
- [ ] Music list poster bar and artist screen agree