### PR TITLE
fix(dashboard): stop now-playing cards flickering when a server is unreachable

### DIFF
--- a/components/dashboard/combined-now-playing-card.tsx
+++ b/components/dashboard/combined-now-playing-card.tsx
@@ -128,7 +128,7 @@ export function CombinedNowPlayingCard({ slotId }: WidgetComponentProps) {
 
   useHideWhenEmpty(slotId, {
     enabled: settings.hideWhenEmpty,
-    isEmpty: sources.length === 0 || display.length === 0,
+    isEmpty: sources.length === 0 || (!isAllErrored && display.length === 0),
     isLoading: isInitialLoading,
   });
 

--- a/components/dashboard/combined-now-playing-card.tsx
+++ b/components/dashboard/combined-now-playing-card.tsx
@@ -92,7 +92,9 @@ export function CombinedNowPlayingCard({ slotId }: WidgetComponentProps) {
   });
   // Initial-load gate only — once any instance returns sessions we keep
   // rendering across refetches even if a sibling is failing its retry loop.
-  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  // When every instance is failing, say so instead of a misleading "Nothing
+  // playing" (#400).
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState(queries);
 
   const allStreams: NowPlayingStream[] = queries.flatMap((q, i) => {
     const src = sources[i]!;
@@ -149,6 +151,8 @@ export function CombinedNowPlayingCard({ slotId }: WidgetComponentProps) {
         <EmptyState compact title="No media servers enabled" />
       ) : isInitialLoading ? (
         <PosterSkeletonRow count={2} />
+      ) : isAllErrored ? (
+        <EmptyState compact title="Couldn't reach any media server" />
       ) : display.length === 0 ? (
         <EmptyState compact title="Nothing playing" />
       ) : (

--- a/components/dashboard/plex-now-playing-card.tsx
+++ b/components/dashboard/plex-now-playing-card.tsx
@@ -38,8 +38,9 @@ export function PlexNowPlayingCard({ slotId }: WidgetComponentProps) {
   });
   // Initial-load gate only — see lib/multi-instance-query.ts. Once any Plex
   // returns sessions we keep rendering them across refetches even if a sibling
-  // instance is currently failing.
-  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  // instance is currently failing. When every instance is failing, say so
+  // instead of a misleading "Nothing playing" (#400).
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState(queries);
 
   // Tag every session with its source instance so per-tile poster URLs hit the
   // right Plex (thumb paths are token-scoped), then normalize to a stream.
@@ -84,6 +85,8 @@ export function PlexNowPlayingCard({ slotId }: WidgetComponentProps) {
         <EmptyState compact title="No Plex instances enabled" />
       ) : isInitialLoading ? (
         <PosterSkeletonRow count={2} />
+      ) : isAllErrored ? (
+        <EmptyState compact title="Couldn't reach Plex" />
       ) : display.length === 0 ? (
         <EmptyState compact title="Nothing playing" />
       ) : (

--- a/components/dashboard/plex-now-playing-card.tsx
+++ b/components/dashboard/plex-now-playing-card.tsx
@@ -62,7 +62,7 @@ export function PlexNowPlayingCard({ slotId }: WidgetComponentProps) {
 
   useHideWhenEmpty(slotId, {
     enabled: settings.hideWhenEmpty,
-    isEmpty: instances.length === 0 || display.length === 0,
+    isEmpty: instances.length === 0 || (!isAllErrored && display.length === 0),
     isLoading: isInitialLoading,
   });
 

--- a/components/dashboard/stream-monitor-card.tsx
+++ b/components/dashboard/stream-monitor-card.tsx
@@ -78,7 +78,7 @@ export function StreamMonitorCard({ slotId }: WidgetComponentProps) {
 
   useHideWhenEmpty(slotId, {
     enabled: settings.hideWhenEmpty,
-    isEmpty: sources.length === 0 || display.length === 0,
+    isEmpty: sources.length === 0 || (!isAllErrored && display.length === 0),
     isLoading: isInitialLoading,
   });
 

--- a/components/dashboard/stream-monitor-card.tsx
+++ b/components/dashboard/stream-monitor-card.tsx
@@ -56,8 +56,9 @@ export function StreamMonitorCard({ slotId }: WidgetComponentProps) {
   });
 
   // Initial-load gate only — keep loaded streams visible across refetches even
-  // if a sibling monitor is currently failing.
-  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  // if a sibling monitor is currently failing. When every monitor is failing,
+  // say so instead of a misleading "Nothing playing" (#400).
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState(queries);
 
   const allStreams = queries.flatMap((q) => q.data?.streams ?? []);
   const hiddenUsers = parseHiddenUsers(settings.hideUsers);
@@ -100,6 +101,8 @@ export function StreamMonitorCard({ slotId }: WidgetComponentProps) {
         <EmptyState compact title="No stream monitor enabled" />
       ) : isInitialLoading ? (
         <PosterSkeletonRow count={2} />
+      ) : isAllErrored ? (
+        <EmptyState compact title="Couldn't reach any stream monitor" />
       ) : display.length === 0 ? (
         <EmptyState compact title="Nothing playing" />
       ) : (

--- a/components/media-server/media-server-now-playing-card.tsx
+++ b/components/media-server/media-server-now-playing-card.tsx
@@ -45,8 +45,9 @@ export function MediaServerNowPlayingCard({
   });
   // Initial-load gate only — once any instance returns sessions, render them
   // even if a sibling instance is currently failing its retry loop. Prevents
-  // the "one offline server flickers the card every 5s" problem.
-  const { isInitialLoading } = aggregateMultiInstanceState(queries);
+  // the "one offline server flickers the card every 5s" problem. When every
+  // instance is failing, say so instead of a misleading "Nothing playing" (#400).
+  const { isInitialLoading, isAllErrored } = aggregateMultiInstanceState(queries);
 
   const allStreams = queries.flatMap((q, i) =>
     (q.data ?? []).map((s) => mediaServerSessionToStream(s, instances[i].id, serviceId)),
@@ -89,6 +90,8 @@ export function MediaServerNowPlayingCard({
         <EmptyState compact title={`No ${displayName} instances enabled`} />
       ) : isInitialLoading ? (
         <PosterSkeletonRow count={2} />
+      ) : isAllErrored ? (
+        <EmptyState compact title={`Couldn't reach ${displayName}`} />
       ) : display.length === 0 ? (
         <EmptyState compact title="Nothing playing" />
       ) : (

--- a/components/media-server/media-server-now-playing-card.tsx
+++ b/components/media-server/media-server-now-playing-card.tsx
@@ -67,7 +67,7 @@ export function MediaServerNowPlayingCard({
 
   useHideWhenEmpty(slotId, {
     enabled: settings.hideWhenEmpty,
-    isEmpty: instances.length === 0 || display.length === 0,
+    isEmpty: instances.length === 0 || (!isAllErrored && display.length === 0),
     isLoading: isInitialLoading,
   });
 

--- a/lib/multi-instance-query.test.ts
+++ b/lib/multi-instance-query.test.ts
@@ -1,0 +1,155 @@
+import { QueryClient, QueryObserver } from "@tanstack/query-core";
+import {
+  aggregateMultiInstanceState,
+  type MultiInstanceQueryLike,
+} from "./multi-instance-query";
+
+// Snapshots of the TanStack result shapes a fan-out widget sees. The two that
+// matter for #400 are `errored` and `erroredRefetching`: a query with no data
+// is reset to `pending` when its next poll starts, so the only thing telling a
+// failing instance apart from a first load is `errorUpdateCount`.
+const firstLoad: MultiInstanceQueryLike = {
+  data: undefined,
+  isLoading: true,
+  isError: false,
+  errorUpdateCount: 0,
+};
+const errored: MultiInstanceQueryLike = {
+  data: undefined,
+  isLoading: false,
+  isError: true,
+  errorUpdateCount: 1,
+};
+const erroredRefetching: MultiInstanceQueryLike = {
+  data: undefined,
+  isLoading: true,
+  isError: false,
+  errorUpdateCount: 1,
+};
+const loadedEmpty: MultiInstanceQueryLike = {
+  data: [],
+  isLoading: false,
+  isError: false,
+  errorUpdateCount: 0,
+};
+
+describe("aggregateMultiInstanceState", () => {
+  it("reports nothing for an empty fan-out", () => {
+    expect(aggregateMultiInstanceState([])).toEqual({
+      hasAnyData: false,
+      isInitialLoading: false,
+      isAllErrored: false,
+    });
+  });
+
+  it("shows the skeleton while every instance is on its first load", () => {
+    expect(aggregateMultiInstanceState([firstLoad, firstLoad])).toEqual({
+      hasAnyData: false,
+      isInitialLoading: true,
+      isAllErrored: false,
+    });
+  });
+
+  it("treats an empty successful payload as data, not as loading", () => {
+    expect(aggregateMultiInstanceState([loadedEmpty])).toEqual({
+      hasAnyData: true,
+      isInitialLoading: false,
+      isAllErrored: false,
+    });
+  });
+
+  it("is all-errored once every instance has failed without data", () => {
+    expect(aggregateMultiInstanceState([errored, errored])).toEqual({
+      hasAnyData: false,
+      isInitialLoading: false,
+      isAllErrored: true,
+    });
+  });
+
+  it("keeps a failed instance errored while its next poll is in flight (#400)", () => {
+    // Before the fix this read as isInitialLoading=true, so a single unreachable
+    // server flipped its widget between the empty row and the skeleton every poll.
+    expect(aggregateMultiInstanceState([erroredRefetching])).toEqual({
+      hasAnyData: false,
+      isInitialLoading: false,
+      isAllErrored: true,
+    });
+  });
+
+  it("still shows the skeleton when a sibling has never settled", () => {
+    expect(aggregateMultiInstanceState([erroredRefetching, firstLoad])).toEqual({
+      hasAnyData: false,
+      isInitialLoading: true,
+      isAllErrored: false,
+    });
+  });
+
+  it("renders data from any instance regardless of failing siblings", () => {
+    expect(aggregateMultiInstanceState([loadedEmpty, erroredRefetching])).toEqual({
+      hasAnyData: true,
+      isInitialLoading: false,
+      isAllErrored: false,
+    });
+  });
+
+  it("falls back to isError when errorUpdateCount is absent", () => {
+    const legacyErrored = { data: undefined, isLoading: false, isError: true };
+    const legacyLoading = { data: undefined, isLoading: true, isError: false };
+    expect(aggregateMultiInstanceState([legacyErrored]).isAllErrored).toBe(true);
+    expect(aggregateMultiInstanceState([legacyLoading]).isInitialLoading).toBe(true);
+  });
+});
+
+describe("aggregateMultiInstanceState against a real QueryClient", () => {
+  it("stays errored across the pending reset a refetch performs on a failed query", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const observer = new QueryObserver(client, {
+      queryKey: ["jellyfin", "home", "sessions"],
+      queryFn: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    try {
+      expect(aggregateMultiInstanceState([observer.getCurrentResult()])).toEqual({
+        hasAnyData: false,
+        isInitialLoading: true,
+        isAllErrored: false,
+      });
+
+      const settled = await observer.refetch();
+      expect(settled.isError).toBe(true);
+      expect(aggregateMultiInstanceState([settled])).toEqual({
+        hasAnyData: false,
+        isInitialLoading: false,
+        isAllErrored: true,
+      });
+
+      // The next poll fires. Capture the result mid-flight: this is the state
+      // TanStack hands the widget every 5s for an unreachable server.
+      const inFlight = observer.refetch();
+      const mid = observer.getCurrentResult();
+      expect(mid.status).toBe("pending");
+      expect(mid.isLoading).toBe(true);
+      expect(mid.isError).toBe(false);
+      expect(mid.errorUpdateCount).toBe(1);
+      expect(aggregateMultiInstanceState([mid])).toEqual({
+        hasAnyData: false,
+        isInitialLoading: false,
+        isAllErrored: true,
+      });
+
+      const again = await inFlight;
+      expect(aggregateMultiInstanceState([again])).toEqual({
+        hasAnyData: false,
+        isInitialLoading: false,
+        isAllErrored: true,
+      });
+    } finally {
+      unsubscribe();
+      client.clear();
+    }
+  });
+});

--- a/lib/multi-instance-query.ts
+++ b/lib/multi-instance-query.ts
@@ -9,17 +9,35 @@
  * soon as any instance has it, only show the skeleton when nothing has loaded
  * yet, and only surface the error UI when every instance has errored without
  * ever returning data.
+ *
+ * "Errored" has to outlive the error itself. TanStack resets a query that holds
+ * no data back to `status: "pending"` (and clears `error`) the moment a refetch
+ * starts, so an unreachable instance polling every 5s reads as `isError` while
+ * idle and as `isLoading` while in flight, which is indistinguishable from a
+ * first load by those two flags alone. Gating on them made single-instance
+ * widgets flip between their empty row and the full-height skeleton on every
+ * poll (#400). `errorUpdateCount` is the one field the reset leaves alone, so a
+ * data-less query that has failed at least once stays "errored" here until it
+ * actually succeeds.
  */
 export interface MultiInstanceQueryLike<T = unknown> {
   data: T | undefined;
   isLoading: boolean;
   isError: boolean;
+  /** TanStack's running count of error results; a refetch never resets it. */
+  errorUpdateCount?: number;
 }
 
 export interface MultiInstanceState {
   hasAnyData: boolean;
   isInitialLoading: boolean;
   isAllErrored: boolean;
+}
+
+// A query with nothing to render that has failed at least once, whether it is
+// sitting in its error state or part-way through the next attempt.
+function hasFailedWithoutData(q: MultiInstanceQueryLike): boolean {
+  return q.data === undefined && (q.isError || (q.errorUpdateCount ?? 0) > 0);
 }
 
 export function aggregateMultiInstanceState(
@@ -29,8 +47,10 @@ export function aggregateMultiInstanceState(
     return { hasAnyData: false, isInitialLoading: false, isAllErrored: false };
   }
   const hasAnyData = queries.some((q) => q.data !== undefined);
-  const isAllErrored = !hasAnyData && queries.every((q) => q.isError);
+  const isAllErrored = !hasAnyData && queries.every(hasFailedWithoutData);
   const isInitialLoading =
-    !hasAnyData && !isAllErrored && queries.some((q) => q.isLoading);
+    !hasAnyData &&
+    !isAllErrored &&
+    queries.some((q) => q.isLoading && !hasFailedWithoutData(q));
   return { hasAnyData, isInitialLoading, isAllErrored };
 }


### PR DESCRIPTION
## Summary
- TanStack resets a query with no data to `pending` on every refetch, so an unreachable instance flipped `aggregateMultiInstanceState` between errored and loading on each poll. Single-instance now-playing widgets alternated between "Nothing playing" and the full-height skeleton every 5s.
- Gate on `errorUpdateCount`, which the reset never touches, so a data-less query that has failed once stays errored until it actually succeeds. Applies to every widget and screen using the helper.
- The now-playing cards (Jellyfin/Emby, Plex, All Servers, Stream Monitor) now show "Couldn't reach X" when every instance is failing instead of a misleading "Nothing playing".

Refs #400

## Test plan
- [x] `lib/multi-instance-query.test.ts`, including a real `QueryClient` case that captures the mid-refetch pending state
- [x] Full jest suite (80 suites, 1618 tests)
- [x] `tsc --noEmit`