### PR TITLE
feat(widgets): let the Downloads and Usenet queue sorts be reversed

### DIFF
--- a/components/dashboard/download-card.tsx
+++ b/components/dashboard/download-card.tsx
@@ -22,8 +22,8 @@ import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   DOWNLOADS_DEFAULT_SETTINGS,
   type DownloadsSettingsValue,
-  type DownloadsSortBy,
 } from "@/components/dashboard/widget-settings/downloads-settings";
+import { compareDownloads, hasEta, qbSortParams } from "@/lib/downloads-sort";
 import { aggregateMultiInstanceState } from "@/lib/multi-instance-query";
 import type { WidgetComponentProps } from "@/components/dashboard/widget-registry";
 import { isTorrentPaused, type QBTorrent, type TorrentState } from "@/lib/types";
@@ -48,8 +48,6 @@ import { ViewAllTile } from "@/components/dashboard/view-all-tile";
 import { downloadStatusColor } from "@/lib/download-status";
 
 type StateGroup = "downloading" | "seeding" | "paused" | "errored" | "other";
-
-const ETA_UNKNOWN = 8640000;
 
 // Source-agnostic display row. Each client computes its own `group` with its
 // native classifier (so qBittorrent's exact grouping is preserved) and the rest
@@ -189,35 +187,6 @@ function delugeRow(t: UnifiedTorrent, instanceId: string): DownloadRow {
   };
 }
 
