### PR TITLE
feat(add): remember the last-used add config per instance (#341)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,6 +19,7 @@ import { useSortStore } from "@/store/sort-store";
 import { useGlancesUiStore } from "@/store/glances-ui-store";
 import { useUnraidUiStore } from "@/store/unraid-ui-store";
 import { useReleaseFilterStore } from "@/store/releases-filter-store";
+import { useAddDefaultsStore } from "@/store/add-defaults-store";
 import { useIntroStore } from "@/store/intro-store";
 import { queryClient } from "@/lib/query-client";
 import { configureNotifications } from "@/lib/notifications";
@@ -331,6 +332,7 @@ export default function RootLayout() {
   const hydrateGlancesUi = useGlancesUiStore((s) => s.hydrate);
   const hydrateUnraidUi = useUnraidUiStore((s) => s.hydrate);
   const hydrateReleaseFilters = useReleaseFilterStore((s) => s.hydrate);
+  const hydrateAddDefaults = useAddDefaultsStore((s) => s.hydrate);
   const hydrateIntro = useIntroStore((s) => s.hydrate);
   const introHydrated = useIntroStore((s) => s.hydrated);
   const introSeen = useIntroStore((s) => s.workspaceIntroSeen);
@@ -362,6 +364,7 @@ export default function RootLayout() {
       hydrateGlancesUi();
       hydrateUnraidUi();
       hydrateReleaseFilters();
+      hydrateAddDefaults();
       hydrateIntro();
     }
   }, [
@@ -370,6 +373,7 @@ export default function RootLayout() {
     hydrateGlancesUi,
     hydrateUnraidUi,
     hydrateReleaseFilters,
+    hydrateAddDefaults,
     hydrateIntro,
   ]);
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,7 @@ import { useGlancesUiStore } from "@/store/glances-ui-store";
 import { useUnraidUiStore } from "@/store/unraid-ui-store";
 import { useReleaseFilterStore } from "@/store/releases-filter-store";
 import { useLibraryTagFilterStore } from "@/store/library-tag-filter-store";
+import { useAddDefaultsStore } from "@/store/add-defaults-store";
 import { useIntroStore } from "@/store/intro-store";
 import { queryClient } from "@/lib/query-client";
 import { configureNotifications } from "@/lib/notifications";
@@ -346,6 +347,7 @@ export default function RootLayout() {
   const hydrateUnraidUi = useUnraidUiStore((s) => s.hydrate);
   const hydrateReleaseFilters = useReleaseFilterStore((s) => s.hydrate);
   const hydrateLibraryTagFilters = useLibraryTagFilterStore((s) => s.hydrate);
+  const hydrateAddDefaults = useAddDefaultsStore((s) => s.hydrate);
   const hydrateIntro = useIntroStore((s) => s.hydrate);
   const introHydrated = useIntroStore((s) => s.hydrated);
   const introSeen = useIntroStore((s) => s.workspaceIntroSeen);
@@ -378,6 +380,7 @@ export default function RootLayout() {
       hydrateUnraidUi();
       hydrateReleaseFilters();
       hydrateLibraryTagFilters();
+      hydrateAddDefaults();
       hydrateIntro();
     }
   }, [
@@ -387,6 +390,7 @@ export default function RootLayout() {
     hydrateUnraidUi,
     hydrateReleaseFilters,
     hydrateLibraryTagFilters,
+    hydrateAddDefaults,
     hydrateIntro,
   ]);
 

--- a/components/common/add-media-sheet.tsx
+++ b/components/common/add-media-sheet.tsx
@@ -143,16 +143,22 @@ export function AddMediaSheet({
     });
   };
 
+  // Require tags to have loaded so submit cannot send [] while the persist branch
+  // below still reports the remembered tags: the two halves must agree (#341).
   const canSubmit =
