### PR TITLE
fix(http): name the host and mention certificates on https transport failures

### DIFF
--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -581,6 +581,90 @@ describe("testServiceConnection — auth-proxy detection (#239)", () => {
   });
 });
 
+describe("testServiceConnection — TLS hint on transport failure", () => {
+  let originalFetch: typeof global.fetch;
+  let fetchSpy: jest.Mock;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetchSpy = fetchMock();
+    global.fetch = fetchSpy as any;
+    mockStateRef.current = makeState();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // React Native rejects with a bare TypeError for every pre-HTTP failure —
+  // DNS, refused connection, cleartext block and untrusted certificate alike —
+  // so this is the shape the real failure arrives in.
+  const networkFailure = () => new TypeError("Network request failed");
+
+  it("names the host and mentions certificates for an https URL", async () => {
+    fetchSpy.mockRejectedValue(networkFailure());
+    const result = await testServiceConnection("radarr", {
+      url: "https://radarr.example.com:7878",
+      apiKey: "k",
+    });
+    expect(result.kind).toBe("unreachable");
+    expect(result.message).toContain("radarr.example.com");
+    expect(result.message).toContain("Allow invalid certificates");
+    // The mismatched-hostname case is the one a generic "check connectivity"
+    // message hides: the server answers, the certificate just names another host.
+    expect(result.message).toContain("hostname mismatch");
+  });
+
+  // #357 caps these at 160 chars because toasts clamp to 4 lines. This one is
+  // additionally prefixed by service-editor before display, so the budget has
+  // to be measured against the string the user actually sees, or the tail —
+  // the part naming the fix — is what gets cut.
+  it("stays inside the toast budget once service-editor prefixes it", async () => {
+    fetchSpy.mockRejectedValue(networkFailure());
+    const result = await testServiceConnection("radarr", {
+      url: "https://a-fairly-long-service-hostname.example.com:7878",
+      apiKey: "k",
+    });
+    expect(result.message.length).toBeLessThanOrEqual(160);
+    const toasted = `Could not reach Remote URL: ${result.message}`;
+    expect(toasted.length).toBeLessThanOrEqual(200);
+    expect(result.message).toContain("hostname mismatch");
+  });
+
+  it("does not mention certificates for an http URL", async () => {
+    fetchSpy.mockRejectedValue(networkFailure());
+    const result = await testServiceConnection("radarr", {
+      url: "http://radarr.local:7878",
+      apiKey: "k",
+    });
+    expect(result.kind).toBe("unreachable");
+    expect(result.message).not.toContain("certificate");
+    expect(result.message).toBe("Network error — check URL and connectivity");
+  });
+
+  it("leaves the timeout message alone", async () => {
+    const abort = new Error("Aborted");
+    abort.name = "AbortError";
+    fetchSpy.mockRejectedValue(abort);
+    const result = await testServiceConnection("radarr", {
+      url: "https://radarr.example.com:7878",
+      apiKey: "k",
+    });
+    expect(result.message).toBe("Request timed out");
+  });
+
+  it("keeps the Tdarr port hint, which is more specific than the TLS one", async () => {
+    fetchSpy.mockRejectedValue(networkFailure());
+    const result = await testServiceConnection("tdarr", {
+      url: "https://tdarr.example.com:8265",
+      apiKey: "k",
+    });
+    expect(result.message).toContain("8266");
+    // The port hint replaces the TLS one rather than concatenating with it.
+    expect(result.message).not.toContain("certificates");
+  });
+});
+
 describe("testServiceConnection — rTorrent authentication diagnostics (#352)", () => {
   let originalFetch: typeof global.fetch;
   let fetchSpy: jest.Mock;

--- a/lib/http-client.test.ts
+++ b/lib/http-client.test.ts
@@ -7,6 +7,7 @@ import {
   AuthProxyResponseError,
   HttpError,
   isAbortError,
+  type ConnectionTestResult,
 } from "./http-client";
 
 // jest.mock factories run before module-scope code; the only refs allowed
@@ -601,18 +602,29 @@ describe("testServiceConnection — TLS hint on transport failure", () => {
   // so this is the shape the real failure arrives in.
   const networkFailure = () => new TypeError("Network request failed");
 
+  // The `ok` variant carries no `message`, and Jest transpiles without
+  // type-checking, so reading it unnarrowed passes the suite and fails tsc.
+  const unreachable = (
+    result: ConnectionTestResult,
+  ): Extract<ConnectionTestResult, { kind: "unreachable" }> => {
+    if (result.kind !== "unreachable") {
+      throw new Error(`expected unreachable, got ${result.kind}`);
+    }
+    return result;
+  };
+
   it("names the host and mentions certificates for an https URL", async () => {
     fetchSpy.mockRejectedValue(networkFailure());
     const result = await testServiceConnection("radarr", {
       url: "https://radarr.example.com:7878",
       apiKey: "k",
     });
-    expect(result.kind).toBe("unreachable");
-    expect(result.message).toContain("radarr.example.com");
-    expect(result.message).toContain("Allow invalid certificates");
+    const { message } = unreachable(result);
+    expect(message).toContain("radarr.example.com");
+    expect(message).toContain("Allow invalid certificates");
     // The mismatched-hostname case is the one a generic "check connectivity"
     // message hides: the server answers, the certificate just names another host.
-    expect(result.message).toContain("hostname mismatch");
+    expect(message).toContain("hostname mismatch");
   });
 
   // #357 caps these at 160 chars because toasts clamp to 4 lines. This one is
@@ -625,10 +637,11 @@ describe("testServiceConnection — TLS hint on transport failure", () => {
       url: "https://a-fairly-long-service-hostname.example.com:7878",
       apiKey: "k",
     });
-    expect(result.message.length).toBeLessThanOrEqual(160);
-    const toasted = `Could not reach Remote URL: ${result.message}`;
+    const { message } = unreachable(result);
+    expect(message.length).toBeLessThanOrEqual(160);
+    const toasted = `Could not reach Remote URL: ${message}`;
     expect(toasted.length).toBeLessThanOrEqual(200);
-    expect(result.message).toContain("hostname mismatch");
+    expect(message).toContain("hostname mismatch");
   });
 
   it("does not mention certificates for an http URL", async () => {
@@ -637,9 +650,9 @@ describe("testServiceConnection — TLS hint on transport failure", () => {
       url: "http://radarr.local:7878",
       apiKey: "k",
     });
-    expect(result.kind).toBe("unreachable");
-    expect(result.message).not.toContain("certificate");
-    expect(result.message).toBe("Network error — check URL and connectivity");
+    const { message } = unreachable(result);
+    expect(message).not.toContain("certificate");
+    expect(message).toBe("Network error — check URL and connectivity");
   });
 
   it("leaves the timeout message alone", async () => {
@@ -650,7 +663,7 @@ describe("testServiceConnection — TLS hint on transport failure", () => {
       url: "https://radarr.example.com:7878",
       apiKey: "k",
     });
-    expect(result.message).toBe("Request timed out");
+    expect(result).toMatchObject({ message: "Request timed out" });
   });
 
   it("keeps the Tdarr port hint, which is more specific than the TLS one", async () => {
@@ -659,9 +672,10 @@ describe("testServiceConnection — TLS hint on transport failure", () => {
       url: "https://tdarr.example.com:8265",
       apiKey: "k",
     });
-    expect(result.message).toContain("8266");
+    const { message } = unreachable(result);
+    expect(message).toContain("8266");
     // The port hint replaces the TLS one rather than concatenating with it.
-    expect(result.message).not.toContain("certificates");
+    expect(message).not.toContain("certificates");
   });
 });
 

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -718,6 +718,25 @@ export interface ConnectionTestInput {
   instanceId?: string;
 }
 
