### PR TITLE
feat(arr): manual import for a stuck download

### DIFF
--- a/app/(tabs)/(dashboard,movies,tv,library)/manual-import.tsx
+++ b/app/(tabs)/(dashboard,movies,tv,library)/manual-import.tsx
@@ -1,0 +1,48 @@
+import { useLocalSearchParams } from "expo-router";
+import { FileQuestion } from "lucide-react-native";
+import { BackHeader } from "@/components/common/back-header";
+import { ScreenWrapper } from "@/components/common/screen-wrapper";
+import { ManualImportView } from "@/components/services/manual-import-view";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Icon } from "@/components/ui/icon";
+import type { ManualImportService } from "@/lib/manual-import";
+
+/**
+ * Manual import for one stuck Radarr/Sonarr grab (#306), pushed from the queue
+ * issues sheet on the Movies, TV and Library tabs — the three that render
+ * QueueIssuesBanner for those two services, which is exactly the array group
+ * this file lives in.
+ */
+export default function ManualImportScreen() {
+  const params = useLocalSearchParams<{
+    service?: string;
+    downloadId?: string;
+    instanceId?: string;
+    title?: string;
+  }>();
+
+  const service: ManualImportService | null =
+    params.service === "radarr" || params.service === "sonarr"
+      ? params.service
+      : null;
+
+  return (
+    <ScreenWrapper scrollable={false}>
+      <BackHeader title="Manual import" />
+      {service && params.downloadId ? (
+        <ManualImportView
+          service={service}
+          downloadId={params.downloadId}
+          instanceId={params.instanceId}
+          releaseTitle={params.title}
+        />
+      ) : (
+        <EmptyState
+          icon={<Icon icon={FileQuestion} size={24} color="#71717a" />}
+          title="Nothing to import"
+          message="This screen needs a download to work on. Open it from the queue issues on the Movies or TV screen."
+        />
+      )}
+    </ScreenWrapper>
+  );
+}

