### PR TITLE
feat(calendar): mark season premieres on the calendar and event rows

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -34,6 +34,7 @@ import {
   orderedWeekdays,
 } from "@/lib/calendar-grid";
 import { resolveWeekStartDow } from "@/lib/week-start";
+import { isSeasonPremiere, PREMIERE_BADGE } from "@/lib/season-premiere";
 import { useConfigStore } from "@/store/config-store";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
@@ -529,6 +530,9 @@ export default function CalendarScreen() {
               const events = itemsByDate.get(cell.dateKey);
               const hasEpisodes = events?.some((e) => e.type === "episode");
               const hasMovies = events?.some((e) => e.type === "movie");
+              const startsSeason = events?.some(
+                (e) => e.type === "episode" && isSeasonPremiere(e.data),
+              );
 
               return (
                 <Pressable
@@ -564,9 +568,17 @@ export default function CalendarScreen() {
                   </View>
                   {/* Event dots */}
                   <View className="flex-row gap-0.5 mt-0.5 h-1.5">
-                    {hasEpisodes && (
-                      <View className="w-1.5 h-1.5 rounded-full bg-green-500" />
-                    )}
+                    {/* A day that opens a season widens its episode dot into
+                        a capsule, reusing the same slot so the grid keeps its
+                        height at every uiScale. Sky, not blue: `primary` is
+                        #3b82f6, so a blue-500/600 marker would read as the
+                        selected-day circle sitting right above it. */}
+                    {hasEpisodes &&
+                      (startsSeason ? (
+                        <View className="w-3.5 h-1.5 rounded-full bg-sky-400" />
+                      ) : (
+                        <View className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                      ))}
                     {hasMovies && (
                       <View className="w-1.5 h-1.5 rounded-full bg-amber-500" />
                     )}
@@ -650,12 +662,14 @@ function EpisodeRow({
   downloading: boolean;
   onPress: () => void;
 }) {
+  const badge = isSeasonPremiere(episode) ? PREMIERE_BADGE : undefined;
   return (
     <CalendarEventRow
       images={episode.series.images}
       service="sonarr"
       title={episode.series.title}
       subtitle={`${formatEpisodeCode(episode.seasonNumber, episode.episodeNumber)} — ${episode.title}`}
+      badge={badge}
       hasFile={episode.hasFile}
       downloading={downloading}
       barColor={BAR_KIND_COLOR[sonarrEpisodeBarKind(episode, downloading)]}

--- a/components/common/calendar-event-row.tsx
+++ b/components/common/calendar-event-row.tsx
@@ -3,6 +3,7 @@ import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 import { Tv, Film, Check, Download, type LucideIcon } from "lucide-react-native";
 import { Icon } from "@/components/ui/icon";
+import { Badge, type BadgeVariant } from "@/components/ui/badge";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import {
@@ -32,6 +33,8 @@ export interface CalendarEventRowProps {
   service: "sonarr" | "radarr";
   title: string;
   subtitle: string;
+  /** Optional pill beside the title, e.g. the "New Season" marker (#354). */
+  badge?: { label: string; variant?: BadgeVariant };
   /** Drives the status indicators: green when downloaded, gray when missing. */
   hasFile: boolean;
   /**
@@ -70,6 +73,7 @@ export function CalendarEventRow({
   service,
   title,
   subtitle,
+  badge,
   hasFile,
   downloading = false,
   barColor,
@@ -157,9 +161,19 @@ export function CalendarEventRow({
         </View>
 
         <View className="flex-1">
-          <Text className="text-zinc-50 text-sm font-semibold" numberOfLines={1}>
-            {title}
-          </Text>
+          <View className="flex-row items-center gap-1.5">
+            {/* `shrink` so a long series title truncates instead of pushing
+                the badge out — RN defaults flexShrink to 0. */}
+            <Text
+              className="text-zinc-50 text-sm font-semibold shrink"
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+            {badge ? (
+              <Badge label={badge.label} variant={badge.variant} />
+            ) : null}
+          </View>
           <Text className="text-zinc-300 text-xs" numberOfLines={1}>
             {subtitle}
           </Text>

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -34,6 +34,7 @@ import {
   getQueue as getRadarrQueue,
 } from "@/services/radarr-api";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
+import { isSeasonPremiere, PREMIERE_BADGE } from "@/lib/season-premiere";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
 import { pickRadarrDate } from "@/lib/calendar-agenda";
 import {
@@ -333,12 +334,14 @@ function EpisodeRow({
   downloading: boolean;
   onPress: () => void;
 }) {
+  const badge = isSeasonPremiere(entry) ? PREMIERE_BADGE : undefined;
   return (
     <CalendarEventRow
       images={entry.series.images}
       service="sonarr"
       title={entry.series.title}
       subtitle={`${formatEpisodeCode(entry.seasonNumber, entry.episodeNumber)} — ${entry.title}`}
+      badge={badge}
       hasFile={entry.hasFile}
       downloading={downloading}
       barColor={BAR_KIND_COLOR[sonarrEpisodeBarKind(entry, downloading)]}

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -69,6 +69,7 @@ import {
 import { useServiceHealth } from "@/hooks/use-service-health";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
+import { isSeasonPremiere, PREMIERE_BADGE } from "@/lib/season-premiere";
 import { useUiScale } from "@/hooks/use-ui-scale";
 import { useModalFlow } from "@/hooks/use-modal-flow";
 import {
@@ -627,6 +628,7 @@ function CalendarView({
                   service="sonarr"
                   title={ep.series.title}
                   subtitle={`${formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} — ${ep.title}`}
+                  badge={isSeasonPremiere(ep) ? PREMIERE_BADGE : undefined}
                   hasFile={ep.hasFile}
                   downloading={downloadingEpisodeIds.has(ep.id)}
                   barColor={

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,6 +1,6 @@
 import { View, Text } from "react-native";
 
-type BadgeVariant = "default" | "downloading" | "grabbing" | "seeding" | "paused" | "missing" | "wanted" | "warning" | "error" | "success" | "info";
+export type BadgeVariant = "default" | "downloading" | "grabbing" | "seeding" | "paused" | "missing" | "wanted" | "warning" | "error" | "success" | "info";
 
 const VARIANT_CLASSES: Record<BadgeVariant, string> = {
   default: "bg-zinc-700",

--- a/lib/season-premiere.test.ts
+++ b/lib/season-premiere.test.ts
@@ -1,0 +1,22 @@
+import { isSeasonPremiere } from "./season-premiere";
+
+describe("isSeasonPremiere", () => {
+  it("accepts the first episode of any numbered season", () => {
+    expect(isSeasonPremiere({ seasonNumber: 1, episodeNumber: 1 })).toBe(true);
+    expect(isSeasonPremiere({ seasonNumber: 2, episodeNumber: 1 })).toBe(true);
+    expect(isSeasonPremiere({ seasonNumber: 10, episodeNumber: 1 })).toBe(true);
+  });
+
+  it("rejects every episode after the first", () => {
+    expect(isSeasonPremiere({ seasonNumber: 4, episodeNumber: 2 })).toBe(false);
+    expect(isSeasonPremiere({ seasonNumber: 1, episodeNumber: 13 })).toBe(false);
+  });
+
+  // Specials are one running list across the whole series, so an S00E01 is an
+  // extra. A real library returns entries as high as S00E51, which is what
+  // makes the bare `episodeNumber === 1` check wrong.
+  it("never treats a special as a premiere", () => {
+    expect(isSeasonPremiere({ seasonNumber: 0, episodeNumber: 1 })).toBe(false);
+    expect(isSeasonPremiere({ seasonNumber: 0, episodeNumber: 50 })).toBe(false);
+  });
+});

--- a/lib/season-premiere.ts
+++ b/lib/season-premiere.ts
@@ -1,0 +1,25 @@
+import type { SonarrCalendarEntry } from "@/lib/types";
+
+// Sonarr marks finales (`finaleType`: "season" | "series" | null) but ships no
+// premiere equivalent, so the calendar surfaces derive it from the episode
+// numbering the response already carries (issue #354).
+
+/** The minimum shape the check needs, so `SonarrEpisode` works here too. */
+type NumberedEpisode = Pick<
+  SonarrCalendarEntry,
+  "seasonNumber" | "episodeNumber"
+>;
+
+/** The pill every calendar surface shows for a premiere. */
+export const PREMIERE_BADGE = { label: "New Season", variant: "info" } as const;
+
+/**
+ * Whether an episode opens a season.
+ *
+ * Season 0 has to be excluded: it is Sonarr's specials bucket, numbered as one
+ * running list across the whole series, so an S00E01 is an extra rather than
+ * the start of anything.
+ */
+export function isSeasonPremiere(ep: NumberedEpisode): boolean {
+  return ep.episodeNumber === 1 && ep.seasonNumber >= 1;
+}


### PR DESCRIPTION
Closes #354.

Sonarr's calendar already returns `seasonNumber` and `episodeNumber`, so a season premiere is derivable client side. Sonarr marks finales (`finaleType`: `"season" | "series" | null`) but ships no premiere equivalent, so the check lives in `lib/season-premiere.ts` and is shared by every surface that renders a `CalendarEventRow`, rather than recomputed per screen.

## What it does

**Month grid.** A day that opens a season widens its green episode dot into a sky capsule. It reuses the existing dot slot, so the grid keeps its height at every uiScale, and the difference is a shape and not only a color.

Sky rather than blue is deliberate: `primary` is `#3b82f6`, which is `blue-500`, so a blue marker would read as the selected-day circle sitting directly above it.

**Event rows.** A "New Season" `Badge` sits beside the series title, which is where there is room for the words. That covers the Calendar tab's selected-day list, the dashboard's Releasing Soon card, and the TV tab's weekly list, since all three share `CalendarEventRow`. The title gains `shrink` so a long series name truncates instead of pushing the badge off the row. Rows without a badge render as before.

## Three decisions worth arguing with

**1. It does not reproduce nzb360's in-cell text label.** nzb360's day cells are large squares with room in the top left. Dashboarr's are a centered `w-8 h-8` circle plus an `h-1.5` dot row, seven across. Two lines of "New Season" above every cell would add roughly a text line height per row across six rows and break at uiScale 1.3. Widening the dot that already meant "an episode airs today" costs no layout and loses no signal, and the literal words go where a title column exists. If you would rather have the text in the cell, say so and I will redo it that way.

**2. Season 0 is excluded.** Season 0 is Sonarr's specials bucket and is numbered as one running list across the whole series, so an S00E01 is an extra rather than the start of anything. Checked against a live library, which returns entries as high as S00E51. That is what makes the bare `episodeNumber === 1` check in the issue wrong.

**3. No setting to exclude series premieres.** The issue offers `seasonNumber > 1` or a toggle. A toggle needs the full versioned-migration treatment (`CURRENT_CONFIG_VERSION`, a migration, `ExportPayload`, the import schema) for a preference most people would never open, and S01E01 genuinely is the start of a season, so it is marked like any other.

## Notes

`BadgeVariant` is now exported from `components/ui/badge.tsx`, matching `StatusDotState` and `ActionSheetVariant`, so the row prop can name the type rather than duplicate the union.

No config schema change, no new service or widget, so nothing in `docs/` needs updating.

## Testing

- `pnpm test`: 77 suites, 1592 tests, all passing. `lib/season-premiere.test.ts` covers the premiere cases, the non-premiere cases, and the specials trap.
- `npx tsc --noEmit`: clean for the app. The pre-existing `backend/dashboarr-backend` errors are unrelated (its dependencies are not installed in the app workspace) and are present on `main` too.
- `pnpm lint` could not run: there is no `eslint.config.*` in the repo, so ESLint 9 exits before looking at anything. Also true on `main`.
