### PR TITLE
fix(calendar): refresh episode status after a grab and after import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 *-firebase-adminsdk-*.json
 play-service-account.json
 coverage/*
+
+# Local pnpm content-addressable store (created by a store path override).
+.pnpm-store/

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -20,14 +20,8 @@ import { FilterChip } from "@/components/ui/filter-chip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ActionSheet, type ActionSheetAction } from "@/components/ui/action-sheet";
 import { ICON, POLLING_INTERVALS, SERVICE_DEFAULTS } from "@/lib/constants";
-import {
-  getCalendar as getSonarrCalendar,
-  getQueue as getSonarrQueue,
-} from "@/services/sonarr-api";
-import {
-  getCalendar as getRadarrCalendar,
-  getQueue as getRadarrQueue,
-} from "@/services/radarr-api";
+import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
+import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
 import {
   getCalendarGrid,
   getFetchRange,
@@ -37,6 +31,8 @@ import { resolveWeekStartDow } from "@/lib/week-start";
 import { isSeasonPremiere, PREMIERE_BADGE } from "@/lib/season-premiere";
 import { useConfigStore } from "@/store/config-store";
 import { useEnabledInstances } from "@/hooks/use-instance-target";
+import { useArrDownloadingKeys } from "@/hooks/use-arr-downloading-keys";
+import { useRefreshOnDownloadComplete } from "@/hooks/use-refresh-on-download-complete";
 import { useAttachedInstances } from "@/hooks/use-active-dashboard";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
@@ -201,43 +197,9 @@ export default function CalendarScreen() {
 
   // Per-instance download queues, so an episode/movie currently grabbing reads
   // purple in the day list — same indicator as the poster grid and the detail
-  // screens (issue #207). Reuses the shared ["sonarr"/"radarr", id, "queue"]
-  // cache key, so this rides whatever the rest of the app already polls.
-  const sonarrQueueQueries = useQueries({
-    queries: sonarrInstances.map((inst) => ({
-      queryKey: ["sonarr", inst.id, "queue"] as const,
-      queryFn: () => getSonarrQueue(1, 20, true, true, inst.id),
-      refetchInterval: POLLING_INTERVALS.queue,
-    })),
-  });
-  const radarrQueueQueries = useQueries({
-    queries: radarrInstances.map((inst) => ({
-      queryKey: ["radarr", inst.id, "queue"] as const,
-      queryFn: () => getRadarrQueue(1, 20, true, inst.id),
-      refetchInterval: POLLING_INTERVALS.queue,
-    })),
-  });
-
-  // Keyed by `instanceId:episodeId` / `instanceId:movieId` because ids aren't
-  // globally unique across instances.
-  const downloadingKeys = useMemo(() => {
-    const keys = new Set<string>();
-    sonarrQueueQueries.forEach((q, i) => {
-      const instanceId = sonarrInstances[i]?.id;
-      if (!instanceId) return;
-      (q.data?.records ?? []).forEach((r) =>
-        keys.add(`${instanceId}:${r.episodeId}`),
-      );
-    });
-    radarrQueueQueries.forEach((q, i) => {
-      const instanceId = radarrInstances[i]?.id;
-      if (!instanceId) return;
-      (q.data?.records ?? []).forEach((r) =>
-        keys.add(`${instanceId}:${r.movieId}`),
-      );
-    });
-    return keys;
-  }, [sonarrQueueQueries, radarrQueueQueries, sonarrInstances, radarrInstances]);
+  // screens (issue #207). Rides the shared ["sonarr"/"radarr", id, "queue"]
+  // cache the rest of the app already polls.
+  const downloadingKeys = useArrDownloadingKeys(sonarrInstances, radarrInstances);
 
   // Tag each calendar entry with the source instance so navigation can route
   // detail-screen queries to the correct Sonarr/Radarr (ids aren't globally
@@ -277,7 +239,7 @@ export default function CalendarScreen() {
   // Pull-to-refresh invalidates every per-instance calendar slot. Building
   // these key lists from the live instance arrays guarantees we don't miss
   // (or stale-refresh) an instance the user just added or disabled.
-  const refreshKeys = useMemo<unknown[][]>(
+  const calendarKeys = useMemo<unknown[][]>(
     () => [
       ...sonarrInstances.map((inst) => [
         "sonarr",
@@ -298,7 +260,22 @@ export default function CalendarScreen() {
     ],
     [sonarrInstances, radarrInstances, start, end, includeUnmonitored],
   );
+  // The queues drive the purple "downloading" bar, so a manual pull has to
+  // refresh them too — otherwise pulling only updates half the row's state.
+  const refreshKeys = useMemo<unknown[][]>(
+    () => [
+      ...calendarKeys,
+      ...sonarrInstances.map((inst) => ["sonarr", inst.id, "queue"]),
+      ...radarrInstances.map((inst) => ["radarr", inst.id, "queue"]),
+    ],
+    [calendarKeys, sonarrInstances, radarrInstances],
+  );
   const { refreshing, onRefresh } = usePullToRefresh(refreshKeys);
+
+  // `hasFile` only lives in the calendar payload, which nothing invalidates —
+  // without this an imported item reverts from purple to red until the 60s poll
+  // comes round, instead of turning green (#401).
+  useRefreshOnDownloadComplete(downloadingKeys, calendarKeys);
 
   // Build items map keyed by date
   const { itemsByDate, allItems } = useMemo(() => {

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -199,7 +199,7 @@ export default function CalendarScreen() {
   // purple in the day list — same indicator as the poster grid and the detail
   // screens (issue #207). Rides the shared ["sonarr"/"radarr", id, "queue"]
   // cache the rest of the app already polls.
-  const downloadingKeys = useArrDownloadingKeys(sonarrInstances, radarrInstances);
+  const queuedKeys = useArrDownloadingKeys(sonarrInstances, radarrInstances);
 
   // Tag each calendar entry with the source instance so navigation can route
   // detail-screen queries to the correct Sonarr/Radarr (ids aren't globally
@@ -272,10 +272,11 @@ export default function CalendarScreen() {
   );
   const { refreshing, onRefresh } = usePullToRefresh(refreshKeys);
 
-  // `hasFile` only lives in the calendar payload, which nothing invalidates —
-  // without this an imported item reverts from purple to red until the 60s poll
-  // comes round, instead of turning green (#401).
-  useRefreshOnDownloadComplete(downloadingKeys, calendarKeys);
+  // `hasFile` only lives in the calendar payload, which nothing else
+  // invalidates — without this an imported item reverts from purple to red
+  // until the 60s poll comes round, instead of turning green (#401). The hook
+  // also holds a just-departed item purple until that refresh lands.
+  const downloadingKeys = useRefreshOnDownloadComplete(queuedKeys, calendarKeys);
 
   // Build items map keyed by date
   const { itemsByDate, allItems } = useMemo(() => {
@@ -597,7 +598,7 @@ function SelectedDayList({
   downloadingKeys,
 }: {
   items: CalendarItem[];
-  downloadingKeys: Set<string>;
+  downloadingKeys: ReadonlySet<string | number>;
 }) {
   const router = useRouter();
 

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -106,15 +106,16 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   // Download queues per instance, so a release already grabbing reads purple —
   // same indicator as the poster grid, detail screens and Calendar tab (#207).
   // Shares the ["sonarr"/"radarr", id, "queue"] cache the rest of the app polls.
-  const downloadingKeys = useArrDownloadingKeys(
+  const queuedKeys = useArrDownloadingKeys(
     showSonarr ? sonarrInstances : NO_INSTANCES,
     showRadarr ? radarrInstances : NO_INSTANCES,
   );
 
-  // `hasFile` only lives in the calendar payload, which nothing invalidates —
-  // without this an imported item reverts from purple to red until the 60s poll
-  // comes round, instead of turning green (#401).
-  useRefreshOnDownloadComplete(downloadingKeys, [
+  // `hasFile` only lives in the calendar payload, which nothing else
+  // invalidates — without this an imported item reverts from purple to red
+  // until the 60s poll comes round, instead of turning green (#401). The hook
+  // also holds a just-departed item purple until that refresh lands.
+  const downloadingKeys = useRefreshOnDownloadComplete(queuedKeys, [
     ...sonarrInstances.map((inst) => sonarrCalendarKey(inst.id, settings.daysAhead)),
     ...radarrInstances.map((inst) => radarrCalendarKey(inst.id, settings.daysAhead)),
   ]);

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -10,6 +10,8 @@ import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
+import { sonarrCalendarKey } from "@/hooks/use-sonarr";
+import { radarrCalendarKey } from "@/hooks/use-radarr";
 import { useArrDownloadingKeys, NO_INSTANCES } from "@/hooks/use-arr-downloading-keys";
 import { useRefreshOnDownloadComplete } from "@/hooks/use-refresh-on-download-complete";
 import { POLLING_INTERVALS } from "@/lib/constants";
@@ -85,7 +87,7 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   const sonarrQueries = useQueries({
     queries: showSonarr
       ? sonarrInstances.map((inst) => ({
-          queryKey: ["sonarr", inst.id, "calendar", settings.daysAhead] as const,
+          queryKey: sonarrCalendarKey(inst.id, settings.daysAhead),
           queryFn: () => getSonarrCalendar(start, end, {}, inst.id),
           refetchInterval: POLLING_INTERVALS.calendar,
         }))
@@ -94,7 +96,7 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   const radarrQueries = useQueries({
     queries: showRadarr
       ? radarrInstances.map((inst) => ({
-          queryKey: ["radarr", inst.id, "calendar", settings.daysAhead] as const,
+          queryKey: radarrCalendarKey(inst.id, settings.daysAhead),
           queryFn: () => getRadarrCalendar(start, end, {}, inst.id),
           refetchInterval: POLLING_INTERVALS.calendar,
         }))
@@ -113,8 +115,8 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   // without this an imported item reverts from purple to red until the 60s poll
   // comes round, instead of turning green (#401).
   useRefreshOnDownloadComplete(downloadingKeys, [
-    ...sonarrInstances.map((inst) => ["sonarr", inst.id, "calendar"]),
-    ...radarrInstances.map((inst) => ["radarr", inst.id, "calendar"]),
+    ...sonarrInstances.map((inst) => sonarrCalendarKey(inst.id, settings.daysAhead)),
+    ...radarrInstances.map((inst) => radarrCalendarKey(inst.id, settings.daysAhead)),
   ]);
 
   // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton

--- a/components/dashboard/calendar-card.tsx
+++ b/components/dashboard/calendar-card.tsx
@@ -10,6 +10,8 @@ import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
+import { useArrDownloadingKeys, NO_INSTANCES } from "@/hooks/use-arr-downloading-keys";
+import { useRefreshOnDownloadComplete } from "@/hooks/use-refresh-on-download-complete";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   CALENDAR_DEFAULT_SETTINGS,
@@ -25,14 +27,8 @@ import {
   localDateKey,
   releaseDateKey,
 } from "@/lib/utils";
-import {
-  getCalendar as getSonarrCalendar,
-  getQueue as getSonarrQueue,
-} from "@/services/sonarr-api";
-import {
-  getCalendar as getRadarrCalendar,
-  getQueue as getRadarrQueue,
-} from "@/services/radarr-api";
+import { getCalendar as getSonarrCalendar } from "@/services/sonarr-api";
+import { getCalendar as getRadarrCalendar } from "@/services/radarr-api";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { isSeasonPremiere, PREMIERE_BADGE } from "@/lib/season-premiere";
 import { CardHeaderLink } from "@/components/dashboard/card-header-link";
@@ -108,40 +104,18 @@ export function CalendarCard({ slotId }: WidgetComponentProps) {
   // Download queues per instance, so a release already grabbing reads purple —
   // same indicator as the poster grid, detail screens and Calendar tab (#207).
   // Shares the ["sonarr"/"radarr", id, "queue"] cache the rest of the app polls.
-  const sonarrQueueQueries = useQueries({
-    queries: showSonarr
-      ? sonarrInstances.map((inst) => ({
-          queryKey: ["sonarr", inst.id, "queue"] as const,
-          queryFn: () => getSonarrQueue(1, 20, true, true, inst.id),
-          refetchInterval: POLLING_INTERVALS.queue,
-        }))
-      : [],
-  });
-  const radarrQueueQueries = useQueries({
-    queries: showRadarr
-      ? radarrInstances.map((inst) => ({
-          queryKey: ["radarr", inst.id, "queue"] as const,
-          queryFn: () => getRadarrQueue(1, 20, true, inst.id),
-          refetchInterval: POLLING_INTERVALS.queue,
-        }))
-      : [],
-  });
+  const downloadingKeys = useArrDownloadingKeys(
+    showSonarr ? sonarrInstances : NO_INSTANCES,
+    showRadarr ? radarrInstances : NO_INSTANCES,
+  );
 
-  // Keyed by `instanceId:episodeId` / `instanceId:movieId` (ids aren't unique
-  // across instances).
-  const downloadingKeys = new Set<string>();
-  sonarrQueueQueries.forEach((q, i) => {
-    const instanceId = sonarrInstances[i]?.id;
-    if (!instanceId) return;
-    for (const r of q.data?.records ?? [])
-      downloadingKeys.add(`${instanceId}:${r.episodeId}`);
-  });
-  radarrQueueQueries.forEach((q, i) => {
-    const instanceId = radarrInstances[i]?.id;
-    if (!instanceId) return;
-    for (const r of q.data?.records ?? [])
-      downloadingKeys.add(`${instanceId}:${r.movieId}`);
-  });
+  // `hasFile` only lives in the calendar payload, which nothing invalidates —
+  // without this an imported item reverts from purple to red until the 60s poll
+  // comes round, instead of turning green (#401).
+  useRefreshOnDownloadComplete(downloadingKeys, [
+    ...sonarrInstances.map((inst) => ["sonarr", inst.id, "calendar"]),
+    ...radarrInstances.map((inst) => ["radarr", inst.id, "calendar"]),
+  ]);
 
   // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton
   // shows only while we're truly cold across both kinds; a single failing

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -101,7 +101,7 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
   // Download queues per instance: an overdue item that's already grabbing reads
   // purple instead of the neutral "pending" spine — same indicator as the rest
   // of the app (issue #207). Shares the ["sonarr"/"radarr", id, "queue"] cache.
-  const downloadingKeys = useArrDownloadingKeys(
+  const queuedKeys = useArrDownloadingKeys(
     showSonarr ? sonarrInstances : NO_INSTANCES,
     showRadarr ? radarrInstances : NO_INSTANCES,
   );
@@ -110,7 +110,7 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
   // spine falls from purple straight back to red and the item keeps counting as
   // overdue until "wanted" polls 60s later. Refresh it the moment the download
   // completes instead (#401).
-  useRefreshOnDownloadComplete(downloadingKeys, [
+  const downloadingKeys = useRefreshOnDownloadComplete(queuedKeys, [
     ...sonarrInstances.map((inst) => ["sonarr", inst.id, "wanted"]),
     ...radarrInstances.map((inst) => ["radarr", inst.id, "wanted"]),
   ]);

--- a/components/dashboard/still-pending-card.tsx
+++ b/components/dashboard/still-pending-card.tsx
@@ -10,6 +10,11 @@ import { useConfigStore } from "@/store/config-store";
 import { useWidgetSettings } from "@/hooks/use-widget-settings";
 import { useHideWhenEmpty } from "@/hooks/use-hide-when-empty";
 import { useWorkspaceScopedInstances } from "@/hooks/use-workspace-instances";
+import {
+  useArrDownloadingKeys,
+  NO_INSTANCES,
+} from "@/hooks/use-arr-downloading-keys";
+import { useRefreshOnDownloadComplete } from "@/hooks/use-refresh-on-download-complete";
 import { POLLING_INTERVALS } from "@/lib/constants";
 import {
   STILL_PENDING_DEFAULT_SETTINGS,
@@ -24,14 +29,8 @@ import {
   getDateOffset,
   localDateKey,
 } from "@/lib/utils";
-import {
-  getWantedMissing as getSonarrWantedMissing,
-  getQueue as getSonarrQueue,
-} from "@/services/sonarr-api";
-import {
-  getAllWantedMissing as getRadarrWantedMissing,
-  getQueue as getRadarrQueue,
-} from "@/services/radarr-api";
+import { getWantedMissing as getSonarrWantedMissing } from "@/services/sonarr-api";
+import { getAllWantedMissing as getRadarrWantedMissing } from "@/services/radarr-api";
 import { radarrPendingTime } from "@/lib/radarr-release-date";
 import { useSearchForMovie } from "@/hooks/use-radarr";
 import { useSearchForEpisodes } from "@/hooks/use-sonarr";
@@ -102,40 +101,19 @@ export function StillPendingCard({ slotId }: WidgetComponentProps) {
   // Download queues per instance: an overdue item that's already grabbing reads
   // purple instead of the neutral "pending" spine — same indicator as the rest
   // of the app (issue #207). Shares the ["sonarr"/"radarr", id, "queue"] cache.
-  const sonarrQueueQueries = useQueries({
-    queries: showSonarr
-      ? sonarrInstances.map((inst) => ({
-          queryKey: ["sonarr", inst.id, "queue"] as const,
-          queryFn: () => getSonarrQueue(1, 20, true, true, inst.id),
-          refetchInterval: POLLING_INTERVALS.queue,
-        }))
-      : [],
-  });
-  const radarrQueueQueries = useQueries({
-    queries: showRadarr
-      ? radarrInstances.map((inst) => ({
-          queryKey: ["radarr", inst.id, "queue"] as const,
-          queryFn: () => getRadarrQueue(1, 20, true, inst.id),
-          refetchInterval: POLLING_INTERVALS.queue,
-        }))
-      : [],
-  });
+  const downloadingKeys = useArrDownloadingKeys(
+    showSonarr ? sonarrInstances : NO_INSTANCES,
+    showRadarr ? radarrInstances : NO_INSTANCES,
+  );
 
-  // Keyed by `instanceId:episodeId` / `instanceId:movieId` (ids aren't unique
-  // across instances).
-  const downloadingKeys = new Set<string>();
-  sonarrQueueQueries.forEach((q, i) => {
-    const instanceId = sonarrInstances[i]?.id;
-    if (!instanceId) return;
-    for (const r of q.data?.records ?? [])
-      downloadingKeys.add(`${instanceId}:${r.episodeId}`);
-  });
-  radarrQueueQueries.forEach((q, i) => {
-    const instanceId = radarrInstances[i]?.id;
-    if (!instanceId) return;
-    for (const r of q.data?.records ?? [])
-      downloadingKeys.add(`${instanceId}:${r.movieId}`);
-  });
+  // Every row here is already overdue, so once a download leaves the queue the
+  // spine falls from purple straight back to red and the item keeps counting as
+  // overdue until "wanted" polls 60s later. Refresh it the moment the download
+  // completes instead (#401).
+  useRefreshOnDownloadComplete(downloadingKeys, [
+    ...sonarrInstances.map((inst) => ["sonarr", inst.id, "wanted"]),
+    ...radarrInstances.map((inst) => ["radarr", inst.id, "wanted"]),
+  ]);
 
   // Initial-load gate per kind — see lib/multi-instance-query.ts. The skeleton
   // shows only while we're truly cold across both kinds; a single failing

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -52,6 +52,7 @@ import {
   useSonarrSeries,
   useSonarrQueue,
   useSonarrCalendar,
+  sonarrCalendarKey,
   useSearchForSeries,
   useSearchForEpisodes,
   useSearchAllMissingEpisodes,
@@ -587,7 +588,7 @@ function CalendarView({
   // without this an imported episode reverts from purple to red until the 60s
   // poll comes round, instead of turning green (#401).
   useRefreshOnDownloadComplete(downloadingEpisodeIds, [
-    ["sonarr", instanceId, "calendar"],
+    sonarrCalendarKey(instanceId),
   ]);
 
   if (isLoading) return <SkeletonCardContent rows={4} />;

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -67,6 +67,8 @@ import {
   sonarrEpisodeBarKind,
 } from "@/lib/arr-poster-status";
 import { useServiceHealth } from "@/hooks/use-service-health";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
+import { useRefreshOnDownloadComplete } from "@/hooks/use-refresh-on-download-complete";
 import { usePullToRefresh } from "@/components/common/pull-to-refresh";
 import { CalendarEventRow } from "@/components/common/calendar-event-row";
 import { isSeasonPremiere, PREMIERE_BADGE } from "@/lib/season-premiere";
@@ -573,12 +575,20 @@ function CalendarView({
 }) {
   const { data: episodes, isLoading, error } = useSonarrCalendar();
   const { data: queue } = useSonarrQueue();
+  const { instanceId } = useInstanceTarget("sonarr");
   const router = useRouter();
 
   const downloadingEpisodeIds = useMemo(
     () => new Set((queue?.records ?? []).map((r) => r.episodeId)),
     [queue],
   );
+
+  // `hasFile` only lives in the calendar payload, which nothing invalidates —
+  // without this an imported episode reverts from purple to red until the 60s
+  // poll comes round, instead of turning green (#401).
+  useRefreshOnDownloadComplete(downloadingEpisodeIds, [
+    ["sonarr", instanceId, "calendar"],
+  ]);
 
   if (isLoading) return <SkeletonCardContent rows={4} />;
   if (error) {

--- a/components/sonarr/tv-view.tsx
+++ b/components/sonarr/tv-view.tsx
@@ -579,15 +579,16 @@ function CalendarView({
   const { instanceId } = useInstanceTarget("sonarr");
   const router = useRouter();
 
-  const downloadingEpisodeIds = useMemo(
+  const queuedEpisodeIds = useMemo(
     () => new Set((queue?.records ?? []).map((r) => r.episodeId)),
     [queue],
   );
 
-  // `hasFile` only lives in the calendar payload, which nothing invalidates —
-  // without this an imported episode reverts from purple to red until the 60s
-  // poll comes round, instead of turning green (#401).
-  useRefreshOnDownloadComplete(downloadingEpisodeIds, [
+  // `hasFile` only lives in the calendar payload, which nothing else
+  // invalidates — without this an imported episode reverts from purple to red
+  // until the 60s poll comes round, instead of turning green (#401). The hook
+  // also holds a just-departed episode purple until that refresh lands.
+  const downloadingEpisodeIds = useRefreshOnDownloadComplete(queuedEpisodeIds, [
     sonarrCalendarKey(instanceId),
   ]);
 

--- a/hooks/use-arr-downloading-keys.ts
+++ b/hooks/use-arr-downloading-keys.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { radarrQueueQuery, sonarrQueueQuery } from "@/lib/arr-queue-query";
+import type { ServiceInstance } from "@/store/config-store";
+
+/** Stable empty list, so a caller hiding a kind doesn't churn the memo. */
+export const NO_INSTANCES: ServiceInstance[] = [];
+
+/**
+ * `instanceId:episodeId` / `instanceId:movieId` for everything currently in a
+ * Sonarr/Radarr download queue — the set every calendar-shaped surface reads to
+ * paint a grabbing item purple (#207). Ids aren't unique across instances,
+ * hence the composite key.
+ *
+ * Fans out across the instances it's given, so a caller hiding a kind passes
+ * `NO_INSTANCES` for it. Shares the `["sonarr"/"radarr", id, "queue"]` cache
+ * with the rest of the app via lib/arr-queue-query.
+ */
+export function useArrDownloadingKeys(
+  sonarrInstances: ServiceInstance[],
+  radarrInstances: ServiceInstance[],
+): Set<string> {
+  const sonarrQueues = useQueries({
+    queries: sonarrInstances.map((inst) => sonarrQueueQuery(inst.id)),
+  });
+  const radarrQueues = useQueries({
+    queries: radarrInstances.map((inst) => radarrQueueQuery(inst.id)),
+  });
+
+  return useMemo(() => {
+    const keys = new Set<string>();
+    sonarrQueues.forEach((q, i) => {
+      const instanceId = sonarrInstances[i]?.id;
+      if (!instanceId) return;
+      for (const r of q.data?.records ?? [])
+        keys.add(`${instanceId}:${r.episodeId}`);
+    });
+    radarrQueues.forEach((q, i) => {
+      const instanceId = radarrInstances[i]?.id;
+      if (!instanceId) return;
+      for (const r of q.data?.records ?? [])
+        keys.add(`${instanceId}:${r.movieId}`);
+    });
+    return keys;
+  }, [sonarrQueues, radarrQueues, sonarrInstances, radarrInstances]);
+}

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -50,10 +50,18 @@ export function useRadarrMovies(instanceId?: string) {
   });
 }
 