--- a/components/services/manual-import-view.tsx
+++ b/components/services/manual-import-view.tsx
@@ -1,0 +1,545 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import {
+  AlertTriangle,
+  Check,
+  Clapperboard,
+  FileVideo,
+  FolderInput,
+  Tv,
+} from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBanner } from "@/components/common/error-banner";
+import { PickerSheet, type PickerOption } from "@/components/ui/picker-sheet";
+import { useRefreshSpinner } from "@/components/common/pull-to-refresh";
+import { useModalFlow } from "@/hooks/use-modal-flow";
+import {
+  manualImportServiceName,
+  useArrQualityDefinitions,
+  useManualImportCandidates,
+  useManualImportLibrary,
+  useRunManualImport,
+} from "@/hooks/use-manual-import";
+import { useSonarrEpisodes } from "@/hooks/use-sonarr";
+import {
+  qualityFromDefinition,
+  qualityLabel,
+  type ManualImportRow,
+  type ManualImportService,
+} from "@/lib/manual-import";
+import { formatBytes, formatEpisodeCode } from "@/lib/utils";
+import { lightHaptic } from "@/lib/haptics";
+import type { ArrQualityModel } from "@/lib/types";
+
+interface ManualImportViewProps {
+  service: ManualImportService;
+  /** Download-client id of the stuck grab — the /manualimport lookup key. */
+  downloadId: string;
+  instanceId?: string;
+  /** Release name of the grab, shown so the user knows what they are mapping. */
+  releaseTitle?: string;
+}
+
+// The picker chain. `season`/`episodes`/`quality` carry the file they act on;
+// `media` is screen-wide (a download folder belongs to one series or movie).
+type PickerStep = {
+  media: void;
+  season: number;
+  episodes: { candidateId: number; season: number };
+  quality: number;
+};
+
+/**
+ * Manual import (#306) — map a stuck download's files by hand and import them.
+ *
+ * The one-tap Force import in the queue-issues sheet (#325) only works when
+ * *arr matched the files itself. When the release is named in a way it cannot
+ * parse, `/manualimport` comes back with no series/movie and no episodes, and
+ * force import correctly refuses rather than importing nothing. This screen is
+ * that case: pick the destination, map each file to its episodes, and send the
+ * same ManualImport command with the mapping filled in.
+ *
+ * Radarr and Sonarr differ only in what a file needs to be importable — a
+ * movie, versus a series plus at least one episode — so the branches here are
+ * narrow and the payload shapes live in lib/manual-import.ts.
+ */
+export function ManualImportView({
+  service,
+  downloadId,
+  instanceId,
+  releaseTitle,
+}: ManualImportViewProps) {
+  const isSonarr = service === "sonarr";
+  const serviceName = manualImportServiceName(service);
+
+  const candidatesQuery = useManualImportCandidates(service, downloadId, instanceId);
+  const candidates = candidatesQuery.data;
+
+  const library = useManualImportLibrary(service, instanceId);
+  const importMutation = useRunManualImport(service, downloadId, instanceId);
+
+  // Destination: the series (Sonarr) or movie (Radarr) every file goes to.
+  const [mediaId, setMediaId] = useState<number>();
+  // Per-file mapping, keyed by candidate id.
+  const [episodeIds, setEpisodeIds] = useState<Record<number, number[]>>({});
+  const [qualities, setQualities] = useState<Record<number, ArrQualityModel>>({});
+  const [included, setIncluded] = useState<Record<number, boolean>>({});
+
+  // Episodes of the chosen series, for the season/episode pickers. seriesId 0
+  // disables the query, which is how the Radarr side never fetches them.
+  const episodesQuery = useSonarrEpisodes(
+    isSonarr ? (mediaId ?? 0) : 0,
+    instanceId,
+  );
+  const episodes = useMemo(() => episodesQuery.data ?? [], [episodesQuery.data]);
+
+  // Only fetched once a quality picker is actually opened — most files already
+  // carry a parsed quality, so this is usually never requested.
+  const [qualityAsked, setQualityAsked] = useState(false);
+  const qualityQuery = useArrQualityDefinitions(service, qualityAsked, instanceId);
+
+  // Seed the mapping from what *arr resolved on its own, once per fetch. A
+  // pull-to-refresh re-arms this so the screen genuinely reloads from the
+  // server instead of keeping selections that no longer match the new ids.
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current || !candidates?.length) return;
+    seeded.current = true;
+    setMediaId(candidates.find((c) => c.mediaId)?.mediaId);
+    setEpisodeIds(
+      Object.fromEntries(
+        candidates.filter((c) => c.episodeIds.length).map((c) => [c.id, c.episodeIds]),
+      ),
+    );
+    // Radarr has no per-file mapping to imply intent, so inclusion is explicit:
+    // start with the files Radarr matched, or the largest one when it matched
+    // none (sample and subtitle files are exactly what the user is deselecting).
+    const matched = candidates.filter((c) => c.mediaId);
+    const seedIncluded = matched.length
+      ? matched
+      : candidates.slice().sort((a, b) => b.size - a.size).slice(0, 1);
+    setIncluded(Object.fromEntries(seedIncluded.map((c) => [c.id, true])));
+  }, [candidates]);
+
+  const { refreshing, onRefresh } = useRefreshSpinner(async () => {
+    seeded.current = false;
+    await candidatesQuery.refetch();
+  });
+
+  const flow = useModalFlow<PickerStep>();
+
+  const mediaOptions = useMemo<PickerOption[]>(
+    () =>
+      library.entries.map((entry) => ({
+        value: entry.id,
+        label: entry.title,
+        description: entry.year ? String(entry.year) : undefined,
+      })),
+    [library.entries],
+  );
+
+  const seasonOptions = useMemo<PickerOption[]>(() => {
+    const counts = new Map<number, number>();
+    for (const ep of episodes) {
+      counts.set(ep.seasonNumber, (counts.get(ep.seasonNumber) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([season, count]) => ({
+        value: season,
+        label: season === 0 ? "Specials" : `Season ${season}`,
+        description: count === 1 ? "1 episode" : `${count} episodes`,
+      }));
+  }, [episodes]);
+
+  const seasonStep = flow.payload("season");
+  const episodeStep = flow.payload("episodes");
+  const episodeOptions = useMemo<PickerOption[]>(() => {
+    if (!episodeStep) return [];
+    return episodes
+      .filter((ep) => ep.seasonNumber === episodeStep.season)
+      .sort((a, b) => a.episodeNumber - b.episodeNumber)
+      .map((ep) => ({
+        value: ep.id,
+        label: `${formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)} · ${ep.title}`,
+        description: ep.hasFile ? "Already has a file" : undefined,
+      }));
+  }, [episodes, episodeStep]);
+
+  const qualityOptions = useMemo<PickerOption[]>(
+    () =>
+      (qualityQuery.data ?? [])
+        .slice()
+        .sort((a, b) => a.weight - b.weight)
+        .map((definition) => ({
+          value: definition.quality.id,
+          label: definition.quality.name,
+          description: definition.quality.resolution
+            ? `${definition.quality.resolution}p`
+            : undefined,
+        })),
+    [qualityQuery.data],
+  );
+
+  // Seasons the file is already mapped into, so reopening the season picker
+  // shows where it currently points instead of a blank list.
+  function mappedSeasons(candidateId: number): number[] {
+    const mapped = episodeIds[candidateId] ?? [];
+    const seasons = new Set<number>();
+    for (const id of mapped) {
+      const ep = episodes.find((e) => e.id === id);
+      if (ep) seasons.add(ep.seasonNumber);
+    }
+    return [...seasons];
+  }
+
+  const mediaTitle = useMemo(
+    () => library.entries.find((entry) => entry.id === mediaId)?.title,
+    [library.entries, mediaId],
+  );
+
+  // Everything the Import button will send. A file that isn't importable —
+  // no episode mapped, no quality, deselected — is simply left out.
+  const rows = useMemo<ManualImportRow[]>(() => {
+    if (!candidates || !mediaId) return [];
+    const out: ManualImportRow[] = [];
+    for (const candidate of candidates) {
+      const quality = qualities[candidate.id] ?? candidate.quality;
+      if (!quality) continue;
+      if (isSonarr) {
+        const eps = episodeIds[candidate.id] ?? [];
+        if (eps.length === 0) continue;
+        out.push({ candidate, mediaId, quality, episodeIds: eps });
+      } else {
+        if (!included[candidate.id]) continue;
+        out.push({ candidate, mediaId, quality, episodeIds: [] });
+      }
+    }
+    return out;
+  }, [candidates, mediaId, qualities, episodeIds, included, isSonarr]);
+
+  function pickMedia(value: number) {
+    // A different destination invalidates every episode mapping — those ids
+    // belong to the previous series.
+    if (value !== mediaId) setEpisodeIds({});
+    setMediaId(value);
+    flow.close();
+  }
+
+  function toggleEpisode(candidateId: number, episodeId: number) {
+    setEpisodeIds((prev) => {
+      const current = prev[candidateId] ?? [];
+      return {
+        ...prev,
+        [candidateId]: current.includes(episodeId)
+          ? current.filter((id) => id !== episodeId)
+          : [...current, episodeId],
+      };
+    });
+  }
+
+  function pickQuality(candidateId: number, qualityId: number) {
+    const definition = (qualityQuery.data ?? []).find(
+      (d) => d.quality.id === qualityId,
+    );
+    if (definition) {
+      setQualities((prev) => ({
+        ...prev,
+        [candidateId]: qualityFromDefinition(definition.quality),
+      }));
+    }
+    flow.close();
+  }
+
+  function openQuality(candidateId: number) {
+    setQualityAsked(true);
+    flow.open("quality", candidateId);
+  }
+
+  // The import runs async on the server, so leaving right away is correct: the
+  // queue screen behind picks the result up on its next poll.
+  function runImport() {
+    importMutation.mutate(rows, { onSuccess: () => flow.back() });
+  }
+
+  if (candidatesQuery.isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator color="#a1a1aa" />
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="gap-3 pb-4"
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor="#3b82f6"
+            colors={["#3b82f6"]}
+          />
+        }
+      >
+        {releaseTitle ? (
+          <Text className="text-zinc-500 text-xs" numberOfLines={2}>
+            {releaseTitle}
+          </Text>
+        ) : null}
+
+        {candidatesQuery.isError ? (
+          <ErrorBanner
+            error={candidatesQuery.error}
+            title={`${serviceName} couldn't list this download's files`}
+          />
+        ) : null}
+
+        {/* Destination — one series or movie for the whole download folder. */}
+        <Pressable
+          onPress={() => {
+            lightHaptic();
+            flow.open("media");
+          }}
+          className="flex-row items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3 active:opacity-70"
+        >
+          <Icon icon={isSonarr ? Tv : Clapperboard} size={18} color="#a1a1aa" />
+          <View className="flex-1">
+            <Text className="text-zinc-500 text-xs">
+              {isSonarr ? "Series" : "Movie"}
+            </Text>
+            <Text
+              className={`text-sm font-semibold ${
+                mediaTitle ? "text-zinc-100" : "text-amber-200"
+              }`}
+              numberOfLines={2}
+            >
+              {mediaTitle ?? `Choose the ${isSonarr ? "series" : "movie"}`}
+            </Text>
+          </View>
+        </Pressable>
+
+        {candidates?.length ? (
+          <Text className="text-zinc-400 text-sm font-semibold mt-1">
+            {candidates.length === 1 ? "1 file" : `${candidates.length} files`}
+          </Text>
+        ) : null}
+
+        {candidates?.length === 0 && !candidatesQuery.isError ? (
+          <EmptyState
+            icon={<Icon icon={FileVideo} size={24} color="#71717a" />}
+            title="No files to import"
+            message={`${serviceName} found nothing in this download's folder. It may already have been imported or moved.`}
+          />
+        ) : null}
+
+        {(candidates ?? []).map((candidate) => {
+          const quality = qualities[candidate.id] ?? candidate.quality;
+          const mappedEpisodes = episodeIds[candidate.id] ?? [];
+          const willImport = rows.some((row) => row.candidate.id === candidate.id);
+          const episodeText = mappedEpisodes
+            .map((id) => {
+              const ep = episodes.find((e) => e.id === id);
+              return ep
+                ? formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)
+                : `#${id}`;
+            })
+            .join(", ");
+
+          return (
+            <View
+              key={candidate.id}
+              className={`rounded-2xl border p-3 gap-2 ${
+                willImport ? "border-primary/40 bg-primary/5" : "border-border bg-surface"
+              }`}
+            >
+              <View className="flex-row items-start gap-2">
+                <View className="pt-0.5">
+                  <Icon
+                    icon={willImport ? Check : FileVideo}
+                    size={16}
+                    color={willImport ? "#3b82f6" : "#71717a"}
+                  />
+                </View>
+                <Text className="text-zinc-100 text-sm flex-1" numberOfLines={3}>
+                  {candidate.name}
+                </Text>
+              </View>
+
+              <View className="flex-row items-center gap-2 flex-wrap">
+                {candidate.size > 0 ? (
+                  <Text className="text-zinc-500 text-xs">
+                    {formatBytes(candidate.size)}
+                  </Text>
+                ) : null}
+                <Pressable
+                  onPress={() => {
+                    lightHaptic();
+                    openQuality(candidate.id);
+                  }}
+                  className="rounded-full border border-border px-2.5 py-1 active:opacity-70"
+                >
+                  <Text
+                    className={`text-xs ${
+                      quality ? "text-zinc-300" : "text-amber-200"
+                    }`}
+                  >
+                    {qualityLabel(quality)}
+                  </Text>
+                </Pressable>
+              </View>
+
+              {candidate.rejections.map((reason) => (
+                <View key={reason} className="flex-row items-start gap-1.5">
+                  <View className="pt-0.5">
+                    <Icon icon={AlertTriangle} size={12} color="#fbbf24" />
+                  </View>
+                  <Text className="text-amber-200/90 text-xs flex-1">{reason}</Text>
+                </View>
+              ))}
+
+              {isSonarr ? (
+                <Pressable
+                  onPress={() => {
+                    lightHaptic();
+                    // Nothing to map episodes against yet — send the user to
+                    // the destination picker instead of an empty season list.
+                    if (mediaId) flow.open("season", candidate.id);
+                    else flow.open("media");
+                  }}
+                  className="flex-row items-center justify-between rounded-xl bg-surface-light px-3 py-2 active:opacity-70"
+                >
+                  <Text className="text-zinc-500 text-xs">Episodes</Text>
+                  <Text
+                    className={`text-sm font-semibold ${
+                      episodeText ? "text-zinc-100" : "text-amber-200"
+                    }`}
+                    numberOfLines={1}
+                  >
+                    {episodeText || "Choose"}
+                  </Text>
+                </Pressable>
+              ) : (
+                <Pressable
+                  onPress={() => {
+                    lightHaptic();
+                    setIncluded((prev) => ({
+                      ...prev,
+                      [candidate.id]: !prev[candidate.id],
+                    }));
+                  }}
+                  className="flex-row items-center justify-between rounded-xl bg-surface-light px-3 py-2 active:opacity-70"
+                >
+                  <Text className="text-zinc-500 text-xs">Import this file</Text>
+                  <Icon
+                    icon={Check}
+                    size={16}
+                    color={included[candidate.id] ? "#3b82f6" : "#52525b"}
+                  />
+                </Pressable>
+              )}
+            </View>
+          );
+        })}
+      </ScrollView>
+
+      <View className="pt-3">
+        <Button
+          label={
+            rows.length === 0
+              ? "Import"
+              : rows.length === 1
+                ? "Import 1 file"
+                : `Import ${rows.length} files`
+          }
+          size="lg"
+          icon={<Icon icon={FolderInput} size={18} color="#ffffff" />}
+          disabled={rows.length === 0 || importMutation.isPending}
+          loading={importMutation.isPending}
+          onPress={runImport}
+        />
+      </View>
+
+      <PickerSheet
+        {...flow.bind("media")}
+        title={isSonarr ? "Choose series" : "Choose movie"}
+        options={mediaOptions}
+        selected={mediaId === undefined ? [] : [mediaId]}
+        loading={library.isLoading}
+        searchable
+        emptyTitle={isSonarr ? "No series" : "No movies"}
+        emptyMessage={`${serviceName} has nothing in its library yet.`}
+        onPick={pickMedia}
+      />
+
+      <PickerSheet
+        {...flow.bind("season")}
+        title="Choose season"
+        options={seasonOptions}
+        selected={seasonStep === undefined ? [] : mappedSeasons(seasonStep)}
+        loading={episodesQuery.isLoading}
+        emptyTitle="No seasons"
+        emptyMessage={`${serviceName} has no episodes for this series yet.`}
+        onPick={(season) => {
+          const candidateId = flow.payload("season");
+          if (candidateId === undefined) return;
+          // Switching season drops the old season's episodes, so a file can
+          // never end up mapped across two seasons.
+          const current = mappedSeasons(candidateId);
+          if (current.length !== 1 || current[0] !== season) {
+            setEpisodeIds((prev) => ({ ...prev, [candidateId]: [] }));
+          }
+          // Chaining picker to picker: the flow presents the episode list only
+          // once this sheet is fully dismissed (see hooks/use-modal-flow.ts).
+          flow.open("episodes", { candidateId, season });
+        }}
+      />
+
+      <PickerSheet
+        {...flow.bind("episodes")}
+        title="Choose episodes"
+        options={episodeOptions}
+        selected={episodeStep ? (episodeIds[episodeStep.candidateId] ?? []) : []}
+        multiple
+        emptyTitle="No episodes"
+        onPick={(episodeId) => {
+          if (!episodeStep) return;
+          toggleEpisode(episodeStep.candidateId, episodeId);
+        }}
+      />
+
+      <PickerSheet
+        {...flow.bind("quality")}
+        title="Choose quality"
+        options={qualityOptions}
+        selected={(() => {
+          const candidateId = flow.payload("quality");
+          if (candidateId === undefined) return [];
+          const current =
+            qualities[candidateId] ??
+            candidates?.find((c) => c.id === candidateId)?.quality;
+          return current?.quality?.id === undefined ? [] : [current.quality.id];
+        })()}
+        loading={qualityQuery.isLoading}
+        emptyTitle="No qualities"
+        onPick={(qualityId) => {
+          const candidateId = flow.payload("quality");
+          if (candidateId === undefined) return;
+          pickQuality(candidateId, qualityId);
+        }}
+      />
+    </>
+  );
+}