+/** Hostname of a probe URL, for naming what we couldn't reach. Null if unparseable. */
+function hostOfUrl(url: string): string | null {
+  try {
+    const host = new URL(normalizeServiceUrl(url)).hostname;
+    return host.length > 0 ? host : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the probe URL resolves to https, i.e. a certificate is involved. */
+function isHttpsUrl(url: string): boolean {
+  try {
+    return new URL(normalizeServiceUrl(url)).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export async function testServiceConnection(
   serviceId: ServiceId,
   input: ConnectionTestInput,
@@ -767,6 +786,26 @@ export async function testServiceConnection(
           kind: "unreachable",
           message:
             "Network error — Tdarr's REST API runs on port 8266, not the WebUI's 8265. Check the URL.",
+        };
+      }
+      // An untrusted certificate reaches JS as the same
+      // TypeError("Network request failed") as a refused connection or a DNS
+      // miss — React Native does not surface the underlying
+      // SSLPeerUnverifiedException / NSURLError — so the cause cannot be
+      // proven here. Name the host and mention the certificate on https only,
+      // where it is a plausible cause; on http it would be noise. Same
+      // treatment the backend path already gets in
+      // lib/backend-error.ts (#357), and held to the same 160-char budget:
+      // error toasts clamp to 4 lines (LINE_CLAMP in components/ui/toast.tsx)
+      // and service-editor prefixes this with "Could not reach X URL: ", so a
+      // longer string loses its tail — which is the actionable half.
+      const host = hostOfUrl(baseUrl);
+      if (host && isHttpsUrl(baseUrl)) {
+        return {
+          kind: "unreachable",
+          message:
+            `Can't reach ${host}. Check the URL, or turn on "Allow invalid ` +
+            'certificates" (self-signed, private CA, or hostname mismatch).',
         };
       }
       return { kind: "unreachable", message: "Network error — check URL and connectivity" };


### PR DESCRIPTION
## Problem

React Native rejects with a bare `TypeError("Network request failed")` for every pre-HTTP failure: DNS, refused connection, cleartext block, and an untrusted certificate. The underlying `SSLPeerUnverifiedException` / `NSURLError` never reaches JS.

So a certificate problem currently reports as:

> Network error - check URL and connectivity

which points the user at connectivity that is fine.

**The case that prompted this:** a Plex server reachable at one hostname, serving a valid Let's Encrypt certificate issued for a different one. The connection worked end to end; only the name on the certificate did not match. That message sent me checking firewalls, ports and URLs for a long time before I thought to test TLS directly.

## Approach

This is the service-side counterpart to the treatment the backend path already got in `lib/backend-error.ts` (#357), whose own comment says *"The service path already does this at `testServiceConnection`"*. This makes that true.

Same approach as #357, deliberately: the cause **cannot be proven from JS**, so it does not try. It names the host and says what to try, on `https` only. On `http` a certificate is not a plausible cause and the hint would be noise.

```
Can't reach radarr.example.com. Check the URL, or turn on "Allow invalid
certificates" (self-signed, private CA, or hostname mismatch).
```

### Why the wording differs from #357

One addition carries the motivating case: **"hostname mismatch"**. A certificate that is valid but issued for another host is neither self-signed nor from a private CA, so a user reading the #357 phrasing skips right past it. The toggle's own description ("self-signed or otherwise invalid certs") does not cover it either.

### Length

Held to the same 160-character budget `backend-error.test.ts` enforces, and for a sharper reason here: `service-editor.tsx` prefixes this with `Could not reach ${which} URL: ` before toasting, so the 4-line `LINE_CLAMP` bites earlier. Over budget, the clause naming the fix is exactly the part that gets cut. There is a test for the prefixed length, not just the raw message.

### Precedence

The Tdarr `:8265` port hint still wins. A wrong port is wrong whatever the certificate says. Covered by a test using `https://...:8265`, the case where both would otherwise apply.

## What this deliberately does not do

I first built a version that **proved** the cause: retry the probe once with trust bypassed for that host via `modules/insecure-tls`, then restore. It worked and was fully tested, and I threw it away.

Three reasons, in case the same idea comes up later:

1. It sent credentials over an unverified connection with no user opt-in, which is the opposite of what the toggle's own copy asks for.
2. It would have run on `checkInstanceHealth` too, since that ends in `return testServiceConnection(...)`, doubling poll traffic for every failing HTTPS service.
3. It mutated a global allowlist as a diagnostic register, with no mutex, while the store subscription resyncs it independently.

If a proven diagnosis is ever wanted, the right shape looks like a `probeTrust(host, port)` in the native module that reports a failure class, rather than anything that touches `InsecureHostStore`.

## Tests

Five cases in `lib/http-client.test.ts`, all driving `testServiceConnection` with the real RN rejection shape:

- https `TypeError`: names the host, names the toggle, includes "hostname mismatch"
- http `TypeError`: unchanged message, no mention of certificates
- `AbortError`: timeout message untouched
- Tdarr `:8265`: port hint still wins, and does not concatenate with the TLS one
- prefixed length stays inside the toast clamp

`pnpm test`: 76 suites, 1594 tests passing. `tsc --noEmit` clean.