-export function useRadarrCalendar(days = 30, instanceId?: string) {
+export const RADARR_CALENDAR_DAYS = 30;
+
+/** See sonarrCalendarKey — same reason, same shape. */
+export const radarrCalendarKey = (
+  instanceId: string | null,
+  days: number = RADARR_CALENDAR_DAYS,
+) => ["radarr", instanceId, "calendar", days] as const;
+
+export function useRadarrCalendar(days = RADARR_CALENDAR_DAYS, instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
-    queryKey: ["radarr", id, "calendar", days],
+    queryKey: radarrCalendarKey(id, days),
     queryFn: () => getCalendar(getDateOffset(0), getDateOffset(days), {}, id ?? undefined),
     refetchInterval: POLLING_INTERVALS.calendar,
     enabled: enabled && !!id,

--- a/hooks/use-radarr.ts
+++ b/hooks/use-radarr.ts
@@ -8,7 +8,6 @@ import {
   getMovies,
   getMovie,
   getCollectionByTmdbId,
-  getQueue,
   getHistory,
   getMovieHistory,
   getAllWantedMissing,
@@ -32,6 +31,8 @@ import type { RadarrMovie } from "@/lib/types";
 import { getMovieDetails, deleteMedia } from "@/services/overseerr-api";
 import { useConfigStore } from "@/store/config-store";
 import { POLLING_INTERVALS } from "@/lib/constants";
+import { radarrQueueQuery } from "@/lib/arr-queue-query";
+import { scheduleGrabRecheck } from "@/lib/post-grab-refresh";
 import { describeGrabFailure } from "@/lib/download-client-error";
 import { getDateOffset } from "@/lib/utils";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
@@ -88,11 +89,9 @@ export function useRadarrCollection(
 export function useRadarrQueue(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("radarr", instanceId);
   return useQuery({
-    queryKey: ["radarr", id, "queue"],
-    // Args must stay identical to radarrArrQueueAdapter.fetchQueue — the
-    // dashboard widget and the queue-issues banner share this cache entry.
-    queryFn: () => getQueue(1, 100, true, id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.queue,
+    // Key, args and interval come from lib/arr-queue-query so every producer of
+    // this shared cache entry requests the same page.
+    ...radarrQueueQuery(id ?? undefined),
     enabled: enabled && !!id,
   });
 }
@@ -475,7 +474,13 @@ export function useGrabRadarrRelease(instanceId?: string) {
       grabRadarrRelease(guid, indexerId, id ?? undefined),
     onSuccess: () => {
       toast("Sent to download client");
-      queryClient.invalidateQueries({ queryKey: ["radarr", id, "queue"] });
+      // Radarr populates /queue on a trailing 5s debounce, so a single
+      // invalidate here always reads a queue without the grab in it — see
+      // lib/post-grab-refresh (#401).
+      const queryKey = ["radarr", id, "queue"] as const;
+      scheduleGrabRecheck(`radarr:${id}:queue`, () =>
+        queryClient.invalidateQueries({ queryKey }),
+      );
     },
     onError: (err) => {
       toastError("Failed to grab release", err, (msg) =>

--- a/hooks/use-refresh-on-download-complete.test.ts
+++ b/hooks/use-refresh-on-download-complete.test.ts
@@ -1,0 +1,43 @@
+import {
+  SETTLE_MAX_MS,
+  departedIds,
+} from "./use-refresh-on-download-complete";
+
+describe("departedIds", () => {
+  it("reports ids that left the queue", () => {
+    expect(departedIds(new Set([1, 2, 3]), new Set([1, 3]))).toEqual([2]);
+  });
+
+  it("ignores ids that joined the queue", () => {
+    expect(departedIds(new Set([1]), new Set([1, 2]))).toEqual([]);
+  });
+
+  it("is empty when nothing moved", () => {
+    expect(departedIds(new Set([1, 2]), new Set([1, 2]))).toEqual([]);
+  });
+
+  // A queue query that errors into no data empties the set, which reads as
+  // "everything completed". One redundant calendar refresh is the correct,
+  // self-correcting outcome — the hold is released by the same refresh.
+  it("treats an emptied queue as every id departing", () => {
+    expect(departedIds(new Set(["a:1", "a:2"]), new Set())).toEqual([
+      "a:1",
+      "a:2",
+    ]);
+  });
+
+  it("handles the first render, when nothing was seen yet", () => {
+    expect(departedIds(new Set(), new Set([1]))).toEqual([]);
+  });
+});
+
+describe("SETTLE_MAX_MS", () => {
+  // The hold must outlive a normal calendar round trip but expire well before
+  // lib/query-client.ts's retry ladder (2 retries, exponential backoff, 15s
+  // request timeout) would resolve against an unreachable server — otherwise a
+  // dead Sonarr leaves rows stuck on "downloading".
+  it("is bounded well below the retry ladder's worst case", () => {
+    expect(SETTLE_MAX_MS).toBeGreaterThanOrEqual(1_000);
+    expect(SETTLE_MAX_MS).toBeLessThan(15_000);
+  });
+});

--- a/hooks/use-refresh-on-download-complete.ts
+++ b/hooks/use-refresh-on-download-complete.ts
@@ -1,46 +1,115 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
+type DownloadId = string | number;
+
+const NONE: ReadonlySet<DownloadId> = new Set();
+
 /**
- * Refresh the payloads that carry `hasFile` the moment a download finishes.
+ * Ceiling on how long an id is held in the "settling" state below. The refresh
+ * normally lands in one round trip, but lib/query-client.ts retries twice with
+ * exponential backoff behind a 15s request timeout, so an unreachable server can
+ * keep that promise pending for ~50s. Holding "downloading" that long would be a
+ * worse lie than the red frame the hold exists to avoid, so time it out.
+ */
+export const SETTLE_MAX_MS = 3_000;
+
+/** Ids present in `previous` that are gone from `current`. */
+export function departedIds(
+  previous: ReadonlySet<DownloadId>,
+  current: ReadonlySet<DownloadId>,
+): DownloadId[] {
+  return [...previous].filter((id) => !current.has(id));
+}
+
+/**
+ * Refresh the payloads that carry `hasFile` the moment a download finishes, and
+ * hold the row purple until that refresh lands.
  *
  * `hasFile` is the only source of the green "downloaded" bar, and it lives in
- * the `/calendar` (or `/wanted`) response — which nothing in the app has ever
- * invalidated: it rides a 60s poll. The download queue polls at 30s, so an
- * episode that finishes importing drops out of the downloading set well before
- * the calendar learns it has a file, and the row flashes back to *red* for up
- * to a minute instead of going purple → green (#401).
+ * the `/calendar` (or `/wanted`) response — which nothing in the app used to
+ * invalidate: it rode a 60s poll. The download queue polls at 30s, so an episode
+ * that finishes importing drops out of the downloading set well before the
+ * calendar learns it has a file, and the row flashed back to *red* for up to a
+ * minute instead of going purple → green (#401).
  *
  * Leaving the queue is the app's only observable proxy for "import finished" —
  * there's no SignalR client, and the REST episode resource never populates
- * `grabbed` — so watch for ids disappearing from `downloading` and invalidate
- * right then. Costs one extra fetch per completed download.
+ * `grabbed` — so watch for ids disappearing and invalidate right then.
+ *
+ * Invalidating alone still leaves a visible red window: the departure renders
+ * `downloading: false` against the not-yet-refreshed `hasFile: false`, and the
+ * replacement request takes a round trip to answer. So a departed id is also
+ * held in the returned set until its refresh resolves (or SETTLE_MAX_MS
+ * elapses), which keeps it purple across that gap. The hold runs in a *layout*
+ * effect so the state lands before the frame is painted, not one frame after it.
+ *
+ * Returns the set to paint purple: everything still queued, plus everything
+ * settling. Callers must keep passing the raw queue set in — feeding this return
+ * value back would mask the very departure it detects.
  */
 export function useRefreshOnDownloadComplete(
-  downloading: ReadonlySet<string | number>,
+  downloading: ReadonlySet<DownloadId>,
   queryKeys: readonly (readonly unknown[])[],
-): void {
+): ReadonlySet<DownloadId> {
   const queryClient = useQueryClient();
   const previous = useRef(downloading);
+  const [settling, setSettling] = useState<ReadonlySet<DownloadId>>(NONE);
   // Read the keys through a ref: callers build the list inline, and depending on
   // a fresh array identity would re-run the effect (and invalidate) every render.
   const keys = useRef(queryKeys);
   keys.current = queryKeys;
 
-  useEffect(() => {
-    const settled = [...previous.current].some((id) => !downloading.has(id));
+  const mounted = useRef(true);
+  useLayoutEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const departed = departedIds(previous.current, downloading);
     previous.current = downloading;
-    if (!settled) return;
-    for (const queryKey of keys.current) {
-      // Deliberately the default `cancelRefetch: true`. A fetch already in
-      // flight was very likely issued *before* the import landed, so joining it
-      // (cancelRefetch: false) returns pre-import data — and its success clears
-      // `isInvalidated`, so nothing refetches afterwards and the row stays red
-      // until the 60s poll, which is the bug this hook exists to fix. Cancelling
-      // and restarting guarantees at least one request begins after departure.
-      // Callers pass the exact keys they observe so this stays one request per
-      // surface rather than a cross-matching stampede.
-      queryClient.invalidateQueries({ queryKey });
-    }
+    if (!departed.length) return;
+
+    setSettling((s) => new Set([...s, ...departed]));
+
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      if (!mounted.current) return;
+      setSettling((s) => {
+        const next = new Set(s);
+        for (const id of departed) next.delete(id);
+        return next.size ? next : NONE;
+      });
+    };
+    const cap = setTimeout(release, SETTLE_MAX_MS);
+
+    Promise.all(
+      keys.current.map((queryKey) =>
+        // Deliberately the default `cancelRefetch: true`. A fetch already in
+        // flight was very likely issued *before* the import landed, so joining
+        // it returns pre-import data — and its success clears `isInvalidated`,
+        // so nothing refetches afterwards and the row stays red until the 60s
+        // poll, which is the bug this hook exists to fix. Cancelling and
+        // restarting guarantees at least one request begins after departure.
+        // Callers pass the exact keys they observe, so this stays one request
+        // per surface rather than a cross-matching stampede.
+        queryClient.invalidateQueries({ queryKey }),
+      ),
+    )
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(cap);
+        release();
+      });
   }, [downloading, queryClient]);
+
+  return useMemo(
+    () => (settling.size ? new Set([...downloading, ...settling]) : downloading),
+    [downloading, settling],
+  );
 }

--- a/hooks/use-refresh-on-download-complete.ts
+++ b/hooks/use-refresh-on-download-complete.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+/**
+ * Refresh the payloads that carry `hasFile` the moment a download finishes.
+ *
+ * `hasFile` is the only source of the green "downloaded" bar, and it lives in
+ * the `/calendar` (or `/wanted`) response — which nothing in the app has ever
+ * invalidated: it rides a 60s poll. The download queue polls at 30s, so an
+ * episode that finishes importing drops out of the downloading set well before
+ * the calendar learns it has a file, and the row flashes back to *red* for up
+ * to a minute instead of going purple → green (#401).
+ *
+ * Leaving the queue is the app's only observable proxy for "import finished" —
+ * there's no SignalR client, and the REST episode resource never populates
+ * `grabbed` — so watch for ids disappearing from `downloading` and invalidate
+ * right then. Costs one extra fetch per completed download.
+ */
+export function useRefreshOnDownloadComplete(
+  downloading: ReadonlySet<string | number>,
+  queryKeys: readonly unknown[][],
+): void {
+  const queryClient = useQueryClient();
+  const previous = useRef(downloading);
+  // Read the keys through a ref: callers build the list inline, and depending on
+  // a fresh array identity would re-run the effect (and invalidate) every render.
+  const keys = useRef(queryKeys);
+  keys.current = queryKeys;
+
+  useEffect(() => {
+    const settled = [...previous.current].some((id) => !downloading.has(id));
+    previous.current = downloading;
+    if (!settled) return;
+    for (const queryKey of keys.current) {
+      // `cancelRefetch: false` because several calendar surfaces can be mounted
+      // at once and all observe the same queue: they invalidate overlapping key
+      // prefixes in the same commit, and the default would abort each in-flight
+      // calendar request and start it over. getCalendar forwards no AbortSignal,
+      // so those cancelled requests still run server-side, just discarded. This
+      // way the later invalidations join the fetch already in flight.
+      queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false });
+    }
+  }, [downloading, queryClient]);
+}

--- a/hooks/use-refresh-on-download-complete.ts
+++ b/hooks/use-refresh-on-download-complete.ts
@@ -18,7 +18,7 @@ import { useQueryClient } from "@tanstack/react-query";
  */
 export function useRefreshOnDownloadComplete(
   downloading: ReadonlySet<string | number>,
-  queryKeys: readonly unknown[][],
+  queryKeys: readonly (readonly unknown[])[],
 ): void {
   const queryClient = useQueryClient();
   const previous = useRef(downloading);
@@ -32,13 +32,15 @@ export function useRefreshOnDownloadComplete(
     previous.current = downloading;
     if (!settled) return;
     for (const queryKey of keys.current) {
-      // `cancelRefetch: false` because several calendar surfaces can be mounted
-      // at once and all observe the same queue: they invalidate overlapping key
-      // prefixes in the same commit, and the default would abort each in-flight
-      // calendar request and start it over. getCalendar forwards no AbortSignal,
-      // so those cancelled requests still run server-side, just discarded. This
-      // way the later invalidations join the fetch already in flight.
-      queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false });
+      // Deliberately the default `cancelRefetch: true`. A fetch already in
+      // flight was very likely issued *before* the import landed, so joining it
+      // (cancelRefetch: false) returns pre-import data — and its success clears
+      // `isInvalidated`, so nothing refetches afterwards and the row stays red
+      // until the 60s poll, which is the bug this hook exists to fix. Cancelling
+      // and restarting guarantees at least one request begins after departure.
+      // Callers pass the exact keys they observe so this stays one request per
+      // surface rather than a cross-matching stampede.
+      queryClient.invalidateQueries({ queryKey });
     }
   }, [downloading, queryClient]);
 }

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -80,10 +80,23 @@ export function useSonarrEpisodeFiles(seriesId: number, instanceId?: string) {
   });
 }
 