--- a/components/services/manual-import-view.tsx
+++ b/components/services/manual-import-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -33,6 +33,8 @@ import { useSonarrEpisodes } from "@/hooks/use-sonarr";
 import {
   qualityFromDefinition,
   qualityLabel,
+  seedMapping,
+  type ManualImportCandidate,
   type ManualImportRow,
   type ManualImportService,
 } from "@/lib/manual-import";
@@ -107,32 +109,31 @@ export function ManualImportView({
   const [qualityAsked, setQualityAsked] = useState(false);
   const qualityQuery = useArrQualityDefinitions(service, qualityAsked, instanceId);
 
-  // Seed the mapping from what *arr resolved on its own, once per fetch. A
-  // pull-to-refresh re-arms this so the screen genuinely reloads from the
-  // server instead of keeping selections that no longer match the new ids.
+  // Everything *arr resolved on its own becomes the starting mapping.
+  const seedFrom = useCallback((list: ManualImportCandidate[]) => {
+    const seed = seedMapping(list);
+    setMediaId(seed.mediaId);
+    setEpisodeIds(seed.episodeIds);
+    setIncluded(seed.included);
+    // Any quality the user overrode belonged to the previous fetch.
+    setQualities({});
+  }, []);
+
   const seeded = useRef(false);
   useEffect(() => {
     if (seeded.current || !candidates?.length) return;
     seeded.current = true;
-    setMediaId(candidates.find((c) => c.mediaId)?.mediaId);
-    setEpisodeIds(
-      Object.fromEntries(
-        candidates.filter((c) => c.episodeIds.length).map((c) => [c.id, c.episodeIds]),
-      ),
-    );
-    // Radarr has no per-file mapping to imply intent, so inclusion is explicit:
-    // start with the files Radarr matched, or the largest one when it matched
-    // none (sample and subtitle files are exactly what the user is deselecting).
-    const matched = candidates.filter((c) => c.mediaId);
-    const seedIncluded = matched.length
-      ? matched
-      : candidates.slice().sort((a, b) => b.size - a.size).slice(0, 1);
-    setIncluded(Object.fromEntries(seedIncluded.map((c) => [c.id, true])));
-  }, [candidates]);
+    seedFrom(candidates);
+  }, [candidates, seedFrom]);
 
+  // Reseed from what the refetch handed back rather than leaving it to the
+  // effect above: TanStack's structural sharing returns the SAME array
+  // reference when the response is unchanged, so an effect keyed on
+  // `candidates` would not rerun and the refresh would silently keep the edits
+  // it is meant to discard.
   const { refreshing, onRefresh } = useRefreshSpinner(async () => {
-    seeded.current = false;
-    await candidatesQuery.refetch();
+    const { data } = await candidatesQuery.refetch();
+    if (data?.length) seedFrom(data);
   });
 
   const flow = useModalFlow<PickerStep>();

--- a/components/services/queue-issues-banner.tsx
+++ b/components/services/queue-issues-banner.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState, type ComponentType } from "react";
 import { View, Text, Pressable } from "react-native";
+import { useRouter } from "expo-router";
 import {
   AlertTriangle,
   ChevronRight,
   Ban,
   FolderInput,
+  ListChecks,
   Search,
   Trash2,
 } from "lucide-react-native";
@@ -103,7 +105,11 @@ export function QueueIssuesBanner({
   instanceId,
   className = "",
 }: QueueIssuesBannerProps) {
-  const { issues: fetched } = useArrQueueIssues(adapter, instanceId);
+  const router = useRouter();
+  const { issues: fetched, instanceId: queueInstanceId } = useArrQueueIssues(
+    adapter,
+    instanceId,
+  );
   const removeMutation = useRemoveFromArrQueue(adapter, instanceId);
   const forceImportMutation = useForceImportArrQueue(adapter, instanceId);
 
@@ -152,6 +158,33 @@ export function QueueIssuesBanner({
                     item: sheetItem,
                     mode: "forceImport" as const,
                   }),
+              },
+            ]
+          : []),
+        // The by-hand fallback (#306): the release is named in a way *arr
+        // can't parse, so it matched no episode/movie and Force import above
+        // would refuse. Offered on the same items, since which of the two is
+        // needed only becomes clear once the candidates are listed.
+        ...(sheetItem.canForceImport && adapter.supportsManualImport
+          ? [
+              {
+                label: "Manual import",
+                subtitle: "Map the files yourself",
+                icon: <Icon icon={ListChecks} size={18} color="#a1a1aa" />,
+                onPress: () => {
+                  const target = {
+                    pathname: "/manual-import" as const,
+                    params: {
+                      service: adapter.serviceId,
+                      downloadId: sheetItem.downloadId!,
+                      title: sheetItem.releaseTitle,
+                      ...(queueInstanceId ? { instanceId: queueInstanceId } : {}),
+                    },
+                  };
+                  // Pushing a route is a "present" for iOS's purposes, so it
+                  // waits for the sheet to be fully gone — see CLAUDE.md.
+                  flow.whenClear(() => router.push(target));
+                },
               },
             ]
           : []),

--- a/components/ui/picker-sheet.tsx
+++ b/components/ui/picker-sheet.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, FlatList, Modal, Pressable, Text, View } from "react-native";
+import { Check, SearchX } from "lucide-react-native";
+import { Icon } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SheetHeader } from "@/components/ui/sheet-header";
+import { TextInput } from "@/components/ui/text-input";
+import { useSheetBottomPadding } from "@/hooks/use-bottom-inset";
+import { useModalClosed } from "@/hooks/use-modal-closed";
+import { lightHaptic } from "@/lib/haptics";
+
+export interface PickerOption {
+  value: number;
+  label: string;
+  description?: string;
+}
+
+interface PickerSheetProps {
+  visible: boolean;
+  title: string;
+  options: PickerOption[];
+  /** Values currently ticked. Single-select passes at most one. */
+  selected: readonly number[];
+  /** Keeps the sheet open per tap and shows a Done button. */
+  multiple?: boolean;
+  loading?: boolean;
+  /** Search field above the list; on by default past a screenful of options. */
+  searchable?: boolean;
+  emptyTitle?: string;
+  emptyMessage?: string;
+  onPick: (value: number) => void;
+  onClose: () => void;
+  /**
+   * Fired once the native `<Modal>` is fully gone. Required whenever picking
+   * chains into another picker — see hooks/use-modal-flow.ts.
+   */
+  onClosed?: () => void;
+}
+
+/**
+ * A searchable list picker in a page sheet: one row per option, a tick on the
+ * selected ones, single- or multi-select.
+ *
+ * Why a page sheet rather than the `Select` bottom sheet: the lists this backs
+ * (a whole Sonarr/Radarr library, every episode of a season) are far too long
+ * for a bottom sheet's ScrollView, and they need a search field. The search
+ * input is pinned above the list rather than scrolling with it, so the keyboard
+ * can never cover it — the top-anchored variant of the keyboard rules in
+ * CLAUDE.md, which is why no KeyboardAwareScrollView is involved.
+ *
+ * It wires `onClosed`, so it is safe to use as a `useModalFlow` step and to
+ * chain one picker into the next.
+ */
+export function PickerSheet({
+  visible,
+  title,
+  options,
+  selected,
+  multiple = false,
+  loading = false,
+  searchable,
+  emptyTitle = "Nothing to pick",
+  emptyMessage,
+  onPick,
+  onClose,
+  onClosed,
+}: PickerSheetProps) {
+  const handleDismiss = useModalClosed(visible, onClosed);
+  const listPadding = useSheetBottomPadding(16);
+  const footerPadding = useSheetBottomPadding(12);
+  const [query, setQuery] = useState("");
+
+  const showSearch = searchable ?? options.length > 12;
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return options;
+    return options.filter(
+      (o) =>
+        o.label.toLowerCase().includes(term) ||
+        o.description?.toLowerCase().includes(term),
+    );
+  }, [options, query]);
+
+  // The query belongs to one visit, so a reopened picker starts unfiltered.
+  // Reset on open rather than on close: the flow can close this sheet without
+  // going through onClose (a chained `open` flips `visible` directly), and
+  // clearing mid-dismiss would re-render the whole list as it slides away.
+  useEffect(() => {
+    if (visible) setQuery("");
+  }, [visible]);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+      onDismiss={handleDismiss}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title={title} onClose={onClose} />
+
+        {showSearch ? (
+          <View className="px-4 pt-4">
+            <TextInput
+              placeholder="Search…"
+              value={query}
+              onChangeText={setQuery}
+              autoCorrect={false}
+              autoCapitalize="none"
+              clearButtonMode="while-editing"
+            />
+          </View>
+        ) : null}
+
+        {loading ? (
+          <View className="flex-1 items-center justify-center">
+            {/* Native indicator, not the reanimated Spinner: this one has to be
+                visibly moving under OS Reduce Motion too (#196). */}
+            <ActivityIndicator color="#a1a1aa" />
+          </View>
+        ) : (
+          <FlatList
+            data={filtered}
+            keyExtractor={(option) => String(option.value)}
+            contentContainerClassName="px-4 py-4 gap-2"
+            contentContainerStyle={listPadding}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+            initialNumToRender={16}
+            windowSize={9}
+            ListEmptyComponent={
+              <EmptyState
+                icon={<Icon icon={SearchX} size={24} color="#71717a" />}
+                title={query ? "No matches" : emptyTitle}
+                message={query ? undefined : emptyMessage}
+              />
+            }
+            renderItem={({ item }) => {
+              const isSelected = selected.includes(item.value);
+              return (
+                <Pressable
+                  onPress={() => {
+                    lightHaptic();
+                    onPick(item.value);
+                  }}
+                  className={`flex-row items-center gap-3 rounded-2xl border px-4 py-3 active:opacity-70 ${
+                    isSelected
+                      ? "border-primary/50 bg-primary/10"
+                      : "border-border bg-surface"
+                  }`}
+                >
+                  <View className="flex-1">
+                    <Text
+                      className={`text-sm ${
+                        isSelected
+                          ? "text-primary font-semibold"
+                          : "text-zinc-100 font-medium"
+                      }`}
+                      numberOfLines={2}
+                    >
+                      {item.label}
+                    </Text>
+                    {item.description ? (
+                      <Text className="text-zinc-500 text-xs mt-0.5" numberOfLines={1}>
+                        {item.description}
+                      </Text>
+                    ) : null}
+                  </View>
+                  {isSelected ? <Icon icon={Check} size={18} color="#3b82f6" /> : null}
+                </Pressable>
+              );
+            }}
+          />
+        )}
+
+        {multiple ? (
+          <View className="border-t border-border px-4 py-3" style={footerPadding}>
+            <Button
+              label={selected.length > 0 ? `Done (${selected.length})` : "Done"}
+              onPress={onClose}
+              size="lg"
+            />
+          </View>
+        ) : null}
+      </View>
+    </Modal>
+  );
+}

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -789,16 +789,20 @@
         </p>
         <p>
           Tapping it lists every stuck grab with the reason the service gave and the release name.