-function compareRows(a: DownloadRow, b: DownloadRow, sortBy: DownloadsSortBy): number {
-  switch (sortBy) {
-    case "speed":
-      return b.dlSpeed + b.upSpeed - (a.dlSpeed + a.upSpeed);
-    case "progress":
-      return b.progress - a.progress;
-    case "eta": {
-      const ae = !a.eta || a.eta >= ETA_UNKNOWN || a.eta < 0 ? Number.POSITIVE_INFINITY : a.eta;
-      const be = !b.eta || b.eta >= ETA_UNKNOWN || b.eta < 0 ? Number.POSITIVE_INFINITY : b.eta;
-      return ae - be;
-    }
-    case "added":
-      return b.addedOn - a.addedOn;
-  }
-}
-
-function sortByToQB(sortBy: DownloadsSortBy): { sort: keyof QBTorrent; reverse: boolean } {
-  switch (sortBy) {
-    case "speed":
-      return { sort: "dlspeed", reverse: true };
-    case "progress":
-      return { sort: "progress", reverse: true };
-    case "eta":
-      return { sort: "eta", reverse: false };
-    case "added":
-      return { sort: "added_on", reverse: true };
-  }
-}
-
 function pickServerFilter(s: DownloadsSettingsValue): QBTorrentFilter | undefined {
   const flags: { flag: boolean; filter: QBTorrentFilter }[] = [
     { flag: s.showDownloading, filter: "downloading" },
@@ -249,7 +218,7 @@ export function DownloadCard({ slotId }: WidgetComponentProps) {
     slotId,
     DOWNLOADS_DEFAULT_SETTINGS,
   );
-  const { sort, reverse } = sortByToQB(settings.sortBy);
+  const { sort, reverse } = qbSortParams(settings.sortBy, settings.reverseSort);
   const queryOptions: GetTorrentsOptions = {
     filter: pickServerFilter(settings),
     sort,
@@ -349,7 +318,9 @@ export function DownloadCard({ slotId }: WidgetComponentProps) {
 
   const filtered = rows
     .filter((row) => allowedGroups.has(row.group))
-    .sort((a, b) => compareRows(a, b, settings.sortBy));
+    .sort((a, b) =>
+      compareDownloads(a, b, settings.sortBy, settings.reverseSort),
+    );
 
   const displayTorrents = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;
@@ -460,7 +431,7 @@ function TorrentTile({
   const subtitle =
     row.group === "downloading"
       ? formatSpeed(row.dlSpeed)
-      : row.eta > 0 && row.eta < ETA_UNKNOWN
+      : hasEta(row)
         ? `ETA ${formatEta(row.eta)}`
         : row.upSpeed > 0
           ? `↑ ${formatSpeed(row.upSpeed)}`

--- a/components/dashboard/usenet-queue-card.tsx
+++ b/components/dashboard/usenet-queue-card.tsx
@@ -31,17 +31,19 @@ function compareTagged(
   a: TaggedItem,
   b: TaggedItem,
   sortBy: UsenetQueueSortBy,
+  reverse: boolean,
 ): number {
+  const direction = reverse ? -1 : 1;
   switch (sortBy) {
     case "progress":
-      return b.item.progress - a.item.progress;
+      return direction * (b.item.progress - a.item.progress);
     case "name":
-      return a.item.name.localeCompare(b.item.name);
+      return direction * a.item.name.localeCompare(b.item.name);
     case "size":
-      return b.item.bytes - a.item.bytes;
+      return direction * (b.item.bytes - a.item.bytes);
     case "added":
       // Per-instance index — across instances this is stable-but-rough.
-      return b.item.index - a.item.index;
+      return direction * (b.item.index - a.item.index);
   }
 }
 
@@ -81,7 +83,7 @@ export function UsenetQueueCard({ slotId, adapter }: Props) {
 
   const filtered = allTagged
     .filter((t) => allowedStatuses.has(t.item.status))
-    .sort((a, b) => compareTagged(a, b, settings.sortBy));
+    .sort((a, b) => compareTagged(a, b, settings.sortBy, settings.reverseSort));
 
   const display = filtered.slice(0, settings.maxItems);
   const hasMore = filtered.length > settings.maxItems;

--- a/components/dashboard/widget-settings/downloads-settings.tsx
+++ b/components/dashboard/widget-settings/downloads-settings.tsx
@@ -8,14 +8,13 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
-  ChipGroup,
   HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
+  SortSelector,
   ToggleCard,
 } from "@/components/dashboard/widget-settings/widget-settings-blocks";
-
-export type DownloadsSortBy = "speed" | "progress" | "eta" | "added";
+import type { DownloadsSortBy } from "@/lib/downloads-sort";
 
 export interface DownloadsSettingsValue extends Record<string, unknown> {
   // Which qBittorrent instances this widget shows. "all" aggregates every
@@ -27,6 +26,7 @@ export interface DownloadsSettingsValue extends Record<string, unknown> {
   showPaused: boolean;
   showErrored: boolean;
   sortBy: DownloadsSortBy;
+  reverseSort: boolean;
   hideWhenEmpty: boolean;
 }
 
@@ -38,6 +38,7 @@ export const DOWNLOADS_DEFAULT_SETTINGS: DownloadsSettingsValue = {
   showPaused: false,
   showErrored: false,
   sortBy: "speed",
+  reverseSort: false,
   hideWhenEmpty: false,
 };
 
@@ -98,11 +99,12 @@ export function DownloadsSettings({ slotId }: WidgetSettingsComponentProps) {
         onChange={(maxItems) => update({ maxItems })}
       />
 
-      <ChipGroup
-        label="Sort by"
+      <SortSelector
         options={SORT_OPTIONS}
         value={settings.sortBy}
         onChange={(sortBy) => update({ sortBy })}
+        reversed={settings.reverseSort}
+        onReversedChange={(reverseSort) => update({ reverseSort })}
       />
 
       <HideWhenEmptyToggle

--- a/components/dashboard/widget-settings/usenet-queue-settings.tsx
+++ b/components/dashboard/widget-settings/usenet-queue-settings.tsx
@@ -8,10 +8,10 @@ import {
   type InstanceBindingValue,
 } from "@/components/dashboard/widget-settings/instance-picker-row";
 import {
-  ChipGroup,
   HideWhenEmptyToggle,
   MaxItemsSelector,
   SettingsSection,
+  SortSelector,
   ToggleCard,
 } from "@/components/dashboard/widget-settings/widget-settings-blocks";
 import type { ServiceId } from "@/lib/constants";
@@ -25,6 +25,7 @@ export interface UsenetQueueSettingsValue extends Record<string, unknown> {
   showPaused: boolean;
   showQueued: boolean;
   sortBy: UsenetQueueSortBy;
+  reverseSort: boolean;
   hideWhenEmpty: boolean;
 }
 
@@ -35,6 +36,7 @@ export const USENET_QUEUE_DEFAULT_SETTINGS: UsenetQueueSettingsValue = {
   showPaused: true,
   showQueued: true,
   sortBy: "progress",
+  reverseSort: false,
   hideWhenEmpty: false,
 };
 
@@ -88,11 +90,12 @@ export function UsenetQueueSettings({ slotId, serviceId }: Props) {
         onChange={(maxItems) => update({ maxItems })}
       />
 
-      <ChipGroup
-        label="Sort by"
+      <SortSelector
         options={SORT_OPTIONS}
         value={settings.sortBy}
         onChange={(sortBy) => update({ sortBy })}
+        reversed={settings.reverseSort}
+        onReversedChange={(reverseSort) => update({ reverseSort })}
       />
 
       <HideWhenEmptyToggle

--- a/components/dashboard/widget-settings/widget-settings-blocks.tsx
+++ b/components/dashboard/widget-settings/widget-settings-blocks.tsx
@@ -47,11 +47,13 @@ export function ChipGroup<T extends string | number>({
   options,
   value,
   onChange,
+  footer,
 }: {
   label: string;
   options: readonly { value: T; label: string }[];
   value: T;
   onChange: (value: T) => void;
+  footer?: ReactNode;
 }) {
   return (
     <SettingsSection label={label}>
@@ -65,7 +67,40 @@ export function ChipGroup<T extends string | number>({
           />
         ))}
       </View>
+      {footer ? <View className="mt-3">{footer}</View> : null}
     </SettingsSection>
+  );
+}
+
+export function SortSelector<T extends string>({
+  options,
+  value,
+  onChange,
+  reversed,
+  onReversedChange,
+}: {
+  options: readonly { value: T; label: string }[];
+  value: T;
+  onChange: (value: T) => void;
+  reversed: boolean;
+  onReversedChange: (value: boolean) => void;
+}) {
+  return (
+    <ChipGroup
+      label="Sort by"
+      options={options}
+      value={value}
+      onChange={onChange}
+      footer={
+        <ToggleCard>
+          <Toggle
+            label="Reverse order"
+            value={reversed}
+            onValueChange={onReversedChange}
+          />
+        </ToggleCard>
+      }
+    />
   );
 }
 

--- a/lib/downloads-sort.test.ts
+++ b/lib/downloads-sort.test.ts
@@ -1,0 +1,116 @@
+import {
+  compareDownloads,
+  hasEta,
+  qbSortParams,
+  type SortableDownload,
+} from "./downloads-sort";
+
+const QB_ETA_UNKNOWN = 8640000;
+
+function row(over: Partial<SortableDownload> = {}): SortableDownload {
+  return {
+    progress: 0.5,
+    dlSpeed: 0,
+    upSpeed: 0,
+    eta: 60,
+    addedOn: 1_700_000_000,
+    ...over,
+  };
+}
+
+function order(
+  rows: (SortableDownload & { name: string })[],
+  sortBy: Parameters<typeof compareDownloads>[2],
+  reverse: boolean,
+): string[] {
+  return [...rows]
+    .sort((a, b) => compareDownloads(a, b, sortBy, reverse))
+    .map((r) => r.name);
+}
+
+describe("hasEta", () => {
+  // qBittorrent reports no estimate as 8640000 seconds, rtorrent as -1,
+  // Transmission as -1 or -2, and Deluge as 0 or -1.
+  it("rejects every client's no-estimate value", () => {
+    expect(hasEta({ eta: 300 })).toBe(true);
+    expect(hasEta({ eta: QB_ETA_UNKNOWN })).toBe(false);
+    expect(hasEta({ eta: 0 })).toBe(false);
+    expect(hasEta({ eta: -1 })).toBe(false);
+    expect(hasEta({ eta: -2 })).toBe(false);
+  });
+});
+
+describe("compareDownloads", () => {
+  it("puts the fastest first, and the slowest first when reversed", () => {
+    const fast = { ...row({ dlSpeed: 900, upSpeed: 100 }), name: "fast" };
+    const slow = { ...row({ dlSpeed: 10, upSpeed: 0 }), name: "slow" };
+    expect(order([slow, fast], "speed", false)).toEqual(["fast", "slow"]);
+    expect(order([slow, fast], "speed", true)).toEqual(["slow", "fast"]);
+  });
+
+  it("reverses progress", () => {
+    const nearly = { ...row({ progress: 0.9 }), name: "nearly" };
+    const barely = { ...row({ progress: 0.1 }), name: "barely" };
+    expect(order([barely, nearly], "progress", false)).toEqual(["nearly", "barely"]);
+    expect(order([barely, nearly], "progress", true)).toEqual(["barely", "nearly"]);
+  });
+
+  it("reverses added-on", () => {
+    const older = { ...row({ addedOn: 1 }), name: "older" };
+    const newer = { ...row({ addedOn: 2 }), name: "newer" };
+    expect(order([older, newer], "added", false)).toEqual(["newer", "older"]);
+    expect(order([older, newer], "added", true)).toEqual(["older", "newer"]);
+  });
+
+  it("sorts by soonest ETA, and by longest when reversed", () => {
+    const soon = { ...row({ eta: 60 }), name: "soon" };
+    const later = { ...row({ eta: 6000 }), name: "later" };
+    expect(order([later, soon], "eta", false)).toEqual(["soon", "later"]);
+    expect(order([later, soon], "eta", true)).toEqual(["later", "soon"]);
+  });
+
+  // Reversing "soonest first" must not promote every paused and stalled
+  // torrent to the top of the widget.
+  it("keeps torrents with no estimate last in both directions", () => {
+    const known = { ...row({ eta: 300 }), name: "known" };
+    const qb = { ...row({ eta: QB_ETA_UNKNOWN }), name: "qb" };
+    const transmission = { ...row({ eta: -1 }), name: "transmission" };
+    for (const reverse of [false, true]) {
+      const result = order([qb, transmission, known], "eta", reverse);
+      expect(result[0]).toBe("known");
+      expect(result.slice(1).sort()).toEqual(["qb", "transmission"]);
+    }
+  });
+
+  it("treats two unknown estimates as equal rather than NaN", () => {
+    const a = row({ eta: QB_ETA_UNKNOWN });
+    const b = row({ eta: -1 });
+    expect(compareDownloads(a, b, "eta", false)).toBe(0);
+    expect(compareDownloads(a, b, "eta", true)).toBe(0);
+  });
+});
+
+describe("qbSortParams", () => {
+  it("asks for the same order the merged list uses", () => {
+    expect(qbSortParams("speed")).toEqual({ sort: "dlspeed", reverse: true });
+    expect(qbSortParams("progress")).toEqual({ sort: "progress", reverse: true });
+    expect(qbSortParams("added")).toEqual({ sort: "added_on", reverse: true });
+    expect(qbSortParams("eta")).toEqual({ sort: "eta", reverse: false });
+  });
+
+  // The widget slices a capped page out of what qBittorrent returns, so the
+  // server-side direction has to flip with the client-side one. Left alone it
+  // would show the slowest of the fastest hundred.
+  it("flips the server-side direction when the widget is reversed", () => {
+    expect(qbSortParams("speed", true)).toEqual({ sort: "dlspeed", reverse: false });
+    expect(qbSortParams("added", true)).toEqual({ sort: "added_on", reverse: false });
+    expect(qbSortParams("progress", true)).toEqual({ sort: "progress", reverse: false });
+  });
+
+  // 8640000 is the top of the ETA axis, so a descending fetch would return a
+  // page of nothing but no-estimate torrents and the ones with a real estimate
+  // would never arrive.
+  it("never flips ETA, whose far end is the no-estimate sentinel", () => {
+    expect(qbSortParams("eta", true)).toEqual({ sort: "eta", reverse: false });
+  });
+});

--- a/lib/downloads-sort.ts
+++ b/lib/downloads-sort.ts
@@ -1,0 +1,68 @@
+import type { QBTorrent } from "@/lib/types";
+
+export type DownloadsSortBy = "speed" | "progress" | "eta" | "added";
+
+/** qBittorrent reports "no estimate" as this many seconds rather than null. */
+const ETA_UNKNOWN = 8640000;
+
+/** The fields the ordering reads. Every client's display row satisfies it. */
+export interface SortableDownload {
+  progress: number;
+  dlSpeed: number;
+  upSpeed: number;
+  eta: number;
+  addedOn: number;
+}
+
+/** qBittorrent uses 8640000; rtorrent -1; Transmission -1/-2; Deluge 0 or -1. */
+export function hasEta(row: Pick<SortableDownload, "eta">): boolean {
+  return row.eta > 0 && row.eta < ETA_UNKNOWN;
+}
+
+const QB_SORT: Record<
+  DownloadsSortBy,
+  { sort: keyof QBTorrent; reverse: boolean }
+> = {
+  speed: { sort: "dlspeed", reverse: true },
+  progress: { sort: "progress", reverse: true },
+  eta: { sort: "eta", reverse: false },
+  added: { sort: "added_on", reverse: true },
+};
+
+// Rows with no estimate stay last in both directions, so reversing "soonest
+// first" does not fill the widget with every paused and stalled torrent.
+export function compareDownloads(
+  a: SortableDownload,
+  b: SortableDownload,
+  sortBy: DownloadsSortBy,
+  reverse = false,
+): number {
+  if (sortBy === "eta" && !(hasEta(a) && hasEta(b))) {
+    if (hasEta(a)) return -1;
+    if (hasEta(b)) return 1;
+    return 0;
+  }
+  const direction = reverse ? -1 : 1;
+  switch (sortBy) {
+    case "speed":
+      return direction * (b.dlSpeed + b.upSpeed - (a.dlSpeed + a.upSpeed));
+    case "progress":
+      return direction * (b.progress - a.progress);
+    case "eta":
+      return direction * (a.eta - b.eta);
+    case "added":
+      return direction * (b.addedOn - a.addedOn);
+  }
+}
+
+// The matching sort for qBittorrent's own `/torrents/info`, which the widget
+// slices a capped page out of. ETA never flips: 8640000 is the top of that
+// axis, so a descending fetch would be a page of nothing but no-estimate rows.
+export function qbSortParams(
+  sortBy: DownloadsSortBy,
+  reverse = false,
+): { sort: keyof QBTorrent; reverse: boolean } {
+  const base = QB_SORT[sortBy];
+  if (sortBy === "eta") return { ...base };
+  return { sort: base.sort, reverse: reverse ? !base.reverse : base.reverse };
+}


### PR DESCRIPTION
Closes #388.

Both widgets that carry a sort get a **"Reverse order"** toggle under their existing Sort by chips: the Downloads widget and the Usenet queue. It is one shared `SortSelector` block, so a third widget with a sort gets the invert for free.

No config migration. `hooks/use-widget-settings.ts` merges defaults at read time and says so in its own docstring, and `store/config-schema.ts:165` validates `slot.settings` as an open object, so existing slots pick up `reverseSort: false` on their own.

## The part that is not just a sign flip

The Downloads widget sorts in **two** places. It asks qBittorrent to sort server side and takes a capped page of that, then re-sorts the merged rows from qBittorrent, rtorrent, Transmission and Deluge on the device. Reversing only the client-side comparator would have shown the slowest of the fastest hundred, so the ordering moved into `lib/downloads-sort.ts` and both entry points take the same flag.

## Two things that turned up on the way

**A latent NaN.** The old ETA comparator mapped no-estimate to `Number.POSITIVE_INFINITY` and returned `ae - be`, so two no-estimate rows compared `Infinity - Infinity`. A comparator returning `NaN` leaves the order undefined. They now compare `0`.

**No-estimate rows stay last in both directions.** Reversing "soonest first" would otherwise promote every paused and stalled torrent to the top, which is not what "longest remaining" means. The sentinel differs per client, so this goes through one `hasEta`: qBittorrent reports `8640000`, rtorrent `-1` (`services/rtorrent-api.ts:152`), Transmission `-1` or `-2` (`services/transmission-api.ts:302`), Deluge `0` or `-1` (`services/deluge-api.ts:594`). The card's subtitle now uses that helper too, instead of repeating the qBittorrent constant inline.

## One deliberate asymmetry, and its limit

ETA is the one axis where the **server-side** direction does not flip. `8640000` is the top of that axis, so a descending fetch would return a page of nothing but no-estimate rows and the torrents that actually have an estimate would never arrive. The fetch stays ascending in both directions.

The honest consequence: reversed ETA orders the estimates that page contains, which is every real estimate unless more than `DASHBOARD_FETCH_LIMIT` (100) torrents are downloading at once. Above that it is "longest of the soonest hundred". Dropping the cap on that one path would make it exact at the cost of pulling the whole library on every poll, which is what the other three clients already do. Say the word and I will switch it.

## Scope note

The issue says "many widgets". Two have a sort setting today: Downloads and the Usenet queue. Both are covered.

## Testing

- `pnpm test`: 77 suites, 1599 tests, all passing. `lib/downloads-sort.test.ts` covers each axis in both directions, all four clients' no-estimate values, the NaN case, and that the qBittorrent params flip for speed, progress and added but never for ETA.
- `npx tsc --noEmit`: clean for the app. The `backend/dashboarr-backend` errors are pre-existing and present on `main` (its dependencies are not installed in the app workspace).
- `pnpm lint` could not run: there is no `eslint.config.*` in the repo, so ESLint 9 exits before looking at anything. Also true on `main`.