-export function useSonarrCalendar(days = 7, instanceId?: string) {
+export const SONARR_CALENDAR_DAYS = 7;
+
+/**
+ * Key builder so a surface can invalidate exactly the calendar entry it
+ * observes. Invalidating the looser ["sonarr", id, "calendar"] prefix instead
+ * cross-matches every other surface's entry, and with several mounted that
+ * turns one completed download into a burst of overlapping calendar requests.
+ */
+export const sonarrCalendarKey = (
+  instanceId: string | null,
+  days: number = SONARR_CALENDAR_DAYS,
+) => ["sonarr", instanceId, "calendar", days] as const;
+
+export function useSonarrCalendar(days = SONARR_CALENDAR_DAYS, instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
-    queryKey: ["sonarr", id, "calendar", days],
+    queryKey: sonarrCalendarKey(id, days),
     // Padded ±1 day: episodes are placed on the local day of airDateUtc, so a
     // boundary airing whose UTC day differs from the local day would fall
     // outside the server-side range filter. Consumers re-bound to [0, days].

--- a/hooks/use-sonarr.ts
+++ b/hooks/use-sonarr.ts
@@ -12,7 +12,6 @@ import {
   deleteEpisodeFile,
   deleteEpisodeFiles,
   getCalendar,
-  getQueue,
   getHistory,
   getEpisodeHistory,
   searchSeries,
@@ -36,7 +35,9 @@ import {
 import { toast, toastError } from "@/components/ui/toast";
 import type { SonarrSeries } from "@/lib/types";
 import { POLLING_INTERVALS } from "@/lib/constants";
+import { sonarrQueueQuery } from "@/lib/arr-queue-query";
 import { describeGrabFailure } from "@/lib/download-client-error";
+import { scheduleGrabRecheck } from "@/lib/post-grab-refresh";
 import { getDateOffset } from "@/lib/utils";
 import { useInstanceTarget } from "@/hooks/use-instance-target";
 
@@ -96,11 +97,9 @@ export function useSonarrCalendar(days = 7, instanceId?: string) {
 export function useSonarrQueue(instanceId?: string) {
   const { instanceId: id, enabled } = useInstanceTarget("sonarr", instanceId);
   return useQuery({
-    queryKey: ["sonarr", id, "queue"],
-    // Args must stay identical to sonarrArrQueueAdapter.fetchQueue — the
-    // dashboard widget and the queue-issues banner share this cache entry.
-    queryFn: () => getQueue(1, 100, true, true, id ?? undefined),
-    refetchInterval: POLLING_INTERVALS.queue,
+    // Key, args and interval come from lib/arr-queue-query so every producer of
+    // this shared cache entry requests the same page.
+    ...sonarrQueueQuery(id ?? undefined),
     enabled: enabled && !!id,
   });
 }
@@ -611,7 +610,13 @@ export function useGrabSonarrRelease(instanceId?: string) {
       grabSonarrRelease(guid, indexerId, id ?? undefined),
     onSuccess: () => {
       toast("Sent to download client");
-      queryClient.invalidateQueries({ queryKey: ["sonarr", id, "queue"] });
+      // Sonarr populates /queue on a trailing 5s debounce, so a single
+      // invalidate here always reads a queue without the grab in it — see
+      // lib/post-grab-refresh (#401).
+      const queryKey = ["sonarr", id, "queue"] as const;
+      scheduleGrabRecheck(`sonarr:${id}:queue`, () =>
+        queryClient.invalidateQueries({ queryKey }),
+      );
     },
     onError: (err) => {
       toastError("Failed to grab release", err, (msg) =>

--- a/lib/arr-queue-adapters/radarr.ts
+++ b/lib/arr-queue-adapters/radarr.ts
@@ -1,5 +1,4 @@
 import {
-  getQueue,
   getWantedMissing,
   getRadarrPoster,
   removeFromQueue,
@@ -7,6 +6,7 @@ import {
 } from "@/services/radarr-api";
 import type { RadarrQueue, RadarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
+import { fetchRadarrQueue } from "@/lib/arr-queue-query";
 import {
   queueImportBlocked,
   queueIssueMessages,
@@ -26,7 +26,7 @@ export const radarrArrQueueAdapter: ArrQueueAdapter = {
   wantedQueryKey: (instanceId) => ["radarr", instanceId, "wanted"] as const,
 
   // Same key + args as useRadarrQueue, so the widget shares its cache entry.
-  fetchQueue: (instanceId) => getQueue(1, 100, true, instanceId),
+  fetchQueue: (instanceId) => fetchRadarrQueue(instanceId),
 
   toItems: (data, instanceId) =>
     ((data as RadarrQueue).records ?? []).map((item) => {

--- a/lib/arr-queue-adapters/sonarr.ts
+++ b/lib/arr-queue-adapters/sonarr.ts
@@ -1,5 +1,4 @@
 import {
-  getQueue,
   getWantedMissing,
   getSonarrPoster,
   removeFromQueue,
@@ -7,6 +6,7 @@ import {
 } from "@/services/sonarr-api";
 import type { SonarrQueue, SonarrQueueItem, SonarrWantedMissing } from "@/lib/types";
 import type { ArrQueueAdapter } from "@/lib/arr-queue-adapter";
+import { fetchSonarrQueue } from "@/lib/arr-queue-query";
 import {
   queueImportBlocked,
   queueIssueMessages,
@@ -38,7 +38,7 @@ export const sonarrArrQueueAdapter: ArrQueueAdapter = {
   wantedQueryKey: (instanceId) => ["sonarr", instanceId, "wanted"] as const,
 
   // Same key + args as useSonarrQueue, so the widget shares its cache entry.
-  fetchQueue: (instanceId) => getQueue(1, 100, true, true, instanceId),
+  fetchQueue: (instanceId) => fetchSonarrQueue(instanceId),
 
   toItems: (data, instanceId) =>
     ((data as SonarrQueue).records ?? []).map((item) => {

--- a/lib/arr-queue-query.test.ts
+++ b/lib/arr-queue-query.test.ts
@@ -1,0 +1,28 @@
+// The adapters reach services -> http-client -> the config store, which pulls
+// in AsyncStorage. Nothing here fetches; stub it so the module graph loads.
+jest.mock("@/store/config-store", () => ({ useConfigStore: { getState: () => ({}) } }));
+
+import { radarrQueueQuery, sonarrQueueQuery } from "@/lib/arr-queue-query";
+import { radarrArrQueueAdapter } from "@/lib/arr-queue-adapters/radarr";
+import { sonarrArrQueueAdapter } from "@/lib/arr-queue-adapters/sonarr";
+
+// TanStack keeps one queryFn per cache key, so two producers of the same key
+// with different request args make the effective page size depend on which
+// screens happen to be mounted (#401). The args are structurally shared now;
+// this pins the other half of the invariant, the key itself.
+describe("shared *arr queue cache entry", () => {
+  it("uses the same key as the queue adapters", () => {
+    expect(sonarrQueueQuery("home").queryKey).toEqual(
+      sonarrArrQueueAdapter.queueQueryKey("home"),
+    );
+    expect(radarrQueueQuery("home").queryKey).toEqual(
+      radarrArrQueueAdapter.queueQueryKey("home"),
+    );
+  });
+
+  it("scopes the key per instance", () => {
+    expect(sonarrQueueQuery("home").queryKey).not.toEqual(
+      sonarrQueueQuery("cabin").queryKey,
+    );
+  });
+});

--- a/lib/arr-queue-query.ts
+++ b/lib/arr-queue-query.ts
@@ -1,0 +1,46 @@
+import { POLLING_INTERVALS } from "@/lib/constants";
+import { getQueue as getRadarrQueue } from "@/services/radarr-api";
+import { getQueue as getSonarrQueue } from "@/services/sonarr-api";
+
+/**
+ * The single source of truth for the shared `["sonarr"/"radarr", id, "queue"]`
+ * cache entry.
+ *
+ * TanStack stores one `queryFn` per cache key, and every observer writes its own
+ * options onto the query as it renders — so whichever one fetched last decides
+ * the request arguments for all of them. The Calendar tab and the two dashboard
+ * cards used to declare that key with `pageSize: 20` while the hooks and the
+ * queue adapters used 100, which left the effective page size depending on
+ * nothing more than which screens happened to be mounted (#401). Every producer
+ * of this key goes through here instead.
+ *
+ * 100 is generous on purpose: `/queue` sorts by `timeleft` descending by
+ * default (see the note in services/sonarr-api.ts), which pushes stalled and
+ * pending items to the front and can bury an in-flight download several pages
+ * deep on a busy instance.
+ */
+export const ARR_QUEUE_PAGE_SIZE = 100;
+
+export function fetchSonarrQueue(instanceId?: string) {
+  return getSonarrQueue(1, ARR_QUEUE_PAGE_SIZE, true, true, instanceId);
+}
+
+export function fetchRadarrQueue(instanceId?: string) {
+  return getRadarrQueue(1, ARR_QUEUE_PAGE_SIZE, true, instanceId);
+}
+
+export function sonarrQueueQuery(instanceId?: string) {
+  return {
+    queryKey: ["sonarr", instanceId, "queue"] as const,
+    queryFn: () => fetchSonarrQueue(instanceId),
+    refetchInterval: POLLING_INTERVALS.queue,
+  };
+}
+
+export function radarrQueueQuery(instanceId?: string) {
+  return {
+    queryKey: ["radarr", instanceId, "queue"] as const,
+    queryFn: () => fetchRadarrQueue(instanceId),
+    refetchInterval: POLLING_INTERVALS.queue,
+  };
+}

--- a/lib/download-complete-refresh.test.ts
+++ b/lib/download-complete-refresh.test.ts
@@ -1,0 +1,114 @@
+import { QueryClient, QueryObserver } from "@tanstack/query-core";
+
+/**
+ * Pins the invalidation semantics `useRefreshOnDownloadComplete` depends on.
+ *
+ * The hook fires when an id leaves the *arr download queue, which is the app's
+ * only signal that an import finished and `hasFile` flipped. If a calendar
+ * request is already in flight at that moment it was issued *before* the
+ * import, so joining it (`cancelRefetch: false`) hands back pre-import data —
+ * and TanStack's success reducer clears `isInvalidated`, so nothing refetches
+ * afterwards and the row stays red until the 60s poll. The hook must therefore
+ * use the default `cancelRefetch: true` (#401).
+ */
+describe("invalidating a calendar query while a fetch is in flight", () => {
+  const KEY = ["sonarr", "home", "calendar", 7];
+
+  function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => (resolve = r));
+    return { promise, resolve };
+  }
+
+  function setup() {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    // What the server would return: false before the import, true after.
+    let hasFile = false;
+    // Values served per call, so we can see which fetches actually ran.
+    const served: boolean[] = [];
+    const gates: ReturnType<typeof deferred>[] = [];
+
+    const observer = new QueryObserver(client, {
+      queryKey: KEY,
+      queryFn: async () => {
+        const value = hasFile;
+        served.push(value);
+        const gate = gates.shift();
+        if (gate) await gate.promise;
+        return { hasFile: value };
+      },
+    });
+
+    return {
+      client,
+      observer,
+      served,
+      /** Make the next fetch hang until the returned handle is resolved. */
+      hold: () => {
+        const gate = deferred();
+        gates.push(gate);
+        return gate;
+      },
+      import: () => {
+        hasFile = true;
+      },
+    };
+  }
+
+  it("cancelRefetch: false swallows the refresh, leaving pre-import data cached", async () => {
+    const s = setup();
+    const unsubscribe = s.observer.subscribe(() => {});
+    try {
+      await s.observer.refetch();
+      expect(s.observer.getCurrentResult().data).toEqual({ hasFile: false });
+
+      // A poll starts and hangs; the import lands while it is still open.
+      const gate = s.hold();
+      const inFlight = s.observer.refetch();
+      s.import();
+
+      const invalidated = s.client.invalidateQueries(
+        { queryKey: KEY },
+        { cancelRefetch: false },
+      );
+      gate.resolve();
+      await inFlight;
+      await invalidated;
+
+      // Only the two stale fetches ever ran, and the second one's success
+      // cleared isInvalidated, so nothing is left to pick up the import.
+      expect(s.served).toEqual([false, false]);
+      expect(s.observer.getCurrentResult().data).toEqual({ hasFile: false });
+      expect(
+        s.client.getQueryCache().find({ queryKey: KEY })?.state.isInvalidated,
+      ).toBe(false);
+    } finally {
+      unsubscribe();
+      s.client.clear();
+    }
+  });
+
+  it("the default cancelRefetch starts a fresh fetch and picks up the import", async () => {
+    const s = setup();
+    const unsubscribe = s.observer.subscribe(() => {});
+    try {
+      await s.observer.refetch();
+
+      const gate = s.hold();
+      s.observer.refetch().catch(() => {});
+      s.import();
+
+      // Cancels the stale in-flight fetch and starts a new one.
+      await s.client.invalidateQueries({ queryKey: KEY });
+
+      expect(s.served).toEqual([false, false, true]);
+      expect(s.observer.getCurrentResult().data).toEqual({ hasFile: true });
+      gate.resolve();
+    } finally {
+      unsubscribe();
+      s.client.clear();
+    }
+  });
+});

--- a/lib/post-grab-refresh.test.ts
+++ b/lib/post-grab-refresh.test.ts
@@ -1,0 +1,78 @@
+import { POLLING_INTERVALS } from "@/lib/constants";
+import {
+  cancelGrabRecheck,
+  scheduleGrabRecheck,
+} from "@/lib/post-grab-refresh";
+
+// Sonarr/Radarr only publish a grab to /queue after a trailing 5s debounce plus
+// a download-client round trip.
+const GRAB_DEBOUNCE_MS = 5_000;
+
+describe("scheduleGrabRecheck", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    cancelGrabRecheck("a");
+    cancelGrabRecheck("b");
+    jest.useRealTimers();
+  });
+
+  it("re-checks at every offset", () => {
+    const refetch = jest.fn();
+    scheduleGrabRecheck("a", refetch, [0, 100, 250]);
+
+    expect(refetch).toHaveBeenCalledTimes(0);
+    jest.advanceTimersByTime(0);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(100);
+    expect(refetch).toHaveBeenCalledTimes(2);
+    jest.advanceTimersByTime(150);
+    expect(refetch).toHaveBeenCalledTimes(3);
+
+    jest.advanceTimersByTime(10_000);
+    expect(refetch).toHaveBeenCalledTimes(3);
+  });
+
+  // The whole point of the burst: land at least one refetch after the server
+  // has published the grab but before the normal queue poll would have.
+  it("re-checks between the server debounce and the next queue poll", () => {
+    const refetch = jest.fn();
+    scheduleGrabRecheck("a", refetch);
+
+    jest.advanceTimersByTime(GRAB_DEBOUNCE_MS);
+    const beforeDebounceElapsed = refetch.mock.calls.length;
+    jest.advanceTimersByTime(POLLING_INTERVALS.queue - GRAB_DEBOUNCE_MS);
+    expect(refetch.mock.calls.length).toBeGreaterThan(beforeDebounceElapsed);
+  });
+
+  it("replaces a burst already scheduled under the same id", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    scheduleGrabRecheck("a", first, [100, 200]);
+    scheduleGrabRecheck("a", second, [100, 200]);
+
+    jest.advanceTimersByTime(500);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps bursts under different ids independent", () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    scheduleGrabRecheck("a", a, [100]);
+    scheduleGrabRecheck("b", b, [100]);
+
+    jest.advanceTimersByTime(100);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels pending re-checks", () => {
+    const refetch = jest.fn();
+    scheduleGrabRecheck("a", refetch, [100, 200]);
+    jest.advanceTimersByTime(100);
+    cancelGrabRecheck("a");
+
+    jest.advanceTimersByTime(1_000);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/post-grab-refresh.ts
+++ b/lib/post-grab-refresh.ts
@@ -1,0 +1,51 @@
+/**
+ * Sonarr and Radarr do not put a freshly grabbed release into `/queue`
+ * synchronously. `DownloadMonitoringService` handles the grabbed event through
+ * a *trailing* 5s debouncer (NzbDrone.Common/TPL/Debouncer.cs — `Execute()`
+ * only starts the timer, the action runs on `Elapsed`), which then pushes a
+ * `RefreshMonitoredDownloads` command that still has to be dequeued and
+ * round-trip the download client before the item becomes trackable.
+ *
+ * So the `invalidateQueries` the grab mutation fires the instant
+ * `POST /release` resolves always reads a queue that doesn't contain the grab
+ * yet: the row stays red instead of turning purple until the next 30s poll
+ * (#401). These offsets straddle that window — 0 catches a delay-profile grab
+ * (pending releases are queued immediately), then two re-checks past the
+ * debounce plus command and download-client latency. Anything slower falls back
+ * to the normal poll.
+ */
+export const POST_GRAB_RECHECK_MS = [0, 6_000, 14_000] as const;
+
+const bursts = new Map<string, ReturnType<typeof setTimeout>[]>();
+
+/**
+ * Calls `refetch` at each offset, replacing any burst already scheduled under
+ * the same `id` so grabbing several releases in a row can't stack timers.
+ *
+ * The timers are module-level on purpose: the release sheet unmounts as soon as
+ * the grab succeeds, and the re-checks have to outlive it to land on whatever
+ * screen the user navigated back to.
+ */
+export function scheduleGrabRecheck(
+  id: string,
+  refetch: () => void,
+  offsets: readonly number[] = POST_GRAB_RECHECK_MS,
+): void {
+  cancelGrabRecheck(id);
+  let remaining = offsets.length;
+  bursts.set(
+    id,
+    offsets.map((ms) =>
+      setTimeout(() => {
+        remaining -= 1;
+        if (remaining === 0) bursts.delete(id);
+        refetch();
+      }, ms),
+    ),
+  );
+}
+
+export function cancelGrabRecheck(id: string): void {
+  bursts.get(id)?.forEach(clearTimeout);
+  bursts.delete(id);
+}

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -70,9 +70,13 @@ export function getCollectionByTmdbId(
 
 // `includeUnknownMovieItems` matters for the queue-issues banner (#285): a
 // grab whose movie was deleted from the library is exactly the kind that gets
-// stuck, and Radarr hides those by default. The page size is generous for the
-// same reason — blocked items have no `timeleft` and sort last under the
-// default sort, so a small page would clip them off.
+// stuck, and Radarr hides those by default. The page size is generous for a
+// related reason: the effective default sort is `timeleft` *descending* (the
+// controller's ascending default only applies to SortDirection.Default, and an
+// omitted direction deserializes to Descending), and TimeleftComparer ranks a
+// missing timeleft highest — so blocked and pending items crowd the front of
+// page 1 and a small page clips the live downloads off the back. Callers must
+// go through lib/arr-queue-query, which owns the shared cache entry's args.
 export function getQueue(
   page = 1,
   pageSize = 100,

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -163,9 +163,13 @@ export function getWantedMissing(
 
 // `includeUnknownSeriesItems` matters for the queue-issues banner (#285): a
 // grab whose series was deleted from the library is exactly the kind that gets
-// stuck, and Sonarr hides those by default. The page size is generous for the
-// same reason — blocked items have no `timeleft` and sort last under the
-// default sort, so a small page would clip them off.
+// stuck, and Sonarr hides those by default. The page size is generous for a
+// related reason: the effective default sort is `timeleft` *descending* (the
+// controller's ascending default only applies to SortDirection.Default, and an
+// omitted direction deserializes to Descending), and TimeleftComparer ranks a
+// missing timeleft highest — so blocked and pending items crowd the front of
+// page 1 and a small page clips the live downloads off the back. Callers must
+// go through lib/arr-queue-query, which owns the shared cache entry's args.
 export function getQueue(
   page = 1,
   pageSize = 100,


### PR DESCRIPTION
Refs #401

The Sonarr Calendar kept showing grabbed episodes as red (missing).

Two causes:

1. Sonarr/Radarr only publish a grab to `/queue` after a **trailing 5s debounce** (`DownloadMonitoringService` -> `new Debouncer(QueueRefresh, TimeSpan.FromSeconds(5))`) plus a `RefreshMonitoredDownloads` command and a download-client round trip. The single `invalidateQueries` fired at grab success always read a queue without the grab in it, so the row stayed red until the next 30s poll. Now `lib/post-grab-refresh.ts` re-checks at 0/6s/14s.
2. `hasFile` (the green bar) lives only in the calendar payload, and nothing ever invalidated a calendar key: it rode a 60s poll. So after import the row went purple -> red -> green, with the red lasting up to a minute. `useRefreshOnDownloadComplete` now refreshes the calendar the moment an item leaves the queue, and holds that item in the "downloading" set until the refresh resolves so it stays purple across the round trip instead of flashing red. The hold runs in a layout effect, so the state lands before paint rather than one frame after, and is capped at 3s so an unreachable server can't strand a row on "downloading".

Also fixed along the way: the Calendar tab and the two dashboard cards declared the shared `["sonarr"/"radarr", id, "queue"]` cache key with `pageSize: 20` while the hooks and adapters used 100. TanStack keeps one queryFn per key, so the effective page size depended on which screens happened to be mounted. `lib/arr-queue-query.ts` is now the single producer of that key's options, and `useArrDownloadingKeys` replaces the three copies of the fan-out. The Calendar tab's pull-to-refresh also refreshes the queue now, not just the calendar.

## Test plan

- `npx jest` - 84 suites, 1636 tests green (new: `lib/post-grab-refresh.test.ts`, `lib/arr-queue-query.test.ts`, `lib/download-complete-refresh.test.ts`, `hooks/use-refresh-on-download-complete.test.ts`)
- `npx tsc --noEmit` clean
- On device: Sonarr tab -> Calendar -> tap a red aired episode -> Interactive Search -> grab -> back. Expect purple within ~15s without leaving the sub-tab; expect purple -> green on import with no red in between.
- Regression: pull-to-refresh still spins and clears on the Sonarr tab and the Calendar tab; the releases screen does not refire its indexer search after a grab.
- Regression: stop Sonarr mid-download and confirm rows fall back to their real colour within ~3s rather than staying purple.