-          Tap one for three actions:
+          Tap one for these actions:
         </p>
         <ul>
+          <li><strong>Force import</strong> (Radarr and Sonarr, blocked imports only): imports the downloaded files anyway, replacing the current file if there is one. This is the fix when the release was fine but the *arr refused it, most often because it is not an upgrade over what you already have.</li>
+          <li><strong>Manual import</strong> (Radarr and Sonarr, blocked imports only): opens the download's files so you can map them yourself. Pick the movie or the series, then the season and episodes for each file, adjust the quality if the *arr could not read one off the file name, and import. This is the fix when the release is named in a way the *arr cannot parse, so it matched nothing and Force import has nothing to send.</li>
           <li><strong>Remove from queue</strong>: drops the grab and deletes it from the download client. The release stays eligible, so the same copy can be grabbed again.</li>
           <li><strong>Blocklist &amp; Search</strong>: also blocks the release so it is never grabbed again, then starts a search for a replacement. This is the one you want for a bad copy.</li>
           <li><strong>Blocklist only</strong>: blocks the release with no replacement search.</li>
         </ul>
         <p>
-          All three ask for confirmation first, and blocklisted releases show up under
-          <em>System &rarr; Blocklist</em> in Radarr, Sonarr or Lidarr itself.
+          Force import and the three disposal actions ask for confirmation first, and blocklisted
+          releases show up under <em>System &rarr; Blocklist</em> in Radarr, Sonarr or Lidarr itself.
+          The import itself runs on the server, so the stuck grab clears from the queue a moment
+          after the app says the import started.
         </p>
 
         <h3>Global search</h3>

--- a/hooks/use-manual-import.ts
+++ b/hooks/use-manual-import.ts
@@ -1,0 +1,187 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast, toastError } from "@/components/ui/toast";
+import {
+  radarrImportFiles,
+  sonarrImportFiles,
+  toRadarrCandidates,
+  toSonarrCandidates,
+  type ManualImportCandidate,
+  type ManualImportRow,
+  type ManualImportService,
+} from "@/lib/manual-import";
+import {
+  getManualImportCandidates as getRadarrCandidates,
+  getMovies,
+  getQualityDefinitions as getRadarrQualityDefinitions,
+  runManualImport as runRadarrManualImport,
+} from "@/services/radarr-api";
+import {
+  getManualImportCandidates as getSonarrCandidates,
+  getQualityDefinitions as getSonarrQualityDefinitions,
+  getSeries,
+  runManualImport as runSonarrManualImport,
+} from "@/services/sonarr-api";
+import { useInstanceTarget } from "@/hooks/use-instance-target";
+import type { ArrQualityDefinition } from "@/lib/types";
+
+/**
+ * Data layer for the manual-import screen (#306) — the by-hand counterpart of
+ * the one-tap force import in use-arr-queue-issues.ts.
+ *
+ * Radarr and Sonarr expose the same three endpoints with different payload
+ * shapes, so the difference is confined to this table; every hook below is
+ * service-agnostic. Normalization happens in the queryFn because nothing else
+ * reads these keys (unlike the queue, whose cache entry is shared).
+ */
+const MANUAL_IMPORT: Record<
+  ManualImportService,
+  {
+    displayName: string;
+    fetchCandidates: (
+      downloadId: string,
+      instanceId: string,
+    ) => Promise<ManualImportCandidate[]>;
+    fetchQualities: (instanceId: string) => Promise<ArrQualityDefinition[]>;
+    runImport: (
+      rows: ManualImportRow[],
+      downloadId: string,
+      instanceId: string,
+    ) => Promise<void>;
+  }
+> = {
+  radarr: {
+    displayName: "Radarr",
+    fetchCandidates: async (downloadId, instanceId) =>
+      toRadarrCandidates(await getRadarrCandidates(downloadId, instanceId)),
+    fetchQualities: (instanceId) => getRadarrQualityDefinitions(instanceId),
+    runImport: (rows, downloadId, instanceId) =>
+      runRadarrManualImport(radarrImportFiles(rows, downloadId), instanceId),
+  },
+  sonarr: {
+    displayName: "Sonarr",
+    fetchCandidates: async (downloadId, instanceId) =>
+      toSonarrCandidates(await getSonarrCandidates(downloadId, instanceId)),
+    fetchQualities: (instanceId) => getSonarrQualityDefinitions(instanceId),
+    runImport: (rows, downloadId, instanceId) =>
+      runSonarrManualImport(sonarrImportFiles(rows, downloadId), instanceId),
+  },
+};
+
+export function manualImportServiceName(service: ManualImportService): string {
+  return MANUAL_IMPORT[service].displayName;
+}
+
+/**
+ * The files *arr found for one completed download, plus whatever it managed to
+ * match them to. Not polled: the scan result only changes when the user acts,
+ * and a refetch mid-mapping would fight the selections on screen.
+ */
+export function useManualImportCandidates(
+  service: ManualImportService,
+  downloadId: string,
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled } = useInstanceTarget(service, instanceId);
+  return useQuery({
+    queryKey: [service, id, "manualimport", downloadId],
+    queryFn: () => MANUAL_IMPORT[service].fetchCandidates(downloadId, id!),
+    enabled: enabled && !!id && !!downloadId,
+    gcTime: 0,
+  });
+}
+
+/**
+ * The instance's quality list, for files *arr parsed no quality off. Rarely
+ * needed, so it is only fetched when the screen actually asks (`enabled`).
+ */
+export function useArrQualityDefinitions(
+  service: ManualImportService,
+  enabled: boolean,
+  instanceId?: string,
+) {
+  const { instanceId: id, enabled: serviceEnabled } = useInstanceTarget(
+    service,
+    instanceId,
+  );
+  return useQuery({
+    queryKey: [service, id, "qualitydefinition"],
+    queryFn: () => MANUAL_IMPORT[service].fetchQualities(id!),
+    enabled: enabled && serviceEnabled && !!id,
+    staleTime: 60 * 60 * 1000,
+  });
+}
+
+/** One pickable destination: a Sonarr series or a Radarr movie. */
+export interface ManualImportLibraryEntry {
+  id: number;
+  title: string;
+  year?: number;
+}
+
+/**
+ * The library the destination picker chooses from. Keyed and fetched exactly
+ * like useSonarrSeries / useRadarrMovies, so it shares their cache entry rather
+ * than issuing a second request; the query for the other service stays
+ * disabled, so opening this screen never pulls a library it will not show.
+ */
+export function useManualImportLibrary(
+  service: ManualImportService,
+  instanceId?: string,
+): { entries: ManualImportLibraryEntry[]; isLoading: boolean } {
+  const { instanceId: id, enabled } = useInstanceTarget(service, instanceId);
+
+  const series = useQuery({
+    queryKey: ["sonarr", id, "series"],
+    queryFn: () => getSeries(id!),
+    enabled: enabled && !!id && service === "sonarr",
+  });
+  const movies = useQuery({
+    queryKey: ["radarr", id, "movie"],
+    queryFn: () => getMovies(id!),
+    enabled: enabled && !!id && service === "radarr",
+  });
+
+  const active = service === "sonarr" ? series : movies;
+
+  const entries = useMemo<ManualImportLibraryEntry[]>(
+    () =>
+      (active.data ?? []).map((item) => ({
+        id: item.id,
+        title: item.title,
+        year: item.year,
+      })),
+    [active.data],
+  );
+
+  return { entries, isLoading: active.isLoading };
+}
+
+/**
+ * Sends the mapped files as a ManualImport command. Success only means *arr
+ * accepted the command — the import itself runs async on the server, so the
+ * toast says "started" and the invalidated queue refetch is what clears the
+ * stuck grab.
+ */
+export function useRunManualImport(
+  service: ManualImportService,
+  downloadId: string,
+  instanceId?: string,
+) {
+  const { instanceId: id } = useInstanceTarget(service, instanceId);
+  const queryClient = useQueryClient();
+  const displayName = MANUAL_IMPORT[service].displayName;
+
+  return useMutation({
+    mutationFn: (rows: ManualImportRow[]) =>
+      MANUAL_IMPORT[service].runImport(rows, downloadId, id!),
+    onSuccess: () => {
+      toast(`Import started, ${displayName} is processing it`);
+      if (!id) return;
+      queryClient.invalidateQueries({ queryKey: [service, id, "queue"] });
+      // Prefix match — the imported media leaves wanted/missing too.
+      queryClient.invalidateQueries({ queryKey: [service, id, "wanted"] });
+    },
+    onError: (err) => toastError("Manual import failed", err),
+  });
+}