-    !!effectiveQualityProfileId && !!effectiveRootFolderPath && !!result;
+    !!effectiveQualityProfileId && !!effectiveRootFolderPath && !!result && tags !== undefined;
 
   const handleAdd = () => {
     if (!canSubmit) return;
-    // Remember this config so the next add on this instance preselects it (#341).
+    // Remember only what the user actually picked this time (falling back to the
+    // previously remembered pick), not the resolved effective* values. Persisting
+    // effective* would freeze the Settings default into the store on the first
+    // passive add and then permanently outrank it, turning Settings -> Add Defaults
+    // into a dead control; #341 only asks to remember a deliberate pick.
     if (lastUsedKey) {
       rememberLastUsed(lastUsedKey, {
-        qualityProfileId: effectiveQualityProfileId,
-        rootFolderPath: effectiveRootFolderPath,
+        qualityProfileId: qualityProfileId ?? lastUsed?.qualityProfileId,
+        rootFolderPath: rootFolderPath ?? lastUsed?.rootFolderPath,
         // Only rewrite remembered tags once the server list has loaded; adding
         // before it loads must not wipe them with the filtered-to-empty value.
         tags: tags ? effectiveTags : lastUsed?.tags,

--- a/components/common/add-media-sheet.tsx
+++ b/components/common/add-media-sheet.tsx
@@ -11,7 +11,7 @@ import { SheetHeader } from "@/components/ui/sheet-header";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
 import { useTargetInstance } from "@/hooks/use-instance-target";
-import { useAddDefaultsStore, addDefaultsKey } from "@/store/add-defaults-store";
+import { useAddDefaultsStore, addDefaultsKey, validRememberedTags } from "@/store/add-defaults-store";
 import { formatBytes } from "@/lib/utils";
 
 export interface AddMediaSheetCommonState {
@@ -130,7 +130,7 @@ export function AddMediaSheet({
 
   const effectiveQualityProfileId = qualityProfileId ?? lastProfileId ?? defaultProfileId;
   const effectiveRootFolderPath = rootFolderPath ?? lastFolderPath ?? defaultFolderPath;
-  const effectiveTags = selectedTags ?? lastUsed?.tags ?? [];
+  const effectiveTags = selectedTags ?? validRememberedTags(lastUsed?.tags, tags);
   const effectiveSearchOnAdd = searchOnAdd ?? lastUsed?.searchOnAdd ?? true;
 
   const poster = result?.images.find((i) => i.coverType === "poster");
@@ -153,7 +153,9 @@ export function AddMediaSheet({
       rememberLastUsed(lastUsedKey, {
         qualityProfileId: effectiveQualityProfileId,
         rootFolderPath: effectiveRootFolderPath,
-        tags: effectiveTags,
+        // Only rewrite remembered tags once the server list has loaded; adding
+        // before it loads must not wipe them with the filtered-to-empty value.
+        tags: tags ? effectiveTags : lastUsed?.tags,
         searchOnAdd: effectiveSearchOnAdd,
       });
     }

--- a/components/common/add-media-sheet.tsx
+++ b/components/common/add-media-sheet.tsx
@@ -11,6 +11,7 @@ import { SheetHeader } from "@/components/ui/sheet-header";
 import { useServiceImage } from "@/hooks/use-service-image";
 import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
 import { useTargetInstance } from "@/hooks/use-instance-target";
+import { useAddDefaultsStore, addDefaultsKey } from "@/store/add-defaults-store";
 import { formatBytes } from "@/lib/utils";
 
 export interface AddMediaSheetCommonState {
@@ -89,8 +90,8 @@ export function AddMediaSheet({
 }: AddMediaSheetProps) {
   const [qualityProfileId, setQualityProfileId] = useState<number | undefined>();
   const [rootFolderPath, setRootFolderPath] = useState<string | undefined>();
-  const [selectedTags, setSelectedTags] = useState<number[]>([]);
-  const [searchOnAdd, setSearchOnAdd] = useState(true);
+  const [selectedTags, setSelectedTags] = useState<number[] | undefined>();
+  const [searchOnAdd, setSearchOnAdd] = useState<boolean | undefined>();
   const footerPadding = useSheetBottomPadding();
 
   // User-configured defaults for this instance (Settings → Add Defaults), with
@@ -98,6 +99,15 @@ export function AddMediaSheet({
   // exists on the server (profile/folder deleted upstream). An in-sheet pick
   // (qualityProfileId / rootFolderPath state) always wins over the default.
   const inst = useTargetInstance(serviceId, instanceId);
+
+  // Last config used to add on this instance, so the sheet defaults to it the
+  // way Radarr's own web UI does (#341). Precedence below is: in-sheet pick >
+  // last-used (if it still exists on the server) > Settings default > first in
+  // list, so the Settings default still applies until the first add.
+  const lastUsedKey = inst ? addDefaultsKey(serviceId, inst.id) : null;
+  const lastUsed = useAddDefaultsStore((s) => (lastUsedKey ? s.lastUsed[lastUsedKey] : undefined));
+  const rememberLastUsed = useAddDefaultsStore((s) => s.remember);
+
   const storedProfileId = inst?.defaultQualityProfileId;
   const defaultProfileId =
     storedProfileId != null && profiles?.some((p) => p.id === storedProfileId)
@@ -109,16 +119,28 @@ export function AddMediaSheet({
       ? storedFolderPath
       : folders?.[0]?.path;
 
-  const effectiveQualityProfileId = qualityProfileId ?? defaultProfileId;
-  const effectiveRootFolderPath = rootFolderPath ?? defaultFolderPath;
+  const lastProfileId =
+    lastUsed?.qualityProfileId != null && profiles?.some((p) => p.id === lastUsed.qualityProfileId)
+      ? lastUsed.qualityProfileId
+      : undefined;
+  const lastFolderPath =
+    lastUsed?.rootFolderPath != null && folders?.some((f) => f.path === lastUsed.rootFolderPath)
+      ? lastUsed.rootFolderPath
+      : undefined;
+
+  const effectiveQualityProfileId = qualityProfileId ?? lastProfileId ?? defaultProfileId;
+  const effectiveRootFolderPath = rootFolderPath ?? lastFolderPath ?? defaultFolderPath;
+  const effectiveTags = selectedTags ?? lastUsed?.tags ?? [];
+  const effectiveSearchOnAdd = searchOnAdd ?? lastUsed?.searchOnAdd ?? true;
 
   const poster = result?.images.find((i) => i.coverType === "poster");
   const { src: posterUrl, onError: onPosterError } = useServiceImage(poster, serviceId);
 
   const toggleTag = (tagId: number) => {
-    setSelectedTags((prev) =>
-      prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId],
-    );
+    setSelectedTags((prev) => {
+      const base = prev ?? effectiveTags;
+      return base.includes(tagId) ? base.filter((t) => t !== tagId) : [...base, tagId];
+    });
   };
 
   const canSubmit =
@@ -126,11 +148,20 @@ export function AddMediaSheet({
 
   const handleAdd = () => {
     if (!canSubmit) return;
+    // Remember this config so the next add on this instance preselects it (#341).
+    if (lastUsedKey) {
+      rememberLastUsed(lastUsedKey, {
+        qualityProfileId: effectiveQualityProfileId,
+        rootFolderPath: effectiveRootFolderPath,
+        tags: effectiveTags,
+        searchOnAdd: effectiveSearchOnAdd,
+      });
+    }
     onSubmit({
       qualityProfileId: effectiveQualityProfileId!,
       rootFolderPath: effectiveRootFolderPath!,
-      selectedTags,
-      searchOnAdd,
+      selectedTags: effectiveTags,
+      searchOnAdd: effectiveSearchOnAdd,
     });
   };
 
@@ -216,7 +247,7 @@ export function AddMediaSheet({
                   <FilterChip
                     key={tag.id}
                     label={tag.label}
-                    selected={selectedTags.includes(tag.id)}
+                    selected={effectiveTags.includes(tag.id)}
                     onPress={() => toggleTag(tag.id)}
                   />
                 ))}
@@ -227,7 +258,7 @@ export function AddMediaSheet({
           <Toggle
             label="Start Search on Add"
             description={searchToggleDescription}
-            value={searchOnAdd}
+            value={effectiveSearchOnAdd}
             onValueChange={setSearchOnAdd}
           />
 

--- a/components/common/add-media-sheet.tsx
+++ b/components/common/add-media-sheet.tsx
@@ -143,8 +143,10 @@ export function AddMediaSheet({
     });
   };
 
-  // Require tags to have loaded so submit cannot send [] while the persist branch
-  // below still reports the remembered tags: the two halves must agree (#341).
+  // tags is undefined only when there is no list to show yet and no error (still
+  // loading, or the query is disabled). The call sites pass any cached list
+  // through and [] only on a hard failure, so Add is gated only while genuinely
+  // waiting and never blocked by a failed fetch (#402).
   const canSubmit =
     !!effectiveQualityProfileId && !!effectiveRootFolderPath && !!result && tags !== undefined;
 
@@ -159,9 +161,8 @@ export function AddMediaSheet({
       rememberLastUsed(lastUsedKey, {
         qualityProfileId: qualityProfileId ?? lastUsed?.qualityProfileId,
         rootFolderPath: rootFolderPath ?? lastUsed?.rootFolderPath,
-        // Only rewrite remembered tags once the server list has loaded; adding
-        // before it loads must not wipe them with the filtered-to-empty value.
-        tags: tags ? effectiveTags : lastUsed?.tags,
+        // Same value submit sends, so what's remembered matches what was added.
+        tags: effectiveTags,
         searchOnAdd: effectiveSearchOnAdd,
       });
     }

--- a/components/lidarr/add-artist-sheet.tsx
+++ b/components/lidarr/add-artist-sheet.tsx
@@ -36,7 +36,7 @@ export function AddArtistSheet({ result, visible, onClose }: AddArtistSheetProps
   const { data: profiles } = useLidarrQualityProfiles();
   const { data: metadataProfiles } = useLidarrMetadataProfiles();
   const { data: folders } = useLidarrRootFolders();
-  const { data: tags } = useLidarrTags();
+  const { data: tags, isError: tagsError } = useLidarrTags();
   const addArtist = useAddArtist();
 
   const [metadataProfileId, setMetadataProfileId] = useState<number | undefined>();
@@ -77,7 +77,7 @@ export function AddArtistSheet({ result, visible, onClose }: AddArtistSheetProps
       placeholderIcon={Mic2}
       profiles={profiles}
       folders={folders}
-      tags={tags}
+      tags={tags ?? (tagsError ? [] : undefined)}
       isSubmitting={addArtist.isPending}
       searchToggleDescription="Trigger a search for the artist's albums once added"
       onSubmit={({ qualityProfileId, rootFolderPath, selectedTags, searchOnAdd }) => {

--- a/components/radarr/add-movie-sheet.tsx
+++ b/components/radarr/add-movie-sheet.tsx
@@ -54,7 +54,7 @@ export function AddMovieSheet({
 }: AddMovieSheetProps) {
   const { data: profiles } = useRadarrQualityProfiles(instanceId);
   const { data: folders } = useRadarrRootFolders(instanceId);
-  const { data: tags } = useRadarrTags(instanceId);
+  const { data: tags, isError: tagsError } = useRadarrTags(instanceId);
   const addMovie = useAddMovie(instanceId);
 
   const [minimumAvailability, setMinimumAvailability] =
@@ -83,7 +83,7 @@ export function AddMovieSheet({
       }
       profiles={profiles}
       folders={folders}
-      tags={tags}
+      tags={tags ?? (tagsError ? [] : undefined)}
       isSubmitting={addMovie.isPending}
       searchToggleDescription="Trigger an automatic search once the movie is added"
       onSubmit={({ qualityProfileId, rootFolderPath, selectedTags, searchOnAdd }) => {

--- a/components/sonarr/add-series-sheet.tsx
+++ b/components/sonarr/add-series-sheet.tsx
@@ -49,7 +49,7 @@ export const SERIES_TYPE_OPTIONS: {
 export function AddSeriesSheet({ result, visible, onClose }: AddSeriesSheetProps) {
   const { data: profiles } = useSonarrQualityProfiles();
   const { data: folders } = useSonarrRootFolders();
-  const { data: tags } = useSonarrTags();
+  const { data: tags, isError: tagsError } = useSonarrTags();
   const addSeries = useAddSeries();
 
   const [monitor, setMonitor] = useState<SonarrMonitorOption>("all");
@@ -72,7 +72,7 @@ export function AddSeriesSheet({ result, visible, onClose }: AddSeriesSheetProps
       placeholderIcon={Tv}
       profiles={profiles}
       folders={folders}
-      tags={tags}
+      tags={tags ?? (tagsError ? [] : undefined)}
       isSubmitting={addSeries.isPending}
       searchToggleDescription="Trigger an automatic search once the series is added"
       onSubmit={({ qualityProfileId, rootFolderPath, selectedTags, searchOnAdd }) => {

--- a/store/add-defaults-store.test.ts
+++ b/store/add-defaults-store.test.ts
@@ -1,0 +1,77 @@
+// Mock the storage layer before importing the store — add-defaults-store imports
+// storage.ts at module load, which pulls in AsyncStorage/SecureStore (native
+// modules unavailable in the jest-expo node environment). setJSON/getJSON
+// round-trip through storage.ts's synchronous in-memory cache, so persistence
+// is still observable in tests.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => {}),
+    removeItem: jest.fn(async () => {}),
+    getAllKeys: jest.fn(async () => []),
+    multiGet: jest.fn(async () => []),
+    multiSet: jest.fn(async () => {}),
+    multiRemove: jest.fn(async () => {}),
+  },
+}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+import { useAddDefaultsStore, addDefaultsKey, type LastUsedAdd } from "./add-defaults-store";
+import { getJSON, setJSON, deleteKey } from "./storage";
+
+const STORAGE_KEY = "ui.lastUsedAdd";
+
+beforeEach(() => {
+  deleteKey(STORAGE_KEY);
+  useAddDefaultsStore.setState({ lastUsed: {} });
+});
+
+describe("useAddDefaultsStore (#341)", () => {
+  it("remembers a config per instance key and persists it", () => {
+    const key = addDefaultsKey("radarr", "inst-1");
+    const config: LastUsedAdd = {
+      qualityProfileId: 4,
+      rootFolderPath: "/movies",
+      tags: [2, 5],
+      searchOnAdd: false,
+    };
+    useAddDefaultsStore.getState().remember(key, config);
+
+    expect(useAddDefaultsStore.getState().lastUsed[key]).toEqual(config);
+    expect(getJSON<Record<string, LastUsedAdd>>(STORAGE_KEY)?.[key]).toEqual(config);
+  });
+
+  it("keeps each instance's config separate (ids are per-instance)", () => {
+    const store = useAddDefaultsStore.getState();
+    store.remember(addDefaultsKey("radarr", "a"), { qualityProfileId: 1, searchOnAdd: true });
+    store.remember(addDefaultsKey("sonarr", "a"), { qualityProfileId: 9, searchOnAdd: false });
+
+    const all = useAddDefaultsStore.getState().lastUsed;
+    expect(all["radarr:a"]?.qualityProfileId).toBe(1);
+    expect(all["sonarr:a"]?.qualityProfileId).toBe(9);
+  });
+
+  it("a second remember for the same key overwrites the first", () => {
+    const key = addDefaultsKey("lidarr", "x");
+    const store = useAddDefaultsStore.getState();
+    store.remember(key, { qualityProfileId: 1, tags: [1] });
+    store.remember(key, { qualityProfileId: 2, tags: [] });
+    expect(useAddDefaultsStore.getState().lastUsed[key]).toEqual({ qualityProfileId: 2, tags: [] });
+  });
+
+  it("hydrate loads a persisted blob back into the store", () => {
+    setJSON(STORAGE_KEY, { "radarr:x": { rootFolderPath: "/m", tags: [1] } });
+    useAddDefaultsStore.getState().hydrate();
+    expect(useAddDefaultsStore.getState().lastUsed["radarr:x"]).toEqual({ rootFolderPath: "/m", tags: [1] });
+  });
+
+  it("hydrate is a safe no-op when nothing is stored", () => {
+    expect(() => useAddDefaultsStore.getState().hydrate()).not.toThrow();
+    expect(useAddDefaultsStore.getState().lastUsed).toEqual({});
+  });
+});

--- a/store/add-defaults-store.test.ts
+++ b/store/add-defaults-store.test.ts
@@ -21,7 +21,12 @@ jest.mock("expo-secure-store", () => ({
   deleteItemAsync: jest.fn(async () => {}),
 }));
 
-import { useAddDefaultsStore, addDefaultsKey, type LastUsedAdd } from "./add-defaults-store";
+import {
+  useAddDefaultsStore,
+  addDefaultsKey,
+  validRememberedTags,
+  type LastUsedAdd,
+} from "./add-defaults-store";
 import { getJSON, setJSON, deleteKey } from "./storage";
 
 const STORAGE_KEY = "ui.lastUsedAdd";
@@ -73,5 +78,18 @@ describe("useAddDefaultsStore (#341)", () => {
   it("hydrate is a safe no-op when nothing is stored", () => {
     expect(() => useAddDefaultsStore.getState().hydrate()).not.toThrow();
     expect(useAddDefaultsStore.getState().lastUsed).toEqual({});
+  });
+});
+
+describe("validRememberedTags (#402)", () => {
+  const tags = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+  it("drops a remembered tag that was deleted on the server", () => {
+    expect(validRememberedTags([1, 2, 99], tags)).toEqual([1, 2]);
+  });
+
+  it("is empty when tags haven't loaded or nothing was remembered", () => {
+    expect(validRememberedTags([1, 2], undefined)).toEqual([]);
+    expect(validRememberedTags(undefined, tags)).toEqual([]);
   });
 });

--- a/store/add-defaults-store.test.ts
+++ b/store/add-defaults-store.test.ts
@@ -81,6 +81,29 @@ describe("useAddDefaultsStore (#341)", () => {
   });
 });
 
+describe("prune orphaned keys on instance delete (#402)", () => {
+  it("drops the deleted instance's entry and persists the removal", () => {
+    const store = useAddDefaultsStore.getState();
+    store.remember(addDefaultsKey("radarr", "gone"), { qualityProfileId: 1 });
+    store.remember(addDefaultsKey("radarr", "stay"), { qualityProfileId: 2 });
+
+    store.prune(addDefaultsKey("radarr", "gone"));
+
+    const all = useAddDefaultsStore.getState().lastUsed;
+    expect(all["radarr:gone"]).toBeUndefined();
+    expect(all["radarr:stay"]?.qualityProfileId).toBe(2);
+    expect(getJSON<Record<string, LastUsedAdd>>(STORAGE_KEY)?.["radarr:gone"]).toBeUndefined();
+    expect(getJSON<Record<string, LastUsedAdd>>(STORAGE_KEY)?.["radarr:stay"]?.qualityProfileId).toBe(2);
+  });
+
+  it("is a no-op for a key that was never stored", () => {
+    const store = useAddDefaultsStore.getState();
+    store.remember(addDefaultsKey("radarr", "a"), { qualityProfileId: 1 });
+    store.prune(addDefaultsKey("radarr", "never"));
+    expect(useAddDefaultsStore.getState().lastUsed["radarr:a"]?.qualityProfileId).toBe(1);
+  });
+});
+
 describe("validRememberedTags (#402)", () => {
   const tags = [{ id: 1 }, { id: 2 }, { id: 3 }];
 
@@ -88,8 +111,12 @@ describe("validRememberedTags (#402)", () => {
     expect(validRememberedTags([1, 2, 99], tags)).toEqual([1, 2]);
   });
 
-  it("is empty when tags haven't loaded or nothing was remembered", () => {
+  it("is empty for both undefined (no list yet) and [] (empty list)", () => {
+    // No remembered id can be validated against a missing or empty server list,
+    // so this returns []. It is the value used only once Add is allowed (a
+    // still-loading query keeps Add gated, so nothing is submitted then).
     expect(validRememberedTags([1, 2], undefined)).toEqual([]);
+    expect(validRememberedTags([1, 2], [])).toEqual([]);
     expect(validRememberedTags(undefined, tags)).toEqual([]);
   });
 });

--- a/store/add-defaults-store.ts
+++ b/store/add-defaults-store.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import { getJSON, setJSON } from "@/store/storage";
+
+const STORAGE_KEY = "ui.lastUsedAdd";
+
+// The add sheet (components/common/add-media-sheet.tsx) resets its Quality
+// Profile, Root Folder, Tags and "Start Search on Add" every time it opens, so
+// anyone who adds with the same choices re-picks them every time (#341). This
+// remembers the last config used to add, per instance, and preselects it next
+// time, the way Radarr's own web UI defaults its add dialog to your last
+// configuration.
+//
+// Kept out of the exported config: it is a local convenience, not settings
+// worth backing up. Keyed per `${serviceId}:${instanceId}` (like
+// releases-filter-store's saved filters) because a profile id or a root-folder
+// path is per-instance (Radarr #3 is not Sonarr #3).
+
+export interface LastUsedAdd {
+  qualityProfileId?: number;
+  rootFolderPath?: string;
+  tags?: number[];
+  searchOnAdd?: boolean;
+}
+
+interface AddDefaultsStore {
+  lastUsed: Record<string, LastUsedAdd>;
+  hydrate: () => void;
+  /** Remember the config just used to add for one `${serviceId}:${instanceId}` key. */
+  remember: (key: string, config: LastUsedAdd) => void;
+}
+
+/** Cache key for one service instance's last-used add config. */
+export function addDefaultsKey(serviceId: string, instanceId: string): string {
+  return `${serviceId}:${instanceId}`;
+}
+
+export const useAddDefaultsStore = create<AddDefaultsStore>((set, get) => ({
+  lastUsed: {},
+
+  // Reads from the storage cache, populated by useConfigStore.hydrate(). Must
+  // be called after that; safe to call multiple times.
+  hydrate: () => {
+    const stored = getJSON<Record<string, LastUsedAdd>>(STORAGE_KEY);
+    if (stored) set({ lastUsed: stored });
+  },
+
+  remember: (key, config) => {
+    const lastUsed = { ...get().lastUsed, [key]: config };
+    set({ lastUsed });
+    setJSON(STORAGE_KEY, lastUsed);
+  },
+}));

--- a/store/add-defaults-store.ts
+++ b/store/add-defaults-store.ts
@@ -50,3 +50,17 @@ export const useAddDefaultsStore = create<AddDefaultsStore>((set, get) => ({
     setJSON(STORAGE_KEY, lastUsed);
   },
 }));
+
+/**
+ * Keep only remembered tag IDs that still exist on the server. A tag deleted in
+ * Radarr/Sonarr/Lidarr leaves a stale id that would otherwise be shown as no
+ * chip, submitted invisibly, and re-persisted (#402 review). Mirrors the
+ * quality-profile / root-folder validity fallback in the add sheet.
+ */
+export function validRememberedTags(
+  rememberedTags: number[] | undefined,
+  currentTags: { id: number }[] | undefined,
+): number[] {
+  if (!rememberedTags) return [];
+  return rememberedTags.filter((id) => currentTags?.some((t) => t.id === id));
+}

--- a/store/add-defaults-store.ts
+++ b/store/add-defaults-store.ts
@@ -27,6 +27,8 @@ interface AddDefaultsStore {
   hydrate: () => void;
   /** Remember the config just used to add for one `${serviceId}:${instanceId}` key. */
   remember: (key: string, config: LastUsedAdd) => void;
+  /** Drop one instance's remembered config when that instance is deleted. */
+  prune: (key: string) => void;
 }
 
 /** Cache key for one service instance's last-used add config. */
@@ -46,6 +48,16 @@ export const useAddDefaultsStore = create<AddDefaultsStore>((set, get) => ({
 
   remember: (key, config) => {
     const lastUsed = { ...get().lastUsed, [key]: config };
+    set({ lastUsed });
+    setJSON(STORAGE_KEY, lastUsed);
+  },
+
+  // Drop a deleted instance's entry, like removeInstance prunes its other
+  // per-instance keys.
+  prune: (key) => {
+    const current = get().lastUsed;
+    if (!(key in current)) return;
+    const { [key]: _removed, ...lastUsed } = current;
     set({ lastUsed });
     setJSON(STORAGE_KEY, lastUsed);
   },

--- a/store/config-store.ts
+++ b/store/config-store.ts
@@ -72,6 +72,7 @@ import {
   isEncryptedEnvelope,
 } from "@/lib/config-crypto";
 import { useBackendStore } from "@/store/backend-store";
+import { useAddDefaultsStore, addDefaultsKey } from "@/store/add-defaults-store";
 import { queryClient } from "@/lib/query-client";
 import type { ServiceId, WidgetId } from "@/lib/constants";
 import { normalizeBssid } from "@/lib/wifi";
@@ -1664,6 +1665,8 @@ export const useConfigStore = create<ConfigStore>((set, get) => ({
     // runs before removal); this only stops a deleted id from lingering.
     forgetSeerrSession(instanceId);
     get().forgetSeerrStaleHosts(instanceId);
+    // Drop this instance's remembered add-sheet defaults.
+    useAddDefaultsStore.getState().prune(addDefaultsKey(id, instanceId));
     // Clear SecureStore entries for this instance before mutating state so a
     // crash mid-delete doesn't leave orphaned secrets behind.
     await deleteSecret(`${SECRET_PREFIX}.${instanceId}.apiKey`);


### PR DESCRIPTION
Refs #341.

The reporter's original ask (add without auto-search) already works via the "Start Search on Add" toggle, and they confirmed that. This implements the follow-up they endorsed: default the add dialog to the last configuration you used, the way Radarr's own web UI does.

What changed:
- The add sheet (components/common/add-media-sheet.tsx) reset Quality Profile, Root Folder, Tags and "Start Search on Add" on every open. It now remembers the last config used to add, per instance, and preselects it next time.
- The remembered config lives in a small local store (store/add-defaults-store.ts), following the releases-filter-store pattern. It is keyed per serviceId:instanceId because a profile id or a root-folder path is per-instance. It is deliberately kept out of the exported config, since it is a local convenience rather than settings worth backing up, so there is no schema migration.

Precedence in the sheet is: in-sheet pick, then last-used (only if the profile/folder still exists on the server), then the Settings default (Settings, Add Defaults), then first in the list. A fresh instance that has never been added to still starts from the Settings default, and last-used takes over after the first add. Profile and Root Folder already had a Settings default; letting last-used take precedence over it matches Radarr's behaviour. Happy to gate that to Tags and the search toggle only if you would rather the Settings default always win for Profile and Folder.

Testing:
- store/add-defaults-store.test.ts (5 tests): per-instance persistence, isolation between instances, overwrite, hydrate round-trip, and a safe no-op hydrate.
- npx tsc --noEmit is clean and the full jest suite passes (1597).
- I have not run it on a device myself, so a quick UI check on your end would be welcome.