--- a/lib/arr-queue-adapter.ts
+++ b/lib/arr-queue-adapter.ts
@@ -92,6 +92,12 @@ export interface ArrQueueAdapter {
   // payload is track-level and unverified, so it doesn't implement this.
   forceImport?: (instanceId: string, downloadId: string) => Promise<void>;
 
+  // Whether /manual-import can map this service's files by hand (#306) — the
+  // case forceImport can't cover, where *arr parsed no series/movie off the
+  // release name and so matched nothing to import. Only set where that screen
+  // knows the service's payload shape (Radarr, Sonarr).
+  supportsManualImport?: boolean;
+
   // Whether the service can blocklist a release as part of a queue removal.
   // Defaults to true — every *arr can, via the `blocklist` DELETE param. Set
   // false when it can't (Bindery: its removal routes take no blocklist flag,

--- a/lib/arr-queue-adapters/radarr.ts
+++ b/lib/arr-queue-adapters/radarr.ts
@@ -61,4 +61,6 @@ export const radarrArrQueueAdapter: ArrQueueAdapter = {
 
   forceImport: (instanceId, downloadId) =>
     forceImportQueueItem(downloadId, instanceId),
+
+  supportsManualImport: true,
 };

--- a/lib/arr-queue-adapters/sonarr.ts
+++ b/lib/arr-queue-adapters/sonarr.ts
@@ -73,4 +73,6 @@ export const sonarrArrQueueAdapter: ArrQueueAdapter = {
 
   forceImport: (instanceId, downloadId) =>
     forceImportQueueItem(downloadId, instanceId),
+
+  supportsManualImport: true,
 };

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -587,6 +587,51 @@ const DEMO_SONARR_SERIES = [
   makeSeries(5, "Severance", 2022, 403891),
 ];
 
+// Neutral episode titles, cycled per season. Demo mode needs a real episode
+// list so the series screen and manual import's season/episode pickers (#306)
+// are usable, but inventing 80 titles for five real shows is worse than a
+// small honest pool.
+const DEMO_EPISODE_TITLES = [
+  "Cold Open",
+  "Fault Lines",
+  "The Long Way Down",
+  "Static",
+  "Borrowed Time",
+  "The Quiet Part",
+  "Fallout Shelter",
+  "Last Light",
+];
+
+// Matches the season shape makeSeries reports: two seasons of eight, all of
+// season 1 on disk and the last two of season 2 still missing.
+function makeEpisodes(seriesId: number) {
+  const out = [];
+  for (const seasonNumber of [1, 2]) {
+    for (let episodeNumber = 1; episodeNumber <= 8; episodeNumber += 1) {
+      // Weekly airings ending on the 15th episode, so the two without a file
+      // are the two most recent rather than something that aired a year ago.
+      const airedDaysAgo = ((seasonNumber - 1) * 8 + episodeNumber - 15) * 7;
+      out.push({
+        // Distinct from the calendar's 20x ids so the two fixtures can't collide.
+        id: seriesId * 1000 + seasonNumber * 100 + episodeNumber,
+        seriesId,
+        seasonNumber,
+        episodeNumber,
+        title: DEMO_EPISODE_TITLES[episodeNumber - 1]!,
+        airDate: daysFromNow(airedDaysAgo),
+        airDateUtc: daysFromNowFull(airedDaysAgo),
+        hasFile: seasonNumber === 1 || episodeNumber <= 6,
+        monitored: true,
+      });
+    }
+  }
+  return out;
+}
+
+const DEMO_SONARR_EPISODES = DEMO_SONARR_SERIES.flatMap((series) =>
+  makeEpisodes(series.id),
+);
+
 const DEMO_SONARR_CALENDAR = [
   {
     id: 201,
@@ -646,7 +691,7 @@ const DEMO_SONARR_QUEUE = {
     {
       id: 301,
       seriesId: 3,
-      episodeId: 203,
+      episodeId: 3106,
       title: "Fallout.S01E06.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb",
       status: "downloading",
       trackedDownloadStatus: "ok",
@@ -665,7 +710,7 @@ const DEMO_SONARR_QUEUE = {
     {
       id: 302,
       seriesId: 3,
-      episodeId: 204,
+      episodeId: 3107,
       title: "Fallout.S01E07.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb",
       status: "completed",
       trackedDownloadStatus: "warning",
@@ -700,7 +745,7 @@ const DEMO_SONARR_MANUAL_IMPORT = [
     size: 2952790016,
     series: makeSeries(3, "Fallout", 2024, 456789),
     seasonNumber: 1,
-    episodes: [{ id: 204 }],
+    episodes: [{ id: 3107 }],
     episodeFileId: 0,
     releaseType: "singleEpisode",
     quality: { quality: { id: 3, name: "WEBDL-1080p" } },
@@ -3124,6 +3169,15 @@ export function getDemoResponse(
       if (normalized.startsWith("/system/status")) return DEMO_SYSTEM_STATUS;
       if (normalized.startsWith("/health")) return DEMO_SONARR_HEALTH;
       if (normalized.startsWith("/series/lookup")) return [];
+      if (normalized === "/episode") {
+        const seriesId = Number(params?.seriesId);
+        return DEMO_SONARR_EPISODES.filter((e) => e.seriesId === seriesId);
+      }
+      if (normalized === "/episode/:id") {
+        const episodeId = Number(basePath.split("/").pop());
+        return DEMO_SONARR_EPISODES.find((e) => e.id === episodeId);
+      }
+      // /episodefile and anything else under /episode has no fixture.
       if (normalized.startsWith("/episode")) return [];
       return undefined;
     }

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -523,6 +523,17 @@ const DEMO_RADARR_MANUAL_IMPORT = [
   },
 ];
 
+// GET /qualitydefinition — the quality list the manual-import screen offers for
+// a file *arr parsed no quality off (#306). Trimmed to the common tiers.
+const DEMO_ARR_QUALITY_DEFINITIONS = [
+  { id: 1, title: "Unknown", weight: 1, quality: { id: 0, name: "Unknown" } },
+  { id: 2, title: "SDTV", weight: 2, quality: { id: 1, name: "SDTV", resolution: 480 } },
+  { id: 3, title: "HDTV-720p", weight: 3, quality: { id: 4, name: "HDTV-720p", resolution: 720 } },
+  { id: 4, title: "WEBDL-1080p", weight: 4, quality: { id: 3, name: "WEBDL-1080p", resolution: 1080 } },
+  { id: 5, title: "Bluray-1080p", weight: 5, quality: { id: 7, name: "Bluray-1080p", resolution: 1080 } },
+  { id: 6, title: "Bluray-2160p", weight: 6, quality: { id: 19, name: "Bluray-2160p", resolution: 2160 } },
+];
+
 const DEMO_RADARR_WANTED = {
   page: 1,
   pageSize: 20,
@@ -3085,6 +3096,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/manualimport")) return DEMO_RADARR_MANUAL_IMPORT;
       if (normalized.startsWith("/wanted/missing")) return DEMO_RADARR_WANTED;
       if (normalized.startsWith("/calendar")) return DEMO_RADARR_CALENDAR;
+      if (normalized.startsWith("/qualitydefinition")) return DEMO_ARR_QUALITY_DEFINITIONS;
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "HD-1080p" }, { id: 2, name: "Ultra-HD" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/movies", freeSpace: 2199023255552 }];
       if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;
@@ -3103,6 +3115,7 @@ export function getDemoResponse(
       if (normalized.startsWith("/calendar")) return DEMO_SONARR_CALENDAR;
       if (normalized.startsWith("/queue")) return DEMO_SONARR_QUEUE;
       if (normalized.startsWith("/manualimport")) return DEMO_SONARR_MANUAL_IMPORT;
+      if (normalized.startsWith("/qualitydefinition")) return DEMO_ARR_QUALITY_DEFINITIONS;
       if (normalized.startsWith("/qualityprofile")) return [{ id: 1, name: "Any" }, { id: 2, name: "HD-1080p" }];
       if (normalized.startsWith("/rootfolder")) return [{ id: 1, path: "/tv", freeSpace: 2199023255552 }];
       if (normalized.startsWith("/diskspace")) return DEMO_ARR_DISKSPACE;

--- a/lib/manual-import.test.ts
+++ b/lib/manual-import.test.ts
@@ -1,5 +1,6 @@
 import {
   autoRows,
+  seedMapping,
   qualityFromDefinition,
   qualityLabel,
   radarrImportFiles,
@@ -151,6 +152,46 @@ describe("autoRows", () => {
   it("skips candidates missing media or quality on either service", () => {
     expect(autoRows("radarr", [candidate({ mediaId: undefined })])).toEqual([]);
     expect(autoRows("sonarr", [candidate({ quality: undefined })])).toEqual([]);
+  });
+});
+
+describe("seedMapping", () => {
+  it("carries over what *arr resolved for the chosen destination", () => {
+    expect(seedMapping([candidate()])).toEqual({
+      mediaId: 7,
+      episodeIds: { 1: [42] },
+      included: { 1: true },
+    });
+  });
+
+  it("drops episode ids belonging to another series", () => {
+    // A folder holding two shows: file 2 matched series 9, but the screen
+    // imports into series 7, so its episode ids must NOT ride along.
+    const seed = seedMapping([
+      candidate({ id: 1, mediaId: 7, episodeIds: [42] }),
+      candidate({ id: 2, mediaId: 9, episodeIds: [88] }),
+    ]);
+    expect(seed.mediaId).toBe(7);
+    expect(seed.episodeIds).toEqual({ 1: [42] });
+    expect(seed.included).toEqual({ 1: true });
+  });
+
+  it("selects the largest file when *arr matched nothing", () => {
+    const seed = seedMapping([
+      candidate({ id: 1, mediaId: undefined, episodeIds: [], size: 100 }),
+      candidate({ id: 2, mediaId: undefined, episodeIds: [], size: 900 }),
+    ]);
+    expect(seed.mediaId).toBeUndefined();
+    expect(seed.episodeIds).toEqual({});
+    expect(seed.included).toEqual({ 2: true });
+  });
+
+  it("leaves an unmatched file out when another file did match", () => {
+    const seed = seedMapping([
+      candidate({ id: 1, mediaId: 7, episodeIds: [42] }),
+      candidate({ id: 2, mediaId: undefined, episodeIds: [] }),
+    ]);
+    expect(seed.included).toEqual({ 1: true });
   });
 });
 

--- a/lib/manual-import.test.ts
+++ b/lib/manual-import.test.ts
@@ -1,0 +1,234 @@
+import {
+  autoRows,
+  qualityFromDefinition,
+  qualityLabel,
+  radarrImportFiles,
+  sonarrImportFiles,
+  toRadarrCandidates,
+  toSonarrCandidates,
+  type ManualImportCandidate,
+} from "@/lib/manual-import";
+import type { RadarrManualImportItem, SonarrManualImportItem } from "@/lib/types";
+
+const WEBDL = { quality: { id: 3, name: "WEBDL-1080p" } };
+
+function sonarrItem(
+  over: Partial<SonarrManualImportItem> = {},
+): SonarrManualImportItem {
+  return {
+    id: 1,
+    path: "/downloads/Show.S01E01/show.s01e01.mkv",
+    relativePath: "show.s01e01.mkv",
+    folderName: "Show.S01E01",
+    size: 1000,
+    series: { id: 7, title: "Show" },
+    seasonNumber: 1,
+    episodes: [{ id: 42 }],
+    quality: WEBDL,
+    languages: [{ id: 1, name: "English" }],
+    releaseGroup: "GRP",
+    indexerFlags: 0,
+    ...over,
+  };
+}
+
+function radarrItem(
+  over: Partial<RadarrManualImportItem> = {},
+): RadarrManualImportItem {
+  return {
+    id: 1,
+    path: "/downloads/Movie.2024/movie.2024.mkv",
+    relativePath: "movie.2024.mkv",
+    folderName: "Movie.2024",
+    size: 2000,
+    movie: { id: 11, title: "Movie" },
+    quality: WEBDL,
+    languages: [{ id: 1, name: "English" }],
+    indexerFlags: 0,
+    ...over,
+  };
+}
+
+function candidate(
+  over: Partial<ManualImportCandidate> = {},
+): ManualImportCandidate {
+  return {
+    id: 1,
+    path: "/downloads/Show.S01E01/show.s01e01.mkv",
+    folderName: "Show.S01E01",
+    name: "show.s01e01.mkv",
+    size: 1000,
+    mediaId: 7,
+    episodeIds: [42],
+    quality: WEBDL,
+    languages: [{ id: 1, name: "English" }],
+    indexerFlags: 0,
+    rejections: [],
+    ...over,
+  };
+}
+
+describe("toSonarrCandidates", () => {
+  it("normalizes a matched candidate", () => {
+    expect(toSonarrCandidates([sonarrItem()])).toEqual([
+      expect.objectContaining({
+        id: 1,
+        name: "show.s01e01.mkv",
+        mediaId: 7,
+        mediaTitle: "Show",
+        seasonNumber: 1,
+        episodeIds: [42],
+        quality: WEBDL,
+      }),
+    ]);
+  });
+
+  it("keeps an unmatched candidate, with no media and no episodes", () => {
+    const [row] = toSonarrCandidates([
+      sonarrItem({ series: undefined, episodes: [], seasonNumber: undefined }),
+    ]);
+    expect(row.mediaId).toBeUndefined();
+    expect(row.episodeIds).toEqual([]);
+  });
+
+  it("falls back to the path basename when relativePath is absent", () => {
+    const [row] = toSonarrCandidates([sonarrItem({ relativePath: undefined })]);
+    expect(row.name).toBe("show.s01e01.mkv");
+  });
+
+  it("drops a candidate with no path — the command imports by path", () => {
+    expect(toSonarrCandidates([sonarrItem({ path: undefined })])).toEqual([]);
+  });
+
+  it("dedupes rejection reasons", () => {
+    const [row] = toSonarrCandidates([
+      sonarrItem({
+        rejections: [{ reason: "Not an upgrade" }, { reason: "Not an upgrade" }],
+      }),
+    ]);
+    expect(row.rejections).toEqual(["Not an upgrade"]);
+  });
+
+  it("tolerates a missing response", () => {
+    expect(toSonarrCandidates(undefined)).toEqual([]);
+  });
+});
+
+describe("toRadarrCandidates", () => {
+  it("normalizes a matched candidate and leaves episodes empty", () => {
+    expect(toRadarrCandidates([radarrItem()])).toEqual([
+      expect.objectContaining({
+        mediaId: 11,
+        mediaTitle: "Movie",
+        episodeIds: [],
+        name: "movie.2024.mkv",
+      }),
+    ]);
+  });
+
+  it("keeps an unmatched candidate", () => {
+    const [row] = toRadarrCandidates([radarrItem({ movie: undefined })]);
+    expect(row.mediaId).toBeUndefined();
+  });
+});
+
+describe("autoRows", () => {
+  it("takes a fully matched Sonarr candidate", () => {
+    expect(autoRows("sonarr", [candidate()])).toEqual([
+      { candidate: candidate(), mediaId: 7, quality: WEBDL, episodeIds: [42] },
+    ]);
+  });
+
+  it("skips a Sonarr candidate with no episode — force import can't map it", () => {
+    expect(autoRows("sonarr", [candidate({ episodeIds: [] })])).toEqual([]);
+  });
+
+  it("takes a Radarr candidate with no episodes", () => {
+    const row = candidate({ episodeIds: [], mediaId: 11 });
+    expect(autoRows("radarr", [row])).toHaveLength(1);
+  });
+
+  it("skips candidates missing media or quality on either service", () => {
+    expect(autoRows("radarr", [candidate({ mediaId: undefined })])).toEqual([]);
+    expect(autoRows("sonarr", [candidate({ quality: undefined })])).toEqual([]);
+  });
+});
+
+describe("sonarrImportFiles", () => {
+  it("builds the command payload, with the caller's mapping winning", () => {
+    const files = sonarrImportFiles(
+      [
+        {
+          candidate: candidate({ episodeIds: [42], releaseType: "singleEpisode" }),
+          mediaId: 99,
+          quality: WEBDL,
+          episodeIds: [500, 501],
+        },
+      ],
+      "abc123",
+    );
+    expect(files).toEqual([
+      {
+        path: "/downloads/Show.S01E01/show.s01e01.mkv",
+        folderName: "Show.S01E01",
+        seriesId: 99,
+        episodeIds: [500, 501],
+        quality: WEBDL,
+        languages: [{ id: 1, name: "English" }],
+        releaseGroup: undefined,
+        indexerFlags: 0,
+        releaseType: "singleEpisode",
+        episodeFileId: undefined,
+        downloadId: "abc123",
+      },
+    ]);
+  });
+});
+
+describe("radarrImportFiles", () => {
+  it("builds the command payload without episode fields", () => {
+    const files = radarrImportFiles(
+      [{ candidate: candidate(), mediaId: 11, quality: WEBDL, episodeIds: [] }],
+      "abc123",
+    );
+    expect(files[0]).toEqual({
+      path: "/downloads/Show.S01E01/show.s01e01.mkv",
+      folderName: "Show.S01E01",
+      movieId: 11,
+      quality: WEBDL,
+      languages: [{ id: 1, name: "English" }],
+      releaseGroup: undefined,
+      indexerFlags: 0,
+      downloadId: "abc123",
+    });
+    expect(files[0]).not.toHaveProperty("episodeIds");
+  });
+});
+
+describe("qualityLabel", () => {
+  it("names the quality", () => {
+    expect(qualityLabel(WEBDL)).toBe("WEBDL-1080p");
+  });
+
+  it("flags repacks and propers", () => {
+    expect(qualityLabel({ ...WEBDL, revision: { version: 2, isRepack: true } })).toBe(
+      "WEBDL-1080p REPACK",
+    );
+    expect(qualityLabel({ ...WEBDL, revision: { version: 2 } })).toBe(
+      "WEBDL-1080p PROPER",
+    );
+  });
+
+  it("falls back when *arr parsed nothing", () => {
+    expect(qualityLabel(undefined)).toBe("Unknown quality");
+  });
+});
+
+describe("qualityFromDefinition", () => {
+  it("adds the neutral revision the parser would have produced", () => {
+    expect(qualityFromDefinition({ id: 3, name: "WEBDL-1080p" })).toEqual({
+      quality: { id: 3, name: "WEBDL-1080p" },
+      revision: { version: 1, real: 0, isRepack: false },
+    });
+  });
+});

--- a/lib/manual-import.ts
+++ b/lib/manual-import.ts
@@ -1,0 +1,247 @@
+import type {
+  ArrQualityModel,
+  RadarrManualImportItem,
+  SonarrManualImportItem,
+} from "@/lib/types";
+
+/**
+ * Manual import — the app-side equivalent of Radarr's and Sonarr's own
+ * Interactive/Manual Import screen (#306).
+ *
+ * `GET /manualimport?downloadId=` returns the files *arr found for a completed
+ * download plus whatever it managed to match them to. One-tap force import
+ * (#325) only works when *arr matched everything itself; when the release is
+ * named in a way it can't parse, `series`/`movie`/`episodes` come back empty
+ * and the mapping has to be supplied by hand. That is what this module models:
+ * a normalized candidate shape both services share, and the two `files[]`
+ * payloads their `ManualImport` command takes.
+ *
+ * Kept pure (no React, no network) so the payload shapes — the part that fails
+ * silently against a real server — are unit-testable.
+ */
+
+export type ManualImportService = "radarr" | "sonarr";
+
+/** A candidate file from `GET /manualimport`, normalized across both services. */
+export interface ManualImportCandidate {
+  /** Candidate id; unique within one /manualimport response, used as the key. */
+  id: number;
+  /** Absolute path on the *arr host — the field the command imports by. */
+  path: string;
+  folderName?: string;
+  /** File name for display: the relative path, else the basename of `path`. */
+  name: string;
+  size: number;
+  /** What *arr matched on its own: a Sonarr series id / a Radarr movie id. */
+  mediaId?: number;
+  mediaTitle?: string;
+  /** Sonarr only — its guess at the season, and the episodes it resolved. */
+  seasonNumber?: number;
+  episodeIds: number[];
+  episodeFileId?: number;
+  releaseType?: string;
+  /** Parsed off the file name; absent when *arr could not parse one. */
+  quality?: ArrQualityModel;
+  languages: { id: number; name: string }[];
+  releaseGroup?: string;
+  indexerFlags: number;
+  /** Why *arr refused to import the file, deduped. */
+  rejections: string[];
+}
+
+/** One file plus the destination it will be imported to. */
+export interface ManualImportRow {
+  candidate: ManualImportCandidate;
+  /** Sonarr: the series id. Radarr: the movie id. */
+  mediaId: number;
+  quality: ArrQualityModel;
+  /** Sonarr only; ignored by the Radarr payload. */
+  episodeIds: number[];
+}
+
+/** `files[]` entry of Sonarr's ManualImport command. */
+export interface SonarrManualImportFile {
+  path: string;
+  folderName?: string;
+  seriesId: number;
+  episodeIds: number[];
+  quality: ArrQualityModel;
+  languages: { id: number; name: string }[];
+  releaseGroup?: string;
+  indexerFlags: number;
+  releaseType?: string;
+  episodeFileId?: number;
+  downloadId?: string;
+}
+
+/** `files[]` entry of Radarr's ManualImport command. */
+export interface RadarrManualImportFile {
+  path: string;
+  folderName?: string;
+  movieId: number;
+  quality: ArrQualityModel;
+  languages: { id: number; name: string }[];
+  releaseGroup?: string;
+  indexerFlags: number;
+  downloadId?: string;
+}
+
+// `relativePath` is what both web UIs show; `path` is absolute and `name` is
+// only set on some records, so both are fallbacks rather than the first choice.
+function fileName(item: {
+  relativePath?: string;
+  path?: string;
+  name?: string;
+}): string {
+  if (item.relativePath) return item.relativePath;
+  const base = (item.path ?? "").split(/[\\/]/).pop();
+  return base || item.name || item.path || "";
+}
+
+function rejectionReasons(
+  rejections: { reason: string }[] | undefined,
+): string[] {
+  const out: string[] = [];
+  for (const entry of rejections ?? []) {
+    const reason = entry?.reason?.trim();
+    if (reason && !out.includes(reason)) out.push(reason);
+  }
+  return out;
+}
+
+/**
+ * Candidates without a `path` are dropped: the command imports by path, so a
+ * pathless record could never be sent and would only render as a dead row.
+ */
+export function toSonarrCandidates(
+  items: SonarrManualImportItem[] | undefined,
+): ManualImportCandidate[] {
+  return (items ?? [])
+    .filter((item) => !!item.path)
+    .map((item) => ({
+      id: item.id,
+      path: item.path!,
+      folderName: item.folderName,
+      name: fileName(item),
+      size: item.size ?? 0,
+      mediaId: item.series?.id,
+      mediaTitle: item.series?.title,
+      seasonNumber: item.seasonNumber,
+      episodeIds: (item.episodes ?? []).map((e) => e.id),
+      episodeFileId: item.episodeFileId,
+      releaseType: item.releaseType,
+      quality: item.quality,
+      languages: item.languages ?? [],
+      releaseGroup: item.releaseGroup,
+      indexerFlags: item.indexerFlags ?? 0,
+      rejections: rejectionReasons(item.rejections),
+    }));
+}
+
+export function toRadarrCandidates(
+  items: RadarrManualImportItem[] | undefined,
+): ManualImportCandidate[] {
+  return (items ?? [])
+    .filter((item) => !!item.path)
+    .map((item) => ({
+      id: item.id,
+      path: item.path!,
+      folderName: item.folderName,
+      name: fileName(item),
+      size: item.size ?? 0,
+      mediaId: item.movie?.id,
+      mediaTitle: item.movie?.title,
+      episodeIds: [],
+      quality: item.quality,
+      languages: item.languages ?? [],
+      releaseGroup: item.releaseGroup,
+      indexerFlags: item.indexerFlags ?? 0,
+      rejections: rejectionReasons(item.rejections),
+    }));
+}
+
+/**
+ * The rows *arr already resolved by itself — exactly what one-tap force import
+ * (#325) sends. A Sonarr file needs a series, at least one episode and a parsed
+ * quality; a Radarr file needs a movie and a quality. Anything short of that
+ * has to be mapped on the manual-import screen instead.
+ */
+export function autoRows(
+  service: ManualImportService,
+  candidates: ManualImportCandidate[],
+): ManualImportRow[] {
+  const rows: ManualImportRow[] = [];
+  for (const candidate of candidates) {
+    if (!candidate.mediaId || !candidate.quality) continue;
+    if (service === "sonarr" && candidate.episodeIds.length === 0) continue;
+    rows.push({
+      candidate,
+      mediaId: candidate.mediaId,
+      quality: candidate.quality,
+      episodeIds: candidate.episodeIds,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Payload mirroring Sonarr's web UI (InteractiveImportModalContent). The
+ * per-file `downloadId` is what ties the import back to the queue item, so the
+ * grab leaves the queue instead of lingering as a second stuck entry.
+ */
+export function sonarrImportFiles(
+  rows: ManualImportRow[],
+  downloadId?: string,
+): SonarrManualImportFile[] {
+  return rows.map((row) => ({
+    path: row.candidate.path,
+    folderName: row.candidate.folderName,
+    seriesId: row.mediaId,
+    episodeIds: row.episodeIds,
+    quality: row.quality,
+    languages: row.candidate.languages,
+    releaseGroup: row.candidate.releaseGroup,
+    indexerFlags: row.candidate.indexerFlags,
+    releaseType: row.candidate.releaseType,
+    episodeFileId: row.candidate.episodeFileId,
+    downloadId,
+  }));
+}
+
+export function radarrImportFiles(
+  rows: ManualImportRow[],
+  downloadId?: string,
+): RadarrManualImportFile[] {
+  return rows.map((row) => ({
+    path: row.candidate.path,
+    folderName: row.candidate.folderName,
+    movieId: row.mediaId,
+    quality: row.quality,
+    languages: row.candidate.languages,
+    releaseGroup: row.candidate.releaseGroup,
+    indexerFlags: row.candidate.indexerFlags,
+    downloadId,
+  }));
+}
+
+/** "WEBDL-1080p", with the proper/repack revision appended when there is one. */
+export function qualityLabel(quality: ArrQualityModel | undefined): string {
+  if (!quality?.quality?.name) return "Unknown quality";
+  const version = quality.revision?.version ?? 1;
+  if (quality.revision?.isRepack) return `${quality.quality.name} REPACK`;
+  if (version > 1) return `${quality.quality.name} PROPER`;
+  return quality.quality.name;
+}
+
+/**
+ * A quality picked from `/qualitydefinition` carries no revision, so give it
+ * the neutral one the parser would have produced for a first release.
+ */
+export function qualityFromDefinition(quality: {
+  id: number;
+  name: string;
+  source?: string;
+  resolution?: number;
+}): ArrQualityModel {
+  return { quality, revision: { version: 1, real: 0, isRepack: false } };
+}

--- a/lib/manual-import.ts
+++ b/lib/manual-import.ts
@@ -185,6 +185,42 @@ export function autoRows(
 }
 
 /**
+ * The starting mapping for the manual-import screen: what *arr already
+ * resolved by itself, plus which files begin selected.
+ *
+ * The destination is screen-wide — one series or movie for the whole download
+ * folder — so a file's episode ids are only carried over when that file matched
+ * THAT destination. A folder holding two series would otherwise pair one file's
+ * episode ids with the other file's seriesId, and the command would import into
+ * the wrong show. Files matched to something else start unmapped, for the user
+ * to map by hand or leave out.
+ */
+export function seedMapping(candidates: ManualImportCandidate[]): {
+  mediaId?: number;
+  episodeIds: Record<number, number[]>;
+  included: Record<number, boolean>;
+} {
+  const mediaId = candidates.find((c) => c.mediaId)?.mediaId;
+  const onTarget =
+    mediaId === undefined ? [] : candidates.filter((c) => c.mediaId === mediaId);
+
+  // Radarr has no per-file mapping to imply intent, so inclusion is explicit:
+  // start from the files it matched, or the largest one when it matched none
+  // (sample and subtitle files are exactly what the user deselects).
+  const seedIncluded = onTarget.length
+    ? onTarget
+    : candidates.slice().sort((a, b) => b.size - a.size).slice(0, 1);
+
+  return {
+    mediaId,
+    episodeIds: Object.fromEntries(
+      onTarget.filter((c) => c.episodeIds.length).map((c) => [c.id, c.episodeIds]),
+    ),
+    included: Object.fromEntries(seedIncluded.map((c) => [c.id, true])),
+  };
+}
+
+/**
  * Payload mirroring Sonarr's web UI (InteractiveImportModalContent). The
  * per-file `downloadId` is what ties the import back to the queue item, so the
  * grab leaves the queue instead of lingering as a second stuck entry.

--- a/lib/tab-route-resolution.test.ts
+++ b/lib/tab-route-resolution.test.ts
@@ -180,7 +180,7 @@ describe("tab route resolution", () => {
       });
       checked += 1;
     }
-    expect(checked).toBe(32);
+    expect(checked).toBe(33);
   });
 
   it("keeps a rewritten link in the Dashboard stack even from another tab", () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -422,6 +422,16 @@ export interface ArrQualityModel {
   revision?: { version?: number; real?: number; isRepack?: boolean };
 }
 
+// One entry of `GET /qualitydefinition` — every quality the instance knows,
+// which is what the manual-import screen offers when *arr parsed none off the
+// file name (#306). Radarr and Sonarr answer the same shape.
+export interface ArrQualityDefinition {
+  id: number;
+  title: string;
+  weight: number;
+  quality: { id: number; name: string; source?: string; resolution?: number };
+}
+
 // A candidate file from `GET /manualimport?downloadId=` — the list Radarr's own
 // Manual Import screen shows for a completed download (#325). `quality` and
 // `languages` round-trip verbatim into the ManualImport command, so only the

--- a/services/radarr-api.ts
+++ b/services/radarr-api.ts
@@ -1,5 +1,11 @@
 import { serviceRequest } from "@/lib/http-client";
 import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
+import {
+  autoRows,
+  radarrImportFiles,
+  toRadarrCandidates,
+  type RadarrManualImportFile,
+} from "@/lib/manual-import";
 import type {
   RadarrMovie,
   RadarrQueue,
@@ -11,6 +17,7 @@ import type {
   RadarrImage,
   RadarrRelease,
   RadarrCollection,
+  ArrQualityDefinition,
   ArrQueueRemoveOptions,
 } from "@/lib/types";
 
@@ -109,12 +116,14 @@ export function removeFromQueue(
   });
 }
 
-// --- Force import (#325) ---
+// --- Manual import (#325, #306) ---
 
-// The import candidates Radarr matched for a completed download — the same
-// list its own Manual Import screen shows. `filterExistingFiles: false` so
-// nothing the scan found is hidden from the eligibility check below.
-function getManualImportItems(
+/**
+ * The import candidates Radarr matched for a completed download — the same
+ * list its own Manual Import screen shows. `filterExistingFiles: false` so
+ * nothing the scan found is hidden, including files it could not map.
+ */
+export function getManualImportCandidates(
   downloadId: string,
   instanceId?: string,
 ): Promise<RadarrManualImportItem[]> {
@@ -125,44 +134,57 @@ function getManualImportItems(
 }
 
 /**
- * Imports a completed download Radarr refused to import ("Import blocked",
- * typically a grab-anyway release that isn't a quality upgrade), replacing the
- * existing movie file. The app-side equivalent of desktop Manual Import: fetch
- * Radarr's own candidates for the download, then issue a ManualImport command
- * for every file it identified — the command imports regardless of rejections,
- * which is the "force". File payload mirrors Radarr's web UI
- * (InteractiveImportModalContent). Only files Radarr matched to a movie with a
- * parsed quality qualify; anything unidentified needs the desktop screen's
- * manual mapping, so with no qualifying file this rejects instead of silently
- * importing nothing.
+ * Every quality this instance knows. The manual-import screen offers these
+ * when Radarr parsed no quality off the file name, which is exactly the case
+ * where the release is named in a way it can't read (#306).
  */
-export async function forceImportQueueItem(
-  downloadId: string,
+export function getQualityDefinitions(
+  instanceId?: string,
+): Promise<ArrQualityDefinition[]> {
+  return serviceRequest<ArrQualityDefinition[]>("radarr", "/qualitydefinition", {
+    instanceId,
+  });
+}
+
+/**
+ * Issues the ManualImport command for already-built file payloads. The command
+ * imports regardless of rejections, which is what makes it a *force*.
+ * `importMode: "auto"` matches Radarr's own default (copy vs. hardlink/move is
+ * decided from the download client's setting).
+ */
+export function runManualImport(
+  files: RadarrManualImportFile[],
   instanceId?: string,
 ): Promise<void> {
-  const candidates = await getManualImportItems(downloadId, instanceId);
-  const files = candidates
-    .filter((c) => c.path && c.movie && c.quality)
-    .map((c) => ({
-      path: c.path,
-      folderName: c.folderName,
-      movieId: c.movie!.id,
-      quality: c.quality,
-      languages: c.languages ?? [],
-      releaseGroup: c.releaseGroup,
-      indexerFlags: c.indexerFlags ?? 0,
-      downloadId,
-    }));
-  if (files.length === 0) {
-    throw new Error(
-      "Radarr couldn't match this download to a movie. Use Manual Import in Radarr to map it.",
-    );
-  }
   return serviceRequest<void>("radarr", "/command", {
     method: "POST",
     body: JSON.stringify({ name: "ManualImport", files, importMode: "auto" }),
     instanceId,
   });
+}
+
+/**
+ * Imports a completed download Radarr refused to import ("Import blocked",
+ * typically a grab-anyway release that isn't a quality upgrade), replacing the
+ * existing movie file. The one-tap path: it sends only what Radarr already
+ * matched by itself. A release whose name Radarr can't parse resolves to no
+ * movie at all, so this rejects instead of silently importing nothing — that
+ * case needs the manual-import screen, where the mapping is chosen by hand.
+ */
+export async function forceImportQueueItem(
+  downloadId: string,
+  instanceId?: string,
+): Promise<void> {
+  const candidates = toRadarrCandidates(
+    await getManualImportCandidates(downloadId, instanceId),
+  );
+  const rows = autoRows("radarr", candidates);
+  if (rows.length === 0) {
+    throw new Error(
+      "Radarr couldn't match this download to a movie. Use Manual import to map the files yourself.",
+    );
+  }
+  return runManualImport(radarrImportFiles(rows, downloadId), instanceId);
 }
 
 // --- History ---

--- a/services/sonarr-api.ts
+++ b/services/sonarr-api.ts
@@ -1,5 +1,11 @@
 import { serviceRequest } from "@/lib/http-client";
 import { INTERACTIVE_SEARCH_TIMEOUT } from "@/lib/constants";
+import {
+  autoRows,
+  sonarrImportFiles,
+  toSonarrCandidates,
+  type SonarrManualImportFile,
+} from "@/lib/manual-import";
 import type {
   SonarrSeries,
   SonarrEpisode,
@@ -14,6 +20,7 @@ import type {
   SonarrImage,
   SonarrRelease,
   SonarrWantedMissing,
+  ArrQualityDefinition,
   ArrQueueRemoveOptions,
 } from "@/lib/types";
 
@@ -209,12 +216,14 @@ export function removeFromQueue(
   });
 }
 
-// --- Force import (#325) ---
+// --- Manual import (#325, #306) ---
 
-// The import candidates Sonarr matched for a completed download — the same
-// list its own Manual Import screen shows. `filterExistingFiles: false` so
-// nothing the scan found is hidden from the eligibility check below.
-function getManualImportItems(
+/**
+ * The import candidates Sonarr matched for a completed download — the same
+ * list its own Manual Import screen shows. `filterExistingFiles: false` so
+ * nothing the scan found is hidden, including files it could not map.
+ */
+export function getManualImportCandidates(
   downloadId: string,
   instanceId?: string,
 ): Promise<SonarrManualImportItem[]> {
@@ -225,47 +234,57 @@ function getManualImportItems(
 }
 
 /**
- * Imports a completed download Sonarr refused to import ("Import blocked",
- * typically a grab-anyway release that isn't a quality upgrade), replacing the
- * existing episode files. The app-side equivalent of desktop Manual Import:
- * fetch Sonarr's own candidates for the download, then issue a ManualImport
- * command for every file it identified — the command imports regardless of
- * rejections, which is the "force". File payload mirrors Sonarr's web UI
- * (InteractiveImportModalContent). Only files Sonarr mapped to episodes with a
- * parsed quality qualify; anything unidentified needs the desktop screen's
- * manual mapping, so with no qualifying file this rejects instead of silently
- * importing nothing.
+ * Every quality this instance knows. The manual-import screen offers these
+ * when Sonarr parsed no quality off the file name, which is exactly the case
+ * where the release is named in a way it can't read (#306).
  */
-export async function forceImportQueueItem(
-  downloadId: string,
+export function getQualityDefinitions(
+  instanceId?: string,
+): Promise<ArrQualityDefinition[]> {
+  return serviceRequest<ArrQualityDefinition[]>("sonarr", "/qualitydefinition", {
+    instanceId,
+  });
+}
+
+/**
+ * Issues the ManualImport command for already-built file payloads. The command
+ * imports regardless of rejections, which is what makes it a *force*.
+ * `importMode: "auto"` matches Sonarr's own default (copy vs. hardlink/move is
+ * decided from the download client's setting).
+ */
+export function runManualImport(
+  files: SonarrManualImportFile[],
   instanceId?: string,
 ): Promise<void> {
-  const candidates = await getManualImportItems(downloadId, instanceId);
-  const files = candidates
-    .filter((c) => c.path && c.series && c.episodes?.length && c.quality)
-    .map((c) => ({
-      path: c.path,
-      folderName: c.folderName,
-      seriesId: c.series!.id,
-      episodeIds: c.episodes!.map((e) => e.id),
-      quality: c.quality,
-      languages: c.languages ?? [],
-      releaseGroup: c.releaseGroup,
-      indexerFlags: c.indexerFlags ?? 0,
-      releaseType: c.releaseType,
-      episodeFileId: c.episodeFileId,
-      downloadId,
-    }));
-  if (files.length === 0) {
-    throw new Error(
-      "Sonarr couldn't match this download to any episode. Use Manual Import in Sonarr to map it.",
-    );
-  }
   return serviceRequest<void>("sonarr", "/command", {
     method: "POST",
     body: JSON.stringify({ name: "ManualImport", files, importMode: "auto" }),
     instanceId,
   });
+}
+
+/**
+ * Imports a completed download Sonarr refused to import ("Import blocked",
+ * typically a grab-anyway release that isn't a quality upgrade), replacing the
+ * existing episode files. The one-tap path: it sends only what Sonarr already
+ * mapped by itself. A release whose name Sonarr can't parse resolves to no
+ * episode at all, so this rejects instead of silently importing nothing — that
+ * case needs the manual-import screen, where the mapping is chosen by hand.
+ */
+export async function forceImportQueueItem(
+  downloadId: string,
+  instanceId?: string,
+): Promise<void> {
+  const candidates = toSonarrCandidates(
+    await getManualImportCandidates(downloadId, instanceId),
+  );
+  const rows = autoRows("sonarr", candidates);
+  if (rows.length === 0) {
+    throw new Error(
+      "Sonarr couldn't match this download to any episode. Use Manual import to map the files yourself.",
+    );
+  }
+  return runManualImport(sonarrImportFiles(rows, downloadId), instanceId);
 }
 
 // --- History ---


### PR DESCRIPTION
Force import (#325) only sends what Radarr/Sonarr already matched themselves. When a release is named in a way they cannot parse, `/manualimport` returns no series, movie or episodes and force import correctly refuses. That is the case reported in #306.

This adds the by-hand path: a `/manual-import` screen reachable from the queue issues sheet, next to Force import. Pick the series or movie, then the season, episodes and quality per file, and it sends the same `ManualImport` command with the mapping filled in.

- `lib/manual-import.ts` normalizes both services' candidates and builds the two `files[]` payloads
- new `getManualImportCandidates`, `getQualityDefinitions`, `runManualImport`; `forceImportQueueItem` refactored onto them
- `PickerSheet`: searchable single/multi list, wired for `useModalFlow` so season into episodes is safe on iOS
- route lives in `(dashboard,movies,tv,library)`, the tabs that render the banner
- demo mode gets `/qualitydefinition`; the guide's queue issues section now documents Force import too

## Test plan

- `lib/manual-import.test.ts` covers normalization, the auto rows force import sends, and both command payloads
- `tsc --noEmit` clean, 1718 tests pass
- `expo export` bundles clean for Android and iOS
- not verified on a device yet

Refs #306